### PR TITLE
Bugfix: Add back token price snapshot entity.

### DIFF
--- a/src/PriceOracle.ts
+++ b/src/PriceOracle.ts
@@ -66,13 +66,25 @@ export async function refreshTokenPrice(
   }
 
   const tokenPriceData = await getTokenPriceData(token.address, blockNumber, chainId);
+  const currentPrice = tokenPriceData.pricePerUSDNew;
   const updatedToken: Token = {
     ...token,
-    pricePerUSDNew: tokenPriceData.pricePerUSDNew,
+    pricePerUSDNew: currentPrice,
     decimals: tokenPriceData.decimals,
     lastUpdatedTimestamp: new Date(blockTimestampMs)
   };
   context.Token.set(updatedToken);
+
+  // Create new TokenPrice entity
+  const tokenPrice: TokenPriceSnapshot = {
+      id: TokenIdByBlock(token.address, chainId, blockNumber),
+      address: toChecksumAddress(token.address),
+      pricePerUSDNew: currentPrice,
+      chainId: chainId,
+      lastUpdatedTimestamp: new Date(blockTimestampMs),
+  };
+
+  context.TokenPriceSnapshot.set(tokenPrice);
   return updatedToken;
 }
 

--- a/test/PriceOracle.test.ts
+++ b/test/PriceOracle.test.ts
@@ -74,6 +74,8 @@ describe("PriceOracle", () => {
       });
       it("should not update prices if the update interval hasn't passed", async () => {
         expect(mockContract.called).to.be.false;
+        expect(mockContext.Token.set.called).to.be.false;
+        expect(mockContext.TokenPriceSnapshot.set.called).to.be.false;
       });
     });
     describe("if the update interval has passed", () => {
@@ -92,6 +94,11 @@ describe("PriceOracle", () => {
       it("should update prices if the update interval has passed", async () => {
         expect(updatedToken.pricePerUSDNew).to.equal(mockTokenPriceData.pricePerUSDNew);
         expect(updatedToken.lastUpdatedTimestamp.getTime()).greaterThan(testLastUpdated.getTime());
+      });
+      it("should create a new TokenPriceSnapshot entity", async () => {
+        const tokenPrice = mockContext.TokenPriceSnapshot.set.lastCall.args[0];
+        expect(tokenPrice.pricePerUSDNew).to.equal(mockTokenPriceData.pricePerUSDNew);
+        expect(tokenPrice.lastUpdatedTimestamp.getTime()).greaterThan(testLastUpdated.getTime());
       });
     });
   });


### PR DESCRIPTION
# Description

Adds token price snapshot entity setting back into the database.

# Issue

https://linear.app/velodrome/issue/DATA-176/fix-tokenpricesnapshots-in-envio-indexer