### PR TITLE
Removing total liquidity added/removed field from user entity

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -166,8 +166,6 @@ type UserStatsPerPool {
   currentLiquidityUSD: BigInt! @config(precision: 76) # current net liquidity position in USD
   currentLiquidityToken0: BigInt! @config(precision: 76) # current net liquidity position in token0
   currentLiquidityToken1: BigInt! @config(precision: 76) # current net liquidity position in token1
-  totalLiquidityAddedUSD: BigInt! @config(precision: 76) # total liquidity added in USD
-  totalLiquidityRemovedUSD: BigInt! @config(precision: 76) # total liquidity removed in USD
 
   # Fee metrics
   totalFeesContributedUSD: BigInt! @config(precision: 76) # total fees contributed in USD

--- a/src/Aggregators/UserStatsPerPool.ts
+++ b/src/Aggregators/UserStatsPerPool.ts
@@ -90,8 +90,6 @@ export function createUserStatsPerPoolEntity(
     currentLiquidityUSD: 0n,
     currentLiquidityToken0: 0n,
     currentLiquidityToken1: 0n,
-    totalLiquidityAddedUSD: 0n,
-    totalLiquidityRemovedUSD: 0n,
 
     // Fee metrics
     totalFeesContributedUSD: 0n,
@@ -154,14 +152,6 @@ export async function updateUserStatsPerPool(
       diff.currentLiquidityUSD !== undefined
         ? current.currentLiquidityUSD + diff.currentLiquidityUSD
         : current.currentLiquidityUSD,
-    totalLiquidityAddedUSD:
-      diff.currentLiquidityUSD !== undefined && diff.currentLiquidityUSD > 0n
-        ? current.totalLiquidityAddedUSD + diff.currentLiquidityUSD
-        : current.totalLiquidityAddedUSD,
-    totalLiquidityRemovedUSD:
-      diff.currentLiquidityUSD !== undefined && diff.currentLiquidityUSD < 0n
-        ? current.totalLiquidityRemovedUSD + -diff.currentLiquidityUSD
-        : current.totalLiquidityRemovedUSD,
     currentLiquidityToken0:
       diff.currentLiquidityToken0 !== undefined
         ? current.currentLiquidityToken0 + diff.currentLiquidityToken0

--- a/test/Aggregators/UserStatsPerPoolLiquidity.test.ts
+++ b/test/Aggregators/UserStatsPerPoolLiquidity.test.ts
@@ -45,8 +45,6 @@ describe("UserStatsPerPool Liquidity Logic", () => {
       );
 
       expect(result.currentLiquidityUSD).toBe(1000n);
-      expect(result.totalLiquidityAddedUSD).toBe(1000n);
-      expect(result.totalLiquidityRemovedUSD).toBe(0n);
     });
 
     it("should handle multiple liquidity additions correctly", async () => {
@@ -74,8 +72,6 @@ describe("UserStatsPerPool Liquidity Logic", () => {
       );
 
       expect(userStats.currentLiquidityUSD).toBe(1000n);
-      expect(userStats.totalLiquidityAddedUSD).toBe(1000n);
-      expect(userStats.totalLiquidityRemovedUSD).toBe(0n);
 
       // Second addition
       userStats = await updateUserStatsPerPool(
@@ -88,8 +84,6 @@ describe("UserStatsPerPool Liquidity Logic", () => {
       );
 
       expect(userStats.currentLiquidityUSD).toBe(1500n);
-      expect(userStats.totalLiquidityAddedUSD).toBe(1500n);
-      expect(userStats.totalLiquidityRemovedUSD).toBe(0n);
     });
   });
 
@@ -119,8 +113,6 @@ describe("UserStatsPerPool Liquidity Logic", () => {
       );
 
       expect(result.currentLiquidityUSD).toBe(-500n);
-      expect(result.totalLiquidityAddedUSD).toBe(0n);
-      expect(result.totalLiquidityRemovedUSD).toBe(500n);
     });
 
     it("should handle multiple liquidity removals correctly", async () => {
@@ -148,8 +140,6 @@ describe("UserStatsPerPool Liquidity Logic", () => {
       );
 
       expect(userStats.currentLiquidityUSD).toBe(-300n);
-      expect(userStats.totalLiquidityAddedUSD).toBe(0n);
-      expect(userStats.totalLiquidityRemovedUSD).toBe(300n);
 
       // Second removal
       userStats = await updateUserStatsPerPool(
@@ -162,8 +152,6 @@ describe("UserStatsPerPool Liquidity Logic", () => {
       );
 
       expect(userStats.currentLiquidityUSD).toBe(-500n);
-      expect(userStats.totalLiquidityAddedUSD).toBe(0n);
-      expect(userStats.totalLiquidityRemovedUSD).toBe(500n);
     });
   });
 
@@ -193,8 +181,6 @@ describe("UserStatsPerPool Liquidity Logic", () => {
       );
 
       expect(userStats.currentLiquidityUSD).toBe(1000n);
-      expect(userStats.totalLiquidityAddedUSD).toBe(1000n);
-      expect(userStats.totalLiquidityRemovedUSD).toBe(0n);
 
       // Remove some liquidity
       userStats = await updateUserStatsPerPool(
@@ -207,8 +193,6 @@ describe("UserStatsPerPool Liquidity Logic", () => {
       );
 
       expect(userStats.currentLiquidityUSD).toBe(700n);
-      expect(userStats.totalLiquidityAddedUSD).toBe(1000n);
-      expect(userStats.totalLiquidityRemovedUSD).toBe(300n);
     });
 
     it("should handle removing then adding liquidity correctly", async () => {
@@ -236,8 +220,6 @@ describe("UserStatsPerPool Liquidity Logic", () => {
       );
 
       expect(userStats.currentLiquidityUSD).toBe(-500n);
-      expect(userStats.totalLiquidityAddedUSD).toBe(0n);
-      expect(userStats.totalLiquidityRemovedUSD).toBe(500n);
 
       // Add liquidity
       userStats = await updateUserStatsPerPool(
@@ -250,8 +232,6 @@ describe("UserStatsPerPool Liquidity Logic", () => {
       );
 
       expect(userStats.currentLiquidityUSD).toBe(300n);
-      expect(userStats.totalLiquidityAddedUSD).toBe(800n);
-      expect(userStats.totalLiquidityRemovedUSD).toBe(500n);
     });
 
     it("should handle complex liquidity operations correctly", async () => {
@@ -309,8 +289,6 @@ describe("UserStatsPerPool Liquidity Logic", () => {
       );
 
       expect(userStats.currentLiquidityUSD).toBe(1200n); // 1000 - 200 + 500 - 100
-      expect(userStats.totalLiquidityAddedUSD).toBe(1500n); // 1000 + 500
-      expect(userStats.totalLiquidityRemovedUSD).toBe(300n); // 200 + 100
     });
   });
 
@@ -338,8 +316,6 @@ describe("UserStatsPerPool Liquidity Logic", () => {
       );
 
       expect(result.currentLiquidityUSD).toBe(0n);
-      expect(result.totalLiquidityAddedUSD).toBe(0n);
-      expect(result.totalLiquidityRemovedUSD).toBe(0n);
     });
 
     it("should handle very large liquidity amounts", async () => {
@@ -367,8 +343,6 @@ describe("UserStatsPerPool Liquidity Logic", () => {
       );
 
       expect(result.currentLiquidityUSD).toBe(largeAmount);
-      expect(result.totalLiquidityAddedUSD).toBe(largeAmount);
-      expect(result.totalLiquidityRemovedUSD).toBe(0n);
     });
   });
 });

--- a/test/Aggregators/Users.test.ts
+++ b/test/Aggregators/Users.test.ts
@@ -30,8 +30,6 @@ describe("UserStatsPerPool Aggregator", () => {
       expect(userStats.currentLiquidityUSD).toBe(0n);
       expect(userStats.currentLiquidityToken0).toBe(0n);
       expect(userStats.currentLiquidityToken1).toBe(0n);
-      expect(userStats.totalLiquidityAddedUSD).toBe(0n);
-      expect(userStats.totalLiquidityRemovedUSD).toBe(0n);
       expect(userStats.totalFeesContributedUSD).toBe(0n);
       expect(userStats.totalFeesContributed0).toBe(0n);
       expect(userStats.totalFeesContributed1).toBe(0n);
@@ -107,8 +105,6 @@ describe("UserStatsPerPool Aggregator", () => {
       );
 
       expect(result.currentLiquidityUSD).toBe(netLiquidityAddedUSD);
-      expect(result.totalLiquidityAddedUSD).toBe(netLiquidityAddedUSD);
-      expect(result.totalLiquidityRemovedUSD).toBe(0n);
       expect(result.lastActivityTimestamp).toEqual(mockTimestamp);
       expect(savedUserStats).toEqual(result);
     });
@@ -141,8 +137,6 @@ describe("UserStatsPerPool Aggregator", () => {
       );
 
       expect(result.currentLiquidityUSD).toBe(netLiquidityRemovedUSD);
-      expect(result.totalLiquidityAddedUSD).toBe(0n);
-      expect(result.totalLiquidityRemovedUSD).toBe(500n);
       expect(result.lastActivityTimestamp).toEqual(mockTimestamp);
     });
 
@@ -350,8 +344,6 @@ describe("UserStatsPerPool Aggregator", () => {
       );
 
       expect(result.currentLiquidityUSD).toBe(2000n);
-      expect(result.totalLiquidityAddedUSD).toBe(2000n);
-      expect(result.totalLiquidityRemovedUSD).toBe(0n);
       expect(result.totalFeesContributedUSD).toBe(500n);
       expect(result.numberOfSwaps).toBe(2n);
       expect(result.totalSwapVolumeUSD).toBe(8000n);
@@ -369,7 +361,6 @@ describe("UserStatsPerPool Aggregator", () => {
         currentLiquidityUSD: 2000n,
         currentLiquidityToken0: 1000n,
         currentLiquidityToken1: 1000n,
-        totalLiquidityAddedUSD: 2000n,
         totalFeesContributedUSD: 1000n,
         totalFeesContributed0: 500n,
         totalFeesContributed1: 300n,
@@ -404,8 +395,6 @@ describe("UserStatsPerPool Aggregator", () => {
       );
 
       expect(result.currentLiquidityUSD).toBe(3000n); // 2000 + 1000
-      expect(result.totalLiquidityAddedUSD).toBe(3000n); // 2000 + 1000
-      expect(result.totalLiquidityRemovedUSD).toBe(0n); // No removal
       expect(result.totalFeesContributedUSD).toBe(1500n); // 1000 + 500
       expect(result.numberOfSwaps).toBe(6n); // 5 + 1
       expect(result.totalSwapVolumeUSD).toBe(13000n); // 10000 + 3000
@@ -423,7 +412,6 @@ describe("UserStatsPerPool Aggregator", () => {
         currentLiquidityUSD: 2000n,
         currentLiquidityToken0: 1000n,
         currentLiquidityToken1: 1000n,
-        totalLiquidityAddedUSD: 2000n,
         totalFeesContributedUSD: 1000n,
         totalFeesContributed0: 500n,
         totalFeesContributed1: 300n,
@@ -455,8 +443,6 @@ describe("UserStatsPerPool Aggregator", () => {
       );
 
       expect(result.currentLiquidityUSD).toBe(1500n); // 2000 - 500
-      expect(result.totalLiquidityAddedUSD).toBe(2000n); // Unchanged
-      expect(result.totalLiquidityRemovedUSD).toBe(500n); // 0 + 500
       expect(result.lastActivityTimestamp).toEqual(mockTimestamp);
     });
   });

--- a/test/EventHandlers/Gauges/GaugeSharedLogic.test.ts
+++ b/test/EventHandlers/Gauges/GaugeSharedLogic.test.ts
@@ -128,7 +128,6 @@ describe("GaugeSharedLogic", () => {
       currentLiquidityUSD: 1000000000000000000000n, // 1K USD in 18 decimals
       currentLiquidityToken0: 500000000n, // 500 USDC (6 decimals)
       currentLiquidityToken1: 500000000n, // 500 USDT (6 decimals)
-      totalLiquidityAddedUSD: 1000000000000000000000n,
       firstActivityTimestamp: mockTimestamp,
       lastActivityTimestamp: mockTimestamp,
     });

--- a/test/EventHandlers/Pool/Fees.test.ts
+++ b/test/EventHandlers/Pool/Fees.test.ts
@@ -156,7 +156,6 @@ describe("Pool Fees Event", () => {
       currentLiquidityUSD: 2000n,
       currentLiquidityToken0: 1000n,
       currentLiquidityToken1: 1000n,
-      totalLiquidityAddedUSD: 2000n,
       totalFeesContributedUSD: 2000n,
       totalFeesContributed0: 1000n,
       totalFeesContributed1: 800n,

--- a/test/EventHandlers/Pool/common.ts
+++ b/test/EventHandlers/Pool/common.ts
@@ -154,8 +154,6 @@ export function setupCommon() {
     currentLiquidityUSD: 0n,
     currentLiquidityToken0: 0n,
     currentLiquidityToken1: 0n,
-    totalLiquidityAddedUSD: 0n,
-    totalLiquidityRemovedUSD: 0n,
 
     // Fee metrics
     totalFeesContributedUSD: 0n,


### PR DESCRIPTION
Removed because it wasn't being updated and doesn't seem to be necessary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed total liquidity added and total liquidity removed metrics from user pool statistics data structure, simplifying per-pool tracking.

* **Tests**
  * Updated test cases to reflect the removal of liquidity tracking metrics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->