### PR TITLE
ALM modules refactor

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -292,6 +292,8 @@ networks:
       - name: VelodromeUniversalRouter
         address:
           - 0x01D40099fCD87C018969B0e8D4aB1633Fb34763C
+      - name: ALMLPWrapper
+        address:
   - id: 42220 # Celo
     hypersync_config:
       url: https://celo.hypersync.xyz

--- a/schema.graphql
+++ b/schema.graphql
@@ -235,6 +235,7 @@ type NonFungiblePosition {
   amount0: BigInt! @config(precision: 76) # Current amount of token0 in position
   amount1: BigInt! @config(precision: 76) # Current amount of token1 in position
   amountUSD: BigInt! @config(precision: 76) # Current USD value of position (amount0 + amount1 in USD)
+  transactionHash: String! @index # Transaction hash of the NFT mint transaction
   lastUpdatedTimestamp: Timestamp! # Timestamp of last update
 }
 
@@ -305,81 +306,39 @@ type VeNFTAggregator {
   isAlive: Boolean!
 }
 
-type ALMCore_Rebalance {
-  id: ID!
-  pool: String!
-  tickLower: BigInt! @config(precision: 76)
-  tickUpper: BigInt! @config(precision: 76)
-  sqrtPriceX96: BigInt! @config(precision: 76)
-  amount0: BigInt! @config(precision: 76)
-  amount1: BigInt! @config(precision: 76)
-  ammPositionIdBefore: BigInt! @config(precision: 76)
-  ammPositionIdAfter: BigInt! @config(precision: 76)
-  timestamp: Timestamp!
-  transactionHash: String!
-  chainId: Int!
-  blockNumber: Int!
-  logIndex: Int!
-}
-
-type ALMCore_Rebalance_AmmPosition {
-  id: ID!
-  pool: String!
-  token0: String!
-  token1: String!
-  property: BigInt! @config(precision: 24)
-  tickLower: BigInt! @config(precision: 24)
-  tickUpper: BigInt! @config(precision: 24)
-  liquidity: BigInt! @config(precision: 76)
-  timestamp: Timestamp!
-  transactionHash: String!
-  chainId: Int!
-  blockNumber: Int!
-  logIndex: Int!
-}
-
-type ALMDeployFactory_StrategyCreated {
-  id: ID!
-  pool: String!
-  lpWrapper: String!
-  strategyType: BigInt! @config(precision: 8)
-  tickNeighborhood: BigInt! @config(precision: 24)
-  tickSpacing: BigInt! @config(precision: 24)
-  width: BigInt! @config(precision: 24)
-  maxLiquidityRatioDeviationX96: BigInt! @config(precision: 76)
-  timestamp: Timestamp!
-  transactionHash: String!
-  chainId: Int!
-  blockNumber: Int!
-  logIndex: Int!
-}
-
-type ALMDeployFactory_StrategyCreated_AmmPosition {
-  id: ID!
-  pool: String!
-  lpWrapper: String!
-  token0: String!
-  token1: String!
-  property: BigInt! @config(precision: 24)
-  tickLower: BigInt! @config(precision: 24)
-  tickUpper: BigInt! @config(precision: 24)
-  liquidity: BigInt! @config(precision: 76)
-  timestamp: Timestamp!
-  transactionHash: String!
-  chainId: Int!
-  blockNumber: Int!
-  logIndex: Int!
-}
-
-# ALM entity on a pool basis
+# ALM LP Wrapper entity
+# Tracks both the LP wrapper state (aggregated deposits/withdrawals) and the strategy position state
+# Relationship: 1 LP wrapper per pool, 1 strategy per LP wrapper, 1 tokenId per strategy, 1 AMM position per tokenId (1:1:1:1 relationship)
+# Therefore this single entity tracks everything for the wrapper and its strategy
 type ALM_LP_Wrapper {
-  id: ID! # {ALMaddress}_{chainId}
-  chainId: Int!
-  pool: String!
-  amount0: BigInt! @config(precision: 76)
-  amount1: BigInt! @config(precision: 76)
-  lpAmount: BigInt! @config(precision: 76) # Number of LP tokens
-  lastUpdatedTimestamp: Timestamp!
+  id: ID! # Unique identifier: {ALM_LP_Wrapper_address}_{chainId}
+  chainId: Int! # The blockchain network ID where this wrapper exists
+  pool: String! @index # Address of the pool this ALM wrapper is associated with
+  token0: String! # Address of token 0
+  token1: String! # Address of token 1
+
+  # Wrapper-level aggregations (updated by Deposit/Withdraw events)
+  amount0: BigInt! @config(precision: 76) # Total underlying amount of token0 in the wrapper (aggregated across all users)
+  amount1: BigInt! @config(precision: 76) # Total underlying amount of token1 in the wrapper (aggregated across all users)
+  lpAmount: BigInt! @config(precision: 76) # Total number of LP tokens wrapped (aggregated across all users)
+  lastUpdatedTimestamp: Timestamp! # Timestamp of the last update to this entity
+
+  # Strategy/Position-level state (updated by StrategyCreated and Rebalance events)
+  # Since there's exactly 1 strategy per wrapper, we store it here
+  tokenId: BigInt! @config(precision: 24) @index # Equal to tokenId. Unique identifier for the strategy/position
+  tickLower: BigInt! @config(precision: 24) # Lower tick bound of the position's price range (in tick units)
+  tickUpper: BigInt! @config(precision: 24) # Upper tick bound of the position's price range (in tick units)
+  property: BigInt! @config(precision: 24) # Pool property parameter from the AMM position struct
+  positionAmount0: BigInt! @config(precision: 76) # Current amount of token0 in the AMM position (updated by Rebalance events)
+  positionAmount1: BigInt! @config(precision: 76) # Current amount of token1 in the AMM position (updated by Rebalance events)
+  liquidity: BigInt! @config(precision: 76) # Amount of liquidity currently in the AMM position
+  strategyType: BigInt! @config(precision: 24) # Type/kind of ALM strategy being used (defines the strategy behavior)
+  tickNeighborhood: BigInt! @config(precision: 24) # Tick neighborhood parameter for the strategy (defines rebalancing range around current price)
+  tickSpacing: BigInt! @config(precision: 24) # Tick spacing for the strategy (minimum tick movement allowed)
+  positionWidth: BigInt! @config(precision: 24) # Width parameter for the strategy (defines the position size in ticks)
+  maxLiquidityRatioDeviationX96: BigInt! @config(precision: 76) # Maximum allowed liquidity ratio deviation in X96 fixed-point format (controls rebalancing thresholds)
+  creationTimestamp: Timestamp! # Timestamp when this strategy was created (from StrategyCreated event)
+  strategyTransactionHash: String! @index # Transaction hash of the StrategyCreated event
 }
 
 type ERC20_Transfer {

--- a/src/Aggregators/ALMLPWrapper.ts
+++ b/src/Aggregators/ALMLPWrapper.ts
@@ -1,48 +1,9 @@
 import type { ALM_LP_Wrapper, handlerContext } from "generated";
-import { toChecksumAddress } from "../Constants";
-
-/**
- * Loads or creates an ALM_LP_Wrapper entity for a given pool and chain
- * @param poolAddress - Optional. If not provided, uses existing wrapper's pool or empty string for new entities
- */
-export async function loadOrCreateALMLPWrapper(
-  lpWrapperAddress: string,
-  poolAddress: string | undefined,
-  chainId: number,
-  context: handlerContext,
-  timestamp: Date,
-): Promise<ALM_LP_Wrapper> {
-  const lpWrapperAddressChecksummed = toChecksumAddress(lpWrapperAddress);
-
-  const id = `${lpWrapperAddressChecksummed}_${chainId}`;
-
-  let wrapper = await context.ALM_LP_Wrapper.get(id);
-
-  if (!wrapper) {
-    // If creating new entity, poolAddress is required
-    if (!poolAddress) {
-      throw new Error(
-        `poolAddress is required when creating a new ALM_LP_Wrapper entity for ${id}`,
-      );
-    }
-    const poolAddressChecksummed = toChecksumAddress(poolAddress);
-    wrapper = {
-      id,
-      chainId,
-      pool: poolAddressChecksummed,
-      amount0: 0n,
-      amount1: 0n,
-      lpAmount: 0n,
-      lastUpdatedTimestamp: timestamp,
-    };
-    context.ALM_LP_Wrapper.set(wrapper);
-  }
-
-  return wrapper;
-}
 
 /**
  * Generic function to update ALM_LP_Wrapper with any combination of fields
+ * - Wrapper-level fields (amount0, amount1, lpAmount) are incremented (for deposits/withdrawals)
+ * - Position-level fields (positionAmount0, positionAmount1, liquidity) are set directly (for rebalances)
  */
 export async function updateALMLPWrapper(
   diff: Partial<ALM_LP_Wrapper>,
@@ -52,9 +13,36 @@ export async function updateALMLPWrapper(
 ): Promise<void> {
   const updated: ALM_LP_Wrapper = {
     ...current,
-    amount0: (diff.amount0 ?? 0n) + current.amount0,
-    amount1: (diff.amount1 ?? 0n) + current.amount1,
-    lpAmount: (diff.lpAmount ?? 0n) + current.lpAmount,
+    // Wrapper-level aggregations: increment (for deposits/withdrawals)
+    amount0:
+      diff.amount0 !== undefined
+        ? diff.amount0 + current.amount0
+        : current.amount0,
+    amount1:
+      diff.amount1 !== undefined
+        ? diff.amount1 + current.amount1
+        : current.amount1,
+    lpAmount:
+      diff.lpAmount !== undefined
+        ? diff.lpAmount + current.lpAmount
+        : current.lpAmount,
+    // Position-level state: set directly (for rebalances)
+    tokenId: diff.tokenId !== undefined ? diff.tokenId : current.tokenId,
+    positionAmount0:
+      diff.positionAmount0 !== undefined
+        ? diff.positionAmount0
+        : current.positionAmount0,
+    positionAmount1:
+      diff.positionAmount1 !== undefined
+        ? diff.positionAmount1
+        : current.positionAmount1,
+    liquidity:
+      diff.liquidity !== undefined ? diff.liquidity : current.liquidity,
+    tickLower:
+      diff.tickLower !== undefined ? diff.tickLower : current.tickLower,
+    tickUpper:
+      diff.tickUpper !== undefined ? diff.tickUpper : current.tickUpper,
+    property: diff.property !== undefined ? diff.property : current.property,
     lastUpdatedTimestamp: timestamp,
   };
 

--- a/src/EventHandlers/ALM/Core.ts
+++ b/src/EventHandlers/ALM/Core.ts
@@ -1,8 +1,5 @@
-import {
-  ALMCore,
-  type ALMCore_Rebalance,
-  type ALMCore_Rebalance_AmmPosition,
-} from "generated";
+import { ALMCore, type ALM_LP_Wrapper } from "generated";
+import { updateALMLPWrapper } from "../../Aggregators/ALMLPWrapper";
 
 ALMCore.Rebalance.handler(async ({ event, context }) => {
   const [
@@ -16,40 +13,34 @@ ALMCore.Rebalance.handler(async ({ event, context }) => {
   ] = event.params.rebalanceEventParams;
   const [token0, token1, property, tickLower, tickUpper, liquidity] =
     ammPositionInfo;
-  const entity: ALMCore_Rebalance = {
-    id: `${event.chainId}_${event.block.number}_${event.logIndex}`,
-    pool,
-    tickLower,
-    tickUpper,
-    sqrtPriceX96,
-    amount0,
-    amount1,
-    ammPositionIdBefore,
-    ammPositionIdAfter,
-    transactionHash: event.transaction.hash,
-    timestamp: new Date(event.block.timestamp * 1000),
-    chainId: event.chainId,
-    blockNumber: event.block.number,
-    logIndex: event.logIndex,
+
+  const timestamp = new Date(event.block.timestamp * 1000);
+
+  // Find the wrapper by pool address (1 wrapper per pool)
+  const poolAddress = pool;
+  const wrappers = await context.ALM_LP_Wrapper.getWhere.pool.eq(poolAddress);
+
+  if (!wrappers || wrappers.length === 0) {
+    context.log.warn(
+      `ALM_LP_Wrapper entity not found for pool ${poolAddress}. Skipping Rebalance update.`,
+    );
+    return;
+  }
+
+  // Since there's exactly 1 wrapper per pool, take the first one
+  const lpWrapper = wrappers[0];
+
+  // Update the wrapper's strategy position state with new amounts from Rebalance
+  const lpWrapperDiff: Partial<ALM_LP_Wrapper> = {
+    tokenId: ammPositionIdAfter,
+    positionAmount0: amount0,
+    positionAmount1: amount1,
+    tickLower: tickLower,
+    tickUpper: tickUpper,
+    property: property,
+    liquidity: liquidity,
+    lastUpdatedTimestamp: timestamp,
   };
 
-  context.ALMCore_Rebalance.set(entity);
-
-  const ammPosition_entity: ALMCore_Rebalance_AmmPosition = {
-    id: `${event.chainId}_${event.block.number}_${event.logIndex}`,
-    pool,
-    token0,
-    token1,
-    property,
-    tickLower,
-    tickUpper,
-    liquidity,
-    transactionHash: event.transaction.hash,
-    timestamp: new Date(event.block.timestamp * 1000),
-    chainId: event.chainId,
-    blockNumber: event.block.number,
-    logIndex: event.logIndex,
-  };
-
-  context.ALMCore_Rebalance_AmmPosition.set(ammPosition_entity);
+  await updateALMLPWrapper(lpWrapperDiff, lpWrapper, timestamp, context);
 });

--- a/src/EventHandlers/ALM/DeployFactory.ts
+++ b/src/EventHandlers/ALM/DeployFactory.ts
@@ -1,8 +1,5 @@
-import {
-  ALMDeployFactory,
-  type ALMDeployFactory_StrategyCreated,
-  type ALMDeployFactory_StrategyCreated_AmmPosition,
-} from "generated";
+import { ALMDeployFactory } from "generated";
+import { toChecksumAddress } from "../../Constants";
 
 ALMDeployFactory.StrategyCreated.contractRegister(({ event, context }) => {
   const [pool, ammPosition, strategyParams, lpWrapper, caller] =
@@ -22,58 +19,54 @@ ALMDeployFactory.StrategyCreated.handler(async ({ event, context }) => {
     maxLiquidityRatioDeviationX96,
   ] = strategyParams;
 
-  const ammPositionList = ammPosition.map((vals) => {
-    const [token0, token1, property, tickLower, tickUpper, liquidity] = vals;
-    return {
-      token0,
-      token1,
-      property,
-      tickLower,
-      tickUpper,
-      liquidity,
-    };
-  });
+  // Contract relationship: 1 LP wrapper per pool, 1 strategy per LP wrapper, 1 tokenId per strategy, 1 AMM position per tokenId
+  // Therefore ammPosition array should have exactly 1 element (not a loop)
+  const [token0, token1, property, tickLower, tickUpper, liquidity] =
+    ammPosition[0];
 
-  const strategy_created_entity: ALMDeployFactory_StrategyCreated = {
-    id: `${event.chainId}_${event.block.number}_${event.logIndex}`,
-    pool,
-    lpWrapper,
-    strategyType,
-    tickNeighborhood,
-    tickSpacing,
-    width,
-    maxLiquidityRatioDeviationX96,
-    transactionHash: event.transaction.hash,
-    timestamp: new Date(event.block.timestamp * 1000),
-    chainId: event.chainId,
-    blockNumber: event.block.number,
-    logIndex: event.logIndex,
-  };
+  const timestamp = new Date(event.block.timestamp * 1000);
 
-  context.ALMDeployFactory_StrategyCreated.set(strategy_created_entity);
-
-  for (const ammPosition of ammPositionList) {
-    const { token0, token1, property, tickLower, tickUpper, liquidity } =
-      ammPosition;
-    const ammPosition_entity: ALMDeployFactory_StrategyCreated_AmmPosition = {
-      id: `${event.chainId}_${event.block.number}_${event.logIndex}`,
-      pool,
-      lpWrapper,
-      token0,
-      token1,
-      property,
-      tickLower,
-      tickUpper,
-      liquidity,
-      transactionHash: event.transaction.hash,
-      timestamp: new Date(event.block.timestamp * 1000),
-      chainId: event.chainId,
-      blockNumber: event.block.number,
-      logIndex: event.logIndex,
-    };
-
-    context.ALMDeployFactory_StrategyCreated_AmmPosition.set(
-      ammPosition_entity,
+  // Fetching tokenId from NonFungiblePosition entity created by CL Pool event handlers
+  const nonFungiblePositions =
+    await context.NonFungiblePosition.getWhere.transactionHash.eq(
+      event.transaction.hash,
     );
+  if (!nonFungiblePositions || nonFungiblePositions.length === 0) {
+    context.log.error(
+      `NonFungiblePosition not found for transaction hash ${event.transaction.hash}. It should have been created by CLPool event handlers.`,
+    );
+    return;
   }
+
+  const tokenId = nonFungiblePositions[0].tokenId;
+
+  // Create ALM_LP_Wrapper (single entity tracks both wrapper and strategy)
+  // This single entity contains both wrapper-level aggregations and strategy/position state
+  context.ALM_LP_Wrapper.set({
+    id: `${toChecksumAddress(lpWrapper)}_${event.chainId}`,
+    chainId: event.chainId,
+    pool: toChecksumAddress(pool),
+    token0: toChecksumAddress(token0),
+    token1: toChecksumAddress(token1),
+    // Wrapper-level aggregations (updated by Deposit/Withdraw events)
+    amount0: 0n,
+    amount1: 0n,
+    lpAmount: 0n,
+    lastUpdatedTimestamp: timestamp,
+    // Strategy/Position-level state (from StrategyCreated event)
+    tokenId: tokenId,
+    tickLower: tickLower,
+    tickUpper: tickUpper,
+    property: property,
+    positionAmount0: 0n, // Initialize to 0 - will be updated by Rebalance events
+    positionAmount1: 0n, // Initialize to 0 - will be updated by Rebalance events
+    liquidity: liquidity,
+    strategyType: strategyType,
+    tickNeighborhood: tickNeighborhood,
+    tickSpacing: tickSpacing,
+    positionWidth: width,
+    maxLiquidityRatioDeviationX96: maxLiquidityRatioDeviationX96,
+    creationTimestamp: timestamp,
+    strategyTransactionHash: event.transaction.hash,
+  });
 });

--- a/test/Aggregators/NonFungiblePosition.test.ts
+++ b/test/Aggregators/NonFungiblePosition.test.ts
@@ -8,6 +8,8 @@ import {
 
 describe("NonFungiblePosition", () => {
   let contextStub: Partial<handlerContext>;
+  const transactionHash =
+    "0x1234567890123456789012345678901234567890123456789012345678901234";
   const mockNonFungiblePosition: NonFungiblePosition = {
     id: "10_1",
     chainId: 10,
@@ -21,6 +23,7 @@ describe("NonFungiblePosition", () => {
     amount0: 1000000000000000000n,
     amount1: 2000000000000000000n,
     amountUSD: 3000000000000000000n,
+    transactionHash: transactionHash,
     lastUpdatedTimestamp: new Date(10000 * 1000),
   };
   const timestamp = new Date(10001 * 1000);
@@ -35,6 +38,10 @@ describe("NonFungiblePosition", () => {
         deleteUnsafe: sinon.stub(),
         getWhere: {
           owner: {
+            eq: sinon.stub(),
+            gt: sinon.stub(),
+          },
+          transactionHash: {
             eq: sinon.stub(),
             gt: sinon.stub(),
           },

--- a/test/EventHandlers/ALM/Core.test.ts
+++ b/test/EventHandlers/ALM/Core.test.ts
@@ -1,0 +1,240 @@
+import { expect } from "chai";
+import { ALMCore, MockDb } from "../../../generated/src/TestHelpers.gen";
+import type { ALM_LP_Wrapper } from "../../../generated/src/Types.gen";
+import { toChecksumAddress } from "../../../src/Constants";
+import { setupCommon } from "../Pool/common";
+
+describe("ALMCore Rebalance Event", () => {
+  const { mockALMLPWrapperData, mockLiquidityPoolData } = setupCommon();
+  const chainId = mockLiquidityPoolData.chainId;
+  const poolAddress = mockLiquidityPoolData.id;
+  const transactionHash =
+    "0x1234567890123456789012345678901234567890123456789012345678901234";
+  const blockTimestamp = 1000000;
+  const blockNumber = 123456;
+
+  const mockEventData = {
+    block: {
+      timestamp: blockTimestamp,
+      number: blockNumber,
+      hash: transactionHash,
+    },
+    chainId,
+    logIndex: 1,
+    transaction: {
+      hash: transactionHash,
+    },
+  };
+
+  describe("Rebalance event", () => {
+    it("should update ALM_LP_Wrapper entity with new position state", async () => {
+      let mockDb = MockDb.createMockDb();
+
+      // Pre-populate with existing wrapper
+      const wrapperId = mockALMLPWrapperData.id;
+      mockDb = mockDb.entities.ALM_LP_Wrapper.set(mockALMLPWrapperData);
+
+      // Track entities for getWhere query
+      const storedEntities = [mockALMLPWrapperData];
+
+      // Extend mockDb to include getWhere for ALM_LP_Wrapper
+      const mockDbWithGetWhere = {
+        ...mockDb,
+        entities: {
+          ...mockDb.entities,
+          ALM_LP_Wrapper: {
+            ...mockDb.entities.ALM_LP_Wrapper,
+            getWhere: {
+              pool: {
+                eq: async (poolAddr: string) => {
+                  return storedEntities.filter(
+                    (entity) => entity.pool === toChecksumAddress(poolAddr),
+                  );
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const newAmount0 = 800n * 10n ** 18n;
+      const newAmount1 = 400n * 10n ** 6n;
+      const newLiquidity = 2000000n;
+      const newTokenId = 2n;
+      const newTickLower = -1500n;
+      const newTickUpper = 1500n;
+      const newProperty = 3000n;
+
+      const mockEvent = ALMCore.Rebalance.createMockEvent({
+        rebalanceEventParams: [
+          poolAddress,
+          [
+            mockALMLPWrapperData.token0,
+            mockALMLPWrapperData.token1,
+            newProperty,
+            newTickLower,
+            newTickUpper,
+            newLiquidity,
+          ],
+          79228162514264337593543950336n, // sqrtPriceX96
+          newAmount0,
+          newAmount1,
+          1n, // ammPositionIdBefore
+          newTokenId, // ammPositionIdAfter
+        ],
+        mockEventData,
+      });
+
+      const result = await ALMCore.Rebalance.processEvent({
+        event: mockEvent,
+        mockDb: mockDbWithGetWhere as typeof mockDb,
+      });
+
+      const updatedWrapper = result.entities.ALM_LP_Wrapper.get(wrapperId);
+
+      expect(updatedWrapper).to.not.be.undefined;
+      expect(updatedWrapper?.positionAmount0).to.equal(newAmount0);
+      expect(updatedWrapper?.positionAmount1).to.equal(newAmount1);
+      expect(updatedWrapper?.liquidity).to.equal(newLiquidity);
+      expect(updatedWrapper?.tokenId).to.equal(newTokenId);
+      expect(updatedWrapper?.tickLower).to.equal(newTickLower);
+      expect(updatedWrapper?.tickUpper).to.equal(newTickUpper);
+      expect(updatedWrapper?.property).to.equal(newProperty);
+      expect(updatedWrapper?.lastUpdatedTimestamp).to.deep.equal(
+        new Date(blockTimestamp * 1000),
+      );
+
+      // Verify wrapper-level aggregations are preserved
+      expect(updatedWrapper?.amount0).to.equal(mockALMLPWrapperData.amount0);
+      expect(updatedWrapper?.amount1).to.equal(mockALMLPWrapperData.amount1);
+      expect(updatedWrapper?.lpAmount).to.equal(mockALMLPWrapperData.lpAmount);
+    });
+
+    it("should not update when ALM_LP_Wrapper entity not found", async () => {
+      const mockDb = MockDb.createMockDb();
+
+      // Extend mockDb to include getWhere (returning empty array)
+      const mockDbWithGetWhere = {
+        ...mockDb,
+        entities: {
+          ...mockDb.entities,
+          ALM_LP_Wrapper: {
+            ...mockDb.entities.ALM_LP_Wrapper,
+            getWhere: {
+              pool: {
+                eq: async (_poolAddr: string) => {
+                  return []; // No entities found
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const mockEvent = ALMCore.Rebalance.createMockEvent({
+        rebalanceEventParams: [
+          poolAddress,
+          [
+            mockALMLPWrapperData.token0,
+            mockALMLPWrapperData.token1,
+            3000n,
+            -1000n,
+            1000n,
+            1000000n,
+          ],
+          79228162514264337593543950336n,
+          500n * 10n ** 18n,
+          250n * 10n ** 6n,
+          1n,
+          2n,
+        ],
+        mockEventData,
+      });
+
+      const result = await ALMCore.Rebalance.processEvent({
+        event: mockEvent,
+        mockDb: mockDbWithGetWhere as typeof mockDb,
+      });
+
+      // Verify that no wrapper was created or updated
+      expect(
+        Array.from(result.entities.ALM_LP_Wrapper.getAll()).length,
+      ).to.equal(0);
+    });
+
+    it("should handle multiple wrappers and update the first one", async () => {
+      let mockDb = MockDb.createMockDb();
+
+      // Create multiple wrappers with the same pool address
+      const wrapper1: ALM_LP_Wrapper = {
+        ...mockALMLPWrapperData,
+        id: `${toChecksumAddress("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")}_${chainId}`,
+      };
+
+      const wrapper2: ALM_LP_Wrapper = {
+        ...mockALMLPWrapperData,
+        id: `${toChecksumAddress("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")}_${chainId}`,
+      };
+
+      mockDb = mockDb.entities.ALM_LP_Wrapper.set(wrapper1);
+      mockDb = mockDb.entities.ALM_LP_Wrapper.set(wrapper2);
+
+      // Track entities for getWhere query
+      const storedEntities = [wrapper1, wrapper2];
+
+      // Extend mockDb to include getWhere
+      const mockDbWithGetWhere = {
+        ...mockDb,
+        entities: {
+          ...mockDb.entities,
+          ALM_LP_Wrapper: {
+            ...mockDb.entities.ALM_LP_Wrapper,
+            getWhere: {
+              pool: {
+                eq: async (poolAddr: string) => {
+                  return storedEntities.filter(
+                    (entity) => entity.pool === toChecksumAddress(poolAddr),
+                  );
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const newTokenId = 3n;
+      const mockEvent = ALMCore.Rebalance.createMockEvent({
+        rebalanceEventParams: [
+          poolAddress,
+          [
+            mockALMLPWrapperData.token0,
+            mockALMLPWrapperData.token1,
+            3000n,
+            -1000n,
+            1000n,
+            1000000n,
+          ],
+          79228162514264337593543950336n,
+          500n * 10n ** 18n,
+          250n * 10n ** 6n,
+          1n,
+          newTokenId,
+        ],
+        mockEventData,
+      });
+
+      const result = await ALMCore.Rebalance.processEvent({
+        event: mockEvent,
+        mockDb: mockDbWithGetWhere as typeof mockDb,
+      });
+
+      // Should update the first wrapper (wrapper1)
+      const updatedWrapper1 = result.entities.ALM_LP_Wrapper.get(wrapper1.id);
+      expect(updatedWrapper1?.tokenId).to.equal(newTokenId);
+
+      // Second wrapper should remain unchanged
+      const unchangedWrapper2 = result.entities.ALM_LP_Wrapper.get(wrapper2.id);
+      expect(unchangedWrapper2?.tokenId).to.equal(wrapper2.tokenId);
+    });
+  });
+});

--- a/test/EventHandlers/ALM/DeployFactory.test.ts
+++ b/test/EventHandlers/ALM/DeployFactory.test.ts
@@ -1,0 +1,215 @@
+import { expect } from "chai";
+import {
+  ALMDeployFactory,
+  MockDb,
+} from "../../../generated/src/TestHelpers.gen";
+import type { NonFungiblePosition } from "../../../generated/src/Types.gen";
+import { toChecksumAddress } from "../../../src/Constants";
+import { setupCommon } from "../Pool/common";
+
+describe("ALMDeployFactory StrategyCreated Event", () => {
+  const { mockLiquidityPoolData, mockToken0Data, mockToken1Data } =
+    setupCommon();
+  const chainId = mockLiquidityPoolData.chainId;
+  const poolAddress = mockLiquidityPoolData.id;
+  const lpWrapperAddress = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+  const callerAddress = "0xcccccccccccccccccccccccccccccccccccccccc";
+  const transactionHash =
+    "0x1234567890123456789012345678901234567890123456789012345678901234";
+  const blockTimestamp = 1000000;
+  const blockNumber = 123456;
+  const tokenId = 42n;
+
+  const mockEventData = {
+    block: {
+      timestamp: blockTimestamp,
+      number: blockNumber,
+      hash: transactionHash,
+    },
+    chainId,
+    logIndex: 1,
+    transaction: {
+      hash: transactionHash,
+    },
+  };
+
+  describe("StrategyCreated event", () => {
+    it("should create ALM_LP_Wrapper entity with strategy and position data", async () => {
+      let mockDb = MockDb.createMockDb();
+
+      // Pre-populate with NonFungiblePosition (created by CLPool handlers)
+      const mockNFPM: NonFungiblePosition = {
+        id: `${chainId}_${tokenId}`,
+        chainId,
+        tokenId,
+        owner: callerAddress,
+        pool: poolAddress,
+        tickUpper: 1000,
+        tickLower: -1000,
+        token0: mockToken0Data.address,
+        token1: mockToken1Data.address,
+        amount0: 500n * 10n ** 18n,
+        amount1: 250n * 10n ** 6n,
+        amountUSD: 750n * 10n ** 18n,
+        transactionHash,
+        lastUpdatedTimestamp: new Date(blockTimestamp * 1000),
+      };
+
+      mockDb = mockDb.entities.NonFungiblePosition.set(mockNFPM);
+
+      // Track entities for getWhere query
+      const storedNFPMs = [mockNFPM];
+
+      // Extend mockDb to include getWhere for NonFungiblePosition
+      const mockDbWithGetWhere = {
+        ...mockDb,
+        entities: {
+          ...mockDb.entities,
+          NonFungiblePosition: {
+            ...mockDb.entities.NonFungiblePosition,
+            getWhere: {
+              transactionHash: {
+                eq: async (txHash: string) => {
+                  return storedNFPMs.filter(
+                    (entity) => entity.transactionHash === txHash,
+                  );
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const strategyType = 1n;
+      const tickNeighborhood = 100n;
+      const tickSpacing = 60n;
+      const width = 2000n;
+      const maxLiquidityRatioDeviationX96 = 79228162514264337593543950336n; // 1 * 2^96
+      const property = 3000n; // uint24
+      const tickLower = -1000n;
+      const tickUpper = 1000n;
+      const liquidity = 1000000n;
+
+      const mockEvent = ALMDeployFactory.StrategyCreated.createMockEvent({
+        params: [
+          toChecksumAddress(poolAddress),
+          [
+            [
+              toChecksumAddress(mockToken0Data.address),
+              toChecksumAddress(mockToken1Data.address),
+              property,
+              tickLower,
+              tickUpper,
+              liquidity,
+            ],
+          ],
+          [
+            strategyType,
+            tickNeighborhood,
+            tickSpacing,
+            width,
+            maxLiquidityRatioDeviationX96,
+          ],
+          toChecksumAddress(lpWrapperAddress),
+          toChecksumAddress(callerAddress),
+        ],
+        mockEventData,
+      });
+
+      const result = await ALMDeployFactory.StrategyCreated.processEvent({
+        event: mockEvent,
+        mockDb: mockDbWithGetWhere as typeof mockDb,
+      });
+
+      const wrapperId = `${toChecksumAddress(lpWrapperAddress)}_${chainId}`;
+      const createdWrapper = result.entities.ALM_LP_Wrapper.get(wrapperId);
+
+      expect(createdWrapper).to.not.be.undefined;
+      expect(createdWrapper?.id).to.equal(wrapperId);
+      expect(createdWrapper?.chainId).to.equal(chainId);
+      expect(createdWrapper?.pool).to.equal(toChecksumAddress(poolAddress));
+      expect(createdWrapper?.token0).to.equal(mockToken0Data.address);
+      expect(createdWrapper?.token1).to.equal(mockToken1Data.address);
+
+      // Wrapper-level aggregations should be initialized to 0
+      expect(createdWrapper?.amount0).to.equal(0n);
+      expect(createdWrapper?.amount1).to.equal(0n);
+      expect(createdWrapper?.lpAmount).to.equal(0n);
+
+      // Strategy/Position-level state should be set from event
+      expect(createdWrapper?.tokenId).to.equal(tokenId);
+      expect(createdWrapper?.tickLower).to.equal(tickLower);
+      expect(createdWrapper?.tickUpper).to.equal(tickUpper);
+      expect(createdWrapper?.property).to.equal(property);
+      expect(createdWrapper?.liquidity).to.equal(liquidity);
+      expect(createdWrapper?.positionAmount0).to.equal(0n); // Initialize to 0
+      expect(createdWrapper?.positionAmount1).to.equal(0n); // Initialize to 0
+      expect(createdWrapper?.strategyType).to.equal(strategyType);
+      expect(createdWrapper?.tickNeighborhood).to.equal(tickNeighborhood);
+      expect(createdWrapper?.tickSpacing).to.equal(tickSpacing);
+      expect(createdWrapper?.positionWidth).to.equal(width);
+      expect(createdWrapper?.maxLiquidityRatioDeviationX96).to.equal(
+        maxLiquidityRatioDeviationX96,
+      );
+      expect(createdWrapper?.creationTimestamp).to.deep.equal(
+        new Date(blockTimestamp * 1000),
+      );
+      expect(createdWrapper?.strategyTransactionHash).to.equal(transactionHash);
+      expect(createdWrapper?.lastUpdatedTimestamp).to.deep.equal(
+        new Date(blockTimestamp * 1000),
+      );
+    });
+
+    it("should not create entity when NonFungiblePosition not found", async () => {
+      const mockDb = MockDb.createMockDb();
+
+      // Extend mockDb to include getWhere (returning empty array)
+      const mockDbWithGetWhere = {
+        ...mockDb,
+        entities: {
+          ...mockDb.entities,
+          NonFungiblePosition: {
+            ...mockDb.entities.NonFungiblePosition,
+            getWhere: {
+              transactionHash: {
+                eq: async (_txHash: string) => {
+                  return []; // No entities found
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const mockEvent = ALMDeployFactory.StrategyCreated.createMockEvent({
+        params: [
+          poolAddress,
+          [
+            [
+              mockToken0Data.address,
+              mockToken1Data.address,
+              3000n,
+              -1000n,
+              1000n,
+              1000000n,
+            ],
+          ],
+          [1n, 100n, 60n, 2000n, 79228162514264337593543950336n],
+          lpWrapperAddress,
+          callerAddress,
+        ],
+        mockEventData,
+      });
+
+      const result = await ALMDeployFactory.StrategyCreated.processEvent({
+        event: mockEvent,
+        mockDb: mockDbWithGetWhere as typeof mockDb,
+      });
+
+      // Verify that no wrapper was created
+      const wrapperId = `${toChecksumAddress(lpWrapperAddress)}_${chainId}`;
+      const createdWrapper = result.entities.ALM_LP_Wrapper.get(wrapperId);
+      expect(createdWrapper).to.be.undefined;
+    });
+  });
+});

--- a/test/EventHandlers/NFPM/NFPM.test.ts
+++ b/test/EventHandlers/NFPM/NFPM.test.ts
@@ -15,6 +15,8 @@ describe("NFPM Events", () => {
   const token0Address = "0xToken0Address0000000000000000000000";
   const token1Address = "0xToken1Address0000000000000000000000";
 
+  const transactionHash =
+    "0x1234567890123456789012345678901234567890123456789012345678901234";
   const mockNonFungiblePosition = {
     id: NonFungiblePositionId(chainId, tokenId),
     chainId: 10,
@@ -28,6 +30,7 @@ describe("NFPM Events", () => {
     amount0: 1000000000000000000n,
     amount1: 2000000000000000000n,
     amountUSD: 3000000000000000000n,
+    transactionHash: transactionHash,
     lastUpdatedTimestamp: new Date(),
   };
 

--- a/test/EventHandlers/Pool/common.ts
+++ b/test/EventHandlers/Pool/common.ts
@@ -114,10 +114,29 @@ export function setupCommon() {
     id: `${toChecksumAddress("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")}_${mockLiquidityPoolData.chainId}`,
     chainId: mockLiquidityPoolData.chainId,
     pool: toChecksumAddress(mockLiquidityPoolData.id),
+    token0: mockToken0Data.address,
+    token1: mockToken1Data.address,
+    // Wrapper-level aggregations
     amount0: 1000n * TEN_TO_THE_18_BI,
     amount1: 500n * TEN_TO_THE_6_BI,
     lpAmount: 2000n * TEN_TO_THE_18_BI,
     lastUpdatedTimestamp: new Date(900000 * 1000),
+    // Strategy/Position-level state
+    tokenId: 1n,
+    tickLower: -1000n,
+    tickUpper: 1000n,
+    property: 3000n, // uint24 tick spacing
+    positionAmount0: 500n * TEN_TO_THE_18_BI,
+    positionAmount1: 250n * TEN_TO_THE_6_BI,
+    liquidity: 1000000n,
+    strategyType: 1n,
+    tickNeighborhood: 100n,
+    tickSpacing: 60n,
+    positionWidth: 2000n,
+    maxLiquidityRatioDeviationX96: 79228162514264337593543950336n, // 1 * 2^96
+    creationTimestamp: new Date(900000 * 1000),
+    strategyTransactionHash:
+      "0x0000000000000000000000000000000000000000000000000000000000000001",
   };
 
   const defaultUserAddress = "0xAbCccccccccccccccccccccccccccccccccccccc";


### PR DESCRIPTION
Implements:

- Updated `ALMLPWrapper` entity to handle both wrapper-level fields (incremented for deposits/withdrawals) and position-level fields (set directly for rebalances) with clear separation of concerns

- Updated `ALMDeployFactory.StrategyCreated` handler to create unified `ALM_LP_Wrapper` entity with both wrapper-level aggregations (`amount0`, `amount1`, `lpAmount`) and strategy/position-level state (`tokenId`, `tickLower`, `tickUpper`, `property`, `liquidity`, `strategyType`, etc.)

- Updated `ALMCore.Rebalance` handler to update position-level fields directly on `ALM_LP_Wrapper` entity using `getWhere` query by pool address, replacing separate `ALMCore_Rebalance` and `ALMCore_Rebalance_AmmPosition` entities (which were deleted).

- Updated `ALMLPWrapper` event handlers (Deposit, Withdraw, Transfer) to use `context.ALM_LP_Wrapper.get()` with proper error handling instead of `loadOrCreateALMLPWrapper` helper function. `ALM_LP_Wrapper` should always be created during `StrategyCreated` events

- Added address checksumming in test mock events (`mockEventData.srcAddress` and event params) to ensure test setup matches handler expectations

- Created comprehensive test suites for ALMCore.Rebalance and ALMDeployFactory.StrategyCreated handlers with proper MockDb setup and getWhere query mocking

- Added `transactionHash` field to `NonFungiblePosition` entity and updated related tests to support `StrategyCreated` handler's `tokenId` lookup