### PR TITLE
`Await` for some `async` missing functions + other minor fixes

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2,7 +2,7 @@
 name: Velodrome_v2
 description: Multi-chain indexer for Velodrome V2 on Optimism and Aerodrome on Base
 unordered_multichain_mode: true
-rollback_on_reorg: false
+rollback_on_reorg: true
 raw_events: false
 event_decoder: hypersync-client
 preload_handlers: true
@@ -293,7 +293,7 @@ networks:
   - id: 42220 # Celo
     hypersync_config:
       url: https://celo.hypersync.xyz
-    start_block: 0
+    start_block: 31597000 # Velodrome contracts were only deployed on Celo mainnet after this block
     contracts:
       - name: CustomFeeSwapModule
         address:

--- a/src/Aggregators/LiquidityPoolAggregator.ts
+++ b/src/Aggregators/LiquidityPoolAggregator.ts
@@ -37,7 +37,7 @@ export async function updateDynamicFeePools(
     await context.DynamicFeeGlobalConfig.getWhere.chainId.eq(chainId);
 
   if (!dynamicFeeGlobalConfigs || dynamicFeeGlobalConfigs.length === 0) {
-    context.log.error(
+    context.log.warn(
       `No dynamic fee global config found for chain ${chainId}. No update to currentFee will be performed.`,
     );
     return;
@@ -236,7 +236,7 @@ export async function updateLiquidityPoolAggregator(
           gaugeFees1CurrentEpoch: gaugeFees.token1Fees,
         };
         setLiquidityPoolAggregatorSnapshot(gaugeFeeUpdated, timestamp, context);
-        updateDynamicFeePools(gaugeFeeUpdated, context, blockNumber);
+        await updateDynamicFeePools(gaugeFeeUpdated, context, blockNumber);
         return;
       } catch (error) {
         // No error if the pool is not a CL pool

--- a/src/Effects/Helpers.ts
+++ b/src/Effects/Helpers.ts
@@ -5,12 +5,13 @@ export enum ErrorType {
   RATE_LIMIT = "RATE_LIMIT",
   OUT_OF_GAS = "OUT_OF_GAS",
   CONTRACT_REVERT = "CONTRACT_REVERT",
+  NETWORK_ERROR = "NETWORK_ERROR",
   UNKNOWN = "UNKNOWN",
 }
 
 /**
  * Error keyword mappings for each error type
-p * Note: Order matters - more specific errors should be checked first
+ * Note: Order matters - more specific errors should be checked first
  */
 const ERROR_KEYWORDS: Record<ErrorType, string[]> = {
   [ErrorType.OUT_OF_GAS]: [
@@ -20,7 +21,13 @@ const ERROR_KEYWORDS: Record<ErrorType, string[]> = {
     "gas limit exceeded",
     "gas limit",
   ],
-  [ErrorType.CONTRACT_REVERT]: ["reverted", "revert", "execution reverted"],
+  [ErrorType.CONTRACT_REVERT]: [
+    "reverted",
+    "revert",
+    "execution reverted",
+    "historical state",
+    "is not available",
+  ],
   [ErrorType.RATE_LIMIT]: [
     "rate limit",
     "rate limit exceeded",
@@ -28,6 +35,7 @@ const ERROR_KEYWORDS: Record<ErrorType, string[]> = {
     "429",
     "too many requests",
   ],
+  [ErrorType.NETWORK_ERROR]: ["network error", "connection error"],
   [ErrorType.UNKNOWN]: [],
 };
 

--- a/src/EventHandlers/CLPool.ts
+++ b/src/EventHandlers/CLPool.ts
@@ -3,7 +3,6 @@ import {
   loadPoolData,
   updateLiquidityPoolAggregator,
 } from "../Aggregators/LiquidityPoolAggregator";
-import { NonFungiblePositionId } from "../Aggregators/NonFungiblePosition";
 import { createOUSDTSwapEntity } from "../Aggregators/OUSDTSwaps";
 import {
   loadUserData,
@@ -66,7 +65,7 @@ CLPool.Burn.handler(async ({ event, context }) => {
   );
 
   // Apply liquidity pool updates
-  updateLiquidityPoolAggregator(
+  await updateLiquidityPoolAggregator(
     result.liquidityPoolDiff,
     liquidityPoolAggregator,
     result.liquidityPoolDiff.lastUpdatedTimestamp,
@@ -119,7 +118,7 @@ CLPool.Collect.handler(async ({ event, context }) => {
   );
 
   // Apply liquidity pool updates
-  updateLiquidityPoolAggregator(
+  await updateLiquidityPoolAggregator(
     result.liquidityPoolDiff,
     liquidityPoolAggregator,
     result.liquidityPoolDiff.lastUpdatedTimestamp,
@@ -174,7 +173,7 @@ CLPool.CollectFees.handler(async ({ event, context }) => {
   );
 
   // Apply liquidity pool updates
-  updateLiquidityPoolAggregator(
+  await updateLiquidityPoolAggregator(
     result.liquidityPoolDiff,
     liquidityPoolAggregator,
     result.liquidityPoolDiff.lastUpdatedTimestamp,
@@ -229,7 +228,7 @@ CLPool.Flash.handler(async ({ event, context }) => {
   );
 
   // Apply liquidity pool updates
-  updateLiquidityPoolAggregator(
+  await updateLiquidityPoolAggregator(
     result.liquidityPoolDiff,
     liquidityPoolAggregator,
     result.liquidityPoolDiff.lastUpdatedTimestamp,
@@ -278,7 +277,7 @@ CLPool.IncreaseObservationCardinalityNext.handler(
       lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
     };
 
-    updateLiquidityPoolAggregator(
+    await updateLiquidityPoolAggregator(
       cardinalityDiff,
       liquidityPoolAggregator,
       new Date(event.block.timestamp * 1000),
@@ -320,7 +319,7 @@ CLPool.Mint.handler(async ({ event, context }) => {
   );
 
   // Apply liquidity pool updates
-  updateLiquidityPoolAggregator(
+  await updateLiquidityPoolAggregator(
     result.liquidityPoolDiff,
     liquidityPoolAggregator,
     result.liquidityPoolDiff.lastUpdatedTimestamp,
@@ -380,7 +379,7 @@ CLPool.SetFeeProtocol.handler(async ({ event, context }) => {
     lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
   };
 
-  updateLiquidityPoolAggregator(
+  await updateLiquidityPoolAggregator(
     feeProtocolDiff,
     liquidityPoolAggregator,
     new Date(event.block.timestamp * 1000),
@@ -422,7 +421,7 @@ CLPool.Swap.handler(async ({ event, context }) => {
   );
 
   // Apply liquidity pool updates
-  updateLiquidityPoolAggregator(
+  await updateLiquidityPoolAggregator(
     result.liquidityPoolDiff,
     liquidityPoolAggregator,
     new Date(event.block.timestamp * 1000),

--- a/src/EventHandlers/Gauges/GaugeSharedLogic.ts
+++ b/src/EventHandlers/Gauges/GaugeSharedLogic.ts
@@ -89,7 +89,7 @@ export async function processGaugeDeposit(
     lastUpdatedTimestamp: new Date(data.timestamp * 1000),
   };
 
-  updateLiquidityPoolAggregator(
+  await updateLiquidityPoolAggregator(
     poolGaugeDepositDiff,
     liquidityPoolAggregator,
     new Date(data.timestamp * 1000),
@@ -167,7 +167,7 @@ export async function processGaugeWithdraw(
     lastUpdatedTimestamp: new Date(data.timestamp * 1000),
   };
 
-  updateLiquidityPoolAggregator(
+  await updateLiquidityPoolAggregator(
     poolGaugeWithdrawalDiff,
     liquidityPoolAggregator,
     new Date(data.timestamp * 1000),
@@ -266,7 +266,7 @@ export async function processGaugeClaimRewards(
     lastUpdatedTimestamp: new Date(data.timestamp * 1000),
   };
 
-  updateLiquidityPoolAggregator(
+  await updateLiquidityPoolAggregator(
     poolGaugeRewardClaimDiff,
     liquidityPoolAggregator,
     new Date(data.timestamp * 1000),

--- a/src/EventHandlers/Pool.ts
+++ b/src/EventHandlers/Pool.ts
@@ -62,7 +62,7 @@ Pool.Mint.handler(async ({ event, context }) => {
 
   if (liquidityPoolDiff) {
     // Apply liquidity pool updates
-    updateLiquidityPoolAggregator(
+    await updateLiquidityPoolAggregator(
       liquidityPoolDiff,
       liquidityPoolAggregator,
       liquidityPoolDiff.lastUpdatedTimestamp as Date,
@@ -126,7 +126,7 @@ Pool.Burn.handler(async ({ event, context }) => {
 
   // Apply liquidity pool updates
   if (liquidityPoolDiff) {
-    updateLiquidityPoolAggregator(
+    await updateLiquidityPoolAggregator(
       liquidityPoolDiff,
       liquidityPoolAggregator,
       liquidityPoolDiff.lastUpdatedTimestamp as Date,
@@ -185,7 +185,7 @@ Pool.Fees.handler(async ({ event, context }) => {
   );
 
   if (liquidityPoolDiff) {
-    updateLiquidityPoolAggregator(
+    await updateLiquidityPoolAggregator(
       liquidityPoolDiff,
       liquidityPoolAggregator,
       liquidityPoolDiff.lastUpdatedTimestamp as Date,
@@ -244,7 +244,7 @@ Pool.Swap.handler(async ({ event, context }) => {
   );
 
   if (liquidityPoolDiff) {
-    updateLiquidityPoolAggregator(
+    await updateLiquidityPoolAggregator(
       liquidityPoolDiff,
       liquidityPoolAggregator,
       liquidityPoolDiff.lastUpdatedTimestamp as Date,
@@ -316,7 +316,7 @@ Pool.Sync.handler(async ({ event, context }) => {
 
   // Apply liquidity pool updates
   if (liquidityPoolDiff) {
-    updateLiquidityPoolAggregator(
+    await updateLiquidityPoolAggregator(
       liquidityPoolDiff,
       liquidityPoolAggregator,
       liquidityPoolDiff.lastUpdatedTimestamp as Date,

--- a/src/EventHandlers/Voter/SuperchainLeafVoter.ts
+++ b/src/EventHandlers/Voter/SuperchainLeafVoter.ts
@@ -54,7 +54,7 @@ SuperchainLeafVoter.Voted.handler(async ({ event, context }) => {
     timestampMs: event.block.timestamp * 1000,
   });
 
-  updateLiquidityPoolAggregator(
+  await updateLiquidityPoolAggregator(
     poolVoteDiff,
     liquidityPoolAggregator,
     new Date(event.block.timestamp * 1000),
@@ -112,7 +112,7 @@ SuperchainLeafVoter.GaugeCreated.handler(async ({ event, context }) => {
       lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
     };
 
-    updateLiquidityPoolAggregator(
+    await updateLiquidityPoolAggregator(
       poolUpdateDiff,
       poolEntity,
       new Date(event.block.timestamp * 1000),

--- a/src/EventHandlers/Voter/Voter.ts
+++ b/src/EventHandlers/Voter/Voter.ts
@@ -54,7 +54,7 @@ Voter.Voted.handler(async ({ event, context }) => {
     timestampMs: event.block.timestamp * 1000,
   });
 
-  updateLiquidityPoolAggregator(
+  await updateLiquidityPoolAggregator(
     poolVoteDiff,
     liquidityPoolAggregator,
     new Date(event.block.timestamp * 1000),
@@ -114,7 +114,7 @@ Voter.GaugeCreated.handler(async ({ event, context }) => {
       lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
     };
 
-    updateLiquidityPoolAggregator(
+    await updateLiquidityPoolAggregator(
       poolUpdateDiff,
       poolEntity,
       new Date(event.block.timestamp * 1000),
@@ -284,7 +284,7 @@ Voter.GaugeKilled.handler(async ({ event, context }) => {
       lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
     };
 
-    updateLiquidityPoolAggregator(
+    await updateLiquidityPoolAggregator(
       poolUpdateDiff,
       poolEntity,
       new Date(event.block.timestamp * 1000),

--- a/src/EventHandlers/Voter/VoterCommonLogic.ts
+++ b/src/EventHandlers/Voter/VoterCommonLogic.ts
@@ -126,14 +126,14 @@ export function buildLpDiffFromDistribute(
   };
 }
 
-export function applyLpDiff(
+export async function applyLpDiff(
   context: handlerContext,
   currentLiquidityPool: LiquidityPoolAggregator,
   lpDiff: Partial<LiquidityPoolAggregator>,
   timestampMs: number,
   blockNumber: number,
 ) {
-  return updateLiquidityPoolAggregator(
+  return await updateLiquidityPoolAggregator(
     lpDiff,
     currentLiquidityPool,
     new Date(timestampMs),

--- a/src/EventHandlers/VotingReward/BribesVotingReward.ts
+++ b/src/EventHandlers/VotingReward/BribesVotingReward.ts
@@ -40,7 +40,7 @@ BribesVotingReward.Deposit.handler(async ({ event, context }) => {
   const result = await processVotingRewardDeposit(data);
 
   if (result.poolDiff) {
-    updateLiquidityPoolAggregator(
+    await updateLiquidityPoolAggregator(
       result.poolDiff,
       loadedData.poolData.liquidityPoolAggregator,
       new Date(data.timestamp * 1000),
@@ -92,7 +92,7 @@ BribesVotingReward.ClaimRewards.handler(async ({ event, context }) => {
   );
 
   if (result.poolDiff) {
-    updateLiquidityPoolAggregator(
+    await updateLiquidityPoolAggregator(
       result.poolDiff,
       loadedData.poolData.liquidityPoolAggregator,
       new Date(data.timestamp * 1000),
@@ -140,7 +140,7 @@ BribesVotingReward.Withdraw.handler(async ({ event, context }) => {
   const result = await processVotingRewardWithdraw(data);
 
   if (result.poolDiff) {
-    updateLiquidityPoolAggregator(
+    await updateLiquidityPoolAggregator(
       result.poolDiff,
       loadedData.poolData.liquidityPoolAggregator,
       new Date(data.timestamp * 1000),

--- a/src/EventHandlers/VotingReward/FeesVotingReward.ts
+++ b/src/EventHandlers/VotingReward/FeesVotingReward.ts
@@ -40,7 +40,7 @@ FeesVotingReward.Deposit.handler(async ({ event, context }) => {
   const result = await processVotingRewardDeposit(data);
 
   if (result.poolDiff) {
-    updateLiquidityPoolAggregator(
+    await updateLiquidityPoolAggregator(
       result.poolDiff,
       loadedData.poolData.liquidityPoolAggregator,
       new Date(data.timestamp * 1000),
@@ -92,7 +92,7 @@ FeesVotingReward.ClaimRewards.handler(async ({ event, context }) => {
   );
 
   if (result.poolDiff) {
-    updateLiquidityPoolAggregator(
+    await updateLiquidityPoolAggregator(
       result.poolDiff,
       loadedData.poolData.liquidityPoolAggregator,
       new Date(data.timestamp * 1000),
@@ -140,7 +140,7 @@ FeesVotingReward.Withdraw.handler(async ({ event, context }) => {
   const result = await processVotingRewardWithdraw(data);
 
   if (result.poolDiff) {
-    updateLiquidityPoolAggregator(
+    await updateLiquidityPoolAggregator(
       result.poolDiff,
       loadedData.poolData.liquidityPoolAggregator,
       new Date(data.timestamp * 1000),

--- a/test/Effects/Helpers.test.ts
+++ b/test/Effects/Helpers.test.ts
@@ -43,11 +43,20 @@ describe("Helpers", () => {
       );
     });
 
-    it("should return UNKNOWN for unrecognized errors", () => {
+    it("should return NETWORK_ERROR for network errors", () => {
       expect(getErrorType(new Error("Network error"))).to.equal(
+        ErrorType.NETWORK_ERROR,
+      );
+
+      expect(getErrorType(new Error("Connection error"))).to.equal(
+        ErrorType.NETWORK_ERROR,
+      );
+    });
+
+    it("should return UNKNOWN for unrecognized errors", () => {
+      expect(getErrorType(new Error("Some random error"))).to.equal(
         ErrorType.UNKNOWN,
       );
-      expect(getErrorType("Some random error")).to.equal(ErrorType.UNKNOWN);
     });
 
     it("should return UNKNOWN for null or undefined", () => {


### PR DESCRIPTION
Implements:
- `await` for `async` functions. In some calls, `await` wasn't present
- `rollback_on_reorg` to `true` based on documentation recommendation. https://docs.envio.dev/docs/HyperIndex/config-schema-reference#rollbackonreorg . For developing, we can temporarily set to `false`
- Other minor fixes