### PR TITLE
Fix bug: chainId collision in NonFungiblePosition

### DIFF
--- a/src/EventHandlers/NFPM/NFPM.ts
+++ b/src/EventHandlers/NFPM/NFPM.ts
@@ -32,6 +32,10 @@ NFPM.Transfer.handler(async ({ event, context }) => {
   let position = await context.NonFungiblePosition.getWhere.tokenId.eq(
     event.params.tokenId,
   );
+  // Filter by chainId to ensure we get the position from the correct chain
+  if (position && position.length > 0) {
+    position = position.filter((pos) => pos.chainId === event.chainId);
+  }
 
   // If not found and this is a mint, look for placeholder by transaction hash
   if ((!position || position.length === 0) && isMint) {
@@ -107,6 +111,10 @@ NFPM.IncreaseLiquidity.handler(async ({ event, context }) => {
   let positions = await context.NonFungiblePosition.getWhere.tokenId.eq(
     event.params.tokenId,
   );
+  // Filter by chainId to ensure we get the position from the correct chain
+  if (positions && positions.length > 0) {
+    positions = positions.filter((pos) => pos.chainId === event.chainId);
+  }
 
   // If not found, try to find by transaction hash and matching amounts (for mint case)
   if (!positions || positions.length === 0) {
@@ -162,9 +170,14 @@ NFPM.IncreaseLiquidity.handler(async ({ event, context }) => {
 NFPM.DecreaseLiquidity.handler(async ({ event, context }) => {
   // Get position by tokenId
   // Transfer should have already run and updated the placeholder, so position should exist when a DecreaseLiquidity event is processed
-  const positions = await context.NonFungiblePosition.getWhere.tokenId.eq(
+  // Filter by chainId to avoid cross-chain collisions (same tokenId can exist on different chains)
+  let positions = await context.NonFungiblePosition.getWhere.tokenId.eq(
     event.params.tokenId,
   );
+  // Filter by chainId to ensure we get the position from the correct chain
+  if (positions && positions.length > 0) {
+    positions = positions.filter((pos) => pos.chainId === event.chainId);
+  }
 
   // This should never happen
   if (!positions || positions.length === 0) {

--- a/src/EventHandlers/NFPM/NFPMLogic.ts
+++ b/src/EventHandlers/NFPM/NFPMLogic.ts
@@ -43,11 +43,12 @@ export async function getPositionWithPlaceholderFallback(
   logIndex?: number,
 ): Promise<NonFungiblePosition | null> {
   // Try to get position by tokenId
-  const positions =
+  let positions =
     await context.NonFungiblePosition.getWhere.tokenId.eq(tokenId);
 
-  // Use position if found (should be unique)
+  // Filter by chainId to avoid cross-chain collisions (same tokenId can exist on different chains)
   if (positions && positions.length > 0) {
+    positions = positions.filter((pos) => pos.chainId === chainId);
     return positions[0];
   }
 


### PR DESCRIPTION
Fixes the following bug:

```typescript
address: "0x827922686190790b37229fd06084350E74485b72"
block: "13899663"
chainId: "8453"
contractName: "NFPM"
error_message: "getSqrtPriceX96 effect failed for pool 0xc2026f3fb6fc51F4EcAE40a88b4509cB6C143ed4 on chain 8453 at block 13899663: Failed to fetch sqrtPriceX96 from pool 0xc2026f3fb6fc51F4EcAE40a88b4509cB6C143ed4 on chain 8453 at block 13899663: The contract function \"slot0\" returned no data (\"0x\").\n\nThis could be due to any of the following:\n - The contract does not have the function \"slot0\",\n - The parameters passed to the contract function may be invalid, or\n - The address is not a contract.\n \nContract Call:\n address: 0xc2026f3fb6fc51F4EcAE40a88b4509cB6C143ed4\n function: slot0()\n\nDocs: https://viem.sh/docs/contract/simulateContract\nVersion: viem@2.24.3"
error_stack_trace: "ContractFunctionExecutionError: The contract function \"slot0\" returned no data (\"0x\").\n\nThis could be due to any of the following:\n - The contract does not have the function \"slot0\",\n - The parameters passed to the contract function may be invalid, or\n - The address is not a contract.\n \nContract Call:\n address: 0xc2026f3fb6fc51F4EcAE40a88b4509cB6C143ed4\n function: slot0()\n\nDocs: https://viem.sh/docs/contract/simulateContract\nVersion: viem@2.24.3\n at getContractError (/app/base-template/node_modules/.pnpm/viem@2.24.3_typescript@5.9.3_zod@3.25.76/node_modules/viem/utils/errors/getContractError.ts:78:10)\n at simulateContract (/app/base-template/node_modules/.pnpm/viem@2.24.3_typescript@5.9.3_zod@3.25.76/node_modules/viem/actions/public/simulateContract.ts:308:27)\n at processTicksAndRejections (node:internal/process/task_queues:105:5)\n at async attemptFetch (/app/base-template/src/Effects/Token.ts:296:24)\n at async fetchSqrtPriceX96 (/app/base-template/src/Effects/Token.ts:307:20)\n at async Object.handler (/app/base-template/src/Effects/Token.ts:716:22)\n at async Promise.all (index 0)\n at async Object.load (/app/base-template/generated/src/LoadLayer.res.js:208:14)\n at async /app/base-template/node_modules/.pnpm/envio@2.32.2_typescript@5.9.3_zod@3.25.76/node_modules/envio/src/LoadManager.res.js:45:13"
error_type: "Error"
eventName: "IncreaseLiquidity"
logIndex: "178"
``` 
