### PR TITLE
Using token prices from PriceFetcher contract

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -34,6 +34,12 @@ contracts:
           - name: Token
             arrayLabels:
               - whitelistedTokens
+  - name: PriceFetcher
+    handler: src/EventHandlers.ts
+    events:
+      - event: PriceFetched(address indexed token, uint256 price)
+        requiredEntities:
+          - name: Token
   - name: Voter
     handler: src/EventHandlers.ts
     events:
@@ -229,22 +235,28 @@ networks:
           # - 0x6443907dF3EB515dcb53f157C078C8Ec7263a7F4
           # - 0x88391365c225973032275DB256b9D15F845D2C72
           # - 0xDB1FE6DA83698885104DA02A6e0b3b65c0B0dE80
+      - name: PriceFetcher
+        address:
+          - 0x11BbF869250424BEDC5f162094afF8b4A45bE841
       - name: Voter
         address:
           - 0x41C914ee0c7E1A5edCD0295623e6dC557B5aBf3C
       - name: VotingReward
-  # - id: 8453 # Base
-  #   start_block: 0
-  #   contracts:
-  #     - name: PoolFactory
-  #       address:
-  #         - 0x420DD381b31aEf6683db6B902084cB0FFECe40Da
-  #     - name: Pool
-  #       address:
-  #         - 0xB4885Bc63399BF5518b994c1d0C153334Ee579D0 # vAMM-WETH/USDbC
-  #         - 0x9287C921f5d920cEeE0d07d7c58d476E46aCC640 # vAMM-WETH/DAI
-  #         - 0x0B25c51637c43decd6CC1C1e3da4518D54ddb528 # sAMM-DOLA/USDbC
-  #     - name: Voter
-  #       address:
-  #         - 0x16613524e02ad97eDfeF371bC883F2F5d6C480A5
-  #     - name: VotingReward
+  - id: 8453 # Base
+    start_block: 0
+    contracts:
+      - name: PoolFactory
+        address:
+          - 0x420DD381b31aEf6683db6B902084cB0FFECe40Da
+      - name: Pool
+        address:
+          - 0xB4885Bc63399BF5518b994c1d0C153334Ee579D0 # vAMM-WETH/USDbC
+          - 0x9287C921f5d920cEeE0d07d7c58d476E46aCC640 # vAMM-WETH/DAI
+          - 0x0B25c51637c43decd6CC1C1e3da4518D54ddb528 # sAMM-DOLA/USDbC
+      - name: PriceFetcher
+        address:
+          - 0x593d092bb28ccefe33bfdd3d9457e77bd3084271
+      - name: Voter
+        address:
+          - 0x16613524e02ad97eDfeF371bC883F2F5d6C480A5
+      - name: VotingReward

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -134,6 +134,7 @@ const BASE_TESTING_POOL_ADDRESSES: string[] = [
 
 type chainConstants = {
   eth: Token;
+  firstPriceFetchedBlockNumber: number;
   rewardToken: Token;
   stablecoinPools: Pool[];
   stablecoinPoolAddresses: string[];
@@ -144,6 +145,7 @@ type chainConstants = {
 
 const OPTIMISM_CONSTANTS: chainConstants = {
   eth: WETH,
+  firstPriceFetchedBlockNumber: 106247807,
   rewardToken: VELO,
   stablecoinPools: OPTIMISM_STABLECOIN_POOLS,
   stablecoinPoolAddresses: OPTIMISM_STABLECOIN_POOLS.map(
@@ -158,6 +160,7 @@ const OPTIMISM_CONSTANTS: chainConstants = {
 
 const BASE_CONSTANTS: chainConstants = {
   eth: WETH,
+  firstPriceFetchedBlockNumber: 3347620,
   rewardToken: AERO,
   stablecoinPools: BASE_STABLECOIN_POOLS,
   stablecoinPoolAddresses: BASE_STABLECOIN_POOLS.map((pool) => pool.address),


### PR DESCRIPTION
Implements:
1. First block number where `PriceFetched` event from `PriceFetcher` smart contract gets emitted per chain
1. Updating of `Token` entity with USD price whenever `PriceFetched` event is emitted
1.  Using USD price from above (instead of relative pricing) when `event.blockNumber` is greater or equal to the block number mentioned in point 1.