### PR TITLE
Feature: Track token whitelisting in snapshots.

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -26,6 +26,8 @@ type LiquidityPoolAggregator {
   totalEmissionsUSD: BigInt! @config(precision: 76) # total emissions for the pool in USD
   totalBribesUSD: BigInt! @config(precision: 76) # total bribes for the pool in USD
   gaugeIsAlive: Boolean! # whether the gauge is alive
+  token0IsWhitelisted: Boolean! # whether the token0 is whitelisted
+  token1IsWhitelisted: Boolean! # whether the token1 is whitelisted
   lastUpdatedTimestamp: Timestamp! # timestamp of last update
   lastSnapshotTimestamp: Timestamp! # timestamp of last snapshot
 }
@@ -60,6 +62,8 @@ type LiquidityPoolAggregatorSnapshot {
   totalEmissionsUSD: BigInt! @config(precision: 76) # total emissions for the pool in USD
   totalBribesUSD: BigInt! @config(precision: 76) # total bribes for the pool in USD
   gaugeIsAlive: Boolean! # whether the gauge is alive
+  token0IsWhitelisted: Boolean! # whether the token0 is whitelisted
+  token1IsWhitelisted: Boolean! # whether the token1 is whitelisted
   timestamp: Timestamp! # timestamp of last update
 }
 
@@ -90,6 +94,7 @@ type TokenPriceSnapshot {
   address: String! @index # Address of the token
   pricePerUSDNew: BigInt! @config(precision: 76) # price of token per USD
   chainId: Int!
+  isWhitelisted: Boolean! # whether the token is whitelisted
   lastUpdatedTimestamp: Timestamp! @index # Timestamp of the last update
 }
 

--- a/src/EventHandlers/CLFactory.ts
+++ b/src/EventHandlers/CLFactory.ts
@@ -89,6 +89,8 @@ CLFactory.PoolCreated.handlerWithLoader({
       totalEmissionsUSD: 0n,
       totalBribesUSD: 0n,
       gaugeIsAlive: false,
+      token0IsWhitelisted: poolToken0?.isWhitelisted ?? false,
+      token1IsWhitelisted: poolToken1?.isWhitelisted ?? false,
       lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
       lastSnapshotTimestamp: new Date(event.block.timestamp * 1000),
     };

--- a/src/EventHandlers/CLPool.ts
+++ b/src/EventHandlers/CLPool.ts
@@ -562,6 +562,8 @@ CLPool.Swap.handlerWithLoader({
           token0Instance?.pricePerUSDNew ?? liquidityPoolAggregator.token0Price,
         token1Price:
           token1Instance?.pricePerUSDNew ?? liquidityPoolAggregator.token1Price,
+        token0IsWhitelisted: token0Instance?.isWhitelisted ?? false,
+        token1IsWhitelisted: token1Instance?.isWhitelisted ?? false,
         numberOfSwaps: liquidityPoolAggregator.numberOfSwaps + 1n,
         reserve0: liquidityPoolAggregator.reserve0 + reserveResult.reserve0,
         reserve1: liquidityPoolAggregator.reserve1 + reserveResult.reserve1,

--- a/src/EventHandlers/Pool.ts
+++ b/src/EventHandlers/Pool.ts
@@ -224,6 +224,8 @@ Pool.Swap.handlerWithLoader({
         token1Price:
           token1Instance?.pricePerUSDNew ?? liquidityPoolAggregator.token1Price,
         numberOfSwaps: liquidityPoolAggregator.numberOfSwaps + 1n,
+        token0IsWhitelisted: token0Instance?.isWhitelisted ?? false,
+        token1IsWhitelisted: token1Instance?.isWhitelisted ?? false,
         lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
       };
 

--- a/src/EventHandlers/PoolFactory.ts
+++ b/src/EventHandlers/PoolFactory.ts
@@ -79,6 +79,8 @@ PoolFactory.PoolCreated.handlerWithLoader({
       totalVotesDeposited: 0n,
       totalVotesDepositedUSD: 0n,
       gaugeIsAlive: false,
+      token0IsWhitelisted: poolToken0?.isWhitelisted ?? false,
+      token1IsWhitelisted: poolToken1?.isWhitelisted ?? false,
       lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
       lastSnapshotTimestamp: new Date(event.block.timestamp * 1000),
     };

--- a/src/PriceOracle.ts
+++ b/src/PriceOracle.ts
@@ -81,6 +81,7 @@ export async function refreshTokenPrice(
       address: toChecksumAddress(token.address),
       pricePerUSDNew: currentPrice,
       chainId: chainId,
+      isWhitelisted: token.isWhitelisted,
       lastUpdatedTimestamp: new Date(blockTimestampMs),
   };
 

--- a/test/EventHandlers/CLPool/CLPool.test.ts
+++ b/test/EventHandlers/CLPool/CLPool.test.ts
@@ -414,6 +414,7 @@ describe("CLPool Event Handlers", () => {
     });
 
     describe("when tokens exist", () => {
+      let updatedLiquidityPool: any;
       beforeEach(async () => {
         let updatedDB = mockDb.entities.LiquidityPoolAggregator.set(mockLiquidityPoolData as LiquidityPoolAggregator);
         updatedDB = updatedDB.entities.Token.set(mockToken0Data as Token);
@@ -425,6 +426,7 @@ describe("CLPool Event Handlers", () => {
         });
         swapEntity = result.entities.CLPool_Swap.get(`1_123456_0`);
         aggregatorCalls = updateLiquidityPoolAggregatorStub.firstCall.args;
+        updatedLiquidityPool = aggregatorCalls[0];
       });
 
       it("should create a CLPool_Swap entity", async () => {
@@ -443,23 +445,20 @@ describe("CLPool Event Handlers", () => {
       });
 
       it("should update nominal volume amounts correctly", async () => {
-        const [diff] = aggregatorCalls;
-        expect(diff.totalVolume0).to.equal(
+        expect(updatedLiquidityPool.totalVolume0).to.equal(
           mockLiquidityPoolData.totalVolume0 + abs(mockEvent.params.amount0)
         );
-        expect(diff.totalVolume1).to.equal(
+        expect(updatedLiquidityPool.totalVolume1).to.equal(
           mockLiquidityPoolData.totalVolume1 + abs(mockEvent.params.amount1)
         );
       });
 
       it("should update number of swaps correctly", async () => {
-        const [diff] = aggregatorCalls;
-        expect(diff.numberOfSwaps).to.equal(2n);
+        expect(updatedLiquidityPool.numberOfSwaps).to.equal(2n);
       });
 
       it("should correctly update total volume in USD", async () => {
-        const [diff] = aggregatorCalls;
-        expect(diff.totalVolumeUSD).to.equal(
+        expect(updatedLiquidityPool.totalVolumeUSD).to.equal(
           mockLiquidityPoolData.totalVolumeUSD +
             (abs(mockEvent.params.amount0) * mockToken0Data.pricePerUSDNew) /
               10n ** mockToken0Data.decimals
@@ -467,20 +466,17 @@ describe("CLPool Event Handlers", () => {
       });
 
       it("should update token prices correctly", async () => {
-        const [diff] = aggregatorCalls;
-        expect(diff.token0Price).to.equal(1n * 10n ** 18n);
-        expect(diff.token1Price).to.equal(1n * 10n ** 18n);
+        expect(updatedLiquidityPool.token0Price).to.equal(1n * 10n ** 18n);
+        expect(updatedLiquidityPool.token1Price).to.equal(1n * 10n ** 18n);
       });
 
       it("should update reserve amounts correctly", async () => {
-        const [diff] = aggregatorCalls;
-        expect(diff.reserve0).to.equal(mockLiquidityPoolData.reserve0 + expectations.amount0In);
-        expect(diff.reserve1).to.equal(mockLiquidityPoolData.reserve1 + expectations.amount1In);
+        expect(updatedLiquidityPool.reserve0).to.equal(mockLiquidityPoolData.reserve0 + expectations.amount0In);
+        expect(updatedLiquidityPool.reserve1).to.equal(mockLiquidityPoolData.reserve1 + expectations.amount1In);
       });
 
       it("should update total liquidity in USD correctly", async () => {
-        const [diff] = aggregatorCalls;
-        expect(diff.totalLiquidityUSD).to.equal(expectations.totalLiquidityUSD);
+        expect(updatedLiquidityPool.totalLiquidityUSD).to.equal(expectations.totalLiquidityUSD);
       });
       it("should call refreshTokenPrice on token0", () => {
         const calledToken = mockPriceOracle.firstCall.args[0];
@@ -489,6 +485,12 @@ describe("CLPool Event Handlers", () => {
       it("should call refreshTokenPrice on token1", () => {
         const calledToken = mockPriceOracle.secondCall.args[0];
         expect(calledToken.address).to.equal(mockToken1Data.address);
+      });
+      it("should update the liquidity pool with token0IsWhitelisted", () => {
+        expect(updatedLiquidityPool.token0IsWhitelisted).to.equal(mockToken0Data.isWhitelisted);
+      });
+      it("should update the liquidity pool with token1IsWhitelisted", () => {
+        expect(updatedLiquidityPool.token1IsWhitelisted).to.equal(mockToken1Data.isWhitelisted);
       });
     });
 

--- a/test/EventHandlers/Pool/Swap.test.ts
+++ b/test/EventHandlers/Pool/Swap.test.ts
@@ -138,6 +138,14 @@ describe("Pool Swap Event", () => {
       );
 
     });
+
+    it("should update the liquidity pool with token0IsWhitelisted as false", () => {
+      expect(updatedPool?.token0IsWhitelisted).to.equal(false);
+    });
+    it("should update the liquidity pool with token1IsWhitelisted as false", () => {
+      expect(updatedPool?.token1IsWhitelisted).to.equal(false);
+    });
+
     it("shouldn't update the liquidity pool volume in USD since it has no prices", () => {
       expect(updatedPool?.totalVolumeUSD).to.equal(
         modifiedMockLiquidityPoolData.totalVolumeUSD
@@ -198,6 +206,13 @@ describe("Pool Swap Event", () => {
       );
     });
 
+    it("should update the liquidity pool with token0IsWhitelisted as false", () => {
+      expect(updatedPool?.token0IsWhitelisted).to.equal(false);
+    });
+    it("should update the liquidity pool with token1IsWhitelisted as true", () => {
+      expect(updatedPool?.token1IsWhitelisted).to.equal(mockToken1Data.isWhitelisted);
+    });
+
     it("should call refreshTokenPrice on token1", () => {
       expect(mockPriceOracle.calledOnce).to.be.true;
       const calledToken = mockPriceOracle.firstCall.args[0];
@@ -256,7 +271,12 @@ describe("Pool Swap Event", () => {
         expectations.expectedLPVolumeUSD0,
         "Total volume USD should be updated."
       );
-
+    });
+    it("should update the liquidity pool with token0IsWhitelisted", () => {
+      expect(updatedPool?.token0IsWhitelisted).to.equal(mockToken0Data.isWhitelisted);
+    });
+    it("should update the liquidity pool with token1IsWhitelisted as false", () => {
+      expect(updatedPool?.token1IsWhitelisted).to.equal(false);
     });
     it("should call refreshTokenPrice on token0", () => {
       expect(mockPriceOracle.calledOnce).to.be.true;
@@ -267,6 +287,7 @@ describe("Pool Swap Event", () => {
 
   describe("when both tokens exist", () => {
     let postEventDB: ReturnType<typeof MockDb.createMockDb>;
+    let updatedPool: any;
 
     beforeEach(async () => {
       const updatedDB1 = mockDb.entities.LiquidityPoolAggregator.set(
@@ -281,6 +302,9 @@ describe("Pool Swap Event", () => {
         event: mockEvent,
         mockDb: updatedDB3,
       });
+      updatedPool = postEventDB.entities.LiquidityPoolAggregator.get(
+        toChecksumAddress(eventData.mockEventData.srcAddress)
+      );
     });
 
     it("should create a new Pool_Swap entity and update LiquidityPool", async () => {
@@ -296,9 +320,6 @@ describe("Pool Swap Event", () => {
     });
 
     it("should update the Liquidity Pool aggregator", async () => {
-      const updatedPool = postEventDB.entities.LiquidityPoolAggregator.get(
-        toChecksumAddress(eventData.mockEventData.srcAddress)
-      );
       expect(updatedPool).to.not.be.undefined;
       expect(updatedPool?.totalVolume0).to.equal(
         expectations.totalVolume0
@@ -323,6 +344,12 @@ describe("Pool Swap Event", () => {
     it("should call refreshTokenPrice on token1", () => {
       const calledToken = mockPriceOracle.secondCall.args[0];
       expect(calledToken.address).to.equal(mockToken1Data.address);
+    });
+    it("should update the liquidity pool with token0IsWhitelisted", () => {
+      expect(updatedPool?.token0IsWhitelisted).to.equal(mockToken0Data.isWhitelisted);
+    });
+    it("should update the liquidity pool with token1IsWhitelisted", () => {
+      expect(updatedPool?.token1IsWhitelisted).to.equal(mockToken1Data.isWhitelisted);
     });
   });
 });

--- a/test/EventHandlers/Pool/common.ts
+++ b/test/EventHandlers/Pool/common.ts
@@ -11,7 +11,7 @@ export function setupCommon() {
     decimals: 18n,
     pricePerUSDNew: 1n * TEN_TO_THE_18_BI, // 1 USD
     chainId: 10,
-    isWhitelisted: true,
+    isWhitelisted: false,
   };
 
   const mockToken1Data = {

--- a/test/PriceOracle.test.ts
+++ b/test/PriceOracle.test.ts
@@ -99,6 +99,7 @@ describe("PriceOracle", () => {
         const tokenPrice = mockContext.TokenPriceSnapshot.set.lastCall.args[0];
         expect(tokenPrice.pricePerUSDNew).to.equal(mockTokenPriceData.pricePerUSDNew);
         expect(tokenPrice.lastUpdatedTimestamp.getTime()).greaterThan(testLastUpdated.getTime());
+        expect(tokenPrice.isWhitelisted).to.equal(mockToken0Data.isWhitelisted);
       });
     });
   });


### PR DESCRIPTION
# Description

This pull request adds fields to track token whitelisting status in liquidity pool aggregators and token snapshots.

# Summary

 - schema.graphql: Added token0IsWhitelisted and token1IsWhitelisted fields to LiquidityPoolAggregator and LiquidityPoolAggregatorSnapshot types.
 - src/PriceOracle.ts: Included isWhitelisted field in the token price data.
 - src/EventHandlers/CLFactory.ts: Updated pool creation event with token0IsWhitelisted and token1IsWhitelisted fields.
 - src/EventHandlers/CLPool.ts: Updated swap event with token0IsWhitelisted and token1IsWhitelisted fields.
 - src/EventHandlers/Pool.ts: Updated swap event with token0IsWhitelisted and token1IsWhitelisted fields.
 - src/EventHandlers/PoolFactory.ts: Updated pool creation event with token0IsWhitelisted and token1IsWhitelisted fields.
 - test/PriceOracle.test.ts: Added test to check if isWhitelisted field is correctly updated.
 - test/EventHandlers/CLPool/CLPool.test.ts: Added tests to check if token0IsWhitelisted and token1IsWhitelisted fields are correctly updated in liquidity pool.
 - test/EventHandlers/Pool/common.ts: Changed default isWhitelisted value to false in mock data.
 - test/EventHandlers/Pool/Swap.test.ts: Added tests to check if token0IsWhitelisted and token1IsWhitelisted fields are correctly updated in liquidity pool.
