### PR TITLE
Historical state RPC error from price fetching fix + logs removal

### DIFF
--- a/src/Effects/DynamicFee.ts
+++ b/src/Effects/DynamicFee.ts
@@ -52,9 +52,6 @@ export async function fetchCurrentAccumulatedFeeCL(
   logger: Envio_logger,
 ): Promise<{ token0Fees: bigint; token1Fees: bigint }> {
   try {
-    logger.info(
-      `[fetchCurrentAccumulatedFeeCL] Fetching accumulated gauge fees for pool ${poolAddress} on chain ${chainId} at block ${blockNumber}`,
-    );
     const CLPoolABI = require("../../abis/CLPool.json");
 
     const { result } = await ethClient.simulateContract({
@@ -71,7 +68,7 @@ export async function fetchCurrentAccumulatedFeeCL(
     };
 
     logger.info(
-      `[fetchCurrentAccumulatedFeeCL] Accumulated gauge fees fetched: token0Fees=${gaugeFees.token0Fees}, token1Fees=${gaugeFees.token1Fees}`,
+      `[fetchCurrentAccumulatedFeeCL] Accumulated gauge fees fetched: token0Fees=${gaugeFees.token0Fees}, token1Fees=${gaugeFees.token1Fees}, pool=${poolAddress} on chain ${chainId} at block ${blockNumber}`,
     );
     return gaugeFees;
   } catch (error) {

--- a/src/Effects/Voter.ts
+++ b/src/Effects/Voter.ts
@@ -16,9 +16,6 @@ export async function fetchTokensDeposited(
   logger: Envio_logger,
 ): Promise<bigint> {
   try {
-    logger.info(
-      `[fetchTokensDeposited] Fetching tokens deposited for gauge ${gaugeAddress} on chain ${eventChainId} at block ${blockNumber}`,
-    );
     const ERC20GaugeABI = require("../../abis/ERC20.json");
 
     const { result } = await ethClient.simulateContract({
@@ -30,7 +27,9 @@ export async function fetchTokensDeposited(
     });
 
     const balance = BigInt(String(result) || "0");
-    logger.info(`[fetchTokensDeposited] Tokens deposited fetched: ${balance}`);
+    logger.info(
+      `[fetchTokensDeposited] Tokens deposited fetched: ${balance}, rewardTokenAddress=${rewardTokenAddress}, gaugeAddress=${gaugeAddress}, blockNumber=${blockNumber}, chainID=${eventChainId}`,
+    );
     return balance;
   } catch (error) {
     logger.error(
@@ -54,9 +53,6 @@ export async function fetchIsAlive(
   logger: Envio_logger,
 ): Promise<boolean> {
   try {
-    logger.info(
-      `[fetchIsAlive] Checking if gauge ${gaugeAddress} is alive on chain ${eventChainId} at block ${blockNumber}`,
-    );
     const VoterABI = require("../../abis/Voter.json");
 
     const { result } = await ethClient.simulateContract({
@@ -68,7 +64,9 @@ export async function fetchIsAlive(
     });
 
     const isAlive = Boolean(result);
-    logger.info(`[fetchIsAlive] Gauge ${gaugeAddress} is alive: ${isAlive}`);
+    logger.info(
+      `[fetchIsAlive] Gauge ${gaugeAddress} is alive: ${isAlive}, voterAddress=${voterAddress}, gaugeAddress=${gaugeAddress}, blockNumber=${blockNumber}, chainID=${eventChainId}`,
+    );
     return isAlive;
   } catch (error) {
     logger.error(

--- a/test/Effects/Token.test.ts
+++ b/test/Effects/Token.test.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import type { logger as Envio_logger } from "envio/src/Envio.gen";
 import sinon from "sinon";
 import type { PublicClient } from "viem";
-import { CHAIN_CONSTANTS } from "../../src/Constants";
+import { CHAIN_CONSTANTS, PriceOracleType } from "../../src/Constants";
 import {
   fetchTokenDetails,
   fetchTokenPrice,
@@ -39,7 +39,7 @@ describe("Token Effects", () => {
     (CHAIN_CONSTANTS as Record<number, unknown>)[10] = {
       eth_client: mockEthClient,
       oracle: {
-        getType: () => "V3",
+        getType: () => PriceOracleType.V3, // Returns "v3" (lowercase)
         getAddress: () => "0x1234567890123456789012345678901234567890",
         getPrice: sinon.stub(),
       },
@@ -265,7 +265,7 @@ describe("Token Effects", () => {
       (CHAIN_CONSTANTS as Record<number, unknown>)[10] = {
         eth_client: mockEthClient,
         oracle: {
-          getType: () => "V2",
+          getType: () => PriceOracleType.V2, // Returns "v2" (lowercase)
           getAddress: () => "0x1234567890123456789012345678901234567890",
           getPrice: sinon.stub(),
         },
@@ -326,6 +326,16 @@ describe("Token Effects", () => {
       const blockNumber = 12345;
       const gasLimit = 1000000n;
 
+      // Mock V2 oracle for this test
+      (CHAIN_CONSTANTS as Record<number, unknown>)[10] = {
+        eth_client: mockEthClient,
+        oracle: {
+          getType: () => PriceOracleType.V2, // Returns "v2" (lowercase)
+          getAddress: () => "0x1234567890123456789012345678901234567890",
+          getPrice: sinon.stub(),
+        },
+      };
+
       // Mock simulateContract to throw an error
       const mockSimulateContract =
         mockEthClient.simulateContract as sinon.SinonStub;
@@ -366,7 +376,7 @@ describe("Token Effects", () => {
       (CHAIN_CONSTANTS as Record<number, unknown>)[10] = {
         eth_client: mockEthClient,
         oracle: {
-          getType: () => "V2",
+          getType: () => PriceOracleType.V2, // Returns "v2" (lowercase)
           getAddress: () => "0x1234567890123456789012345678901234567890",
           getPrice: sinon.stub(),
         },
@@ -419,7 +429,7 @@ describe("Token Effects", () => {
       (CHAIN_CONSTANTS as Record<number, unknown>)[10] = {
         eth_client: mockEthClient,
         oracle: {
-          getType: () => "V2",
+          getType: () => PriceOracleType.V2, // Returns "v2" (lowercase)
           getAddress: () => "0x1234567890123456789012345678901234567890",
           getPrice: sinon.stub(),
         },
@@ -473,7 +483,7 @@ describe("Token Effects", () => {
       (CHAIN_CONSTANTS as Record<number, unknown>)[10] = {
         eth_client: mockEthClient,
         oracle: {
-          getType: () => "V2",
+          getType: () => PriceOracleType.V2, // Returns "v2" (lowercase)
           getAddress: () => "0x1234567890123456789012345678901234567890",
           getPrice: sinon.stub(),
         },


### PR DESCRIPTION
Implements:
- A workaround for when RPC price fetching calls return "historical state does not exist" status. In this case, the previous known token price remains (i.e., no updates occur)
- Cleaning of some logs