### PR TITLE
Correctly updating non cl pools reserves burn events

### DIFF
--- a/src/EventHandlers/Pool/PoolBurnAndMintLogic.ts
+++ b/src/EventHandlers/Pool/PoolBurnAndMintLogic.ts
@@ -39,11 +39,14 @@ export async function processPoolLiquidityEvent(
 
   const netLiquidityUSDChange = reserveData.totalLiquidityUSD ?? 0n;
 
+  // Check if this is a mint event by looking for 'to' parameter (burn events have 'to', mint events don't)
+  const isMintEvent = !("to" in event.params);
+
   // Create liquidity pool diff
   const liquidityPoolDiff = {
     // Update reserves cumulatively
-    incrementalReserve0: amount0,
-    incrementalReserve1: amount1,
+    incrementalReserve0: isMintEvent ? amount0 : -amount0,
+    incrementalReserve1: isMintEvent ? amount1 : -amount1,
     // Update token prices
     token0Price:
       reserveData.token0?.pricePerUSDNew ?? liquidityPoolAggregator.token0Price,
@@ -55,8 +58,6 @@ export async function processPoolLiquidityEvent(
   };
 
   // Create user liquidity diff for tracking user activity
-  // Check if this is a mint event by looking for 'to' parameter (burn events have 'to', mint events don't)
-  const isMintEvent = !("to" in event.params);
   const incrementalCurrentLiquidityUSD = isMintEvent
     ? netLiquidityUSDChange
     : -netLiquidityUSDChange;

--- a/src/EventHandlers/Voter/VoterCommonLogic.ts
+++ b/src/EventHandlers/Voter/VoterCommonLogic.ts
@@ -92,7 +92,7 @@ export function buildLpDiffFromDistribute(
   result: VoterCommonResult,
   gaugeAddress: string,
   timestampMs: number,
-) {
+): Partial<LiquidityPoolAggregatorDiff> {
   return {
     totalVotesDeposited: result.tokensDeposited,
     totalVotesDepositedUSD: result.normalizedVotesDepositedAmountUsd,

--- a/test/EventHandlers/Pool/Burn.test.ts
+++ b/test/EventHandlers/Pool/Burn.test.ts
@@ -47,6 +47,14 @@ describe("Pool Burn Event", () => {
       new Date(1000000 * 1000),
     );
 
+    // Verify that reserves decreased (burn removes liquidity)
+    const initialReserve0 = commonData.mockLiquidityPoolData.reserve0;
+    const initialReserve1 = commonData.mockLiquidityPoolData.reserve1;
+    const burnAmount0 = 500n * 10n ** 18n;
+    const burnAmount1 = 1000n * 10n ** 18n;
+    expect(updatedAggregator?.reserve0).toBe(initialReserve0 - burnAmount0);
+    expect(updatedAggregator?.reserve1).toBe(initialReserve1 - burnAmount1);
+
     // Verify that user stats were updated with negative liquidity (burn removes liquidity)
     const userStats = result.entities.UserStatsPerPool.get(
       `0x1111111111111111111111111111111111111111_${commonData.mockLiquidityPoolData.id}_10`,

--- a/test/EventHandlers/Pool/Mint.test.ts
+++ b/test/EventHandlers/Pool/Mint.test.ts
@@ -45,6 +45,14 @@ describe("Pool Mint Event", () => {
       new Date(1000000 * 1000),
     );
 
+    // Verify that reserves increased (mint adds liquidity)
+    const initialReserve0 = commonData.mockLiquidityPoolData.reserve0;
+    const initialReserve1 = commonData.mockLiquidityPoolData.reserve1;
+    const mintAmount0 = 1000n * 10n ** 18n;
+    const mintAmount1 = 2000n * 10n ** 18n;
+    expect(updatedAggregator?.reserve0).toBe(initialReserve0 + mintAmount0);
+    expect(updatedAggregator?.reserve1).toBe(initialReserve1 + mintAmount1);
+
     // Verify that user stats were updated with positive liquidity (mint adds liquidity)
     const userStats = result.entities.UserStatsPerPool.get(
       `0x1111111111111111111111111111111111111111_${commonData.mockLiquidityPoolData.id}_10`,

--- a/test/EventHandlers/Voter/VoterCommonLogic.test.ts
+++ b/test/EventHandlers/Voter/VoterCommonLogic.test.ts
@@ -166,7 +166,7 @@ describe("buildLpDiffFromDistribute", () => {
     expect(diff.incrementalTotalEmissions).toBe(3n);
     expect(diff.incrementalTotalEmissionsUSD).toBe(6n);
     expect(diff.gaugeIsAlive).toBe(true);
-    expect(+diff.lastUpdatedTimestamp).toBe(ts);
+    expect(diff.lastUpdatedTimestamp).toEqual(new Date(ts));
     expect(diff.gaugeAddress).toBe("0xgauge");
   });
 });


### PR DESCRIPTION
Implements:
- Correct implementation of pool entity reserves (non CL) in burn events
- Other small fixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined event handling to simplify mint/burn processing and added explicit return typing for clearer results.
  * lastUpdatedTimestamp now returned as a Date object (was a numeric timestamp).

* **Tests**
  * Expanded tests to verify reserves update correctly on mint and burn.
  * Added assertions ensuring cumulative totals and user flash-loan stats behave correctly after events.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->