### PR TITLE
Bugfix: Log error when pool_created is not found in a CLPool Swap event.

### DIFF
--- a/src/EventHandlers/CLPool.ts
+++ b/src/EventHandlers/CLPool.ts
@@ -150,6 +150,11 @@ CLPool.Swap.handlerWithLoader({
       pool_id
     );
 
+    if (!pool_created || pool_created.length === 0) {
+      context.log.error(`Pool ${pool_id} not found during swap`);
+      return null;
+    }
+
     const [token0Instance, token1Instance, clPoolAggregator] =
       await Promise.all([
         context.Token.get(pool_created[0].token0),


### PR DESCRIPTION
# Description

Add workaround code for missing Created pools. Linked main issue in enviodev/hyperindex/issues/289. This should stop the indexer from failing for now, but consider removing once 289 is cleared up.