### PR TITLE
Updating ALM LP Wrapper entity fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
       "node_modules/**",
       "**/*.d.ts",
       "src/Constants.ts",
-      "src/CustomTypes.ts"
+      "src/CustomTypes.ts",
+      "src/Pools/common.ts"
     ],
     "extension": [".ts"],
     "require": ["ts-node/register"]

--- a/schema.graphql
+++ b/schema.graphql
@@ -264,9 +264,9 @@ type ALM_LP_Wrapper {
   token0: String! # Address of token 0
   token1: String! # Address of token 1
 
-  # Wrapper-level aggregations (updated by Deposit/Withdraw events)
-  amount0: BigInt! @config(precision: 76) # Total underlying amount of token0 in the wrapper (aggregated across all users)
-  amount1: BigInt! @config(precision: 76) # Total underlying amount of token1 in the wrapper (aggregated across all users)
+  # Wrapper-level amounts (recalculated from liquidity and current price)
+  amount0: BigInt! @config(precision: 76) # Current amount of token0 in the AMM position (recalculated from liquidity and current price)
+  amount1: BigInt! @config(precision: 76) # Current amount of token1 in the AMM position (recalculated from liquidity and current price)
   lpAmount: BigInt! @config(precision: 76) # Total number of LP tokens wrapped (aggregated across all users)
   lastUpdatedTimestamp: Timestamp! # Timestamp of the last update to this entity
 
@@ -276,8 +276,6 @@ type ALM_LP_Wrapper {
   tickLower: BigInt! @config(precision: 24) # Lower tick bound of the position's price range (in tick units)
   tickUpper: BigInt! @config(precision: 24) # Upper tick bound of the position's price range (in tick units)
   property: BigInt! @config(precision: 24) # Pool property parameter from the AMM position struct
-  positionAmount0: BigInt! @config(precision: 76) # Current amount of token0 in the AMM position (updated by Rebalance events)
-  positionAmount1: BigInt! @config(precision: 76) # Current amount of token1 in the AMM position (updated by Rebalance events)
   liquidity: BigInt! @config(precision: 76) # Amount of liquidity currently in the AMM position
   strategyType: BigInt! @config(precision: 24) # Type/kind of ALM strategy being used (defines the strategy behavior)
   tickNeighborhood: BigInt! @config(precision: 24) # Tick neighborhood parameter for the strategy (defines rebalancing range around current price)

--- a/src/Aggregators/ALMLPWrapper.ts
+++ b/src/Aggregators/ALMLPWrapper.ts
@@ -2,8 +2,9 @@ import type { ALM_LP_Wrapper, handlerContext } from "generated";
 
 /**
  * Generic function to update ALM_LP_Wrapper with any combination of fields
- * - Wrapper-level fields (amount0, amount1, lpAmount) are incremented (for deposits/withdrawals)
- * - Position-level fields (positionAmount0, positionAmount1, liquidity) are set directly (for rebalances)
+ * - amount0, amount1: Set directly when recalculated from liquidity and price (for deposits/withdrawals/rebalances)
+ * - lpAmount: Set directly (updated from aggregations in handlers)
+ * - Position-level fields (liquidity, tickLower, tickUpper, etc.) are set directly (for rebalances)
  */
 export async function updateALMLPWrapper(
   diff: Partial<ALM_LP_Wrapper>,
@@ -13,29 +14,15 @@ export async function updateALMLPWrapper(
 ): Promise<void> {
   const updated: ALM_LP_Wrapper = {
     ...current,
-    // Wrapper-level aggregations: increment (for deposits/withdrawals)
-    amount0:
-      diff.amount0 !== undefined
-        ? diff.amount0 + current.amount0
-        : current.amount0,
-    amount1:
-      diff.amount1 !== undefined
-        ? diff.amount1 + current.amount1
-        : current.amount1,
+    // Wrapper-level amounts: set directly (recalculated from liquidity and current price)
+    amount0: diff.amount0 !== undefined ? diff.amount0 : current.amount0,
+    amount1: diff.amount1 !== undefined ? diff.amount1 : current.amount1,
     lpAmount:
       diff.lpAmount !== undefined
         ? diff.lpAmount + current.lpAmount
         : current.lpAmount,
     // Position-level state: set directly (for rebalances)
     tokenId: diff.tokenId !== undefined ? diff.tokenId : current.tokenId,
-    positionAmount0:
-      diff.positionAmount0 !== undefined
-        ? diff.positionAmount0
-        : current.positionAmount0,
-    positionAmount1:
-      diff.positionAmount1 !== undefined
-        ? diff.positionAmount1
-        : current.positionAmount1,
     liquidity:
       diff.liquidity !== undefined ? diff.liquidity : current.liquidity,
     tickLower:

--- a/src/EventHandlers/ALM/DeployFactory.ts
+++ b/src/EventHandlers/ALM/DeployFactory.ts
@@ -58,8 +58,6 @@ ALMDeployFactory.StrategyCreated.handler(async ({ event, context }) => {
     tickLower: tickLower,
     tickUpper: tickUpper,
     property: property,
-    positionAmount0: 0n, // Initialize to 0 - will be updated by Rebalance events
-    positionAmount1: 0n, // Initialize to 0 - will be updated by Rebalance events
     liquidity: liquidity,
     strategyType: strategyType,
     tickNeighborhood: tickNeighborhood,

--- a/src/EventHandlers/ALM/LPWrapperLogic.ts
+++ b/src/EventHandlers/ALM/LPWrapperLogic.ts
@@ -1,0 +1,83 @@
+import type { ALM_LP_Wrapper, handlerContext } from "generated";
+import { getSqrtPriceX96, roundBlockToInterval } from "../../Effects/Token";
+import { calculatePositionAmountsFromLiquidity } from "../../Helpers";
+
+/**
+ * Recalculates amount0 and amount1 from current liquidity and current price
+ * This ensures amounts reflect the current pool price, not stale values from events.
+ *
+ * @param wrapper - The current ALM_LP_Wrapper entity
+ * @param poolAddress - The pool address to fetch price from
+ * @param chainId - The chain ID
+ * @param blockNumber - The block number to fetch price at
+ * @param context - The handler context for effects and logging
+ * @param eventType - The event type for logging purposes (e.g., "Deposit", "Withdraw")
+ * @returns An object with recalculated amount0 and amount1, or the current values if recalculation fails
+ */
+export async function recalculateLPWrapperAmountsFromLiquidity(
+  wrapper: ALM_LP_Wrapper,
+  poolAddress: string,
+  chainId: number,
+  blockNumber: number,
+  context: handlerContext,
+  eventType: string,
+): Promise<{ amount0: bigint; amount1: bigint }> {
+  // Default to current amounts if recalculation fails
+  let recalculatedAmount0 = wrapper.amount0;
+  let recalculatedAmount1 = wrapper.amount1;
+
+  try {
+    // Round block number to nearest hour interval for better cache hits
+    const roundedBlockNumber = roundBlockToInterval(blockNumber, chainId);
+
+    // Fetch current sqrtPriceX96
+    let sqrtPriceX96: bigint | undefined;
+    try {
+      sqrtPriceX96 = await context.effect(getSqrtPriceX96, {
+        poolAddress: poolAddress,
+        chainId: chainId,
+        blockNumber: roundedBlockNumber,
+      });
+    } catch (error) {
+      // Pool might not exist at rounded block, retry with actual block
+      context.log.warn(
+        `[ALMLPWrapper.${eventType}] Pool ${poolAddress} does not exist at rounded block ${roundedBlockNumber} (original: ${blockNumber}) on chain ${chainId}. Retrying with actual block number.`,
+      );
+      try {
+        sqrtPriceX96 = await context.effect(getSqrtPriceX96, {
+          poolAddress: poolAddress,
+          chainId: chainId,
+          blockNumber: blockNumber,
+        });
+      } catch (retryError) {
+        context.log.error(
+          `[ALMLPWrapper.${eventType}] Failed to fetch sqrtPriceX96 for pool ${poolAddress} on chain ${chainId} at both rounded block ${roundedBlockNumber} and actual block ${blockNumber}. Using existing amounts.`,
+        );
+        sqrtPriceX96 = undefined;
+      }
+    }
+
+    // Recalculate amounts from liquidity and current price if we have sqrtPriceX96
+    if (sqrtPriceX96 && wrapper.liquidity > 0n) {
+      const recalculatedAmounts = calculatePositionAmountsFromLiquidity(
+        wrapper.liquidity,
+        sqrtPriceX96,
+        wrapper.tickLower,
+        wrapper.tickUpper,
+      );
+      recalculatedAmount0 = recalculatedAmounts.amount0;
+      recalculatedAmount1 = recalculatedAmounts.amount1;
+    }
+  } catch (error) {
+    context.log.error(
+      `[ALMLPWrapper.${eventType}] Error recalculating amounts from liquidity for wrapper ${wrapper.id}`,
+      error instanceof Error ? error : new Error(String(error)),
+    );
+    // Continue with existing amounts if recalculation fails
+  }
+
+  return {
+    amount0: recalculatedAmount0,
+    amount1: recalculatedAmount1,
+  };
+}

--- a/test/EventHandlers/ALM/DeployFactory.test.ts
+++ b/test/EventHandlers/ALM/DeployFactory.test.ts
@@ -146,8 +146,8 @@ describe("ALMDeployFactory StrategyCreated Event", () => {
       expect(createdWrapper?.tickUpper).to.equal(tickUpper);
       expect(createdWrapper?.property).to.equal(property);
       expect(createdWrapper?.liquidity).to.equal(liquidity);
-      expect(createdWrapper?.positionAmount0).to.equal(0n); // Initialize to 0
-      expect(createdWrapper?.positionAmount1).to.equal(0n); // Initialize to 0
+      expect(createdWrapper?.amount0).to.equal(0n); // Initialize to 0
+      expect(createdWrapper?.amount1).to.equal(0n); // Initialize to 0
       expect(createdWrapper?.strategyType).to.equal(strategyType);
       expect(createdWrapper?.tickNeighborhood).to.equal(tickNeighborhood);
       expect(createdWrapper?.tickSpacing).to.equal(tickSpacing);

--- a/test/EventHandlers/ALM/LPWrapperLogic.test.ts
+++ b/test/EventHandlers/ALM/LPWrapperLogic.test.ts
@@ -1,0 +1,412 @@
+import { expect } from "chai";
+import type { ALM_LP_Wrapper, handlerContext } from "generated";
+import sinon from "sinon";
+import * as TokenEffects from "../../../src/Effects/Token";
+import { recalculateLPWrapperAmountsFromLiquidity } from "../../../src/EventHandlers/ALM/LPWrapperLogic";
+import * as Helpers from "../../../src/Helpers";
+import { setupCommon } from "../Pool/common";
+
+describe("LPWrapperLogic", () => {
+  const { mockALMLPWrapperData } = setupCommon();
+  const chainId = 10;
+  const poolAddress = "0x3333333333333333333333333333333333333333";
+  const blockNumber = 123456;
+  const roundedBlockNumber = 123000; // Example rounded block
+
+  // Mock sqrtPriceX96 value (Q64.96 format)
+  const mockSqrtPriceX96 = 79228162514264337593543950336n; // sqrt(1) * 2^96
+
+  let mockContext: handlerContext;
+  let getSqrtPriceX96Stub: sinon.SinonStub;
+  let roundBlockToIntervalStub: sinon.SinonStub;
+  let calculatePositionAmountsFromLiquidityStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    // Stub roundBlockToInterval
+    roundBlockToIntervalStub = sinon
+      .stub(TokenEffects, "roundBlockToInterval")
+      .returns(roundedBlockNumber);
+
+    // Stub calculatePositionAmountsFromLiquidity
+    calculatePositionAmountsFromLiquidityStub = sinon.stub(
+      Helpers,
+      "calculatePositionAmountsFromLiquidity",
+    );
+
+    // Create mock context with effect stub
+    getSqrtPriceX96Stub = sinon.stub();
+    mockContext = {
+      effect: getSqrtPriceX96Stub,
+      log: {
+        warn: sinon.stub(),
+        error: sinon.stub(),
+      },
+    } as unknown as handlerContext;
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("recalculateLPWrapperAmountsFromLiquidity", () => {
+    it("should successfully recalculate amounts from liquidity and price", async () => {
+      const wrapper: ALM_LP_Wrapper = {
+        ...mockALMLPWrapperData,
+        liquidity: 1000000n,
+        tickLower: -1000n,
+        tickUpper: 1000n,
+        amount0: 500n * 10n ** 18n,
+        amount1: 250n * 10n ** 6n,
+      };
+
+      const expectedAmounts = {
+        amount0: 600n * 10n ** 18n,
+        amount1: 300n * 10n ** 6n,
+      };
+
+      // Mock successful sqrtPriceX96 fetch
+      // The effect is called as: context.effect(getSqrtPriceX96, { poolAddress, chainId, blockNumber })
+      getSqrtPriceX96Stub.resolves(mockSqrtPriceX96);
+
+      // Mock calculation result
+      calculatePositionAmountsFromLiquidityStub.returns(expectedAmounts);
+
+      const result = await recalculateLPWrapperAmountsFromLiquidity(
+        wrapper,
+        poolAddress,
+        chainId,
+        blockNumber,
+        mockContext,
+        "Deposit",
+      );
+
+      expect(result.amount0).to.equal(expectedAmounts.amount0);
+      expect(result.amount1).to.equal(expectedAmounts.amount1);
+      expect(getSqrtPriceX96Stub.callCount).to.equal(1);
+      expect(calculatePositionAmountsFromLiquidityStub.callCount).to.equal(1);
+      expect(
+        calculatePositionAmountsFromLiquidityStub.calledWith(
+          wrapper.liquidity,
+          mockSqrtPriceX96,
+          wrapper.tickLower,
+          wrapper.tickUpper,
+        ),
+      ).to.be.true;
+    });
+
+    it("should retry with actual block number if rounded block fails", async () => {
+      const wrapper: ALM_LP_Wrapper = {
+        ...mockALMLPWrapperData,
+        liquidity: 1000000n,
+        tickLower: -1000n,
+        tickUpper: 1000n,
+        amount0: 500n * 10n ** 18n,
+        amount1: 250n * 10n ** 6n,
+      };
+
+      const expectedAmounts = {
+        amount0: 600n * 10n ** 18n,
+        amount1: 300n * 10n ** 6n,
+      };
+
+      // First call (rounded block) fails, second call (actual block) succeeds
+      getSqrtPriceX96Stub
+        .onCall(0)
+        .rejects(new Error("Pool does not exist at rounded block"));
+      getSqrtPriceX96Stub.onCall(1).resolves(mockSqrtPriceX96);
+
+      calculatePositionAmountsFromLiquidityStub.returns(expectedAmounts);
+
+      const result = await recalculateLPWrapperAmountsFromLiquidity(
+        wrapper,
+        poolAddress,
+        chainId,
+        blockNumber,
+        mockContext,
+        "Withdraw",
+      );
+
+      expect(result.amount0).to.equal(expectedAmounts.amount0);
+      expect(result.amount1).to.equal(expectedAmounts.amount1);
+      expect(getSqrtPriceX96Stub.callCount).to.equal(2);
+      expect((mockContext.log.warn as sinon.SinonStub).callCount).to.equal(1);
+      expect(
+        (mockContext.log.warn as sinon.SinonStub).getCall(0).args[0],
+      ).to.include("does not exist at rounded block");
+    });
+
+    it("should return current amounts if both rounded and actual block fail", async () => {
+      const wrapper: ALM_LP_Wrapper = {
+        ...mockALMLPWrapperData,
+        liquidity: 1000000n,
+        tickLower: -1000n,
+        tickUpper: 1000n,
+        amount0: 500n * 10n ** 18n,
+        amount1: 250n * 10n ** 6n,
+      };
+
+      // Both calls fail
+      getSqrtPriceX96Stub.rejects(new Error("Failed to fetch"));
+
+      const result = await recalculateLPWrapperAmountsFromLiquidity(
+        wrapper,
+        poolAddress,
+        chainId,
+        blockNumber,
+        mockContext,
+        "Deposit",
+      );
+
+      // Should return current amounts
+      expect(result.amount0).to.equal(wrapper.amount0);
+      expect(result.amount1).to.equal(wrapper.amount1);
+      expect(getSqrtPriceX96Stub.callCount).to.equal(2);
+      expect((mockContext.log.error as sinon.SinonStub).callCount).to.equal(1);
+      expect(calculatePositionAmountsFromLiquidityStub.called).to.be.false;
+    });
+
+    it("should return current amounts if liquidity is zero", async () => {
+      const wrapper: ALM_LP_Wrapper = {
+        ...mockALMLPWrapperData,
+        liquidity: 0n,
+        tickLower: -1000n,
+        tickUpper: 1000n,
+        amount0: 500n * 10n ** 18n,
+        amount1: 250n * 10n ** 6n,
+      };
+
+      getSqrtPriceX96Stub.resolves(mockSqrtPriceX96);
+
+      const result = await recalculateLPWrapperAmountsFromLiquidity(
+        wrapper,
+        poolAddress,
+        chainId,
+        blockNumber,
+        mockContext,
+        "Deposit",
+      );
+
+      // Should return current amounts (not recalculated)
+      expect(result.amount0).to.equal(wrapper.amount0);
+      expect(result.amount1).to.equal(wrapper.amount1);
+      expect(calculatePositionAmountsFromLiquidityStub.called).to.be.false;
+    });
+
+    it("should return current amounts if sqrtPriceX96 is undefined", async () => {
+      const wrapper: ALM_LP_Wrapper = {
+        ...mockALMLPWrapperData,
+        liquidity: 1000000n,
+        tickLower: -1000n,
+        tickUpper: 1000n,
+        amount0: 500n * 10n ** 18n,
+        amount1: 250n * 10n ** 6n,
+      };
+
+      // Both calls fail, resulting in undefined
+      getSqrtPriceX96Stub.rejects(new Error("Failed to fetch"));
+
+      const result = await recalculateLPWrapperAmountsFromLiquidity(
+        wrapper,
+        poolAddress,
+        chainId,
+        blockNumber,
+        mockContext,
+        "Withdraw",
+      );
+
+      // Should return current amounts
+      expect(result.amount0).to.equal(wrapper.amount0);
+      expect(result.amount1).to.equal(wrapper.amount1);
+      expect(calculatePositionAmountsFromLiquidityStub.called).to.be.false;
+    });
+
+    it("should return current amounts if sqrtPriceX96 is undefined and liquidity is zero", async () => {
+      const wrapper: ALM_LP_Wrapper = {
+        ...mockALMLPWrapperData,
+        liquidity: 0n,
+        tickLower: -1000n,
+        tickUpper: 1000n,
+        amount0: 500n * 10n ** 18n,
+        amount1: 250n * 10n ** 6n,
+      };
+
+      // Both calls fail, resulting in undefined
+      getSqrtPriceX96Stub.rejects(new Error("Failed to fetch"));
+
+      const result = await recalculateLPWrapperAmountsFromLiquidity(
+        wrapper,
+        poolAddress,
+        chainId,
+        blockNumber,
+        mockContext,
+        "Deposit",
+      );
+
+      // Should return current amounts (both conditions false: sqrtPriceX96 undefined && liquidity === 0n)
+      expect(result.amount0).to.equal(wrapper.amount0);
+      expect(result.amount1).to.equal(wrapper.amount1);
+      expect(calculatePositionAmountsFromLiquidityStub.called).to.be.false;
+    });
+
+    it("should handle unexpected errors gracefully", async () => {
+      const wrapper: ALM_LP_Wrapper = {
+        ...mockALMLPWrapperData,
+        liquidity: 1000000n,
+        tickLower: -1000n,
+        tickUpper: 1000n,
+        amount0: 500n * 10n ** 18n,
+        amount1: 250n * 10n ** 6n,
+      };
+
+      // Throw unexpected error (Error instance)
+      roundBlockToIntervalStub.throws(new Error("Unexpected error"));
+
+      const result = await recalculateLPWrapperAmountsFromLiquidity(
+        wrapper,
+        poolAddress,
+        chainId,
+        blockNumber,
+        mockContext,
+        "Deposit",
+      );
+
+      // Should return current amounts on error
+      expect(result.amount0).to.equal(wrapper.amount0);
+      expect(result.amount1).to.equal(wrapper.amount1);
+      expect((mockContext.log.error as sinon.SinonStub).callCount).to.equal(1);
+      expect(
+        (mockContext.log.error as sinon.SinonStub).getCall(0).args[0],
+      ).to.include("Error recalculating amounts from liquidity");
+      // Verify error is passed as-is when it's an Error instance
+      expect(
+        (mockContext.log.error as sinon.SinonStub).getCall(0).args[1],
+      ).to.be.instanceOf(Error);
+    });
+
+    it("should handle non-Error exceptions (covers error instanceof Error false branch)", async () => {
+      const wrapper: ALM_LP_Wrapper = {
+        ...mockALMLPWrapperData,
+        liquidity: 1000000n,
+        tickLower: -1000n,
+        tickUpper: 1000n,
+        amount0: 500n * 10n ** 18n,
+        amount1: 250n * 10n ** 6n,
+      };
+
+      // Throw a non-Error exception (string) to cover the else branch on line 74
+      // Use callsFake to throw directly, bypassing Sinon's wrapping
+      roundBlockToIntervalStub.callsFake(() => {
+        throw "String error";
+      });
+
+      const result = await recalculateLPWrapperAmountsFromLiquidity(
+        wrapper,
+        poolAddress,
+        chainId,
+        blockNumber,
+        mockContext,
+        "Withdraw",
+      );
+
+      // Should return current amounts on error
+      expect(result.amount0).to.equal(wrapper.amount0);
+      expect(result.amount1).to.equal(wrapper.amount1);
+      expect((mockContext.log.error as sinon.SinonStub).callCount).to.equal(1);
+      // Verify that the error was converted to Error instance (covers line 74 else branch)
+      const errorCall = (mockContext.log.error as sinon.SinonStub).getCall(0);
+      expect(errorCall.args[1]).to.be.instanceOf(Error);
+      expect(errorCall.args[1].message).to.equal("String error");
+    });
+
+    it("should handle non-Error exceptions (string, number, etc.)", async () => {
+      const wrapper: ALM_LP_Wrapper = {
+        ...mockALMLPWrapperData,
+        liquidity: 1000000n,
+        tickLower: -1000n,
+        tickUpper: 1000n,
+        amount0: 500n * 10n ** 18n,
+        amount1: 250n * 10n ** 6n,
+      };
+
+      // Throw a non-Error exception (string)
+      // Use callsFake to throw directly, bypassing Sinon's wrapping
+      roundBlockToIntervalStub.callsFake(() => {
+        throw "String error";
+      });
+
+      const result = await recalculateLPWrapperAmountsFromLiquidity(
+        wrapper,
+        poolAddress,
+        chainId,
+        blockNumber,
+        mockContext,
+        "Withdraw",
+      );
+
+      // Should return current amounts on error
+      expect(result.amount0).to.equal(wrapper.amount0);
+      expect(result.amount1).to.equal(wrapper.amount1);
+      expect((mockContext.log.error as sinon.SinonStub).callCount).to.equal(1);
+      // Verify that the error was converted to Error instance
+      const errorCall = (mockContext.log.error as sinon.SinonStub).getCall(0);
+      expect(errorCall.args[1]).to.be.instanceOf(Error);
+      expect(errorCall.args[1].message).to.equal("String error");
+    });
+
+    it("should use correct event type in log messages", async () => {
+      const wrapper: ALM_LP_Wrapper = {
+        ...mockALMLPWrapperData,
+        liquidity: 1000000n,
+        tickLower: -1000n,
+        tickUpper: 1000n,
+        amount0: 500n * 10n ** 18n,
+        amount1: 250n * 10n ** 6n,
+      };
+
+      getSqrtPriceX96Stub.rejects(new Error("Failed"));
+
+      await recalculateLPWrapperAmountsFromLiquidity(
+        wrapper,
+        poolAddress,
+        chainId,
+        blockNumber,
+        mockContext,
+        "CustomEvent",
+      );
+
+      expect(
+        (mockContext.log.error as sinon.SinonStub).getCall(0).args[0],
+      ).to.include("ALMLPWrapper.CustomEvent");
+    });
+
+    it("should call roundBlockToInterval with correct parameters", async () => {
+      const wrapper: ALM_LP_Wrapper = {
+        ...mockALMLPWrapperData,
+        liquidity: 1000000n,
+        tickLower: -1000n,
+        tickUpper: 1000n,
+        amount0: 500n * 10n ** 18n,
+        amount1: 250n * 10n ** 6n,
+      };
+
+      getSqrtPriceX96Stub.resolves(mockSqrtPriceX96);
+      calculatePositionAmountsFromLiquidityStub.returns({
+        amount0: 600n * 10n ** 18n,
+        amount1: 300n * 10n ** 6n,
+      });
+
+      await recalculateLPWrapperAmountsFromLiquidity(
+        wrapper,
+        poolAddress,
+        chainId,
+        blockNumber,
+        mockContext,
+        "Deposit",
+      );
+
+      expect(roundBlockToIntervalStub.callCount).to.equal(1);
+      expect(roundBlockToIntervalStub.calledWith(blockNumber, chainId)).to.be
+        .true;
+    });
+  });
+});

--- a/test/EventHandlers/Pool/common.ts
+++ b/test/EventHandlers/Pool/common.ts
@@ -127,8 +127,6 @@ export function setupCommon() {
     tickLower: -1000n,
     tickUpper: 1000n,
     property: 3000n, // uint24 tick spacing
-    positionAmount0: 500n * TEN_TO_THE_18_BI,
-    positionAmount1: 250n * TEN_TO_THE_6_BI,
     liquidity: 1000000n,
     strategyType: 1n,
     tickNeighborhood: 100n,


### PR DESCRIPTION
Implements:
- Slight cleanup to `ALM_LP_Wrapper` entity schema
- Recalculating `amount0` and `amount1` based on liquidity/price changes of the pool to reflect the automatic changes in both token amounts of the LP position