### PR TITLE
Removing `_loaderReturn` from `CLPool` modules

### DIFF
--- a/src/EventHandlers/CLFactory.ts
+++ b/src/EventHandlers/CLFactory.ts
@@ -19,34 +19,20 @@ CLFactory.PoolCreated.handler(async ({ event, context }) => {
     return;
   }
 
-  // Create loader return object for compatibility with existing logic
-  const loaderReturn = {
-    _type: "success" as const,
-    poolToken0,
-    poolToken1,
-  };
-
   // Process the pool created event
   const result = await processCLFactoryPoolCreated(
     event,
-    loaderReturn,
+    poolToken0,
+    poolToken1,
     context,
   );
 
-  // Handle errors
-  if (result.error) {
-    context.log.error(result.error);
-    return;
-  }
-
   // Apply liquidity pool aggregator updates
-  if (result.liquidityPoolAggregator) {
-    updateLiquidityPoolAggregator(
-      result.liquidityPoolAggregator,
-      result.liquidityPoolAggregator,
-      new Date(event.block.timestamp * 1000),
-      context,
-      event.block.number,
-    );
-  }
+  updateLiquidityPoolAggregator(
+    result.liquidityPoolAggregator,
+    result.liquidityPoolAggregator,
+    new Date(event.block.timestamp * 1000),
+    context,
+    event.block.number,
+  );
 });

--- a/src/EventHandlers/CLFactory/CLFactoryPoolCreatedLogic.ts
+++ b/src/EventHandlers/CLFactory/CLFactoryPoolCreatedLogic.ts
@@ -10,22 +10,16 @@ import { generatePoolName } from "../../Helpers";
 import { createTokenEntity } from "../../PriceOracle";
 
 export interface CLFactoryPoolCreatedResult {
-  liquidityPoolAggregator?: LiquidityPoolAggregator;
-  error?: string;
-}
-
-export interface CLFactoryPoolCreatedLoaderReturn {
-  poolToken0: Token | undefined;
-  poolToken1: Token | undefined;
+  liquidityPoolAggregator: LiquidityPoolAggregator;
 }
 
 export async function processCLFactoryPoolCreated(
   event: CLFactory_PoolCreated_event,
-  loaderReturn: CLFactoryPoolCreatedLoaderReturn,
+  poolToken0: Token | undefined,
+  poolToken1: Token | undefined,
   context: handlerContext,
 ): Promise<CLFactoryPoolCreatedResult> {
   try {
-    const { poolToken0, poolToken1 } = loaderReturn;
     const poolTokenSymbols: string[] = [];
     const poolTokenAddressMappings: TokenEntityMapping[] = [
       { address: event.params.token0, tokenInstance: poolToken0 },
@@ -137,8 +131,8 @@ export async function processCLFactoryPoolCreated(
       liquidityPoolAggregator,
     };
   } catch (error) {
-    return {
-      error: `Error processing CLFactory PoolCreated: ${error}`,
-    };
+    context.log.error(`Error processing CLFactory PoolCreated: ${error}`);
+    // Re-throw to let the caller handle it
+    throw error;
   }
 }

--- a/src/EventHandlers/CLPool/CLPoolBurnLogic.ts
+++ b/src/EventHandlers/CLPool/CLPoolBurnLogic.ts
@@ -1,96 +1,53 @@
-import type {
-  CLPool_Burn_event,
-  LiquidityPoolAggregator,
-  Token,
-  handlerContext,
-} from "generated";
+import type { CLPool_Burn_event, Token, handlerContext } from "generated";
 import { updateReserveTokenData } from "../../Helpers";
 
 export interface CLPoolBurnResult {
-  liquidityPoolDiff?: {
+  liquidityPoolDiff: {
     reserve0: bigint;
     reserve1: bigint;
     totalLiquidityUSD: bigint;
     lastUpdatedTimestamp: Date;
   };
-  userLiquidityDiff?: {
+  userLiquidityDiff: {
     netLiquidityAddedUSD: bigint;
     currentLiquidityToken0: bigint;
     currentLiquidityToken1: bigint;
     timestamp: Date;
   };
-  error?: string;
 }
-
-export type CLPoolBurnLoaderReturn =
-  | {
-      _type: "success";
-      liquidityPoolAggregator: LiquidityPoolAggregator;
-      token0Instance: Token;
-      token1Instance: Token;
-    }
-  | {
-      _type: "TokenNotFoundError";
-      message: string;
-    }
-  | {
-      _type: "LiquidityPoolAggregatorNotFoundError";
-      message: string;
-    };
 
 export async function processCLPoolBurn(
   event: CLPool_Burn_event,
-  loaderReturn: CLPoolBurnLoaderReturn,
+  token0Instance: Token,
+  token1Instance: Token,
   context: handlerContext,
 ): Promise<CLPoolBurnResult> {
-  // Handle different loader return types
-  switch (loaderReturn._type) {
-    case "success": {
-      const { liquidityPoolAggregator, token0Instance, token1Instance } =
-        loaderReturn;
+  // Update reserve data using the same approach as Pool events
+  const reserveData = await updateReserveTokenData(
+    token0Instance,
+    token1Instance,
+    event.params.amount0,
+    event.params.amount1,
+    event,
+    context,
+  );
 
-      // Update reserve data using the same approach as Pool events
-      const reserveData = await updateReserveTokenData(
-        token0Instance,
-        token1Instance,
-        event.params.amount0,
-        event.params.amount1,
-        event,
-        context,
-      );
+  const liquidityPoolDiff = {
+    reserve0: event.params.amount0,
+    reserve1: event.params.amount1,
+    totalLiquidityUSD: reserveData.totalLiquidityUSD,
+    lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
+  };
 
-      const liquidityPoolDiff = {
-        reserve0: event.params.amount0,
-        reserve1: event.params.amount1,
-        totalLiquidityUSD: reserveData.totalLiquidityUSD,
-        lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
-      };
+  const userLiquidityDiff = {
+    netLiquidityAddedUSD: -reserveData.totalLiquidityUSD, // Negative for burn (removal)
+    currentLiquidityToken0: -event.params.amount0, // Negative amount of token0 removed
+    currentLiquidityToken1: -event.params.amount1, // Negative amount of token1 removed
+    timestamp: new Date(event.block.timestamp * 1000),
+  };
 
-      const userLiquidityDiff = {
-        netLiquidityAddedUSD: -reserveData.totalLiquidityUSD, // Negative for burn (removal)
-        currentLiquidityToken0: -event.params.amount0, // Negative amount of token0 removed
-        currentLiquidityToken1: -event.params.amount1, // Negative amount of token1 removed
-        timestamp: new Date(event.block.timestamp * 1000),
-      };
-
-      return {
-        liquidityPoolDiff,
-        userLiquidityDiff,
-      };
-    }
-    case "TokenNotFoundError":
-      return {
-        error: loaderReturn.message,
-      };
-    case "LiquidityPoolAggregatorNotFoundError":
-      return {
-        error: loaderReturn.message,
-      };
-    default: {
-      // This should never happen due to TypeScript's exhaustive checking
-      return {
-        error: "Unknown error type",
-      };
-    }
-  }
+  return {
+    liquidityPoolDiff,
+    userLiquidityDiff,
+  };
 }

--- a/src/EventHandlers/CLPool/CLPoolCollectLogic.ts
+++ b/src/EventHandlers/CLPool/CLPoolCollectLogic.ts
@@ -1,96 +1,53 @@
-import type {
-  CLPool_Collect_event,
-  LiquidityPoolAggregator,
-  Token,
-  handlerContext,
-} from "generated";
+import type { CLPool_Collect_event, Token, handlerContext } from "generated";
 import { updateReserveTokenData } from "../../Helpers";
 
 export interface CLPoolCollectResult {
-  liquidityPoolDiff?: {
+  liquidityPoolDiff: {
     reserve0: bigint;
     reserve1: bigint;
     totalLiquidityUSD: bigint;
     lastUpdatedTimestamp: Date;
   };
-  userLiquidityDiff?: {
+  userLiquidityDiff: {
     totalFeesContributed0: bigint;
     totalFeesContributed1: bigint;
     totalFeesContributedUSD: bigint;
     timestamp: Date;
   };
-  error?: string;
 }
-
-export type CLPoolCollectLoaderReturn =
-  | {
-      _type: "success";
-      liquidityPoolAggregator: LiquidityPoolAggregator;
-      token0Instance: Token | undefined;
-      token1Instance: Token | undefined;
-    }
-  | {
-      _type: "TokenNotFoundError";
-      message: string;
-    }
-  | {
-      _type: "LiquidityPoolAggregatorNotFoundError";
-      message: string;
-    };
 
 export async function processCLPoolCollect(
   event: CLPool_Collect_event,
-  loaderReturn: CLPoolCollectLoaderReturn,
+  token0Instance: Token | undefined,
+  token1Instance: Token | undefined,
   context: handlerContext,
 ): Promise<CLPoolCollectResult> {
-  // Handle different loader return types
-  switch (loaderReturn._type) {
-    case "success": {
-      const { liquidityPoolAggregator, token0Instance, token1Instance } =
-        loaderReturn;
+  // Update reserve data using the same approach as Pool events
+  const reserveData = await updateReserveTokenData(
+    token0Instance,
+    token1Instance,
+    event.params.amount0,
+    event.params.amount1,
+    event,
+    context,
+  );
 
-      // Update reserve data using the same approach as Pool events
-      const reserveData = await updateReserveTokenData(
-        token0Instance,
-        token1Instance,
-        event.params.amount0,
-        event.params.amount1,
-        event,
-        context,
-      );
+  const liquidityPoolDiff = {
+    reserve0: event.params.amount0,
+    reserve1: event.params.amount1,
+    totalLiquidityUSD: reserveData.totalLiquidityUSD,
+    lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
+  };
 
-      const liquidityPoolDiff = {
-        reserve0: event.params.amount0,
-        reserve1: event.params.amount1,
-        totalLiquidityUSD: reserveData.totalLiquidityUSD,
-        lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
-      };
+  const userLiquidityDiff = {
+    totalFeesContributed0: event.params.amount0, // The collected fees in token0
+    totalFeesContributed1: event.params.amount1, // The collected fees in token1
+    totalFeesContributedUSD: reserveData.totalLiquidityUSD, // The collected fees in USD
+    timestamp: new Date(event.block.timestamp * 1000),
+  };
 
-      const userLiquidityDiff = {
-        totalFeesContributed0: event.params.amount0, // The collected fees in token0
-        totalFeesContributed1: event.params.amount1, // The collected fees in token1
-        totalFeesContributedUSD: reserveData.totalLiquidityUSD, // The collected fees in USD
-        timestamp: new Date(event.block.timestamp * 1000),
-      };
-
-      return {
-        liquidityPoolDiff,
-        userLiquidityDiff,
-      };
-    }
-    case "TokenNotFoundError":
-      return {
-        error: loaderReturn.message,
-      };
-    case "LiquidityPoolAggregatorNotFoundError":
-      return {
-        error: loaderReturn.message,
-      };
-    default: {
-      // This should never happen due to TypeScript's exhaustive checking
-      return {
-        error: "Unknown error type",
-      };
-    }
-  }
+  return {
+    liquidityPoolDiff,
+    userLiquidityDiff,
+  };
 }

--- a/src/EventHandlers/CLPool/CLPoolFlashLogic.ts
+++ b/src/EventHandlers/CLPool/CLPoolFlashLogic.ts
@@ -1,13 +1,8 @@
-import type {
-  CLPool_Flash_event,
-  LiquidityPoolAggregator,
-  Token,
-  handlerContext,
-} from "generated";
+import type { CLPool_Flash_event, Token, handlerContext } from "generated";
 import { updateTokenData } from "../../Helpers";
 
 export interface CLPoolFlashResult {
-  liquidityPoolDiff?: {
+  liquidityPoolDiff: {
     totalFlashLoanFees0: bigint;
     totalFlashLoanFees1: bigint;
     totalFlashLoanFeesUSD: bigint;
@@ -15,116 +10,78 @@ export interface CLPoolFlashResult {
     numberOfFlashLoans: bigint;
     lastUpdatedTimestamp: Date;
   };
-  userFlashLoanDiff?: {
+  userFlashLoanDiff: {
     numberOfFlashLoans: bigint;
     totalFlashLoanVolumeUSD: bigint;
     timestamp: Date;
   };
-  error?: string;
 }
-
-export type CLPoolFlashLoaderReturn =
-  | {
-      _type: "success";
-      liquidityPoolAggregator: LiquidityPoolAggregator;
-      token0Instance: Token;
-      token1Instance: Token;
-    }
-  | {
-      _type: "TokenNotFoundError";
-      message: string;
-    }
-  | {
-      _type: "LiquidityPoolAggregatorNotFoundError";
-      message: string;
-    };
 
 export async function processCLPoolFlash(
   event: CLPool_Flash_event,
-  loaderReturn: CLPoolFlashLoaderReturn,
+  token0Instance: Token,
+  token1Instance: Token,
   context: handlerContext,
 ): Promise<CLPoolFlashResult> {
-  // Handle different loader return types
-  switch (loaderReturn._type) {
-    case "success": {
-      const { liquidityPoolAggregator, token0Instance, token1Instance } =
-        loaderReturn;
-
-      // Calculate flash loan fees in USD
-      let flashLoanFeesUSD = 0n;
-      if (token0Instance && event.params.paid0 > 0n) {
-        const token0Data = await updateTokenData(
-          token0Instance,
-          event.params.paid0,
-          event,
-          context,
-        );
-        flashLoanFeesUSD += token0Data.usdValue;
-      }
-      if (token1Instance && event.params.paid1 > 0n) {
-        const token1Data = await updateTokenData(
-          token1Instance,
-          event.params.paid1,
-          event,
-          context,
-        );
-        flashLoanFeesUSD += token1Data.usdValue;
-      }
-
-      // Calculate flash loan volume in USD (amount borrowed, not fees)
-      let flashLoanVolumeUSD = 0n;
-      if (token0Instance && event.params.amount0 > 0n) {
-        const token0Data = await updateTokenData(
-          token0Instance,
-          event.params.amount0,
-          event,
-          context,
-        );
-        flashLoanVolumeUSD += token0Data.usdValue;
-      }
-      if (token1Instance && event.params.amount1 > 0n) {
-        const token1Data = await updateTokenData(
-          token1Instance,
-          event.params.amount1,
-          event,
-          context,
-        );
-        flashLoanVolumeUSD += token1Data.usdValue;
-      }
-
-      const liquidityPoolDiff = {
-        totalFlashLoanFees0: event.params.paid0,
-        totalFlashLoanFees1: event.params.paid1,
-        totalFlashLoanFeesUSD: flashLoanFeesUSD,
-        totalFlashLoanVolumeUSD: flashLoanVolumeUSD,
-        numberOfFlashLoans: 1n,
-        lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
-      };
-
-      const userFlashLoanDiff = {
-        numberOfFlashLoans: 1n, // Each flash event represents 1 flash loan
-        totalFlashLoanVolumeUSD: flashLoanVolumeUSD,
-        timestamp: new Date(event.block.timestamp * 1000),
-      };
-
-      return {
-        liquidityPoolDiff,
-        userFlashLoanDiff,
-      };
-    }
-    case "TokenNotFoundError":
-      return {
-        error: loaderReturn.message,
-      };
-    case "LiquidityPoolAggregatorNotFoundError":
-      return {
-        error: loaderReturn.message,
-      };
-    default: {
-      // This should never happen due to TypeScript's exhaustive checking
-      return {
-        error: "Unknown error type",
-      };
-    }
+  // Calculate flash loan fees in USD
+  let flashLoanFeesUSD = 0n;
+  if (token0Instance && event.params.paid0 > 0n) {
+    const token0Data = await updateTokenData(
+      token0Instance,
+      event.params.paid0,
+      event,
+      context,
+    );
+    flashLoanFeesUSD += token0Data.usdValue;
   }
+  if (token1Instance && event.params.paid1 > 0n) {
+    const token1Data = await updateTokenData(
+      token1Instance,
+      event.params.paid1,
+      event,
+      context,
+    );
+    flashLoanFeesUSD += token1Data.usdValue;
+  }
+
+  // Calculate flash loan volume in USD (amount borrowed, not fees)
+  let flashLoanVolumeUSD = 0n;
+  if (token0Instance && event.params.amount0 > 0n) {
+    const token0Data = await updateTokenData(
+      token0Instance,
+      event.params.amount0,
+      event,
+      context,
+    );
+    flashLoanVolumeUSD += token0Data.usdValue;
+  }
+  if (token1Instance && event.params.amount1 > 0n) {
+    const token1Data = await updateTokenData(
+      token1Instance,
+      event.params.amount1,
+      event,
+      context,
+    );
+    flashLoanVolumeUSD += token1Data.usdValue;
+  }
+
+  const liquidityPoolDiff = {
+    totalFlashLoanFees0: event.params.paid0,
+    totalFlashLoanFees1: event.params.paid1,
+    totalFlashLoanFeesUSD: flashLoanFeesUSD,
+    totalFlashLoanVolumeUSD: flashLoanVolumeUSD,
+    numberOfFlashLoans: 1n,
+    lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
+  };
+
+  const userFlashLoanDiff = {
+    numberOfFlashLoans: 1n, // Each flash event represents 1 flash loan
+    totalFlashLoanVolumeUSD: flashLoanVolumeUSD,
+    timestamp: new Date(event.block.timestamp * 1000),
+  };
+
+  return {
+    liquidityPoolDiff,
+    userFlashLoanDiff,
+  };
 }

--- a/src/EventHandlers/CLPool/CLPoolMintLogic.ts
+++ b/src/EventHandlers/CLPool/CLPoolMintLogic.ts
@@ -1,96 +1,53 @@
-import type {
-  CLPool_Mint_event,
-  LiquidityPoolAggregator,
-  Token,
-  handlerContext,
-} from "generated";
+import type { CLPool_Mint_event, Token, handlerContext } from "generated";
 import { updateReserveTokenData } from "../../Helpers";
 
 export interface CLPoolMintResult {
-  liquidityPoolDiff?: {
+  liquidityPoolDiff: {
     reserve0: bigint;
     reserve1: bigint;
     totalLiquidityUSD: bigint;
     lastUpdatedTimestamp: Date;
   };
-  userLiquidityDiff?: {
+  userLiquidityDiff: {
     netLiquidityAddedUSD: bigint;
     currentLiquidityToken0: bigint;
     currentLiquidityToken1: bigint;
     timestamp: Date;
   };
-  error?: string;
 }
-
-export type CLPoolMintLoaderReturn =
-  | {
-      _type: "success";
-      liquidityPoolAggregator: LiquidityPoolAggregator;
-      token0Instance: Token;
-      token1Instance: Token;
-    }
-  | {
-      _type: "TokenNotFoundError";
-      message: string;
-    }
-  | {
-      _type: "LiquidityPoolAggregatorNotFoundError";
-      message: string;
-    };
 
 export async function processCLPoolMint(
   event: CLPool_Mint_event,
-  loaderReturn: CLPoolMintLoaderReturn,
+  token0Instance: Token,
+  token1Instance: Token,
   context: handlerContext,
 ): Promise<CLPoolMintResult> {
-  // Handle different loader return types
-  switch (loaderReturn._type) {
-    case "success": {
-      const { liquidityPoolAggregator, token0Instance, token1Instance } =
-        loaderReturn;
+  // Update reserve data using the same approach as Pool events
+  const reserveData = await updateReserveTokenData(
+    token0Instance,
+    token1Instance,
+    event.params.amount0,
+    event.params.amount1,
+    event,
+    context,
+  );
 
-      // Update reserve data using the same approach as Pool events
-      const reserveData = await updateReserveTokenData(
-        token0Instance,
-        token1Instance,
-        event.params.amount0,
-        event.params.amount1,
-        event,
-        context,
-      );
+  const liquidityPoolDiff = {
+    reserve0: event.params.amount0,
+    reserve1: event.params.amount1,
+    totalLiquidityUSD: reserveData.totalLiquidityUSD,
+    lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
+  };
 
-      const liquidityPoolDiff = {
-        reserve0: event.params.amount0,
-        reserve1: event.params.amount1,
-        totalLiquidityUSD: reserveData.totalLiquidityUSD,
-        lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
-      };
+  const userLiquidityDiff = {
+    netLiquidityAddedUSD: reserveData.totalLiquidityUSD, // For mint, we're adding liquidity
+    currentLiquidityToken0: event.params.amount0, // Amount of token0 added
+    currentLiquidityToken1: event.params.amount1, // Amount of token1 added
+    timestamp: new Date(event.block.timestamp * 1000),
+  };
 
-      const userLiquidityDiff = {
-        netLiquidityAddedUSD: reserveData.totalLiquidityUSD, // For mint, we're adding liquidity
-        currentLiquidityToken0: event.params.amount0, // Amount of token0 added
-        currentLiquidityToken1: event.params.amount1, // Amount of token1 added
-        timestamp: new Date(event.block.timestamp * 1000),
-      };
-
-      return {
-        liquidityPoolDiff,
-        userLiquidityDiff,
-      };
-    }
-    case "TokenNotFoundError":
-      return {
-        error: loaderReturn.message,
-      };
-    case "LiquidityPoolAggregatorNotFoundError":
-      return {
-        error: loaderReturn.message,
-      };
-    default: {
-      // This should never happen due to TypeScript's exhaustive checking
-      return {
-        error: "Unknown error type",
-      };
-    }
-  }
+  return {
+    liquidityPoolDiff,
+    userLiquidityDiff,
+  };
 }

--- a/test/EventHandlers/CLFactory/CLFactoryPoolCreatedLogic.test.ts
+++ b/test/EventHandlers/CLFactory/CLFactoryPoolCreatedLogic.test.ts
@@ -64,18 +64,13 @@ describe("CLFactoryPoolCreatedLogic", () => {
     },
   } as unknown as handlerContext;
 
-  // Shared mock loader return for success case
-  const mockSuccessLoaderReturn = {
-    poolToken0: mockToken0Data,
-    poolToken1: mockToken1Data,
-  };
-
   describe("processCLFactoryPoolCreated", () => {
     it("should create entity and liquidity pool aggregator for successful pool creation", async () => {
       // Process the pool created event
       const result = await processCLFactoryPoolCreated(
         mockEvent,
-        mockSuccessLoaderReturn,
+        mockToken0Data,
+        mockToken1Data,
         mockContext,
       );
 
@@ -97,18 +92,13 @@ describe("CLFactoryPoolCreatedLogic", () => {
         token1IsWhitelisted: true,
         gaugeIsAlive: false,
       });
-      expect(result.error).to.be.undefined;
     });
 
     it("should handle missing token0 gracefully", async () => {
-      const mockLoaderReturn = {
-        poolToken0: undefined as Token | undefined,
-        poolToken1: mockToken1Data,
-      };
-
       const result = await processCLFactoryPoolCreated(
         mockEvent,
-        mockLoaderReturn,
+        undefined,
+        mockToken1Data,
         mockContext,
       );
 
@@ -129,18 +119,13 @@ describe("CLFactoryPoolCreatedLogic", () => {
         token1IsWhitelisted: true,
         gaugeIsAlive: false,
       });
-      expect(result.error).to.be.undefined;
     });
 
     it("should handle missing token1 gracefully", async () => {
-      const mockLoaderReturn = {
-        poolToken0: mockToken0Data,
-        poolToken1: undefined as Token | undefined,
-      };
-
       const result = await processCLFactoryPoolCreated(
         mockEvent,
-        mockLoaderReturn,
+        mockToken0Data,
+        undefined,
         mockContext,
       );
 
@@ -161,18 +146,13 @@ describe("CLFactoryPoolCreatedLogic", () => {
         token1IsWhitelisted: false,
         gaugeIsAlive: false,
       });
-      expect(result.error).to.be.undefined;
     });
 
     it("should handle both tokens missing gracefully", async () => {
-      const mockLoaderReturn = {
-        poolToken0: undefined as Token | undefined,
-        poolToken1: undefined as Token | undefined,
-      };
-
       const result = await processCLFactoryPoolCreated(
         mockEvent,
-        mockLoaderReturn,
+        undefined,
+        undefined,
         mockContext,
       );
 
@@ -193,7 +173,6 @@ describe("CLFactoryPoolCreatedLogic", () => {
         token1IsWhitelisted: false,
         gaugeIsAlive: false,
       });
-      expect(result.error).to.be.undefined;
     });
 
     it("should handle different tick spacing values", async () => {
@@ -207,7 +186,8 @@ describe("CLFactoryPoolCreatedLogic", () => {
 
       const result = await processCLFactoryPoolCreated(
         mockEventWithDifferentTickSpacing,
-        mockSuccessLoaderReturn,
+        mockToken0Data,
+        mockToken1Data,
         mockContext,
       );
 
@@ -227,14 +207,10 @@ describe("CLFactoryPoolCreatedLogic", () => {
         isWhitelisted: false,
       };
 
-      const mockLoaderReturn = {
-        poolToken0: mockToken0NonWhitelisted,
-        poolToken1: mockToken1NonWhitelisted,
-      };
-
       const result = await processCLFactoryPoolCreated(
         mockEvent,
-        mockLoaderReturn,
+        mockToken0NonWhitelisted,
+        mockToken1NonWhitelisted,
         mockContext,
       );
 
@@ -255,7 +231,6 @@ describe("CLFactoryPoolCreatedLogic", () => {
         token1IsWhitelisted: false,
         gaugeIsAlive: false,
       });
-      expect(result.error).to.be.undefined;
     });
 
     it("should handle mixed whitelist status correctly", async () => {
@@ -269,14 +244,10 @@ describe("CLFactoryPoolCreatedLogic", () => {
         isWhitelisted: false,
       };
 
-      const mockLoaderReturn = {
-        poolToken0: mockToken0Whitelisted,
-        poolToken1: mockToken1NonWhitelisted,
-      };
-
       const result = await processCLFactoryPoolCreated(
         mockEvent,
-        mockLoaderReturn,
+        mockToken0Whitelisted,
+        mockToken1NonWhitelisted,
         mockContext,
       );
 
@@ -297,7 +268,6 @@ describe("CLFactoryPoolCreatedLogic", () => {
         token1IsWhitelisted: false,
         gaugeIsAlive: false,
       });
-      expect(result.error).to.be.undefined;
     });
 
     it("should handle different chain IDs correctly", async () => {
@@ -308,7 +278,8 @@ describe("CLFactoryPoolCreatedLogic", () => {
 
       const result = await processCLFactoryPoolCreated(
         mockEventWithDifferentChainId,
-        mockSuccessLoaderReturn,
+        mockToken0Data,
+        mockToken1Data,
         mockContext,
       );
 
@@ -334,14 +305,10 @@ describe("CLFactoryPoolCreatedLogic", () => {
         name: "USD Coin",
       };
 
-      const mockLoaderReturn = {
-        poolToken0: mockToken0WithSymbol,
-        poolToken1: mockToken1WithSymbol,
-      };
-
       const result = await processCLFactoryPoolCreated(
         mockEvent,
-        mockLoaderReturn,
+        mockToken0WithSymbol,
+        mockToken1WithSymbol,
         mockContext,
       );
 
@@ -359,26 +326,28 @@ describe("CLFactoryPoolCreatedLogic", () => {
           throw new Error("Token creation failed");
         });
 
-      // Use a loader return with undefined tokens to trigger createTokenEntity
-      const loaderReturnWithMissingTokens = {
-        poolToken0: undefined,
-        poolToken1: undefined,
-      };
-
+      // Use undefined tokens to trigger createTokenEntity
+      // The function catches errors and continues, so it should complete successfully
       const result = await processCLFactoryPoolCreated(
         mockEvent,
-        loaderReturnWithMissingTokens,
+        undefined,
+        undefined,
         mockContext,
       );
 
-      // The function should complete successfully (errors are logged but don't propagate)
-      expect(result.error).to.be.undefined;
+      // The function should complete successfully (errors are logged but don't stop processing)
+      // When token creation fails, symbols will be undefined
+      expect(result.liquidityPoolAggregator).to.exist;
+      expect(result.liquidityPoolAggregator.name).to.equal(
+        "CL-60 AMM - undefined/undefined",
+      );
     });
 
     it("should set all initial values correctly for new pool", async () => {
       const result = await processCLFactoryPoolCreated(
         mockEvent,
-        mockSuccessLoaderReturn,
+        mockToken0Data,
+        mockToken1Data,
         mockContext,
       );
 

--- a/test/EventHandlers/CLPool/CLPoolBurnLogic.test.ts
+++ b/test/EventHandlers/CLPool/CLPoolBurnLogic.test.ts
@@ -84,114 +84,60 @@ describe("CLPoolBurnLogic", () => {
 
   describe("processCLPoolBurn", () => {
     it("should process burn event successfully with valid data", async () => {
-      const loaderReturn = {
-        _type: "success" as const,
-        liquidityPoolAggregator: mockLiquidityPoolAggregator,
-        token0Instance: mockToken0,
-        token1Instance: mockToken1,
-      };
-
       const result = await processCLPoolBurn(
         mockEvent,
-        loaderReturn,
+        mockToken0,
+        mockToken1,
         mockContext,
       );
 
-      expect(result.error).to.be.undefined;
-      expect(result.liquidityPoolDiff).to.not.be.undefined;
-      expect(result.userLiquidityDiff).to.not.be.undefined;
-
       // Check liquidity pool diff with exact values
-      expect(result.liquidityPoolDiff?.reserve0).to.equal(500000n); // New reserve0 value
-      expect(result.liquidityPoolDiff?.reserve1).to.equal(300000n); // New reserve1 value
+      expect(result.liquidityPoolDiff.reserve0).to.equal(500000n); // New reserve0 value
+      expect(result.liquidityPoolDiff.reserve1).to.equal(300000n); // New reserve1 value
 
       // Calculate exact totalLiquidityUSD: (500000 * 1 USD) + (300000 * 2 USD) = 500000 + 600000 = 1100000 USD
-      expect(result.liquidityPoolDiff?.totalLiquidityUSD).to.equal(1100000n); // 1.1M USD in 18 decimals
+      expect(result.liquidityPoolDiff.totalLiquidityUSD).to.equal(1100000n); // 1.1M USD in 18 decimals
 
       // Exact timestamp: 1000000 * 1000 = 1000000000ms
-      expect(result.liquidityPoolDiff?.lastUpdatedTimestamp).to.deep.equal(
+      expect(result.liquidityPoolDiff.lastUpdatedTimestamp).to.deep.equal(
         new Date(1000000000),
       );
 
       // Check user liquidity diff with exact values
       // netLiquidityAddedUSD should be negative for burn (removal): -1100000n
-      expect(result.userLiquidityDiff?.netLiquidityAddedUSD).to.equal(
-        -1100000n,
-      );
-      expect(result.userLiquidityDiff?.currentLiquidityToken0).to.equal(
+      expect(result.userLiquidityDiff.netLiquidityAddedUSD).to.equal(-1100000n);
+      expect(result.userLiquidityDiff.currentLiquidityToken0).to.equal(
         -500000n,
       ); // Negative amount of token0 removed
-      expect(result.userLiquidityDiff?.currentLiquidityToken1).to.equal(
+      expect(result.userLiquidityDiff.currentLiquidityToken1).to.equal(
         -300000n,
       ); // Negative amount of token1 removed
-      expect(result.userLiquidityDiff?.timestamp).to.deep.equal(
+      expect(result.userLiquidityDiff.timestamp).to.deep.equal(
         new Date(1000000000),
       );
     });
 
-    it("should handle TokenNotFoundError", async () => {
-      const loaderReturn = {
-        _type: "TokenNotFoundError" as const,
-        message: "Token not found",
-      };
-
-      const result = await processCLPoolBurn(
-        mockEvent,
-        loaderReturn,
-        mockContext,
-      );
-
-      expect(result.error).to.equal("Token not found");
-      expect(result.liquidityPoolDiff).to.be.undefined;
-      expect(result.userLiquidityDiff).to.be.undefined;
-    });
-
-    it("should handle LiquidityPoolAggregatorNotFoundError", async () => {
-      const loaderReturn = {
-        _type: "LiquidityPoolAggregatorNotFoundError" as const,
-        message: "Pool not found",
-      };
-
-      const result = await processCLPoolBurn(
-        mockEvent,
-        loaderReturn,
-        mockContext,
-      );
-
-      expect(result.error).to.equal("Pool not found");
-      expect(result.liquidityPoolDiff).to.be.undefined;
-      expect(result.userLiquidityDiff).to.be.undefined;
-    });
-
     it("should calculate correct liquidity values for burn event", async () => {
-      const loaderReturn = {
-        _type: "success" as const,
-        liquidityPoolAggregator: mockLiquidityPoolAggregator,
-        token0Instance: mockToken0,
-        token1Instance: mockToken1,
-      };
-
       const result = await processCLPoolBurn(
         mockEvent,
-        loaderReturn,
+        mockToken0,
+        mockToken1,
         mockContext,
       );
 
       // For burn events, we expect negative liquidity change with exact values
-      expect(result.userLiquidityDiff?.netLiquidityAddedUSD).to.equal(
-        -1100000n,
-      );
-      expect(result.userLiquidityDiff?.currentLiquidityToken0).to.equal(
+      expect(result.userLiquidityDiff.netLiquidityAddedUSD).to.equal(-1100000n);
+      expect(result.userLiquidityDiff.currentLiquidityToken0).to.equal(
         -500000n,
       );
-      expect(result.userLiquidityDiff?.currentLiquidityToken1).to.equal(
+      expect(result.userLiquidityDiff.currentLiquidityToken1).to.equal(
         -300000n,
       );
 
       // The liquidity pool diff should reflect the new reserve values
-      expect(result.liquidityPoolDiff?.reserve0).to.equal(500000n); // New reserve0 value
-      expect(result.liquidityPoolDiff?.reserve1).to.equal(300000n); // New reserve1 value
-      expect(result.liquidityPoolDiff?.totalLiquidityUSD).to.equal(1100000n);
+      expect(result.liquidityPoolDiff.reserve0).to.equal(500000n); // New reserve0 value
+      expect(result.liquidityPoolDiff.reserve1).to.equal(300000n); // New reserve1 value
+      expect(result.liquidityPoolDiff.totalLiquidityUSD).to.equal(1100000n);
     });
 
     it("should handle different token decimals correctly", async () => {
@@ -200,20 +146,13 @@ describe("CLPoolBurnLogic", () => {
         decimals: 6n, // USDC-like token
       };
 
-      const loaderReturn = {
-        _type: "success" as const,
-        liquidityPoolAggregator: mockLiquidityPoolAggregator,
-        token0Instance: tokenWithDifferentDecimals,
-        token1Instance: mockToken1,
-      };
-
       const result = await processCLPoolBurn(
         mockEvent,
-        loaderReturn,
+        tokenWithDifferentDecimals,
+        mockToken1,
         mockContext,
       );
 
-      expect(result.error).to.be.undefined;
       expect(result.liquidityPoolDiff).to.not.be.undefined;
       expect(result.userLiquidityDiff).to.not.be.undefined;
     });

--- a/test/EventHandlers/CLPool/CLPoolCollectFeesLogic.test.ts
+++ b/test/EventHandlers/CLPool/CLPoolCollectFeesLogic.test.ts
@@ -77,79 +77,48 @@ describe("CLPoolCollectFeesLogic", () => {
 
   describe("processCLPoolCollectFees", () => {
     it("should process collect fees event successfully with valid data", () => {
-      const loaderReturn = {
-        _type: "success" as const,
-        liquidityPoolAggregator: mockLiquidityPoolAggregator,
-        token0Instance: mockToken0,
-        token1Instance: mockToken1,
-      };
-
-      const result = processCLPoolCollectFees(mockEvent, loaderReturn);
-
-      expect(result.error).to.be.undefined;
-      expect(result.liquidityPoolDiff).to.not.be.undefined;
+      const result = processCLPoolCollectFees(
+        mockEvent,
+        mockLiquidityPoolAggregator,
+        mockToken0,
+        mockToken1,
+      );
 
       // Check liquidity pool diff with exact values
-      expect(result.liquidityPoolDiff?.totalFees0).to.equal(
+      expect(result.liquidityPoolDiff.totalFees0).to.equal(
         1000000000000000000n,
       );
-      expect(result.liquidityPoolDiff?.totalFees1).to.equal(
+      expect(result.liquidityPoolDiff.totalFees1).to.equal(
         2000000000000000000n,
       );
 
       // Exact USD calculation: 1 USD + 4 USD = 5 USD
-      expect(result.liquidityPoolDiff?.totalFeesUSD).to.equal(
+      expect(result.liquidityPoolDiff.totalFeesUSD).to.equal(
         5000000000000000000n,
       );
 
       // Exact timestamp: 1000000 * 1000 = 1000000000ms
-      expect(result.liquidityPoolDiff?.lastUpdatedTimestamp).to.deep.equal(
+      expect(result.liquidityPoolDiff.lastUpdatedTimestamp).to.deep.equal(
         new Date(1000000000),
       );
     });
 
-    it("should handle TokenNotFoundError", () => {
-      const loaderReturn = {
-        _type: "TokenNotFoundError" as const,
-        message: "Token not found",
-      };
-
-      const result = processCLPoolCollectFees(mockEvent, loaderReturn);
-
-      expect(result.error).to.equal("Token not found");
-      expect(result.liquidityPoolDiff).to.be.undefined;
-    });
-
-    it("should handle LiquidityPoolAggregatorNotFoundError", () => {
-      const loaderReturn = {
-        _type: "LiquidityPoolAggregatorNotFoundError" as const,
-        message: "Pool not found",
-      };
-
-      const result = processCLPoolCollectFees(mockEvent, loaderReturn);
-
-      expect(result.error).to.equal("Pool not found");
-      expect(result.liquidityPoolDiff).to.be.undefined;
-    });
-
     it("should calculate correct fee values for collect fees event", () => {
-      const loaderReturn = {
-        _type: "success" as const,
-        liquidityPoolAggregator: mockLiquidityPoolAggregator,
-        token0Instance: mockToken0,
-        token1Instance: mockToken1,
-      };
-
-      const result = processCLPoolCollectFees(mockEvent, loaderReturn);
+      const result = processCLPoolCollectFees(
+        mockEvent,
+        mockLiquidityPoolAggregator,
+        mockToken0,
+        mockToken1,
+      );
 
       // The liquidity pool diff should reflect the fees being collected with exact values
-      expect(result.liquidityPoolDiff?.totalFees0).to.equal(
+      expect(result.liquidityPoolDiff.totalFees0).to.equal(
         1000000000000000000n,
       );
-      expect(result.liquidityPoolDiff?.totalFees1).to.equal(
+      expect(result.liquidityPoolDiff.totalFees1).to.equal(
         2000000000000000000n,
       );
-      expect(result.liquidityPoolDiff?.totalFeesUSD).to.equal(
+      expect(result.liquidityPoolDiff.totalFeesUSD).to.equal(
         5000000000000000000n,
       );
     });
@@ -160,16 +129,13 @@ describe("CLPoolCollectFeesLogic", () => {
         decimals: 6n, // USDC-like token
       };
 
-      const loaderReturn = {
-        _type: "success" as const,
-        liquidityPoolAggregator: mockLiquidityPoolAggregator,
-        token0Instance: tokenWithDifferentDecimals,
-        token1Instance: mockToken1,
-      };
+      const result = processCLPoolCollectFees(
+        mockEvent,
+        mockLiquidityPoolAggregator,
+        tokenWithDifferentDecimals,
+        mockToken1,
+      );
 
-      const result = processCLPoolCollectFees(mockEvent, loaderReturn);
-
-      expect(result.error).to.be.undefined;
       expect(result.liquidityPoolDiff).to.not.be.undefined;
     });
 
@@ -183,22 +149,16 @@ describe("CLPoolCollectFeesLogic", () => {
         },
       };
 
-      const loaderReturn = {
-        _type: "success" as const,
-        liquidityPoolAggregator: mockLiquidityPoolAggregator,
-        token0Instance: mockToken0,
-        token1Instance: mockToken1,
-      };
-
       const result = processCLPoolCollectFees(
         eventWithZeroAmounts,
-        loaderReturn,
+        mockLiquidityPoolAggregator,
+        mockToken0,
+        mockToken1,
       );
 
-      expect(result.error).to.be.undefined;
-      expect(result.liquidityPoolDiff?.totalFees0).to.equal(0n);
-      expect(result.liquidityPoolDiff?.totalFees1).to.equal(0n);
-      expect(result.liquidityPoolDiff?.totalFeesUSD).to.equal(0n);
+      expect(result.liquidityPoolDiff.totalFees0).to.equal(0n);
+      expect(result.liquidityPoolDiff.totalFees1).to.equal(0n);
+      expect(result.liquidityPoolDiff.totalFeesUSD).to.equal(0n);
     });
   });
 });

--- a/test/EventHandlers/CLPool/CLPoolCollectLogic.test.ts
+++ b/test/EventHandlers/CLPool/CLPoolCollectLogic.test.ts
@@ -85,115 +85,65 @@ describe("CLPoolCollectLogic", () => {
 
   describe("processCLPoolCollect", () => {
     it("should process collect event successfully with valid data", async () => {
-      const loaderReturn = {
-        _type: "success" as const,
-        liquidityPoolAggregator: mockLiquidityPoolAggregator,
-        token0Instance: mockToken0,
-        token1Instance: mockToken1,
-      };
-
       const result = await processCLPoolCollect(
         mockEvent,
-        loaderReturn,
+        mockToken0,
+        mockToken1,
         mockContext,
       );
 
-      expect(result.error).to.be.undefined;
-      expect(result.liquidityPoolDiff).to.not.be.undefined;
-      expect(result.userLiquidityDiff).to.not.be.undefined;
-
       // Check liquidity pool diff with exact values
-      expect(result.liquidityPoolDiff?.reserve0).to.equal(1000000000000000000n); // amount0
-      expect(result.liquidityPoolDiff?.reserve1).to.equal(2000000000000000000n); // amount1
+      expect(result.liquidityPoolDiff.reserve0).to.equal(1000000000000000000n); // amount0
+      expect(result.liquidityPoolDiff.reserve1).to.equal(2000000000000000000n); // amount1
 
       // Calculate exact totalLiquidityUSD: (1 * 1 USD) + (2 * 2 USD) = 1 + 4 = 5 USD
-      expect(result.liquidityPoolDiff?.totalLiquidityUSD).to.equal(
+      expect(result.liquidityPoolDiff.totalLiquidityUSD).to.equal(
         5000000000000000000n,
       ); // 5 USD in 18 decimals
 
       // Exact timestamp: 1000000 * 1000 = 1000000000ms
-      expect(result.liquidityPoolDiff?.lastUpdatedTimestamp).to.deep.equal(
+      expect(result.liquidityPoolDiff.lastUpdatedTimestamp).to.deep.equal(
         new Date(1000000000),
       );
 
       // Check user fee contribution diff with exact values
-      expect(result.userLiquidityDiff?.totalFeesContributed0).to.equal(
+      expect(result.userLiquidityDiff.totalFeesContributed0).to.equal(
         1000000000000000000n,
       ); // amount0
-      expect(result.userLiquidityDiff?.totalFeesContributed1).to.equal(
+      expect(result.userLiquidityDiff.totalFeesContributed1).to.equal(
         2000000000000000000n,
       ); // amount1
-      expect(result.userLiquidityDiff?.totalFeesContributedUSD).to.equal(
+      expect(result.userLiquidityDiff.totalFeesContributedUSD).to.equal(
         5000000000000000000n,
       ); // 5 USD in 18 decimals
-      expect(result.userLiquidityDiff?.timestamp).to.deep.equal(
+      expect(result.userLiquidityDiff.timestamp).to.deep.equal(
         new Date(1000000000),
       );
     });
 
-    it("should handle TokenNotFoundError", async () => {
-      const loaderReturn = {
-        _type: "TokenNotFoundError" as const,
-        message: "Token not found",
-      };
-
-      const result = await processCLPoolCollect(
-        mockEvent,
-        loaderReturn,
-        mockContext,
-      );
-
-      expect(result.error).to.equal("Token not found");
-      expect(result.liquidityPoolDiff).to.be.undefined;
-      expect(result.userLiquidityDiff).to.be.undefined;
-    });
-
-    it("should handle LiquidityPoolAggregatorNotFoundError", async () => {
-      const loaderReturn = {
-        _type: "LiquidityPoolAggregatorNotFoundError" as const,
-        message: "Pool not found",
-      };
-
-      const result = await processCLPoolCollect(
-        mockEvent,
-        loaderReturn,
-        mockContext,
-      );
-
-      expect(result.error).to.equal("Pool not found");
-      expect(result.liquidityPoolDiff).to.be.undefined;
-      expect(result.userLiquidityDiff).to.be.undefined;
-    });
-
     it("should calculate correct liquidity values for collect event", async () => {
-      const loaderReturn = {
-        _type: "success" as const,
-        liquidityPoolAggregator: mockLiquidityPoolAggregator,
-        token0Instance: mockToken0,
-        token1Instance: mockToken1,
-      };
-
       const result = await processCLPoolCollect(
         mockEvent,
-        loaderReturn,
+        mockToken0,
+        mockToken1,
         mockContext,
       );
 
       // The liquidity pool diff should reflect the amounts being collected with exact values
-      expect(result.liquidityPoolDiff?.reserve0).to.equal(1000000000000000000n); // amount0
-      expect(result.liquidityPoolDiff?.reserve1).to.equal(2000000000000000000n); // amount1
-      expect(result.liquidityPoolDiff?.totalLiquidityUSD).to.equal(
+      expect(result.liquidityPoolDiff.reserve0).to.equal(1000000000000000000n); // amount0
+      expect(result.liquidityPoolDiff.reserve1).to.equal(2000000000000000000n); // amount1
+      expect(result.liquidityPoolDiff.totalLiquidityUSD).to.equal(
         5000000000000000000n,
       ); // 5 USD in 18 decimals
 
       // User fee contribution should be calculated based on the collected amounts with exact values
-      expect(result.userLiquidityDiff?.totalFeesContributed0).to.equal(
+      expect(result.userLiquidityDiff.totalFeesContributed0).to.equal(
         1000000000000000000n,
       ); // amount0
-      expect(result.userLiquidityDiff?.totalFeesContributed1).to.equal(
+      expect(result.userLiquidityDiff.totalFeesContributed1).to.equal(
         2000000000000000000n,
       ); // amount1
-      expect(result.userLiquidityDiff?.totalFeesContributedUSD).to.equal(
+      expect(result.userLiquidityDiff.totalFeesContributedUSD).to.equal(
         5000000000000000000n,
       ); // 5 USD in 18 decimals
     });
@@ -204,20 +154,13 @@ describe("CLPoolCollectLogic", () => {
         decimals: 6n, // USDC-like token
       };
 
-      const loaderReturn = {
-        _type: "success" as const,
-        liquidityPoolAggregator: mockLiquidityPoolAggregator,
-        token0Instance: tokenWithDifferentDecimals,
-        token1Instance: mockToken1,
-      };
-
       const result = await processCLPoolCollect(
         mockEvent,
-        loaderReturn,
+        tokenWithDifferentDecimals,
+        mockToken1,
         mockContext,
       );
 
-      expect(result.error).to.be.undefined;
       expect(result.liquidityPoolDiff).to.not.be.undefined;
       expect(result.userLiquidityDiff).to.not.be.undefined;
     });
@@ -232,25 +175,18 @@ describe("CLPoolCollectLogic", () => {
         },
       };
 
-      const loaderReturn = {
-        _type: "success" as const,
-        liquidityPoolAggregator: mockLiquidityPoolAggregator,
-        token0Instance: mockToken0,
-        token1Instance: mockToken1,
-      };
-
       const result = await processCLPoolCollect(
         eventWithZeroAmounts,
-        loaderReturn,
+        mockToken0,
+        mockToken1,
         mockContext,
       );
 
-      expect(result.error).to.be.undefined;
-      expect(result.liquidityPoolDiff?.reserve0).to.equal(0n);
-      expect(result.liquidityPoolDiff?.reserve1).to.equal(0n);
-      expect(result.userLiquidityDiff?.totalFeesContributed0).to.equal(0n);
-      expect(result.userLiquidityDiff?.totalFeesContributed1).to.equal(0n);
-      expect(result.userLiquidityDiff?.totalFeesContributedUSD).to.equal(0n);
+      expect(result.liquidityPoolDiff.reserve0).to.equal(0n);
+      expect(result.liquidityPoolDiff.reserve1).to.equal(0n);
+      expect(result.userLiquidityDiff.totalFeesContributed0).to.equal(0n);
+      expect(result.userLiquidityDiff.totalFeesContributed1).to.equal(0n);
+      expect(result.userLiquidityDiff.totalFeesContributedUSD).to.equal(0n);
     });
   });
 });

--- a/test/EventHandlers/CLPool/CLPoolFlashLogic.test.ts
+++ b/test/EventHandlers/CLPool/CLPoolFlashLogic.test.ts
@@ -85,128 +85,72 @@ describe("CLPoolFlashLogic", () => {
 
   describe("processCLPoolFlash", () => {
     it("should process flash event successfully with valid data", async () => {
-      const loaderReturn = {
-        _type: "success" as const,
-        liquidityPoolAggregator: mockLiquidityPoolAggregator,
-        token0Instance: mockToken0,
-        token1Instance: mockToken1,
-      };
-
       const result = await processCLPoolFlash(
         mockEvent,
-        loaderReturn,
+        mockToken0,
+        mockToken1,
         mockContext,
       );
 
-      expect(result.error).to.be.undefined;
-      expect(result.liquidityPoolDiff).to.not.be.undefined;
-      expect(result.userFlashLoanDiff).to.not.be.undefined;
-
       // Check liquidity pool diff with exact values
-      expect(result.liquidityPoolDiff?.totalFlashLoanFees0).to.equal(1000n); // paid0
-      expect(result.liquidityPoolDiff?.totalFlashLoanFees1).to.equal(500n); // paid1
-      expect(result.liquidityPoolDiff?.numberOfFlashLoans).to.equal(1n);
+      expect(result.liquidityPoolDiff.totalFlashLoanFees0).to.equal(1000n); // paid0
+      expect(result.liquidityPoolDiff.totalFlashLoanFees1).to.equal(500n); // paid1
+      expect(result.liquidityPoolDiff.numberOfFlashLoans).to.equal(1n);
 
       // Calculate exact flash loan fees USD: (1000 * 1 USD) + (500 * 2 USD) = 1000 + 1000 = 2000 USD
-      expect(result.liquidityPoolDiff?.totalFlashLoanFeesUSD).to.equal(2000n);
+      expect(result.liquidityPoolDiff.totalFlashLoanFeesUSD).to.equal(2000n);
 
       // Calculate exact flash loan volume USD: (1000000 * 1 USD) + (500000 * 2 USD) = 1000000 + 1000000 = 2000000 USD
-      expect(result.liquidityPoolDiff?.totalFlashLoanVolumeUSD).to.equal(
+      expect(result.liquidityPoolDiff.totalFlashLoanVolumeUSD).to.equal(
         2000000n,
       );
 
       // Exact timestamp: 1000000 * 1000 = 1000000000ms
-      expect(result.liquidityPoolDiff?.lastUpdatedTimestamp).to.deep.equal(
+      expect(result.liquidityPoolDiff.lastUpdatedTimestamp).to.deep.equal(
         new Date(1000000000),
       );
 
       // Check user flash loan diff with exact values
-      expect(result.userFlashLoanDiff?.numberOfFlashLoans).to.equal(1n);
-      expect(result.userFlashLoanDiff?.totalFlashLoanVolumeUSD).to.equal(
+      expect(result.userFlashLoanDiff.numberOfFlashLoans).to.equal(1n);
+      expect(result.userFlashLoanDiff.totalFlashLoanVolumeUSD).to.equal(
         2000000n,
       );
-      expect(result.userFlashLoanDiff?.timestamp).to.deep.equal(
+      expect(result.userFlashLoanDiff.timestamp).to.deep.equal(
         new Date(1000000000),
       );
     });
 
-    it("should handle TokenNotFoundError", async () => {
-      const loaderReturn = {
-        _type: "TokenNotFoundError" as const,
-        message: "Token not found",
-      };
-
-      const result = await processCLPoolFlash(
-        mockEvent,
-        loaderReturn,
-        mockContext,
-      );
-
-      expect(result.error).to.equal("Token not found");
-      expect(result.liquidityPoolDiff).to.be.undefined;
-      expect(result.userFlashLoanDiff).to.be.undefined;
-    });
-
-    it("should handle LiquidityPoolAggregatorNotFoundError", async () => {
-      const loaderReturn = {
-        _type: "LiquidityPoolAggregatorNotFoundError" as const,
-        message: "Pool not found",
-      };
-
-      const result = await processCLPoolFlash(
-        mockEvent,
-        loaderReturn,
-        mockContext,
-      );
-
-      expect(result.error).to.equal("Pool not found");
-      expect(result.liquidityPoolDiff).to.be.undefined;
-      expect(result.userFlashLoanDiff).to.be.undefined;
-    });
-
     it("should calculate flash loan fees correctly", async () => {
-      const loaderReturn = {
-        _type: "success" as const,
-        liquidityPoolAggregator: mockLiquidityPoolAggregator,
-        token0Instance: mockToken0,
-        token1Instance: mockToken1,
-      };
-
       const result = await processCLPoolFlash(
         mockEvent,
-        loaderReturn,
+        mockToken0,
+        mockToken1,
         mockContext,
       );
 
       // Fees should be calculated based on paid amounts and token prices
-      expect(result.liquidityPoolDiff?.totalFlashLoanFees0).to.equal(
+      expect(result.liquidityPoolDiff.totalFlashLoanFees0).to.equal(
         mockEvent.params.paid0,
       );
-      expect(result.liquidityPoolDiff?.totalFlashLoanFees1).to.equal(
+      expect(result.liquidityPoolDiff.totalFlashLoanFees1).to.equal(
         mockEvent.params.paid1,
       );
-      expect(result.liquidityPoolDiff?.totalFlashLoanFeesUSD).to.equal(2000n); // 2000 USD in 18 decimals
+      expect(result.liquidityPoolDiff.totalFlashLoanFeesUSD).to.equal(2000n); // 2000 USD in 18 decimals
     });
 
     it("should calculate flash loan volume correctly", async () => {
-      const loaderReturn = {
-        _type: "success" as const,
-        liquidityPoolAggregator: mockLiquidityPoolAggregator,
-        token0Instance: mockToken0,
-        token1Instance: mockToken1,
-      };
-
       const result = await processCLPoolFlash(
         mockEvent,
-        loaderReturn,
+        mockToken0,
+        mockToken1,
         mockContext,
       );
 
       // Volume should be calculated based on borrowed amounts (not fees)
-      expect(result.userFlashLoanDiff?.totalFlashLoanVolumeUSD).to.equal(
+      expect(result.userFlashLoanDiff.totalFlashLoanVolumeUSD).to.equal(
         2000000n,
       ); // 2M USD in 18 decimals
-      expect(result.userFlashLoanDiff?.numberOfFlashLoans).to.equal(1n);
+      expect(result.userFlashLoanDiff.numberOfFlashLoans).to.equal(1n);
     });
 
     it("should handle zero amounts correctly", async () => {
@@ -221,24 +165,17 @@ describe("CLPoolFlashLogic", () => {
         },
       };
 
-      const loaderReturn = {
-        _type: "success" as const,
-        liquidityPoolAggregator: mockLiquidityPoolAggregator,
-        token0Instance: mockToken0,
-        token1Instance: mockToken1,
-      };
-
       const result = await processCLPoolFlash(
         eventWithZeroAmounts,
-        loaderReturn,
+        mockToken0,
+        mockToken1,
         mockContext,
       );
 
-      expect(result.error).to.be.undefined;
-      expect(result.liquidityPoolDiff?.totalFlashLoanFees0).to.equal(0n);
-      expect(result.liquidityPoolDiff?.totalFlashLoanFees1).to.equal(0n);
-      expect(result.liquidityPoolDiff?.totalFlashLoanFeesUSD).to.equal(0n);
-      expect(result.userFlashLoanDiff?.totalFlashLoanVolumeUSD).to.equal(0n);
+      expect(result.liquidityPoolDiff.totalFlashLoanFees0).to.equal(0n);
+      expect(result.liquidityPoolDiff.totalFlashLoanFees1).to.equal(0n);
+      expect(result.liquidityPoolDiff.totalFlashLoanFeesUSD).to.equal(0n);
+      expect(result.userFlashLoanDiff.totalFlashLoanVolumeUSD).to.equal(0n);
     });
 
     it("should handle different token decimals correctly", async () => {
@@ -247,54 +184,32 @@ describe("CLPoolFlashLogic", () => {
         decimals: 6n, // USDC-like token
       };
 
-      const loaderReturn = {
-        _type: "success" as const,
-        liquidityPoolAggregator: mockLiquidityPoolAggregator,
-        token0Instance: tokenWithDifferentDecimals,
-        token1Instance: mockToken1,
-      };
-
       const result = await processCLPoolFlash(
         mockEvent,
-        loaderReturn,
+        tokenWithDifferentDecimals,
+        mockToken1,
         mockContext,
       );
 
-      expect(result.error).to.be.undefined;
       expect(result.liquidityPoolDiff).to.not.be.undefined;
       expect(result.userFlashLoanDiff).to.not.be.undefined;
     });
 
     it("should handle existing flash loan data correctly", async () => {
-      const poolWithExistingFlashLoans: LiquidityPoolAggregator = {
-        ...mockLiquidityPoolAggregator,
-        totalFlashLoanFees0: 5000n,
-        totalFlashLoanFees1: 3000n,
-        totalFlashLoanFeesUSD: 8000n,
-        totalFlashLoanVolumeUSD: 100000n,
-        numberOfFlashLoans: 5n,
-      };
-
-      const loaderReturn = {
-        _type: "success" as const,
-        liquidityPoolAggregator: poolWithExistingFlashLoans,
-        token0Instance: mockToken0,
-        token1Instance: mockToken1,
-      };
-
       const result = await processCLPoolFlash(
         mockEvent,
-        loaderReturn,
+        mockToken0,
+        mockToken1,
         mockContext,
       );
 
-      expect(result.liquidityPoolDiff?.totalFlashLoanFees0).to.equal(
+      expect(result.liquidityPoolDiff.totalFlashLoanFees0).to.equal(
         mockEvent.params.paid0,
       );
-      expect(result.liquidityPoolDiff?.totalFlashLoanFees1).to.equal(
+      expect(result.liquidityPoolDiff.totalFlashLoanFees1).to.equal(
         mockEvent.params.paid1,
       );
-      expect(result.liquidityPoolDiff?.numberOfFlashLoans).to.equal(1n); // Just the diff
+      expect(result.liquidityPoolDiff.numberOfFlashLoans).to.equal(1n); // Just the diff
     });
   });
 });

--- a/test/EventHandlers/CLPool/CLPoolMintLogic.test.ts
+++ b/test/EventHandlers/CLPool/CLPoolMintLogic.test.ts
@@ -85,115 +85,65 @@ describe("CLPoolMintLogic", () => {
 
   describe("processCLPoolMint", () => {
     it("should process mint event successfully with valid data", async () => {
-      const loaderReturn = {
-        _type: "success" as const,
-        liquidityPoolAggregator: mockLiquidityPoolAggregator,
-        token0Instance: mockToken0,
-        token1Instance: mockToken1,
-      };
-
       const result = await processCLPoolMint(
         mockEvent,
-        loaderReturn,
+        mockToken0,
+        mockToken1,
         mockContext,
       );
 
-      expect(result.error).to.be.undefined;
-      expect(result.liquidityPoolDiff).to.not.be.undefined;
-      expect(result.userLiquidityDiff).to.not.be.undefined;
-
       // Check liquidity pool diff with exact values
-      expect(result.liquidityPoolDiff?.reserve0).to.equal(500000000000000000n); // amount0 (0.5 token)
-      expect(result.liquidityPoolDiff?.reserve1).to.equal(300000000000000000n); // amount1 (0.3 token)
+      expect(result.liquidityPoolDiff.reserve0).to.equal(500000000000000000n); // amount0 (0.5 token)
+      expect(result.liquidityPoolDiff.reserve1).to.equal(300000000000000000n); // amount1 (0.3 token)
 
       // Calculate exact totalLiquidityUSD: (0.5 * 1 USD) + (0.3 * 2 USD) = 0.5 + 0.6 = 1.1 USD
-      expect(result.liquidityPoolDiff?.totalLiquidityUSD).to.equal(
+      expect(result.liquidityPoolDiff.totalLiquidityUSD).to.equal(
         1100000000000000000n,
       ); // 1.1 USD in 18 decimals
 
       // Exact timestamp: 1000000 * 1000 = 1000000000ms
-      expect(result.liquidityPoolDiff?.lastUpdatedTimestamp).to.deep.equal(
+      expect(result.liquidityPoolDiff.lastUpdatedTimestamp).to.deep.equal(
         new Date(1000000000),
       );
 
       // Check user liquidity diff with exact values
-      expect(result.userLiquidityDiff?.netLiquidityAddedUSD).to.equal(
+      expect(result.userLiquidityDiff.netLiquidityAddedUSD).to.equal(
         1100000000000000000n,
       ); // 1.1 USD in 18 decimals (positive for addition)
-      expect(result.userLiquidityDiff?.currentLiquidityToken0).to.equal(
+      expect(result.userLiquidityDiff.currentLiquidityToken0).to.equal(
         500000000000000000n,
       ); // amount0
-      expect(result.userLiquidityDiff?.currentLiquidityToken1).to.equal(
+      expect(result.userLiquidityDiff.currentLiquidityToken1).to.equal(
         300000000000000000n,
       ); // amount1
-      expect(result.userLiquidityDiff?.timestamp).to.deep.equal(
+      expect(result.userLiquidityDiff.timestamp).to.deep.equal(
         new Date(1000000000),
       );
     });
 
-    it("should handle TokenNotFoundError", async () => {
-      const loaderReturn = {
-        _type: "TokenNotFoundError" as const,
-        message: "Token not found",
-      };
-
-      const result = await processCLPoolMint(
-        mockEvent,
-        loaderReturn,
-        mockContext,
-      );
-
-      expect(result.error).to.equal("Token not found");
-      expect(result.liquidityPoolDiff).to.be.undefined;
-      expect(result.userLiquidityDiff).to.be.undefined;
-    });
-
-    it("should handle LiquidityPoolAggregatorNotFoundError", async () => {
-      const loaderReturn = {
-        _type: "LiquidityPoolAggregatorNotFoundError" as const,
-        message: "Pool not found",
-      };
-
-      const result = await processCLPoolMint(
-        mockEvent,
-        loaderReturn,
-        mockContext,
-      );
-
-      expect(result.error).to.equal("Pool not found");
-      expect(result.liquidityPoolDiff).to.be.undefined;
-      expect(result.userLiquidityDiff).to.be.undefined;
-    });
-
     it("should calculate correct liquidity values for mint event", async () => {
-      const loaderReturn = {
-        _type: "success" as const,
-        liquidityPoolAggregator: mockLiquidityPoolAggregator,
-        token0Instance: mockToken0,
-        token1Instance: mockToken1,
-      };
-
       const result = await processCLPoolMint(
         mockEvent,
-        loaderReturn,
+        mockToken0,
+        mockToken1,
         mockContext,
       );
 
       // For mint events, we expect positive liquidity change with exact values
-      expect(result.userLiquidityDiff?.netLiquidityAddedUSD).to.equal(
+      expect(result.userLiquidityDiff.netLiquidityAddedUSD).to.equal(
         1100000000000000000n,
       ); // 1.1 USD in 18 decimals
-      expect(result.userLiquidityDiff?.currentLiquidityToken0).to.equal(
+      expect(result.userLiquidityDiff.currentLiquidityToken0).to.equal(
         500000000000000000n,
       ); // amount0
-      expect(result.userLiquidityDiff?.currentLiquidityToken1).to.equal(
+      expect(result.userLiquidityDiff.currentLiquidityToken1).to.equal(
         300000000000000000n,
       ); // amount1
 
       // The liquidity pool diff should reflect the amounts being added with exact values
-      expect(result.liquidityPoolDiff?.reserve0).to.equal(500000000000000000n); // amount0
-      expect(result.liquidityPoolDiff?.reserve1).to.equal(300000000000000000n); // amount1
-      expect(result.liquidityPoolDiff?.totalLiquidityUSD).to.equal(
+      expect(result.liquidityPoolDiff.reserve0).to.equal(500000000000000000n); // amount0
+      expect(result.liquidityPoolDiff.reserve1).to.equal(300000000000000000n); // amount1
+      expect(result.liquidityPoolDiff.totalLiquidityUSD).to.equal(
         1100000000000000000n,
       ); // 1.1 USD in 18 decimals
     });
@@ -204,20 +154,13 @@ describe("CLPoolMintLogic", () => {
         decimals: 6n, // USDC-like token
       };
 
-      const loaderReturn = {
-        _type: "success" as const,
-        liquidityPoolAggregator: mockLiquidityPoolAggregator,
-        token0Instance: tokenWithDifferentDecimals,
-        token1Instance: mockToken1,
-      };
-
       const result = await processCLPoolMint(
         mockEvent,
-        loaderReturn,
+        tokenWithDifferentDecimals,
+        mockToken1,
         mockContext,
       );
 
-      expect(result.error).to.be.undefined;
       expect(result.liquidityPoolDiff).to.not.be.undefined;
       expect(result.userLiquidityDiff).to.not.be.undefined;
     });
@@ -232,23 +175,16 @@ describe("CLPoolMintLogic", () => {
         },
       };
 
-      const loaderReturn = {
-        _type: "success" as const,
-        liquidityPoolAggregator: mockLiquidityPoolAggregator,
-        token0Instance: mockToken0,
-        token1Instance: mockToken1,
-      };
-
       const result = await processCLPoolMint(
         eventWithZeroAmounts,
-        loaderReturn,
+        mockToken0,
+        mockToken1,
         mockContext,
       );
 
-      expect(result.error).to.be.undefined;
-      expect(result.liquidityPoolDiff?.reserve0).to.equal(0n);
-      expect(result.liquidityPoolDiff?.reserve1).to.equal(0n);
-      expect(result.userLiquidityDiff?.netLiquidityAddedUSD).to.equal(0n);
+      expect(result.liquidityPoolDiff.reserve0).to.equal(0n);
+      expect(result.liquidityPoolDiff.reserve1).to.equal(0n);
+      expect(result.userLiquidityDiff.netLiquidityAddedUSD).to.equal(0n);
     });
   });
 });

--- a/test/EventHandlers/CLPool/CLPoolSwapLogic.test.ts
+++ b/test/EventHandlers/CLPool/CLPoolSwapLogic.test.ts
@@ -84,114 +84,64 @@ describe("CLPoolSwapLogic", () => {
 
   describe("processCLPoolSwap", () => {
     it("should process swap event successfully with valid data", async () => {
-      const loaderReturn = {
-        _type: "success" as const,
-        liquidityPoolAggregator: mockLiquidityPoolAggregator,
-        token0Instance: mockToken0,
-        token1Instance: mockToken1,
-      };
-
       const result = await processCLPoolSwap(
         mockEvent,
-        loaderReturn,
+        mockLiquidityPoolAggregator,
+        mockToken0,
+        mockToken1,
         mockContext,
       );
 
-      expect(result.error).to.be.undefined;
-      expect(result.liquidityPoolDiff).to.not.be.undefined;
-      expect(result.userSwapDiff).to.not.be.undefined;
-
       // Check liquidity pool diff with exact values
-      expect(result.liquidityPoolDiff?.totalVolume0).to.equal(
+      expect(result.liquidityPoolDiff.totalVolume0).to.equal(
         1000000000000000000n,
       ); // amount0 (1 token)
-      expect(result.liquidityPoolDiff?.totalVolume1).to.equal(
+      expect(result.liquidityPoolDiff.totalVolume1).to.equal(
         2000000000000000000n,
       ); // |amount1| (2 tokens, absolute value)
-      expect(result.liquidityPoolDiff?.numberOfSwaps).to.equal(1n);
+      expect(result.liquidityPoolDiff.numberOfSwaps).to.equal(1n);
 
-      expect(result.liquidityPoolDiff?.totalVolumeUSD).to.equal(
+      expect(result.liquidityPoolDiff.totalVolumeUSD).to.equal(
         1000000000000000000n,
       );
 
       // Exact timestamp: 1000000 * 1000 = 1000000000ms
-      expect(result.liquidityPoolDiff?.lastUpdatedTimestamp).to.deep.equal(
+      expect(result.liquidityPoolDiff.lastUpdatedTimestamp).to.deep.equal(
         new Date(1000000000),
       );
 
       // Check user swap diff with exact values
-      expect(result.userSwapDiff?.numberOfSwaps).to.equal(1n);
-      expect(result.userSwapDiff?.totalSwapVolumeUSD).to.equal(
+      expect(result.userSwapDiff.numberOfSwaps).to.equal(1n);
+      expect(result.userSwapDiff.totalSwapVolumeUSD).to.equal(
         1000000000000000000n,
       ); // 5 USD in 18 decimals
-      expect(result.userSwapDiff?.timestamp).to.deep.equal(
-        new Date(1000000000),
-      );
-    });
-
-    it("should handle TokenNotFoundError", async () => {
-      const loaderReturn = {
-        _type: "TokenNotFoundError" as const,
-        message: "Token not found",
-      };
-
-      const result = await processCLPoolSwap(
-        mockEvent,
-        loaderReturn,
-        mockContext,
-      );
-
-      expect(result.error).to.equal("Token not found");
-      expect(result.liquidityPoolDiff).to.be.undefined;
-      expect(result.userSwapDiff).to.be.undefined;
-    });
-
-    it("should handle LiquidityPoolAggregatorNotFoundError", async () => {
-      const loaderReturn = {
-        _type: "LiquidityPoolAggregatorNotFoundError" as const,
-        message: "Pool not found",
-      };
-
-      const result = await processCLPoolSwap(
-        mockEvent,
-        loaderReturn,
-        mockContext,
-      );
-
-      expect(result.error).to.equal("Pool not found");
-      expect(result.liquidityPoolDiff).to.be.undefined;
-      expect(result.userSwapDiff).to.be.undefined;
+      expect(result.userSwapDiff.timestamp).to.deep.equal(new Date(1000000000));
     });
 
     it("should calculate correct volume values for swap event", async () => {
-      const loaderReturn = {
-        _type: "success" as const,
-        liquidityPoolAggregator: mockLiquidityPoolAggregator,
-        token0Instance: mockToken0,
-        token1Instance: mockToken1,
-      };
-
       const result = await processCLPoolSwap(
         mockEvent,
-        loaderReturn,
+        mockLiquidityPoolAggregator,
+        mockToken0,
+        mockToken1,
         mockContext,
       );
 
       // The liquidity pool diff should reflect the swap volumes with exact values
-      expect(result.liquidityPoolDiff?.totalVolume0).to.equal(
+      expect(result.liquidityPoolDiff.totalVolume0).to.equal(
         1000000000000000000n,
       ); // amount0
-      expect(result.liquidityPoolDiff?.totalVolume1).to.equal(
+      expect(result.liquidityPoolDiff.totalVolume1).to.equal(
         2000000000000000000n,
       ); // |amount1|
-      expect(result.liquidityPoolDiff?.totalVolumeUSD).to.equal(
+      expect(result.liquidityPoolDiff.totalVolumeUSD).to.equal(
         1000000000000000000n,
       );
-      expect(result.liquidityPoolDiff?.numberOfSwaps).to.equal(1n);
+      expect(result.liquidityPoolDiff.numberOfSwaps).to.equal(1n);
 
       // User swap diff should track individual user activity with exact values
-      expect(result.userSwapDiff?.numberOfSwaps).to.equal(1n);
-      expect(result.userSwapDiff?.totalSwapVolumeUSD).to.equal(
+      expect(result.userSwapDiff.numberOfSwaps).to.equal(1n);
+      expect(result.userSwapDiff.totalSwapVolumeUSD).to.equal(
         1000000000000000000n,
       );
     });
@@ -202,20 +152,14 @@ describe("CLPoolSwapLogic", () => {
         decimals: 6n, // USDC-like token
       };
 
-      const loaderReturn = {
-        _type: "success" as const,
-        liquidityPoolAggregator: mockLiquidityPoolAggregator,
-        token0Instance: tokenWithDifferentDecimals,
-        token1Instance: mockToken1,
-      };
-
       const result = await processCLPoolSwap(
         mockEvent,
-        loaderReturn,
+        mockLiquidityPoolAggregator,
+        tokenWithDifferentDecimals,
+        mockToken1,
         mockContext,
       );
 
-      expect(result.error).to.be.undefined;
       expect(result.liquidityPoolDiff).to.not.be.undefined;
       expect(result.userSwapDiff).to.not.be.undefined;
     });
@@ -230,24 +174,18 @@ describe("CLPoolSwapLogic", () => {
         },
       };
 
-      const loaderReturn = {
-        _type: "success" as const,
-        liquidityPoolAggregator: mockLiquidityPoolAggregator,
-        token0Instance: mockToken0,
-        token1Instance: mockToken1,
-      };
-
       const result = await processCLPoolSwap(
         eventWithZeroAmounts,
-        loaderReturn,
+        mockLiquidityPoolAggregator,
+        mockToken0,
+        mockToken1,
         mockContext,
       );
 
-      expect(result.error).to.be.undefined;
-      expect(result.liquidityPoolDiff?.totalVolume0).to.equal(0n);
-      expect(result.liquidityPoolDiff?.totalVolume1).to.equal(0n);
-      expect(result.liquidityPoolDiff?.totalVolumeUSD).to.equal(0n);
-      expect(result.userSwapDiff?.totalSwapVolumeUSD).to.equal(0n);
+      expect(result.liquidityPoolDiff.totalVolume0).to.equal(0n);
+      expect(result.liquidityPoolDiff.totalVolume1).to.equal(0n);
+      expect(result.liquidityPoolDiff.totalVolumeUSD).to.equal(0n);
+      expect(result.userSwapDiff.totalSwapVolumeUSD).to.equal(0n);
     });
 
     it("should handle existing swap data correctly", async () => {
@@ -259,27 +197,22 @@ describe("CLPoolSwapLogic", () => {
         numberOfSwaps: 5n,
       };
 
-      const loaderReturn = {
-        _type: "success" as const,
-        liquidityPoolAggregator: poolWithExistingSwaps,
-        token0Instance: mockToken0,
-        token1Instance: mockToken1,
-      };
-
       const result = await processCLPoolSwap(
         mockEvent,
-        loaderReturn,
+        poolWithExistingSwaps,
+        mockToken0,
+        mockToken1,
         mockContext,
       );
 
-      expect(result.liquidityPoolDiff?.numberOfSwaps).to.equal(1n); // Only the diff, not cumulative
-      expect(result.liquidityPoolDiff?.totalVolume0).to.equal(
+      expect(result.liquidityPoolDiff.numberOfSwaps).to.equal(1n); // Only the diff, not cumulative
+      expect(result.liquidityPoolDiff.totalVolume0).to.equal(
         1000000000000000000n,
       ); // amount0
-      expect(result.liquidityPoolDiff?.totalVolume1).to.equal(
+      expect(result.liquidityPoolDiff.totalVolume1).to.equal(
         2000000000000000000n,
       ); // |amount1|
-      expect(result.liquidityPoolDiff?.totalVolumeUSD).to.equal(
+      expect(result.liquidityPoolDiff.totalVolumeUSD).to.equal(
         1000000000000000000n,
       ); // Only the diff, not cumulative
     });


### PR DESCRIPTION
closes #379 

Implements:
- House cleaning  🧹 of `CLPool` module to remove old `_loaderReturn` backwards compatibility logic (no longer needed)