### PR TITLE
CLPool staked fees update fix

### DIFF
--- a/src/Aggregators/LiquidityPoolAggregator.ts
+++ b/src/Aggregators/LiquidityPoolAggregator.ts
@@ -18,6 +18,63 @@ export type DynamicFeeConfig = {
   scalingFactor: bigint;
 };
 
+interface LiquidityPoolAggregatorDiff {
+  reserve0: bigint;
+  reserve1: bigint;
+  totalLiquidityUSD: bigint;
+  totalVolume0: bigint;
+  totalVolume1: bigint;
+  totalVolumeUSD: bigint;
+  totalVolumeUSDWhitelisted: bigint;
+  incrementalFeesUSDWhitelisted: bigint;
+  incrementalUnstakedFeesCollected0: bigint;
+  incrementalUnstakedFeesCollected1: bigint;
+  incrementalUnstakedFeesCollectedUSD: bigint;
+  incrementalStakedFeesCollected0: bigint;
+  incrementalStakedFeesCollected1: bigint;
+  incrementalStakedFeesCollectedUSD: bigint;
+  numberOfSwaps: bigint;
+  totalEmissions: bigint;
+  totalEmissionsUSD: bigint;
+  totalBribesUSD: bigint;
+  totalFlashLoanFees0: bigint;
+  totalFlashLoanFees1: bigint;
+  totalFlashLoanFeesUSD: bigint;
+  totalFlashLoanVolumeUSD: bigint;
+  numberOfFlashLoans: bigint;
+  numberOfGaugeDeposits: bigint;
+  numberOfGaugeWithdrawals: bigint;
+  numberOfGaugeRewardClaims: bigint;
+  totalGaugeRewardsClaimedUSD: bigint;
+  totalGaugeRewardsClaimed: bigint;
+  currentLiquidityStaked: bigint;
+  currentLiquidityStakedUSD: bigint;
+  token0Price: bigint;
+  token1Price: bigint;
+  token0IsWhitelisted: boolean;
+  token1IsWhitelisted: boolean;
+  gaugeIsAlive: boolean;
+  gaugeAddress: string;
+  bribeVotingRewardAddress: string;
+  feeVotingRewardAddress: string;
+  feeProtocol0: bigint;
+  feeProtocol1: bigint;
+  observationCardinalityNext: bigint;
+  totalVotesDeposited: bigint;
+  totalVotesDepositedUSD: bigint;
+  totalBribeClaimed: bigint;
+  totalBribeClaimedUSD: bigint;
+  totalFeeRewardClaimed: bigint;
+  totalFeeRewardClaimedUSD: bigint;
+  veNFTamountStaked: bigint;
+  baseFee: bigint;
+  feeCap: bigint;
+  scalingFactor: bigint;
+  currentFee: bigint;
+  lastUpdatedTimestamp: Date;
+  lastSnapshotTimestamp: Date;
+}
+
 /**
  * Update the dynamic fee pools data from the swap module.
  * @param liquidityPoolAggregator
@@ -107,7 +164,7 @@ export function setLiquidityPoolAggregatorSnapshot(
  * @param context - The handler context used to store the updated state and snapshots.
  */
 export async function updateLiquidityPoolAggregator(
-  diff: Partial<LiquidityPoolAggregator>,
+  diff: Partial<LiquidityPoolAggregatorDiff>,
   current: LiquidityPoolAggregator,
   timestamp: Date,
   context: handlerContext,
@@ -127,26 +184,27 @@ export async function updateLiquidityPoolAggregator(
       (diff.totalVolumeUSDWhitelisted ?? 0n) +
       current.totalVolumeUSDWhitelisted,
     totalFeesUSDWhitelisted:
-      (diff.totalFeesUSDWhitelisted ?? 0n) + current.totalFeesUSDWhitelisted,
+      (diff.incrementalFeesUSDWhitelisted ?? 0n) +
+      current.totalFeesUSDWhitelisted,
     // Unstaked fees (from Collect events - LPs that didn't stake)
     totalUnstakedFeesCollected0:
-      (diff.totalUnstakedFeesCollected0 ?? 0n) +
+      (diff.incrementalUnstakedFeesCollected0 ?? 0n) +
       current.totalUnstakedFeesCollected0,
     totalUnstakedFeesCollected1:
-      (diff.totalUnstakedFeesCollected1 ?? 0n) +
+      (diff.incrementalUnstakedFeesCollected1 ?? 0n) +
       current.totalUnstakedFeesCollected1,
     totalUnstakedFeesCollectedUSD:
-      (diff.totalUnstakedFeesCollectedUSD ?? 0n) +
+      (diff.incrementalUnstakedFeesCollectedUSD ?? 0n) +
       current.totalUnstakedFeesCollectedUSD,
     // Staked fees (from CollectFees events - LPs that staked in gauge)
     totalStakedFeesCollected0:
-      (diff.totalStakedFeesCollected0 ?? 0n) +
+      (diff.incrementalStakedFeesCollected0 ?? 0n) +
       current.totalStakedFeesCollected0,
     totalStakedFeesCollected1:
-      (diff.totalStakedFeesCollected1 ?? 0n) +
+      (diff.incrementalStakedFeesCollected1 ?? 0n) +
       current.totalStakedFeesCollected1,
     totalStakedFeesCollectedUSD:
-      (diff.totalStakedFeesCollectedUSD ?? 0n) +
+      (diff.incrementalStakedFeesCollectedUSD ?? 0n) +
       current.totalStakedFeesCollectedUSD,
     numberOfSwaps: (diff.numberOfSwaps ?? 0n) + current.numberOfSwaps,
     totalEmissions: (diff.totalEmissions ?? 0n) + current.totalEmissions,

--- a/src/Aggregators/UserStatsPerPool.ts
+++ b/src/Aggregators/UserStatsPerPool.ts
@@ -1,6 +1,41 @@
 import type { UserStatsPerPool, handlerContext } from "generated";
 import { toChecksumAddress } from "../Constants";
 
+interface UserStatsPerPoolDiff {
+  currentLiquidityUSD: bigint;
+  currentLiquidityToken0: bigint;
+  currentLiquidityToken1: bigint;
+  totalLiquidityAddedUSD: bigint;
+  totalLiquidityRemovedUSD: bigint;
+  incrementalFeesContributedUSD: bigint;
+  incrementalFeesContributed0: bigint;
+  incrementalFeesContributed1: bigint;
+  numberOfSwaps: bigint;
+  totalSwapVolumeAmount0: bigint;
+  totalSwapVolumeAmount1: bigint;
+  totalSwapVolumeUSD: bigint;
+  numberOfFlashLoans: bigint;
+  totalFlashLoanVolumeUSD: bigint;
+  numberOfGaugeDeposits: bigint;
+  numberOfGaugeWithdrawals: bigint;
+  numberOfGaugeRewardClaims: bigint;
+  totalGaugeRewardsClaimedUSD: bigint;
+  totalGaugeRewardsClaimed: bigint;
+  currentLiquidityStaked: bigint;
+  currentLiquidityStakedUSD: bigint;
+  veNFTamountStaked: bigint;
+  totalBribeClaimed: bigint;
+  totalBribeClaimedUSD: bigint;
+  totalFeeRewardClaimed: bigint;
+  totalFeeRewardClaimedUSD: bigint;
+  almAddress: string;
+  almAmount0: bigint;
+  almAmount1: bigint;
+  almLpAmount: bigint;
+  lastAlmActivityTimestamp: Date;
+  lastActivityTimestamp: Date;
+}
+
 /**
  * Generates the ID for a UserStatsPerPool entity
  * @param userAddress - The user's address
@@ -144,7 +179,7 @@ export function createUserStatsPerPoolEntity(
  * Similar to updateLiquidityPoolAggregator pattern
  */
 export async function updateUserStatsPerPool(
-  diff: Partial<UserStatsPerPool>,
+  diff: Partial<UserStatsPerPoolDiff>,
   current: UserStatsPerPool,
   context: handlerContext,
 ): Promise<UserStatsPerPool> {
@@ -155,12 +190,12 @@ export async function updateUserStatsPerPool(
         ? current.currentLiquidityUSD + diff.currentLiquidityUSD
         : current.currentLiquidityUSD,
     totalLiquidityAddedUSD:
-      diff.currentLiquidityUSD !== undefined && diff.currentLiquidityUSD > 0n
-        ? current.totalLiquidityAddedUSD + diff.currentLiquidityUSD
+      diff.totalLiquidityAddedUSD !== undefined
+        ? current.totalLiquidityAddedUSD + diff.totalLiquidityAddedUSD
         : current.totalLiquidityAddedUSD,
     totalLiquidityRemovedUSD:
-      diff.currentLiquidityUSD !== undefined && diff.currentLiquidityUSD < 0n
-        ? current.totalLiquidityRemovedUSD + -diff.currentLiquidityUSD
+      diff.totalLiquidityRemovedUSD !== undefined
+        ? current.totalLiquidityRemovedUSD + diff.totalLiquidityRemovedUSD
         : current.totalLiquidityRemovedUSD,
     currentLiquidityToken0:
       diff.currentLiquidityToken0 !== undefined
@@ -172,16 +207,16 @@ export async function updateUserStatsPerPool(
         : current.currentLiquidityToken1,
 
     totalFeesContributed0:
-      diff.totalFeesContributed0 !== undefined
-        ? current.totalFeesContributed0 + diff.totalFeesContributed0
+      diff.incrementalFeesContributed0 !== undefined
+        ? current.totalFeesContributed0 + diff.incrementalFeesContributed0
         : current.totalFeesContributed0,
     totalFeesContributed1:
-      diff.totalFeesContributed1 !== undefined
-        ? current.totalFeesContributed1 + diff.totalFeesContributed1
+      diff.incrementalFeesContributed1 !== undefined
+        ? current.totalFeesContributed1 + diff.incrementalFeesContributed1
         : current.totalFeesContributed1,
     totalFeesContributedUSD:
-      diff.totalFeesContributedUSD !== undefined
-        ? current.totalFeesContributedUSD + diff.totalFeesContributedUSD
+      diff.incrementalFeesContributedUSD !== undefined
+        ? current.totalFeesContributedUSD + diff.incrementalFeesContributedUSD
         : current.totalFeesContributedUSD,
 
     numberOfSwaps:

--- a/src/EventHandlers/CLPool.ts
+++ b/src/EventHandlers/CLPool.ts
@@ -163,7 +163,6 @@ CLPool.CollectFees.handler(async ({ event, context }) => {
   // Process the collect fees event
   const result = processCLPoolCollectFees(
     event,
-    liquidityPoolAggregator,
     token0Instance,
     token1Instance,
   );

--- a/src/EventHandlers/CLPool/CLPoolCollectFeesLogic.ts
+++ b/src/EventHandlers/CLPool/CLPoolCollectFeesLogic.ts
@@ -1,30 +1,24 @@
-import type {
-  CLPool_CollectFees_event,
-  LiquidityPoolAggregator,
-  Token,
-  handlerContext,
-} from "generated";
+import type { CLPool_CollectFees_event, Token } from "generated";
 import { calculateTotalLiquidityUSD } from "../../Helpers";
 
 export interface CLPoolCollectFeesResult {
   liquidityPoolDiff: {
-    totalStakedFeesCollected0: bigint;
-    totalStakedFeesCollected1: bigint;
-    totalStakedFeesCollectedUSD: bigint;
-    totalFeesUSDWhitelisted: bigint;
+    incrementalStakedFeesCollected0: bigint;
+    incrementalStakedFeesCollected1: bigint;
+    incrementalStakedFeesCollectedUSD: bigint;
+    incrementalFeesUSDWhitelisted: bigint;
     lastUpdatedTimestamp: Date;
   };
   userDiff: {
-    totalFeesContributedUSD: bigint;
-    totalFeesContributed0: bigint;
-    totalFeesContributed1: bigint;
+    incrementalFeesContributedUSD: bigint;
+    incrementalFeesContributed0: bigint;
+    incrementalFeesContributed1: bigint;
     lastActivityTimestamp: Date;
   };
 }
 
 export function processCLPoolCollectFees(
   event: CLPool_CollectFees_event,
-  liquidityPoolAggregator: LiquidityPoolAggregator,
   token0Instance: Token | undefined,
   token1Instance: Token | undefined,
 ): CLPoolCollectFeesResult {
@@ -69,17 +63,17 @@ export function processCLPoolCollectFees(
   // Therefore, CollectFees events should NOT affect reserves - only track fees collected.
   // Return increments (not new totals) since updateLiquidityPoolAggregator will add them to current values
   const liquidityPoolDiff = {
-    totalStakedFeesCollected0: event.params.amount0,
-    totalStakedFeesCollected1: event.params.amount1,
-    totalStakedFeesCollectedUSD: stakedFeesIncrementUSD,
-    totalFeesUSDWhitelisted: totalFeesUSDWhitelistedIncrement,
+    incrementalStakedFeesCollected0: event.params.amount0,
+    incrementalStakedFeesCollected1: event.params.amount1,
+    incrementalStakedFeesCollectedUSD: stakedFeesIncrementUSD,
+    incrementalFeesUSDWhitelisted: totalFeesUSDWhitelistedIncrement,
     lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
   };
 
   const userDiff = {
-    totalFeesContributedUSD: stakedFeesIncrementUSD,
-    totalFeesContributed0: event.params.amount0,
-    totalFeesContributed1: event.params.amount1,
+    incrementalFeesContributedUSD: stakedFeesIncrementUSD,
+    incrementalFeesContributed0: event.params.amount0,
+    incrementalFeesContributed1: event.params.amount1,
     lastActivityTimestamp: new Date(event.block.timestamp * 1000),
   };
 

--- a/src/EventHandlers/Pool/PoolFeesLogic.ts
+++ b/src/EventHandlers/Pool/PoolFeesLogic.ts
@@ -1,20 +1,22 @@
-import type {
-  LiquidityPoolAggregator,
-  Pool_Fees_event,
-  Token,
-  handlerContext,
-} from "generated";
+import type { Pool_Fees_event, Token, handlerContext } from "generated";
 import { updateFeeTokenData } from "../../Helpers";
 
 export interface UserDiff {
-  totalFeesContributedUSD: bigint;
-  totalFeesContributed0: bigint;
-  totalFeesContributed1: bigint;
+  incrementalFeesContributedUSD: bigint;
+  incrementalFeesContributed0: bigint;
+  incrementalFeesContributed1: bigint;
   lastActivityTimestamp: Date;
 }
 
+export interface LiquidityPoolAggregatorDiff {
+  incrementalUnstakedFeesCollected0: bigint;
+  incrementalUnstakedFeesCollected1: bigint;
+  incrementalUnstakedFeesCollectedUSD: bigint;
+  incrementalFeesUSDWhitelisted: bigint;
+  lastUpdatedTimestamp: Date;
+}
 export interface PoolFeesResult {
-  liquidityPoolDiff?: Partial<LiquidityPoolAggregator>;
+  liquidityPoolDiff?: LiquidityPoolAggregatorDiff;
   userDiff?: UserDiff;
 }
 
@@ -37,19 +39,19 @@ export async function processPoolFees(
   // Create liquidity pool diff
   // For regular pools (non-CL), fees are tracked as unstaked fees
   // since regular pools don't have the staked/unstaked distinction that CL pools have
-  const liquidityPoolDiff: Partial<LiquidityPoolAggregator> = {
-    totalUnstakedFeesCollected0: event.params.amount0,
-    totalUnstakedFeesCollected1: event.params.amount1,
-    totalUnstakedFeesCollectedUSD: feeData.totalFeesUSD,
-    totalFeesUSDWhitelisted: feeData.totalFeesUSDWhitelisted,
+  const liquidityPoolDiff = {
+    incrementalUnstakedFeesCollected0: event.params.amount0,
+    incrementalUnstakedFeesCollected1: event.params.amount1,
+    incrementalUnstakedFeesCollectedUSD: feeData.totalFeesUSD,
+    incrementalFeesUSDWhitelisted: feeData.totalFeesUSDWhitelisted,
     lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
   };
 
   // Prepare user diff data
   const userDiff: UserDiff = {
-    totalFeesContributedUSD: feeData.totalFeesUSD,
-    totalFeesContributed0: event.params.amount0,
-    totalFeesContributed1: event.params.amount1,
+    incrementalFeesContributedUSD: feeData.totalFeesUSD,
+    incrementalFeesContributed0: event.params.amount0,
+    incrementalFeesContributed1: event.params.amount1,
     lastActivityTimestamp: new Date(event.block.timestamp * 1000),
   };
 

--- a/test/Aggregators/LiquidityPoolAggregator.test.ts
+++ b/test/Aggregators/LiquidityPoolAggregator.test.ts
@@ -318,7 +318,7 @@ describe("LiquidityPoolAggregator Functions", () => {
       totalVolumeUSD: 0n,
       numberOfSwaps: 0n,
       totalVolumeUSDWhitelisted: 0n,
-      totalFeesUSDWhitelisted: 0n,
+      incrementalFeesUSDWhitelisted: 0n,
       totalVotesDeposited: 0n,
       totalVotesDepositedUSD: 0n,
       totalEmissions: 0n,
@@ -330,7 +330,7 @@ describe("LiquidityPoolAggregator Functions", () => {
         totalVolumeUSD: 7000n,
         numberOfSwaps: 11n,
         totalVolumeUSDWhitelisted: 8000n,
-        totalFeesUSDWhitelisted: 9000n,
+        incrementalFeesUSDWhitelisted: 9000n,
         totalVotesDeposited: 2000n,
         totalVotesDepositedUSD: 3000n,
         totalEmissions: 4000n,
@@ -355,7 +355,7 @@ describe("LiquidityPoolAggregator Functions", () => {
         diff.totalVolumeUSDWhitelisted,
       );
       expect(updatedAggregator.totalFeesUSDWhitelisted).toBe(
-        diff.totalFeesUSDWhitelisted,
+        diff.incrementalFeesUSDWhitelisted,
       );
     });
 

--- a/test/Aggregators/UserStatsPerPoolLiquidity.test.ts
+++ b/test/Aggregators/UserStatsPerPoolLiquidity.test.ts
@@ -38,6 +38,7 @@ describe("UserStatsPerPool Liquidity Logic", () => {
       const result = await updateUserStatsPerPool(
         {
           currentLiquidityUSD: netLiquidityAddedUSD,
+          totalLiquidityAddedUSD: netLiquidityAddedUSD,
           lastActivityTimestamp: mockTimestamp,
         },
         userStats,
@@ -67,6 +68,7 @@ describe("UserStatsPerPool Liquidity Logic", () => {
       userStats = await updateUserStatsPerPool(
         {
           currentLiquidityUSD: 1000n,
+          totalLiquidityAddedUSD: 1000n,
           lastActivityTimestamp: mockTimestamp,
         },
         userStats,
@@ -81,6 +83,7 @@ describe("UserStatsPerPool Liquidity Logic", () => {
       userStats = await updateUserStatsPerPool(
         {
           currentLiquidityUSD: 500n,
+          totalLiquidityAddedUSD: 500n,
           lastActivityTimestamp: mockTimestamp,
         },
         userStats,
@@ -112,6 +115,7 @@ describe("UserStatsPerPool Liquidity Logic", () => {
       const result = await updateUserStatsPerPool(
         {
           currentLiquidityUSD: netLiquidityRemovedUSD,
+          totalLiquidityRemovedUSD: 500n,
           lastActivityTimestamp: mockTimestamp,
         },
         userStats,
@@ -141,6 +145,7 @@ describe("UserStatsPerPool Liquidity Logic", () => {
       userStats = await updateUserStatsPerPool(
         {
           currentLiquidityUSD: -300n,
+          totalLiquidityRemovedUSD: 300n,
           lastActivityTimestamp: mockTimestamp,
         },
         userStats,
@@ -155,6 +160,7 @@ describe("UserStatsPerPool Liquidity Logic", () => {
       userStats = await updateUserStatsPerPool(
         {
           currentLiquidityUSD: -200n,
+          totalLiquidityRemovedUSD: 200n,
           lastActivityTimestamp: mockTimestamp,
         },
         userStats,
@@ -186,6 +192,7 @@ describe("UserStatsPerPool Liquidity Logic", () => {
       userStats = await updateUserStatsPerPool(
         {
           currentLiquidityUSD: 1000n,
+          totalLiquidityAddedUSD: 1000n,
           lastActivityTimestamp: mockTimestamp,
         },
         userStats,
@@ -200,6 +207,7 @@ describe("UserStatsPerPool Liquidity Logic", () => {
       userStats = await updateUserStatsPerPool(
         {
           currentLiquidityUSD: -300n,
+          totalLiquidityRemovedUSD: 300n,
           lastActivityTimestamp: mockTimestamp,
         },
         userStats,
@@ -229,6 +237,7 @@ describe("UserStatsPerPool Liquidity Logic", () => {
       userStats = await updateUserStatsPerPool(
         {
           currentLiquidityUSD: -500n,
+          totalLiquidityRemovedUSD: 500n,
           lastActivityTimestamp: mockTimestamp,
         },
         userStats,
@@ -243,6 +252,7 @@ describe("UserStatsPerPool Liquidity Logic", () => {
       userStats = await updateUserStatsPerPool(
         {
           currentLiquidityUSD: 800n,
+          totalLiquidityAddedUSD: 800n,
           lastActivityTimestamp: mockTimestamp,
         },
         userStats,
@@ -272,6 +282,7 @@ describe("UserStatsPerPool Liquidity Logic", () => {
       userStats = await updateUserStatsPerPool(
         {
           currentLiquidityUSD: 1000n,
+          totalLiquidityAddedUSD: 1000n,
           lastActivityTimestamp: mockTimestamp,
         },
         userStats,
@@ -282,6 +293,7 @@ describe("UserStatsPerPool Liquidity Logic", () => {
       userStats = await updateUserStatsPerPool(
         {
           currentLiquidityUSD: -200n,
+          totalLiquidityRemovedUSD: 200n,
           lastActivityTimestamp: mockTimestamp,
         },
         userStats,
@@ -292,6 +304,7 @@ describe("UserStatsPerPool Liquidity Logic", () => {
       userStats = await updateUserStatsPerPool(
         {
           currentLiquidityUSD: 500n,
+          totalLiquidityAddedUSD: 500n,
           lastActivityTimestamp: mockTimestamp,
         },
         userStats,
@@ -302,6 +315,7 @@ describe("UserStatsPerPool Liquidity Logic", () => {
       userStats = await updateUserStatsPerPool(
         {
           currentLiquidityUSD: -100n,
+          totalLiquidityRemovedUSD: 100n,
           lastActivityTimestamp: mockTimestamp,
         },
         userStats,
@@ -360,6 +374,7 @@ describe("UserStatsPerPool Liquidity Logic", () => {
       const result = await updateUserStatsPerPool(
         {
           currentLiquidityUSD: largeAmount,
+          totalLiquidityAddedUSD: largeAmount,
           lastActivityTimestamp: mockTimestamp,
         },
         userStats,

--- a/test/Aggregators/Users.test.ts
+++ b/test/Aggregators/Users.test.ts
@@ -97,6 +97,7 @@ describe("UserStatsPerPool Aggregator", () => {
       const netLiquidityAddedUSD = 1000n;
       const diff = {
         currentLiquidityUSD: netLiquidityAddedUSD,
+        totalLiquidityAddedUSD: netLiquidityAddedUSD,
         lastActivityTimestamp: mockTimestamp,
       };
 
@@ -131,6 +132,7 @@ describe("UserStatsPerPool Aggregator", () => {
       const netLiquidityRemovedUSD = -500n;
       const diff = {
         currentLiquidityUSD: netLiquidityRemovedUSD,
+        totalLiquidityRemovedUSD: 500n,
         lastActivityTimestamp: mockTimestamp,
       };
 
@@ -162,9 +164,9 @@ describe("UserStatsPerPool Aggregator", () => {
       );
 
       const diff = {
-        totalFeesContributedUSD: 1000n,
-        totalFeesContributed0: 500n,
-        totalFeesContributed1: 300n,
+        incrementalFeesContributedUSD: 1000n,
+        incrementalFeesContributed0: 500n,
+        incrementalFeesContributed1: 300n,
         lastActivityTimestamp: mockTimestamp,
       };
 
@@ -335,7 +337,8 @@ describe("UserStatsPerPool Aggregator", () => {
 
       const diff = {
         currentLiquidityUSD: 2000n,
-        totalFeesContributedUSD: 500n,
+        totalLiquidityAddedUSD: 2000n,
+        incrementalFeesContributedUSD: 500n,
         numberOfSwaps: 2n,
         totalSwapVolumeUSD: 8000n,
         numberOfFlashLoans: 1n,
@@ -391,7 +394,8 @@ describe("UserStatsPerPool Aggregator", () => {
 
       const diff = {
         currentLiquidityUSD: 1000n, // Adding more liquidity
-        totalFeesContributedUSD: 500n,
+        totalLiquidityAddedUSD: 1000n,
+        incrementalFeesContributedUSD: 500n,
         numberOfSwaps: 1n,
         totalSwapVolumeUSD: 3000n,
         lastActivityTimestamp: mockTimestamp,
@@ -445,6 +449,7 @@ describe("UserStatsPerPool Aggregator", () => {
 
       const diff = {
         currentLiquidityUSD: -500n, // Removing liquidity
+        totalLiquidityRemovedUSD: 500n,
         lastActivityTimestamp: mockTimestamp,
       };
 

--- a/test/EventHandlers/CLPool.test.ts
+++ b/test/EventHandlers/CLPool.test.ts
@@ -552,16 +552,16 @@ describe("CLPool Events", () => {
           liquidityPoolDiff: {
             // In CL pools, CollectFees events do NOT affect reserves - fees were never part of reserves
             // Track staked fees (from CollectFees events - LPs that staked in gauge)
-            totalStakedFeesCollected0: 50n,
-            totalStakedFeesCollected1: 75n,
-            totalStakedFeesCollectedUSD: 125n,
-            totalFeesUSDWhitelisted: 125n,
+            incrementalStakedFeesCollected0: 50n,
+            incrementalStakedFeesCollected1: 75n,
+            incrementalStakedFeesCollectedUSD: 125n,
+            incrementalFeesUSDWhitelisted: 125n,
             lastUpdatedTimestamp: new Date(1000000 * 1000),
           },
           userDiff: {
-            totalFeesContributedUSD: 125n,
-            totalFeesContributed0: 50n,
-            totalFeesContributed1: 75n,
+            incrementalFeesContributedUSD: 125n,
+            incrementalFeesContributed0: 50n,
+            incrementalFeesContributed1: 75n,
             lastActivityTimestamp: new Date(1000000 * 1000),
           },
         });

--- a/test/EventHandlers/CLPool/CLPoolCollectFeesLogic.test.ts
+++ b/test/EventHandlers/CLPool/CLPoolCollectFeesLogic.test.ts
@@ -82,48 +82,50 @@ describe("CLPoolCollectFeesLogic", () => {
     it("should process collect fees event successfully with valid data", () => {
       const result = processCLPoolCollectFees(
         mockEvent,
-        mockLiquidityPoolAggregator,
         mockToken0,
         mockToken1,
       );
 
       // Check liquidity pool diff with exact values (staked fees)
-      expect(result.liquidityPoolDiff.totalStakedFeesCollected0).toBe(
+      expect(result.liquidityPoolDiff.incrementalStakedFeesCollected0).toBe(
         1000000000000000000n,
       );
-      expect(result.liquidityPoolDiff.totalStakedFeesCollected1).toBe(
+      expect(result.liquidityPoolDiff.incrementalStakedFeesCollected1).toBe(
         2000000000000000000n,
       );
 
       // Exact USD calculation: 1 USD + 4 USD = 5 USD
-      expect(result.liquidityPoolDiff.totalStakedFeesCollectedUSD).toBe(
+      expect(result.liquidityPoolDiff.incrementalStakedFeesCollectedUSD).toBe(
         5000000000000000000n,
       );
 
       // Check user diff
-      expect(result.userDiff.totalFeesContributedUSD).toBe(
+      expect(result.userDiff.incrementalFeesContributedUSD).toBe(
         5000000000000000000n,
       );
-      expect(result.userDiff.totalFeesContributed0).toBe(1000000000000000000n);
-      expect(result.userDiff.totalFeesContributed1).toBe(2000000000000000000n);
+      expect(result.userDiff.incrementalFeesContributed0).toBe(
+        1000000000000000000n,
+      );
+      expect(result.userDiff.incrementalFeesContributed1).toBe(
+        2000000000000000000n,
+      );
     });
 
     it("should calculate correct fee values for collect fees event", () => {
       const result = processCLPoolCollectFees(
         mockEvent,
-        mockLiquidityPoolAggregator,
         mockToken0,
         mockToken1,
       );
 
       // The liquidity pool diff should reflect the staked fees being collected with exact values
-      expect(result.liquidityPoolDiff.totalStakedFeesCollected0).toBe(
+      expect(result.liquidityPoolDiff.incrementalStakedFeesCollected0).toBe(
         1000000000000000000n,
       );
-      expect(result.liquidityPoolDiff.totalStakedFeesCollected1).toBe(
+      expect(result.liquidityPoolDiff.incrementalStakedFeesCollected1).toBe(
         2000000000000000000n,
       );
-      expect(result.liquidityPoolDiff.totalStakedFeesCollectedUSD).toBe(
+      expect(result.liquidityPoolDiff.incrementalStakedFeesCollectedUSD).toBe(
         5000000000000000000n,
       );
     });
@@ -136,7 +138,6 @@ describe("CLPoolCollectFeesLogic", () => {
 
       const result = processCLPoolCollectFees(
         mockEvent,
-        mockLiquidityPoolAggregator,
         tokenWithDifferentDecimals,
         mockToken1,
       );
@@ -156,14 +157,15 @@ describe("CLPoolCollectFeesLogic", () => {
 
       const result = processCLPoolCollectFees(
         eventWithZeroAmounts,
-        mockLiquidityPoolAggregator,
         mockToken0,
         mockToken1,
       );
 
-      expect(result.liquidityPoolDiff.totalStakedFeesCollected0).toBe(0n);
-      expect(result.liquidityPoolDiff.totalStakedFeesCollected1).toBe(0n);
-      expect(result.liquidityPoolDiff.totalStakedFeesCollectedUSD).toBe(0n);
+      expect(result.liquidityPoolDiff.incrementalStakedFeesCollected0).toBe(0n);
+      expect(result.liquidityPoolDiff.incrementalStakedFeesCollected1).toBe(0n);
+      expect(result.liquidityPoolDiff.incrementalStakedFeesCollectedUSD).toBe(
+        0n,
+      );
     });
 
     it("should use refreshed token prices for USD calculations", () => {
@@ -180,7 +182,6 @@ describe("CLPoolCollectFeesLogic", () => {
 
       const result = processCLPoolCollectFees(
         mockEvent,
-        mockLiquidityPoolAggregator,
         token0WithNewPrice,
         token1WithNewPrice,
       );
@@ -190,15 +191,15 @@ describe("CLPoolCollectFeesLogic", () => {
       // amount1: 2 tokens * $2.50 = $5.00
       // Total: $6.50
       const expectedUSD = 6500000000000000000n;
-      expect(result.liquidityPoolDiff.totalStakedFeesCollectedUSD).toBe(
+      expect(result.liquidityPoolDiff.incrementalStakedFeesCollectedUSD).toBe(
         expectedUSD,
       );
 
       // Verify the calculation uses the new prices, not old ones
       // If it used old prices ($1.00 and $2.00), it would be $5.00
-      expect(result.liquidityPoolDiff.totalStakedFeesCollectedUSD).not.toBe(
-        5000000000000000000n,
-      );
+      expect(
+        result.liquidityPoolDiff.incrementalStakedFeesCollectedUSD,
+      ).not.toBe(5000000000000000000n);
     });
 
     it("should correctly calculate USD when one token price is zero", () => {
@@ -209,87 +210,73 @@ describe("CLPoolCollectFeesLogic", () => {
 
       const result = processCLPoolCollectFees(
         mockEvent,
-        mockLiquidityPoolAggregator,
         token0WithZeroPrice,
         mockToken1,
       );
 
       // Only token1 contributes to USD (token0 has 0 price)
       // amount1: 2 tokens * $2.00 = $4.00
-      expect(result.liquidityPoolDiff.totalStakedFeesCollectedUSD).toBe(
+      expect(result.liquidityPoolDiff.incrementalStakedFeesCollectedUSD).toBe(
         4000000000000000000n,
       );
     });
 
     it("should handle undefined token0Instance correctly", () => {
-      const result = processCLPoolCollectFees(
-        mockEvent,
-        mockLiquidityPoolAggregator,
-        undefined,
-        mockToken1,
-      );
+      const result = processCLPoolCollectFees(mockEvent, undefined, mockToken1);
 
       // Fees are still tracked even when token instance is undefined
-      expect(result.liquidityPoolDiff.totalStakedFeesCollected0).toBe(
+      expect(result.liquidityPoolDiff.incrementalStakedFeesCollected0).toBe(
         1000000000000000000n,
       );
-      expect(result.liquidityPoolDiff.totalStakedFeesCollected1).toBe(
+      expect(result.liquidityPoolDiff.incrementalStakedFeesCollected1).toBe(
         2000000000000000000n,
       );
       // USD should only include token1 (token0 has no instance to calculate price)
       // token1: 2 tokens * $2.00 = $4.00
-      expect(result.liquidityPoolDiff.totalStakedFeesCollectedUSD).toBe(
+      expect(result.liquidityPoolDiff.incrementalStakedFeesCollectedUSD).toBe(
         4000000000000000000n,
       );
       // Whitelisted fees should not include token0 (undefined), only token1 if whitelisted
       // Since mockToken1.isWhitelisted is false, whitelisted fees should be 0
-      expect(result.liquidityPoolDiff.totalFeesUSDWhitelisted).toBe(0n);
+      expect(result.liquidityPoolDiff.incrementalFeesUSDWhitelisted).toBe(0n);
     });
 
     it("should handle undefined token1Instance correctly", () => {
-      const result = processCLPoolCollectFees(
-        mockEvent,
-        mockLiquidityPoolAggregator,
-        mockToken0,
-        undefined,
-      );
+      const result = processCLPoolCollectFees(mockEvent, mockToken0, undefined);
 
       // Fees are still tracked even when token instance is undefined
-      expect(result.liquidityPoolDiff.totalStakedFeesCollected0).toBe(
+      expect(result.liquidityPoolDiff.incrementalStakedFeesCollected0).toBe(
         1000000000000000000n,
       );
-      expect(result.liquidityPoolDiff.totalStakedFeesCollected1).toBe(
+      expect(result.liquidityPoolDiff.incrementalStakedFeesCollected1).toBe(
         2000000000000000000n,
       );
       // USD should only include token0 (token1 has no instance to calculate price)
       // token0: 1 token * $1.00 = $1.00
-      expect(result.liquidityPoolDiff.totalStakedFeesCollectedUSD).toBe(
+      expect(result.liquidityPoolDiff.incrementalStakedFeesCollectedUSD).toBe(
         1000000000000000000n,
       );
       // Whitelisted fees should not include token1 (undefined), only token0 if whitelisted
       // Since mockToken0.isWhitelisted is false, whitelisted fees should be 0
-      expect(result.liquidityPoolDiff.totalFeesUSDWhitelisted).toBe(0n);
+      expect(result.liquidityPoolDiff.incrementalFeesUSDWhitelisted).toBe(0n);
     });
 
     it("should handle both tokens undefined", () => {
-      const result = processCLPoolCollectFees(
-        mockEvent,
-        mockLiquidityPoolAggregator,
-        undefined,
-        undefined,
-      );
+      const result = processCLPoolCollectFees(mockEvent, undefined, undefined);
 
       // Fees should still be tracked
-      expect(result.liquidityPoolDiff.totalStakedFeesCollected0).toBe(
+      expect(result.liquidityPoolDiff.incrementalStakedFeesCollected0).toBe(
         1000000000000000000n,
       );
-      expect(result.liquidityPoolDiff.totalStakedFeesCollected1).toBe(
+      expect(result.liquidityPoolDiff.incrementalStakedFeesCollected1).toBe(
         2000000000000000000n,
       );
       // USD should be 0 since no tokens to calculate price
-      expect(result.liquidityPoolDiff.totalStakedFeesCollectedUSD).toBe(0n);
+      expect(result.liquidityPoolDiff.incrementalStakedFeesCollectedUSD).toBe(
+        0n,
+      );
       // Whitelisted fees should be 0
-      expect(result.liquidityPoolDiff.totalFeesUSDWhitelisted).toBe(0n);
+      expect(result.liquidityPoolDiff.incrementalFeesUSDWhitelisted).toBe(0n);
     });
 
     it("should add to whitelisted fees when token0 is whitelisted", () => {
@@ -301,7 +288,6 @@ describe("CLPoolCollectFeesLogic", () => {
 
       const result = processCLPoolCollectFees(
         mockEvent,
-        mockLiquidityPoolAggregator,
         whitelistedToken0,
         mockToken1,
       );
@@ -309,11 +295,11 @@ describe("CLPoolCollectFeesLogic", () => {
       // Total fees USD should include both tokens
       // token0: 1 token * $1.00 = $1.00, token1: 2 tokens * $2.00 = $4.00
       // Total: $5.00
-      expect(result.liquidityPoolDiff.totalStakedFeesCollectedUSD).toBe(
+      expect(result.liquidityPoolDiff.incrementalStakedFeesCollectedUSD).toBe(
         5000000000000000000n,
       );
       // Whitelisted fees should include token0 fees (1 token * $1.00 = $1.00)
-      expect(result.liquidityPoolDiff.totalFeesUSDWhitelisted).toBe(
+      expect(result.liquidityPoolDiff.incrementalFeesUSDWhitelisted).toBe(
         1000000000000000000n,
       );
     });
@@ -327,7 +313,6 @@ describe("CLPoolCollectFeesLogic", () => {
 
       const result = processCLPoolCollectFees(
         mockEvent,
-        mockLiquidityPoolAggregator,
         mockToken0,
         whitelistedToken1,
       );
@@ -335,11 +320,11 @@ describe("CLPoolCollectFeesLogic", () => {
       // Total fees USD should include both tokens
       // token0: 1 token * $1.00 = $1.00, token1: 2 tokens * $2.00 = $4.00
       // Total: $5.00
-      expect(result.liquidityPoolDiff.totalStakedFeesCollectedUSD).toBe(
+      expect(result.liquidityPoolDiff.incrementalStakedFeesCollectedUSD).toBe(
         5000000000000000000n,
       );
       // Whitelisted fees should include token1 fees (2 tokens * $2.00 = $4.00)
-      expect(result.liquidityPoolDiff.totalFeesUSDWhitelisted).toBe(
+      expect(result.liquidityPoolDiff.incrementalFeesUSDWhitelisted).toBe(
         4000000000000000000n,
       );
     });
@@ -359,7 +344,6 @@ describe("CLPoolCollectFeesLogic", () => {
 
       const result = processCLPoolCollectFees(
         mockEvent,
-        mockLiquidityPoolAggregator,
         whitelistedToken0,
         whitelistedToken1,
       );
@@ -367,16 +351,16 @@ describe("CLPoolCollectFeesLogic", () => {
       // Total fees USD should include both tokens
       // token0: 1 token * $1.00 = $1.00, token1: 2 tokens * $2.00 = $4.00
       // Total: $5.00
-      expect(result.liquidityPoolDiff.totalStakedFeesCollectedUSD).toBe(
+      expect(result.liquidityPoolDiff.incrementalStakedFeesCollectedUSD).toBe(
         5000000000000000000n,
       );
       // Whitelisted fees should include both: token0 (1 * $1.00 = $1.00) + token1 (2 * $2.00 = $4.00) = $5.00
-      expect(result.liquidityPoolDiff.totalFeesUSDWhitelisted).toBe(
+      expect(result.liquidityPoolDiff.incrementalFeesUSDWhitelisted).toBe(
         5000000000000000000n,
       );
       // Whitelisted fees should equal total fees when both are whitelisted
-      expect(result.liquidityPoolDiff.totalFeesUSDWhitelisted).toBe(
-        result.liquidityPoolDiff.totalStakedFeesCollectedUSD,
+      expect(result.liquidityPoolDiff.incrementalFeesUSDWhitelisted).toBe(
+        result.liquidityPoolDiff.incrementalStakedFeesCollectedUSD,
       );
     });
 
@@ -393,7 +377,6 @@ describe("CLPoolCollectFeesLogic", () => {
 
       const result = processCLPoolCollectFees(
         mockEvent,
-        mockLiquidityPoolAggregator,
         nonWhitelistedToken0,
         nonWhitelistedToken1,
       );
@@ -401,29 +384,28 @@ describe("CLPoolCollectFeesLogic", () => {
       // Total fees USD should still be calculated
       // token0: 1 token * $1.00 = $1.00, token1: 2 tokens * $2.00 = $4.00
       // Total: $5.00
-      expect(result.liquidityPoolDiff.totalStakedFeesCollectedUSD).toBe(
+      expect(result.liquidityPoolDiff.incrementalStakedFeesCollectedUSD).toBe(
         5000000000000000000n,
       );
       // Whitelisted fees should be 0 when neither token is whitelisted
-      expect(result.liquidityPoolDiff.totalFeesUSDWhitelisted).toBe(0n);
+      expect(result.liquidityPoolDiff.incrementalFeesUSDWhitelisted).toBe(0n);
     });
 
     it("should only track staked fees, not unstaked fees", () => {
       const result = processCLPoolCollectFees(
         mockEvent,
-        mockLiquidityPoolAggregator,
         mockToken0,
         mockToken1,
       );
 
       // CollectFees events should only update staked fees
-      expect(result.liquidityPoolDiff.totalStakedFeesCollected0).toBe(
+      expect(result.liquidityPoolDiff.incrementalStakedFeesCollected0).toBe(
         1000000000000000000n,
       );
-      expect(result.liquidityPoolDiff.totalStakedFeesCollected1).toBe(
+      expect(result.liquidityPoolDiff.incrementalStakedFeesCollected1).toBe(
         2000000000000000000n,
       );
-      expect(result.liquidityPoolDiff.totalStakedFeesCollectedUSD).toBe(
+      expect(result.liquidityPoolDiff.incrementalStakedFeesCollectedUSD).toBe(
         5000000000000000000n,
       );
 
@@ -444,19 +426,18 @@ describe("CLPoolCollectFeesLogic", () => {
       // First event
       const result1 = processCLPoolCollectFees(
         mockEvent,
-        mockLiquidityPoolAggregator,
         mockToken0,
         mockToken1,
       );
 
       // Verify first event returns increments (not totals)
-      expect(result1.liquidityPoolDiff.totalStakedFeesCollected0).toBe(
+      expect(result1.liquidityPoolDiff.incrementalStakedFeesCollected0).toBe(
         1000000000000000000n, // Increment: 1 token
       );
-      expect(result1.liquidityPoolDiff.totalStakedFeesCollected1).toBe(
+      expect(result1.liquidityPoolDiff.incrementalStakedFeesCollected1).toBe(
         2000000000000000000n, // Increment: 2 tokens
       );
-      expect(result1.liquidityPoolDiff.totalStakedFeesCollectedUSD).toBe(
+      expect(result1.liquidityPoolDiff.incrementalStakedFeesCollectedUSD).toBe(
         5000000000000000000n, // Increment: $5.00
       );
 
@@ -466,32 +447,31 @@ describe("CLPoolCollectFeesLogic", () => {
         ...mockLiquidityPoolAggregator,
         totalStakedFeesCollected0:
           mockLiquidityPoolAggregator.totalStakedFeesCollected0 +
-          result1.liquidityPoolDiff.totalStakedFeesCollected0, // 0 + 1 = 1
+          result1.liquidityPoolDiff.incrementalStakedFeesCollected0, // 0 + 1 = 1
         totalStakedFeesCollected1:
           mockLiquidityPoolAggregator.totalStakedFeesCollected1 +
-          result1.liquidityPoolDiff.totalStakedFeesCollected1, // 0 + 2 = 2
+          result1.liquidityPoolDiff.incrementalStakedFeesCollected1, // 0 + 2 = 2
         totalStakedFeesCollectedUSD:
           mockLiquidityPoolAggregator.totalStakedFeesCollectedUSD +
-          result1.liquidityPoolDiff.totalStakedFeesCollectedUSD, // 0 + 5 = 5
+          result1.liquidityPoolDiff.incrementalStakedFeesCollectedUSD, // 0 + 5 = 5
       };
 
       // Second event with same amounts
       const result2 = processCLPoolCollectFees(
         mockEvent,
-        aggregatorAfterFirst,
         mockToken0,
         mockToken1,
       );
 
       // Second event should return the same increments (not accumulated totals)
       // The diff contains increments that updateLiquidityPoolAggregator will add
-      expect(result2.liquidityPoolDiff.totalStakedFeesCollected0).toBe(
+      expect(result2.liquidityPoolDiff.incrementalStakedFeesCollected0).toBe(
         1000000000000000000n, // Increment: 1 token (same as first event)
       );
-      expect(result2.liquidityPoolDiff.totalStakedFeesCollected1).toBe(
+      expect(result2.liquidityPoolDiff.incrementalStakedFeesCollected1).toBe(
         2000000000000000000n, // Increment: 2 tokens (same as first event)
       );
-      expect(result2.liquidityPoolDiff.totalStakedFeesCollectedUSD).toBe(
+      expect(result2.liquidityPoolDiff.incrementalStakedFeesCollectedUSD).toBe(
         5000000000000000000n, // Increment: $5.00 (same as first event)
       );
 
@@ -499,13 +479,13 @@ describe("CLPoolCollectFeesLogic", () => {
       // After second event: 1 + 1 = 2 token0, 2 + 2 = 4 token1, 5 + 5 = 10 USD
       const finalTotal0 =
         aggregatorAfterFirst.totalStakedFeesCollected0 +
-        result2.liquidityPoolDiff.totalStakedFeesCollected0;
+        result2.liquidityPoolDiff.incrementalStakedFeesCollected0;
       const finalTotal1 =
         aggregatorAfterFirst.totalStakedFeesCollected1 +
-        result2.liquidityPoolDiff.totalStakedFeesCollected1;
+        result2.liquidityPoolDiff.incrementalStakedFeesCollected1;
       const finalTotalUSD =
         aggregatorAfterFirst.totalStakedFeesCollectedUSD +
-        result2.liquidityPoolDiff.totalStakedFeesCollectedUSD;
+        result2.liquidityPoolDiff.incrementalStakedFeesCollectedUSD;
 
       expect(finalTotal0).toBe(2000000000000000000n); // 1 + 1 = 2
       expect(finalTotal1).toBe(4000000000000000000n); // 2 + 2 = 4

--- a/test/EventHandlers/Pool/PoolFeesLogic.test.ts
+++ b/test/EventHandlers/Pool/PoolFeesLogic.test.ts
@@ -49,22 +49,22 @@ describe("PoolFeesLogic", () => {
         // Check liquidity pool diff
         expect(result.liquidityPoolDiff).toBeDefined();
         // For regular pools, fees are tracked as unstaked fees
-        expect(result.liquidityPoolDiff?.totalUnstakedFeesCollected0).toBe(
-          mockEvent.params.amount0,
-        );
-        expect(result.liquidityPoolDiff?.totalUnstakedFeesCollected1).toBe(
-          mockEvent.params.amount1,
-        );
+        expect(
+          result.liquidityPoolDiff?.incrementalUnstakedFeesCollected0,
+        ).toBe(mockEvent.params.amount0);
+        expect(
+          result.liquidityPoolDiff?.incrementalUnstakedFeesCollected1,
+        ).toBe(mockEvent.params.amount1);
         expect(result.liquidityPoolDiff?.lastUpdatedTimestamp).toEqual(
           new Date(mockEvent.block.timestamp * 1000),
         );
 
         // Check user diff data
         expect(result.userDiff).toBeDefined();
-        expect(result.userDiff?.totalFeesContributed0).toBe(
+        expect(result.userDiff?.incrementalFeesContributed0).toBe(
           mockEvent.params.amount0,
         );
-        expect(result.userDiff?.totalFeesContributed1).toBe(
+        expect(result.userDiff?.incrementalFeesContributed1).toBe(
           mockEvent.params.amount1,
         );
         expect(result.userDiff?.lastActivityTimestamp).toEqual(
@@ -82,10 +82,10 @@ describe("PoolFeesLogic", () => {
 
         // Check that user diff data is prepared correctly
         expect(result.userDiff).toBeDefined();
-        expect(result.userDiff?.totalFeesContributed0).toBe(
+        expect(result.userDiff?.incrementalFeesContributed0).toBe(
           mockEvent.params.amount0,
         );
-        expect(result.userDiff?.totalFeesContributed1).toBe(
+        expect(result.userDiff?.incrementalFeesContributed1).toBe(
           mockEvent.params.amount1,
         );
         expect(result.userDiff?.lastActivityTimestamp).toEqual(
@@ -107,11 +107,11 @@ describe("PoolFeesLogic", () => {
         // We just verify that the result contains the expected structure
         expect(result.liquidityPoolDiff).toBeDefined();
         expect(
-          typeof result.liquidityPoolDiff?.totalUnstakedFeesCollectedUSD,
+          typeof result.liquidityPoolDiff?.incrementalUnstakedFeesCollectedUSD,
         ).toBe("bigint");
-        expect(typeof result.liquidityPoolDiff?.totalFeesUSDWhitelisted).toBe(
-          "bigint",
-        );
+        expect(
+          typeof result.liquidityPoolDiff?.incrementalFeesUSDWhitelisted,
+        ).toBe("bigint");
       });
 
       it("should handle different token decimals correctly", async () => {


### PR DESCRIPTION
Implements:
- Small fixed that updated `diff` variable to return incremental values instead of totals

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Fee reporting now emits incremental diffs (per-event increments) instead of cumulative totals for pools and user fee metrics.
  * Aggregation and per-user stats updates accept diff-style inputs and expose new activity timestamps for accurate event sequencing.

* **Tests**
  * Test suite updated to validate incremental behavior, accumulation via applied diffs, and edge cases (missing tokens, whitelisting, zero/negative amounts).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->