### PR TITLE
Added Token0 Test on Sync event - incomplete

### DIFF
--- a/test/Test.ts
+++ b/test/Test.ts
@@ -315,6 +315,26 @@ describe("Sync event correctly updates LiquidityPool entity", () => {
       expectedLiquidityPoolEntity
     );
   });
+
+  it("Token0 entity is updated correctly", () => {
+    // Getting the entity from the mock database
+    const acutualToken0Entity =
+      updatedMockDb.entities.Token.get(mockToken0Address);
+
+    // Expected LiquidityPool entity
+    const expectedToken0Entity: TokenEntity = {
+      ...mockToken0Entity,
+      pricePerETH: divideBase1e18(
+        mockLatestETHPriceEntity.price,
+        token0PriceUSD
+      ),
+      pricePerUSD: token0PriceUSD,
+      lastUpdatedTimestamp: BigInt(mockSyncEvent.blockTimestamp),
+    };
+
+    // Asserting that the entity in the mock database is the same as the expected entity
+    expect(acutualToken0Entity).to.deep.equal(expectedToken0Entity);
+  });
 });
 
 // 3. Swap event correctly updates liquidityPool and User entities


### PR DESCRIPTION
https://github.com/velodrome-finance/contracts/blob/ee15bd1e63d3b33ce8d179f73bca7390812bd99b/contracts/Pool.sol#L230

Here we can see that sync is emitted when there are swaps as well as mints and burns. 

The current mock sync event  is unrealistic in the sense that the reserve amounts are increasing in the same ratio, so it doesn't efficiently test the swap amount where the reserves would have a different change and consequentially, the prices of the tokens should change. 

@WooSungD I suggest we also test against a sync event that is potentially a burn (decrease in both swap amounts), mint (increase in both swap amounts), and swap (incr/decr) - if we want to exhaustively test. Might not be necessary, but I think the mock events are only as helpful in detecting issues as they are realistic to some extent 