### PR TITLE
Adding veLocks and test support.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -41,6 +41,12 @@ contracts:
     handler: src/EventHandlers/NFPM.ts
     events:
       - event: Transfer(address indexed from, address indexed to, uint256 indexed tokenId)
+  - name: VeNFT
+    handler: src/EventHandlers/VeNFT.ts
+    events:
+      - event: Deposit(address indexed provider, uint256 indexed tokenId, uint8 indexed depositType, uint256 value, uint256 locktime, uint256 ts)
+      - event: Withdraw(address indexed provider, uint256 indexed tokenId, uint256 value, uint256 ts)
+      - event: Transfer(address indexed from, address indexed to, uint256 indexed tokenId)
   - name: Pool
     handler: src/EventHandlers/Pool.ts
     events:
@@ -98,6 +104,9 @@ networks:
   - id: 10 # Optimism
     start_block: 0
     contracts:
+      - name: VeNFT
+        address:
+          - 0xFAf8FD17D9840595845582fCB047DF13f006787d
       - name: NFPM
         address:
           - 0x416b433906b1b72fa758e166e239c43d68dc6f29
@@ -126,6 +135,9 @@ networks:
   - id: 8453 # Base
     start_block: 0
     contracts:
+      - name: VeNFT
+        address:
+          - 0xeBf418Fe2512e7E6bd9b87a8F0f294aCDC67e6B4
       - name: NFPM
         address:
           - 0x827922686190790b37229fd06084350e74485b72

--- a/schema.graphql
+++ b/schema.graphql
@@ -385,3 +385,45 @@ type SuperchainPoolFactory_RootPoolCreated {
   chainId: Int!
   length: BigInt! @config(precision: 76)
 }
+
+type VeNFTAggregator {
+  id: ID!
+  chainId: Int!
+  tokenId: BigInt! @config(precision: 76)
+  owner: String!
+  locktime: BigInt! @config(precision: 76)
+  lastUpdatedTimestamp: Timestamp!
+  totalValueLocked: BigInt! @config(precision: 76)
+  isAlive: Boolean!
+}
+
+type VeNFT_Deposit {
+  id: ID!
+  provider: String!
+  tokenId: BigInt! @config(precision: 76)
+  depositType: BigInt! @config(precision: 76)
+  value: BigInt! @config(precision: 76)
+  locktime: BigInt! @config(precision: 76)
+  ts: BigInt! @config(precision: 76)
+  timestamp: Timestamp!
+  chainId: Int!
+}
+
+type VeNFT_Withdraw {
+  id: ID!
+  provider: String!
+  tokenId: BigInt! @config(precision: 76)
+  value: BigInt! @config(precision: 76)
+  ts: BigInt! @config(precision: 76)
+  timestamp: Timestamp!
+  chainId: Int!
+}
+
+type VeNFT_Transfer {
+  id: ID!
+  from: String!
+  to: String!
+  tokenId: BigInt! @config(precision: 76)
+  timestamp: Timestamp!
+  chainId: Int!
+}

--- a/src/Aggregators/VeNFTAggregator.ts
+++ b/src/Aggregators/VeNFTAggregator.ts
@@ -1,0 +1,90 @@
+import { handlerContext, VeNFT_Deposit, VeNFT_Transfer, VeNFT_Withdraw } from "generated";
+import { VeNFTAggregator } from "generated";
+
+export function updateVeNFTAggregator(diff: any, current: VeNFTAggregator | undefined, timestamp: Date, context: handlerContext) {
+    const updated: VeNFTAggregator = {
+        ...current,
+        ...diff,
+        lastUpdatedTimestamp: timestamp,
+    };
+
+    context.VeNFTAggregator.set(updated);
+}
+
+export const VeNFTId = (chainId: number, tokenId: bigint) => `${chainId}_${tokenId}`;
+
+export function depositVeNFT(deposit: VeNFT_Deposit, current: VeNFTAggregator | undefined, timestamp: Date, context: handlerContext) {
+    let diff = {
+        id: VeNFTId(deposit.chainId, deposit.tokenId),
+        chainId: deposit.chainId,
+        tokenId: deposit.tokenId,
+        owner: "",
+        locktime: deposit.locktime,
+        lastUpdatedTimestamp: timestamp,
+        totalValueLocked: deposit.value,
+        isAlive: true,
+        ...current
+    };
+    if (current) {
+        diff.totalValueLocked += current.totalValueLocked;
+    }
+
+    const veNFTAggregator: VeNFTAggregator = {
+        ...current,
+        ...diff,
+        lastUpdatedTimestamp: timestamp,
+    };
+    context.VeNFTAggregator.set(veNFTAggregator);
+}
+
+export function withdrawVeNFT(withdraw: VeNFT_Withdraw, current: VeNFTAggregator | undefined, timestamp: Date, context: handlerContext) {
+    let diff = {
+        id: VeNFTId(withdraw.chainId, withdraw.tokenId),
+        chainId: withdraw.chainId,
+        tokenId: withdraw.tokenId,
+        owner: "",
+        locktime: 0n,
+        lastUpdatedTimestamp: timestamp,
+        totalValueLocked: 0n,
+        isAlive: true,
+        ...current
+    };
+    if (current) {
+        diff.totalValueLocked -= current.totalValueLocked;
+    }
+
+    const veNFTAggregator: VeNFTAggregator = {
+        ...current,
+        ...diff,
+        lastUpdatedTimestamp: timestamp,
+    };
+    context.VeNFTAggregator.set(veNFTAggregator);
+}
+
+export function transferVeNFT(transfer: VeNFT_Transfer, current: VeNFTAggregator | undefined, timestamp: Date, context: handlerContext) {
+    let diff = {
+        id: VeNFTId(transfer.chainId, transfer.tokenId),
+        chainId: transfer.chainId,
+        tokenId: transfer.tokenId,
+        owner: transfer.to,
+        locktime: 0n,
+        lastUpdatedTimestamp: timestamp,
+        totalValueLocked: 0n,
+        isAlive: true,
+        ...current
+    };
+    if (current) {
+        diff.owner = transfer.to;
+    }
+
+    if (transfer.to === "0x0000000000000000000000000000000000000000") {
+        diff.isAlive = false;
+    }
+
+    const veNFTAggregator: VeNFTAggregator = {
+        ...current,
+        ...diff,
+        lastUpdatedTimestamp: timestamp,
+    };
+    context.VeNFTAggregator.set(veNFTAggregator);
+}

--- a/src/EventHandlers/VeNFT.ts
+++ b/src/EventHandlers/VeNFT.ts
@@ -1,0 +1,105 @@
+import {
+    VeNFT,
+    VeNFT_Deposit,
+    VeNFT_Withdraw,
+    VeNFT_Transfer,
+} from "generated";
+import { VeNFTId, depositVeNFT, withdrawVeNFT, transferVeNFT } from "../Aggregators/VeNFTAggregator";
+
+VeNFT.Withdraw.handlerWithLoader({
+  loader: async ({ event, context }) => {
+    const tokenId = event.params.tokenId;
+
+    const veNFTAggregator = await context.VeNFTAggregator.get(VeNFTId(event.chainId, tokenId));
+
+    if (!veNFTAggregator) {
+      context.log.error(`VeNFTAggregator ${tokenId} not found during VeNFT transfer on chain ${event.chainId}`);
+      return { };
+    }
+
+    return { veNFTAggregator };
+  },
+  handler: async ({ event, context, loaderReturn }) => {
+    const { veNFTAggregator } = loaderReturn;
+    const tokenId = event.params.tokenId;
+    const entity_withdraw: VeNFT_Withdraw = {
+      id: `${event.chainId}_${event.block.number}_${event.logIndex}`,
+      provider: event.params.provider,
+      tokenId: event.params.tokenId,
+      value: event.params.value,
+      ts: event.params.ts,
+      timestamp: new Date(event.block.timestamp * 1000),
+      chainId: event.chainId,
+    };
+
+    context.VeNFT_Withdraw.set(entity_withdraw);
+
+    withdrawVeNFT(entity_withdraw, veNFTAggregator, new Date(event.block.timestamp * 1000), context);
+  },
+});
+
+VeNFT.Transfer.handlerWithLoader({
+  loader: async ({ event, context }) => {
+    const tokenId = event.params.tokenId;
+
+    const veNFTAggregator = await context.VeNFTAggregator.get(VeNFTId(event.chainId, tokenId));
+
+    if (!veNFTAggregator) {
+      context.log.error(`VeNFTAggregator ${tokenId} not found during VeNFT transfer on chain ${event.chainId}`);
+      return { };
+    }
+
+    return { veNFTAggregator };
+  },
+  handler: async ({ event, context, loaderReturn }) => {
+    const { veNFTAggregator } = loaderReturn;
+    const tokenId = event.params.tokenId;
+    const entity_transfer: VeNFT_Transfer = {
+      id: `${event.chainId}_${event.block.number}_${event.logIndex}`,
+      from: event.params.from,
+      to: event.params.to,
+      tokenId: event.params.tokenId,
+      timestamp: new Date(event.block.timestamp * 1000),
+      chainId: event.chainId,
+    };
+
+    context.VeNFT_Transfer.set(entity_transfer);
+
+    transferVeNFT(entity_transfer, veNFTAggregator, new Date(event.block.timestamp * 1000), context);
+  },
+});
+
+VeNFT.Deposit.handlerWithLoader({
+  loader: async ({ event, context }) => {
+    const tokenId = event.params.tokenId;
+
+    const veNFTAggregator = await context.VeNFTAggregator.get(VeNFTId(event.chainId, tokenId));
+
+    if (!veNFTAggregator) {
+      context.log.error(`VeNFTAggregator ${tokenId} not found during VeNFT transfer on chain ${event.chainId}`);
+      return { };
+    }
+
+    return { veNFTAggregator };
+  },
+  handler: async ({ event, context, loaderReturn }) => {
+    const { veNFTAggregator } = loaderReturn;
+    const tokenId = event.params.tokenId;
+
+    const entity_deposit: VeNFT_Deposit = {
+      id: `${event.chainId}_${event.block.number}_${event.logIndex}`,
+      tokenId: event.params.tokenId,
+      value: event.params.value,
+      locktime: event.params.locktime,
+      depositType: event.params.depositType,
+      provider: event.params.provider,
+      ts: event.params.ts,
+      timestamp: new Date(event.block.timestamp * 1000),
+      chainId: event.chainId,
+    };
+
+    context.VeNFT_Deposit.set(entity_deposit);
+
+    depositVeNFT(entity_deposit, veNFTAggregator, new Date(event.block.timestamp * 1000), context);
+  },
+});

--- a/test/Aggregators/VeNFTAggregator.test.ts
+++ b/test/Aggregators/VeNFTAggregator.test.ts
@@ -1,0 +1,167 @@
+import { expect } from "chai";
+import { VeNFT_Deposit, VeNFT_Transfer, VeNFT_Withdraw, VeNFTAggregator } from "generated";
+import { depositVeNFT, withdrawVeNFT, transferVeNFT, VeNFTId } from "../../src/Aggregators/VeNFTAggregator";
+import sinon from "sinon";
+
+describe("VeNFTAggregator", () => {
+
+    let contextStub: any;
+    const mockVeNFTAggregator: VeNFTAggregator = {
+        id: "10_1",
+        chainId: 10,
+        tokenId: 1n,
+        owner: "0x1111111111111111111111111111111111111111",
+        locktime: 100n,
+        lastUpdatedTimestamp: new Date(10000 * 1000),
+        totalValueLocked: 100n,
+        isAlive: true,
+    };
+    const timestamp = new Date(10001 * 1000);
+
+    beforeEach(() => {
+        contextStub = {
+            VeNFTAggregator: { set: sinon.stub() },
+        };
+    });
+    describe("depositVeNFT", () => {
+        const mockDeposit: VeNFT_Deposit = {
+            id: "10_1_1",
+            provider: "0x1111111111111111111111111111111111111111",
+            value: 100n,
+            locktime: 100n,
+            ts: 100n,
+            timestamp: new Date(),
+            chainId: 10,
+            tokenId: 1n,
+            depositType: 1n,
+        };
+        describe("when the veNFT is not found", () => {
+            let result: any;
+            beforeEach(async() => {
+                depositVeNFT(mockDeposit, undefined, timestamp, contextStub);
+                result = contextStub.VeNFTAggregator.set.firstCall.args[0];
+            });
+            it("should create a new veNFTAggregator", () => {
+                expect(result.id).to.equal(VeNFTId(mockDeposit.chainId, mockDeposit.tokenId));
+                expect(result.owner).to.equal("");
+                expect(result.locktime).to.equal(mockDeposit.locktime);
+                expect(result.lastUpdatedTimestamp).to.equal(timestamp);
+                expect(result.totalValueLocked).to.equal(mockDeposit.value);
+                expect(result.isAlive).to.equal(true);
+            });
+        });
+        describe("when the veNFT is found", () => {
+            let result: any;
+            beforeEach(async() => {
+                depositVeNFT(mockDeposit, mockVeNFTAggregator, timestamp, contextStub);
+                result = contextStub.VeNFTAggregator.set.firstCall.args[0];
+            });
+            it("should update the veNFTAggregator", () => {
+                expect(result.id).to.equal(VeNFTId(mockDeposit.chainId, mockDeposit.tokenId));
+                expect(result.owner).to.equal(mockVeNFTAggregator.owner);
+                expect(result.locktime).to.equal(mockDeposit.locktime);
+                expect(result.lastUpdatedTimestamp).to.equal(timestamp);
+                expect(result.totalValueLocked).to.equal(mockVeNFTAggregator.totalValueLocked + mockDeposit.value);
+                expect(result.isAlive).to.equal(true);
+            });
+        });
+    });
+    describe("withdrawVeNFT", () => {
+        const mockWithdraw: VeNFT_Withdraw = {
+            id: "10_1_1",
+            provider: "0x1111111111111111111111111111111111111111",
+            value: 100n,
+            ts: 100n,
+            timestamp: new Date(),
+            chainId: 10,
+            tokenId: 1n,
+        };
+        describe("when the veNFT is not found", () => {
+            let result: any;
+            beforeEach(async() => {
+                withdrawVeNFT(mockWithdraw, undefined, timestamp, contextStub);
+                result = contextStub.VeNFTAggregator.set.firstCall.args[0];
+            });
+            it("should create a new veNFTAggregator", () => {
+                expect(result.id).to.equal(VeNFTId(mockWithdraw.chainId, mockWithdraw.tokenId));
+                expect(result.owner).to.equal("");
+                expect(result.locktime).to.equal(0n);
+                expect(result.lastUpdatedTimestamp).to.equal(timestamp);
+                expect(result.totalValueLocked).to.equal(0n);
+                expect(result.isAlive).to.equal(true);
+            });
+        });
+        describe("when the veNFT is found", () => {
+            let result: any;
+            beforeEach(async() => {
+                withdrawVeNFT(mockWithdraw, mockVeNFTAggregator, timestamp, contextStub);
+                result = contextStub.VeNFTAggregator.set.firstCall.args[0];
+            });
+            it("should update the veNFTAggregator", () => {
+                expect(result.id).to.equal(VeNFTId(mockWithdraw.chainId, mockWithdraw.tokenId));
+                expect(result.owner).to.equal(mockVeNFTAggregator.owner);
+                expect(result.locktime).to.equal(mockVeNFTAggregator.locktime);
+                expect(result.lastUpdatedTimestamp).to.equal(timestamp);
+                expect(result.totalValueLocked).to.equal(mockVeNFTAggregator.totalValueLocked - mockWithdraw.value);
+                expect(result.isAlive).to.equal(true);
+            });
+        });
+    });
+    describe("transferVeNFT", () => {
+        const mockTransfer: VeNFT_Transfer = {
+            id: "10_1_1",
+            from: "0x1111111111111111111111111111111111111111",
+            to: "0x2222222222222222222222222222222222222222",
+            tokenId: 1n,
+            timestamp: new Date(),
+            chainId: 10,
+        };
+        describe("when the veNFT is not found", () => {
+            let result: any;
+            beforeEach(async() => {
+                transferVeNFT(mockTransfer, undefined, timestamp, contextStub);
+                result = contextStub.VeNFTAggregator.set.firstCall.args[0];
+            });
+            it("should create a new veNFTAggregator", () => {
+                expect(result.id).to.equal(VeNFTId(mockTransfer.chainId, mockTransfer.tokenId));
+                expect(result.owner).to.equal(mockTransfer.to);
+                expect(result.locktime).to.equal(0n);
+                expect(result.lastUpdatedTimestamp).to.equal(timestamp);
+                expect(result.totalValueLocked).to.equal(0n);
+                expect(result.isAlive).to.equal(true);
+            });
+        });
+        describe("when the veNFT is found", () => {
+
+            describe("when the transfer is to the zero address", () => {
+                let result: any;
+                beforeEach(async() => {
+                    const zeroTransfer = {
+                        ...mockTransfer,
+                        to: "0x0000000000000000000000000000000000000000",
+                    };
+                    transferVeNFT(zeroTransfer, mockVeNFTAggregator, timestamp, contextStub);
+                    result = contextStub.VeNFTAggregator.set.firstCall.args[0];
+                });
+                it("should set the veNFTAggregator to dead", () => {
+                    expect(result.isAlive).to.equal(false);
+                });
+            });
+            describe("when the transfer is not the zero address", () => {
+                let result: any;
+                beforeEach(async() => {
+                    transferVeNFT(mockTransfer, mockVeNFTAggregator, timestamp, contextStub);
+                    result = contextStub.VeNFTAggregator.set.firstCall.args[0];
+                });
+                it("should update the veNFTAggregator", () => {
+                    expect(result.id).to.equal(VeNFTId(mockTransfer.chainId, mockTransfer.tokenId));
+                    expect(result.owner).to.equal(mockTransfer.to);
+                    expect(result.locktime).to.equal(mockVeNFTAggregator.locktime);
+                    expect(result.lastUpdatedTimestamp).to.equal(timestamp);
+                    expect(result.totalValueLocked).to.equal(mockVeNFTAggregator.totalValueLocked);
+                    expect(result.isAlive).to.equal(true);
+                });
+            });
+        });
+    });
+});

--- a/test/EventHandlers/VeNFT.test.ts
+++ b/test/EventHandlers/VeNFT.test.ts
@@ -1,0 +1,198 @@
+import { expect } from "chai";
+import { MockDb, VeNFT } from "../../generated/src/TestHelpers.gen";
+import * as VeNFTAggregator from "../../src/Aggregators/VeNFTAggregator";
+import sinon from "sinon";
+
+const VeNFTId = (chainId: number, tokenId: bigint) => `${chainId}_${tokenId}`;
+
+describe("VeNFT Events", () => {
+  let mockDb: any;
+  const chainId = 10;
+  const tokenId = 1n;
+
+  const mockVeNFTAggregator = {
+    id: VeNFTId(chainId, tokenId),
+    chainId: 10,
+    tokenId: tokenId,
+  };
+
+  beforeEach(() => {
+      mockDb = MockDb.createMockDb();
+      mockDb = mockDb.entities.VeNFTAggregator.set(mockVeNFTAggregator);
+  });
+
+  describe("Transfer Event", () => {
+    const eventData = {
+        provider: "0x1111111111111111111111111111111111111111",
+        from: "0x1111111111111111111111111111111111111111",
+        to: "0x2222222222222222222222222222222222222222",
+        tokenId: 1n,
+        timestamp: 1n,
+        chainId: 10,
+        mockEventData: {
+            block: {
+                timestamp: 1000000,
+                number: 123456,
+                hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
+            },
+            chainId: 10,
+            logIndex: 1,
+            srcAddress: "0x3333333333333333333333333333333333333333",
+        },
+    };
+
+    let stubVeNFTAggregator: sinon.SinonStub;
+    let postEventDB: any;
+    let expected: any = {};
+    let mockEvent: any;
+
+    beforeEach(async () => {
+        stubVeNFTAggregator = sinon.stub(VeNFTAggregator, "transferVeNFT");
+        mockEvent = VeNFT.Transfer.createMockEvent(eventData);
+        postEventDB = await VeNFT.Transfer.processEvent({
+            event: mockEvent,
+            mockDb: mockDb,
+        });
+
+        expected.id = `${chainId}_${mockEvent.block.number}_${mockEvent.logIndex}`;
+        expected.chainId = chainId;
+        expected.tokenId = eventData.tokenId;
+        expected.from = eventData.from;
+        expected.to = eventData.to;
+        expected.timestamp = new Date(mockEvent.block.timestamp * 1000);
+    });
+    afterEach(() => {
+        stubVeNFTAggregator.restore();
+    });
+    it("should create a new Transfer entity", async () => {
+        const transferEvent = postEventDB.entities.VeNFT_Transfer.get(expected.id);
+        expect(transferEvent).not.to.be.undefined;
+        expect(transferEvent).to.deep.equal(expected);
+    });
+    it("should call transferVeNFT with the correct arguments", async () => {
+        expect(stubVeNFTAggregator.calledOnce).to.be.true;
+        const calledWith = stubVeNFTAggregator.firstCall.args;
+        expect(calledWith[0].id).to.equal(expected.id);
+        expect(calledWith[1].id).to.deep.equal(mockVeNFTAggregator.id);
+        expect(calledWith[2]).to.deep.equal(new Date(mockEvent.block.timestamp * 1000));
+    });
+  });
+  describe("Withdraw Event", () => {
+    const eventData = {
+        provider: "0x1111111111111111111111111111111111111111",
+        tokenId: 1n,
+        value: 1n,
+        ts: 1n,
+        chainId: 10,
+        mockEventData: {
+            block: {
+                timestamp: 1000000,
+                number: 123456,
+                hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
+            },
+            chainId: 10,
+            logIndex: 1,
+            srcAddress: "0x3333333333333333333333333333333333333333",
+        },
+    };
+
+    let stubVeNFTAggregator: sinon.SinonStub;
+    let postEventDB: any;
+    let expected: any = {};
+    let mockEvent: any;
+
+    beforeEach(async () => {
+        stubVeNFTAggregator = sinon.stub(VeNFTAggregator, "withdrawVeNFT");
+        mockEvent = VeNFT.Withdraw.createMockEvent(eventData);
+        postEventDB = await VeNFT.Withdraw.processEvent({
+            event: mockEvent,
+            mockDb: mockDb,
+        });
+
+        expected.id = `${chainId}_${mockEvent.block.number}_${mockEvent.logIndex}`;
+        expected.chainId = chainId;
+        expected.provider = eventData.provider;
+        expected.tokenId = eventData.tokenId;
+        expected.value = eventData.value;
+        expected.ts = eventData.ts;
+        expected.timestamp = new Date(mockEvent.block.timestamp * 1000);
+    });
+    afterEach(() => {
+        stubVeNFTAggregator.restore();
+    });
+    it("should create a new Withdraw entity", async () => {
+        const withdrawEvent = postEventDB.entities.VeNFT_Withdraw.get(expected.id);
+        expect(withdrawEvent).not.to.be.undefined;
+        expect(withdrawEvent).to.deep.equal(expected);
+    });
+    it("should call withdrawVeNFT with the correct arguments", async () => {
+        // Passing along the created entities to the aggregator handler here, so
+        // not doing a full deep equal.
+        expect(stubVeNFTAggregator.calledOnce).to.be.true;
+        const calledWith = stubVeNFTAggregator.firstCall.args;
+        expect(calledWith[0].id).to.equal(expected.id);
+        expect(calledWith[1].id).to.deep.equal(mockVeNFTAggregator.id);
+        expect(calledWith[2]).to.deep.equal(new Date(mockEvent.block.timestamp * 1000));
+    });
+  });
+
+  describe("Deposit Event", () => {
+    const eventData = {
+        provider: "0x1111111111111111111111111111111111111111",
+        tokenId: 1n,
+        value: 1n,
+        locktime: 1n,
+        depositType: 1n,
+        ts: 1n,
+        mockEventData: {
+            block: {
+                timestamp: 1000000,
+                number: 123456,
+                hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
+            },
+            chainId: 10,
+            logIndex: 1,
+            srcAddress: "0x3333333333333333333333333333333333333333",
+        },
+    };
+
+    let stubVeNFTAggregator: sinon.SinonStub;
+    let postEventDB: any;
+    let expected: any = {};
+    let mockEvent: any;
+
+    beforeEach(async () => {
+        stubVeNFTAggregator = sinon.stub(VeNFTAggregator, "depositVeNFT");
+        mockEvent = VeNFT.Deposit.createMockEvent(eventData);
+        postEventDB = await VeNFT.Deposit.processEvent({
+            event: mockEvent,
+            mockDb: mockDb,
+        });
+
+        expected.id = `${chainId}_${mockEvent.block.number}_${mockEvent.logIndex}`;
+        expected.chainId = chainId;
+        expected.provider = eventData.provider;
+        expected.tokenId = eventData.tokenId;
+        expected.value = eventData.value;
+        expected.locktime = eventData.locktime;
+        expected.depositType = eventData.depositType;
+        expected.ts = eventData.ts;
+        expected.timestamp = new Date(mockEvent.block.timestamp * 1000);
+    });
+    afterEach(() => {
+        stubVeNFTAggregator.restore();
+    });
+    it("should create a new Deposit entity", async () => {
+        const depositEvent = postEventDB.entities.VeNFT_Deposit.get(expected.id);
+        expect(depositEvent).not.to.be.undefined;
+        expect(depositEvent).to.deep.equal(expected);
+    });
+    it("should call depositVeNFT with the correct arguments", async () => {
+        expect(stubVeNFTAggregator.calledOnce).to.be.true;
+        const calledWith = stubVeNFTAggregator.firstCall.args;
+        expect(calledWith[0].id).to.equal(expected.id);
+        expect(calledWith[1].id).to.deep.equal(mockVeNFTAggregator.id);
+        expect(calledWith[2]).to.deep.equal(new Date(mockEvent.block.timestamp * 1000));
+    });
+  });
+});


### PR DESCRIPTION
# Description

This pull request adds ve-lock tracking for the Optimism superchain and Base. It introduces new configurations, GraphQL schema types, event handlers, and tests to support ve-lock events such as deposits, withdrawals, and transfers.

# Changes

- config.yaml: Added VeNFT contract with event handlers and addresses for Optimism and Base networks.
- schema.graphql: Added new types (VeNFTAggregator, VeNFT_Deposit, VeNFT_Withdraw, VeNFT_Transfer) to support ve-lock events.
- src/Aggregators/VeNFTAggregator.ts: Implemented functions to handle ve-lock events and update VeNFTAggregator.
- src/EventHandlers/VeNFT.ts: Added event handlers for VeNFT events.
- test/Aggregators/VeNFTAggregator.test.ts: Added tests for VeNFTAggregator functions.
- test/EventHandlers/VeNFT.test.ts: Added tests for VeNFT event handlers.

# Issue

[DATA-182](https://linear.app/velodrome/issue/DATA-182/add-velocker-data-to-envio): Add veLocker data to Envio.