### PR TITLE
Feature/add whitelists voter

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -725,6 +725,7 @@ networks:
       - name: Voter
         address:
           - 0x41C914ee0c7E1A5edCD0295623e6dC557B5aBf3C
+          - 0x09236cfF45047DBee6B921e00704bed6D6B8Cf7e
       - name: VotingReward
         address:
           - 0x9afdC6c6cAaD5Ff953E2cfF9777c3af2e5d796Fb

--- a/config.yaml
+++ b/config.yaml
@@ -47,6 +47,7 @@ contracts:
       - event: Voted(address indexed sender, address indexed pool, uint256 indexed tokenId, uint256 weight, uint256 totalWeight, uint256 timestamp)
       - event: DistributeReward(address indexed sender, address indexed gauge, uint256 amount)
       - event: GaugeCreated(address indexed poolFactory, address indexed votingRewardsFactory, address indexed gaugeFactory, address pool, address bribeVotingReward, address feeVotingReward, address gauge, address creator)
+      - event: WhitelistToken(address indexed whitelister, address indexed token, bool indexed _bool)
   - name: VotingReward
     handler: src/EventHandlers/VotingReward.ts
     events:

--- a/schema.graphql
+++ b/schema.graphql
@@ -416,3 +416,12 @@ type TokenPrice {
   chainID: Int! @index # Chain ID where the token is located
   lastUpdatedTimestamp: Timestamp! @index # Timestamp of the last update
 }
+
+type Voter_WhitelistToken {
+  id: ID!
+  whitelister: String!
+  token: String!
+  isWhitelisted: Boolean!
+  timestamp: Timestamp!
+  chainId: Int!
+}

--- a/src/EventHandlers/Voter.ts
+++ b/src/EventHandlers/Voter.ts
@@ -2,6 +2,7 @@ import {
   Voter,
   Voter_GaugeCreated,
   Voter_Voted,
+  Voter_WhitelistToken,
 } from "generated";
 
 import { LiquidityPoolNew } from "./../src/Types.gen";
@@ -139,4 +140,34 @@ Voter.DistributeReward.handlerWithLoader({
       }
     }
   },
+});
+
+/**
+ * Handles the WhitelistToken event for the Voter contract.
+ * 
+ * This handler is triggered when a WhitelistToken event is emitted by the Voter contract.
+ * It creates a new Voter_WhitelistToken entity and stores it in the context.
+ * 
+ * The Voter_WhitelistToken entity contains the following fields:
+ * - id: A unique identifier for the event, composed of the chain ID, block number, and log index.
+ * - whitelister: The address of the entity that performed the whitelisting.
+ * - token: The address of the token being whitelisted.
+ * - isWhitelisted: A boolean indicating whether the token is whitelisted.
+ * - timestamp: The timestamp of the block in which the event was emitted, converted to a Date object.
+ * - chainId: The ID of the blockchain network where the event occurred.
+ * 
+ * @param {Object} event - The event object containing details of the WhitelistToken event.
+ * @param {Object} context - The context object used to interact with the data store.
+ */
+Voter.WhitelistToken.handler(async ({ event, context }) => {
+  const entity: Voter_WhitelistToken = {
+    id: `${event.chainId}_${event.block.number}_${event.logIndex}`,
+    whitelister: event.params.whitelister,
+    token: event.params.token,
+    isWhitelisted: event.params._bool,
+    timestamp: new Date(event.block.timestamp * 1000),
+    chainId: event.chainId,
+  };
+
+  context.Voter_WhitelistToken.set(entity);
 });

--- a/test/Voter.test.ts
+++ b/test/Voter.test.ts
@@ -1,0 +1,36 @@
+import { expect } from "chai";
+import { MockDb, Voter } from "../generated/src/TestHelpers.gen";
+
+describe("Voter Events", () => {
+  describe("WhitelistToken event", () => {
+    it("should create a new WhitelistToken entity", async () => {
+      const mockDb = MockDb.createMockDb();
+      const mockEvent = Voter.WhitelistToken.createMockEvent({
+        whitelister: "0x1111111111111111111111111111111111111111",
+        token: "0x2222222222222222222222222222222222222222",
+        _bool: true,
+        mockEventData: {
+          block: {
+            number: 123456,
+            timestamp: 1000000,
+            hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
+          },
+          chainId: 10,
+          logIndex: 1,
+        },
+      });
+
+      const expectedId = `${mockEvent.chainId}_${mockEvent.block.number}_${mockEvent.logIndex}`;
+
+      const result = await Voter.WhitelistToken.processEvent({ event: mockEvent, mockDb });
+
+      const whitelistTokenEvent = result.entities.Voter_WhitelistToken.get(expectedId);
+      expect(whitelistTokenEvent).to.not.be.undefined;
+      expect(whitelistTokenEvent?.whitelister).to.equal("0x1111111111111111111111111111111111111111");
+      expect(whitelistTokenEvent?.token).to.equal("0x2222222222222222222222222222222222222222");
+      expect(whitelistTokenEvent?.isWhitelisted).to.be.true;
+      expect(whitelistTokenEvent?.timestamp).to.deep.equal(new Date(1000000 * 1000));
+      expect(whitelistTokenEvent?.chainId).to.equal(10);
+    });
+  });
+});


### PR DESCRIPTION
# Description

To help sync whitelisted tokens, we need to capture the Whitelist event. This adds support to capture the event in the v1, v2, and slipstream contracts. I have also added an update in the config to ad the V1 voter contract.

# Testing

Added test support and can confirm we are seeing WhitelistToken events in Hashura.