### PR TITLE
ALM withdraw logic with correct lpAmount withdrawn/burned

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -488,3 +488,22 @@ type PoolTransferInTx {
   consumedByLogIndex: Int # logIndex of the Mint/Burn event that consumed this transfer (undefined if unused)
   timestamp: Timestamp!
 }
+
+# Temporary entity for matching Withdraw events with Transfer events (burns)
+# Similar to PoolTransferInTx but for ALM LP Wrapper
+# Only needed for burns (to = 0x0) since Deposit events emit the correct minted amount
+# Needed for LPWrapper V1 Withdraw event handler fix
+type ALMLPWrapperTransferInTx {
+  id: ID! # ${chainId}-${txHash}-${wrapperAddress}-${logIndex}
+  chainId: Int! @index
+  txHash: String! @index
+  wrapperAddress: String! @index
+  logIndex: Int!
+  blockNumber: BigInt!
+  from: String!
+  to: String!
+  value: BigInt! @config(precision: 76)
+  isBurn: Boolean! # to == 0x0
+  consumedByLogIndex: Int # logIndex of the Withdraw event that consumed this transfer (undefined if unused)
+  timestamp: Timestamp!
+}

--- a/src/EventHandlers/ALM/LPWrapperV1.ts
+++ b/src/EventHandlers/ALM/LPWrapperV1.ts
@@ -43,14 +43,16 @@ ALMLPWrapperV1.Deposit.handler(async ({ event, context }) => {
  *    (who withdraws and receives tokens) with their reduced ALM position
  *
  * Note: In V1, Withdraw event has both `sender` and `recipient` fields.
- * The `recipient` is the one who receives the tokens and should have their stats updated.
+ * The `sender` is the one who receives the tokens and should have their stats updated.
+ * The above can be observed by the _burn function execution within _withdraw:
+ * - msg.sender is the one whose tokens are being burned/withdrawn
  */
 ALMLPWrapperV1.Withdraw.handler(async ({ event, context }) => {
-  const { recipient, pool, lpAmount, amount0, amount1 } = event.params;
+  const { sender, pool, lpAmount, amount0, amount1 } = event.params;
   const timestamp = new Date(event.block.timestamp * 1000);
 
   await processWithdrawEvent(
-    recipient,
+    sender,
     pool,
     amount0,
     amount1,
@@ -60,6 +62,9 @@ ALMLPWrapperV1.Withdraw.handler(async ({ event, context }) => {
     event.block.number,
     timestamp,
     context,
+    event.transaction.hash,
+    event.logIndex,
+    true, // isV1 = true for V1 wrapper
   );
 });
 
@@ -89,7 +94,11 @@ ALMLPWrapperV1.Transfer.handler(async ({ event, context }) => {
     value,
     event.srcAddress,
     event.chainId,
+    event.transaction.hash,
+    event.logIndex,
+    event.block.number,
     timestamp,
     context,
+    true, // isV1 = true for V1 wrapper
   );
 });

--- a/src/EventHandlers/ALM/LPWrapperV2.ts
+++ b/src/EventHandlers/ALM/LPWrapperV2.ts
@@ -36,15 +36,15 @@ ALMLPWrapperV2.Deposit.handler(async ({ event, context }) => {
  *
  * When a user withdraws from an ALM LP Wrapper:
  * 1. Updates the pool-level ALM_LP_Wrapper entity with decreased amounts
- * 2. Updates the user-level UserStatsPerPool entity for the recipient
+ * 2. Updates the user-level UserStatsPerPool entity for the sender
  *    (who withdraws and receives tokens) with their reduced ALM position
  */
 ALMLPWrapperV2.Withdraw.handler(async ({ event, context }) => {
-  const { recipient, pool, amount0, amount1, lpAmount } = event.params;
+  const { sender, pool, amount0, amount1, lpAmount } = event.params;
   const timestamp = new Date(event.block.timestamp * 1000);
 
   await processWithdrawEvent(
-    recipient,
+    sender,
     pool,
     amount0,
     amount1,
@@ -54,6 +54,9 @@ ALMLPWrapperV2.Withdraw.handler(async ({ event, context }) => {
     event.block.number,
     timestamp,
     context,
+    event.transaction.hash,
+    event.logIndex,
+    false, // isV1 = false for V2 wrapper
   );
 });
 
@@ -83,8 +86,12 @@ ALMLPWrapperV2.Transfer.handler(async ({ event, context }) => {
     value,
     event.srcAddress,
     event.chainId,
+    event.transaction.hash,
+    event.logIndex,
+    event.block.number,
     timestamp,
     context,
+    false, // isV1 = false for V2 wrapper
   );
 });
 

--- a/test/EventHandlers/ALM/LPWrapperV2.test.ts
+++ b/test/EventHandlers/ALM/LPWrapperV2.test.ts
@@ -15,8 +15,8 @@ describe("ALMLPWrapperV2 Events", () => {
   const chainId = mockLiquidityPoolData.chainId;
   const lpWrapperAddress = "0x000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
   const poolAddress = mockLiquidityPoolData.id;
-  const recipientAddress = "0xcccccccccccccccccccccccccccccccccccccccc";
-  const senderAddress = "0xdddddddddddddddddddddddddddddddddddddddd";
+  const userA = "0xcccccccccccccccccccccccccccccccccccccccc";
+  const userB = "0xdddddddddddddddddddddddddddddddddddddddd";
 
   const mockEventData = {
     block: {
@@ -46,7 +46,7 @@ describe("ALMLPWrapperV2 Events", () => {
       // V2: Deposit event has sender, recipient, pool, amount0, amount1, lpAmount, totalSupply
       // The handler only uses recipient (not sender), so we only need to provide recipient in the mock
       const mockEvent = ALMLPWrapperV2.Deposit.createMockEvent({
-        recipient: recipientAddress,
+        recipient: userA,
         pool: poolAddress,
         lpAmount: 1000n * TEN_TO_THE_18_BI,
         amount0: 500n * TEN_TO_THE_18_BI,
@@ -88,7 +88,7 @@ describe("ALMLPWrapperV2 Events", () => {
       // V2: Deposit event has sender, recipient, pool, amount0, amount1, lpAmount, totalSupply
       // The handler only uses recipient (not sender), so we only need to provide recipient in the mock
       const mockEvent = ALMLPWrapperV2.Deposit.createMockEvent({
-        recipient: recipientAddress,
+        recipient: userA,
         pool: poolAddress,
         lpAmount: 1000n * TEN_TO_THE_18_BI,
         amount0: 500n * TEN_TO_THE_18_BI,
@@ -120,7 +120,7 @@ describe("ALMLPWrapperV2 Events", () => {
       // V2: Deposit event has sender, recipient, pool, amount0, amount1, lpAmount, totalSupply
       // The handler only uses recipient (not sender), so we only need to provide recipient in the mock
       const mockEvent = ALMLPWrapperV2.Deposit.createMockEvent({
-        recipient: recipientAddress,
+        recipient: userA,
         pool: poolAddress,
         lpAmount: 1000n * TEN_TO_THE_18_BI,
         amount0: 500n * TEN_TO_THE_18_BI,
@@ -133,12 +133,12 @@ describe("ALMLPWrapperV2 Events", () => {
         mockDb,
       });
 
-      const userStatsId = `${toChecksumAddress(recipientAddress)}_${toChecksumAddress(poolAddress)}_${chainId}`;
+      const userStatsId = `${toChecksumAddress(userA)}_${toChecksumAddress(poolAddress)}_${chainId}`;
       const userStats = result.entities.UserStatsPerPool.get(userStatsId);
 
       expect(userStats).toBeDefined();
       expect(userStats?.id).toBe(userStatsId);
-      expect(userStats?.userAddress).toBe(toChecksumAddress(recipientAddress));
+      expect(userStats?.userAddress).toBe(toChecksumAddress(userA));
       expect(userStats?.poolAddress).toBe(toChecksumAddress(poolAddress));
       expect(userStats?.chainId).toBe(chainId);
       // User amounts are derived from LP share, not directly from event amounts
@@ -160,10 +160,10 @@ describe("ALMLPWrapperV2 Events", () => {
       });
 
       // Pre-populate with existing user stats
-      const userStatsId = `${toChecksumAddress(recipientAddress)}_${toChecksumAddress(poolAddress)}_${chainId}`;
+      const userStatsId = `${toChecksumAddress(userA)}_${toChecksumAddress(poolAddress)}_${chainId}`;
       mockDb = mockDb.entities.UserStatsPerPool.set(
         createMockUserStatsPerPool({
-          userAddress: recipientAddress,
+          userAddress: userA,
           poolAddress: poolAddress,
           chainId: chainId,
           almAmount0: 300n * TEN_TO_THE_18_BI,
@@ -175,7 +175,7 @@ describe("ALMLPWrapperV2 Events", () => {
       // V2: Deposit event has sender, recipient, pool, amount0, amount1, lpAmount, totalSupply
       // The handler only uses recipient (not sender), so we only need to provide recipient in the mock
       const mockEvent = ALMLPWrapperV2.Deposit.createMockEvent({
-        recipient: recipientAddress,
+        recipient: userA,
         pool: poolAddress,
         lpAmount: 1000n * TEN_TO_THE_18_BI,
         amount0: 500n * TEN_TO_THE_18_BI,
@@ -215,7 +215,7 @@ describe("ALMLPWrapperV2 Events", () => {
       // V2: Deposit event has sender, recipient, pool, amount0, amount1, lpAmount, totalSupply
       // The handler only uses recipient (not sender), so we only need to provide recipient in the mock
       const mockEvent = ALMLPWrapperV2.Deposit.createMockEvent({
-        recipient: recipientAddress,
+        recipient: userA,
         pool: poolAddress,
         lpAmount: 1000n * TEN_TO_THE_18_BI,
         amount0: 500n * TEN_TO_THE_18_BI,
@@ -228,7 +228,7 @@ describe("ALMLPWrapperV2 Events", () => {
         mockDb,
       });
 
-      const userStatsId = `${toChecksumAddress(recipientAddress)}_${toChecksumAddress(poolAddress)}_${chainId}`;
+      const userStatsId = `${toChecksumAddress(userA)}_${toChecksumAddress(poolAddress)}_${chainId}`;
 
       const wrapper = result.entities.ALM_LP_Wrapper.get(wrapperId);
       const userStats = result.entities.UserStatsPerPool.get(userStatsId);
@@ -269,9 +269,9 @@ describe("ALMLPWrapperV2 Events", () => {
       });
 
       // V2: Withdraw event has sender, recipient, pool, amount0, amount1, lpAmount
-      // The handler only uses recipient (not sender), so we only need to provide recipient in the mock
+      // The handler uses sender (not recipient), so we need to provide sender in the mock
       const mockEvent = ALMLPWrapperV2.Withdraw.createMockEvent({
-        recipient: recipientAddress,
+        sender: userA,
         pool: poolAddress,
         lpAmount: 500n * TEN_TO_THE_18_BI,
         amount0: 250n * TEN_TO_THE_18_BI,
@@ -306,9 +306,9 @@ describe("ALMLPWrapperV2 Events", () => {
       const mockDb = MockDb.createMockDb();
 
       // V2: Withdraw event has sender, recipient, pool, amount0, amount1, lpAmount
-      // The handler only uses recipient (not sender), so we only need to provide recipient in the mock
+      // The handler uses sender (not recipient), so we need to provide sender in the mock
       const mockEvent = ALMLPWrapperV2.Withdraw.createMockEvent({
-        recipient: recipientAddress,
+        sender: userA,
         pool: poolAddress,
         lpAmount: 500n * TEN_TO_THE_18_BI,
         amount0: 250n * TEN_TO_THE_18_BI,
@@ -338,10 +338,10 @@ describe("ALMLPWrapperV2 Events", () => {
       });
 
       // Pre-populate with existing user stats
-      const userStatsId = `${toChecksumAddress(recipientAddress)}_${toChecksumAddress(poolAddress)}_${chainId}`;
+      const userStatsId = `${toChecksumAddress(userA)}_${toChecksumAddress(poolAddress)}_${chainId}`;
       mockDb = mockDb.entities.UserStatsPerPool.set(
         createMockUserStatsPerPool({
-          userAddress: recipientAddress,
+          userAddress: userA,
           poolAddress: poolAddress,
           chainId: chainId,
           almAmount0: 1000n * TEN_TO_THE_18_BI,
@@ -351,9 +351,9 @@ describe("ALMLPWrapperV2 Events", () => {
       );
 
       // V2: Withdraw event has sender, recipient, pool, amount0, amount1, lpAmount
-      // The handler only uses recipient (not sender), so we only need to provide recipient in the mock
+      // The handler uses sender (not recipient), so we need to provide sender in the mock
       const mockEvent = ALMLPWrapperV2.Withdraw.createMockEvent({
-        recipient: recipientAddress,
+        sender: userA,
         pool: poolAddress,
         lpAmount: 500n * TEN_TO_THE_18_BI,
         amount0: 250n * TEN_TO_THE_18_BI,
@@ -393,12 +393,12 @@ describe("ALMLPWrapperV2 Events", () => {
       });
 
       // Pre-populate with existing user stats for both sender and recipient
-      const userStatsFromId = `${toChecksumAddress(senderAddress)}_${toChecksumAddress(poolAddress)}_${chainId}`;
-      const userStatsToId = `${toChecksumAddress(recipientAddress)}_${toChecksumAddress(poolAddress)}_${chainId}`;
+      const userStatsFromId = `${toChecksumAddress(userB)}_${toChecksumAddress(poolAddress)}_${chainId}`;
+      const userStatsToId = `${toChecksumAddress(userA)}_${toChecksumAddress(poolAddress)}_${chainId}`;
 
       mockDb = mockDb.entities.UserStatsPerPool.set(
         createMockUserStatsPerPool({
-          userAddress: senderAddress,
+          userAddress: userB,
           poolAddress: poolAddress,
           chainId: chainId,
           almLpAmount: 5000n * TEN_TO_THE_18_BI, // Sender has 5000 tokens
@@ -407,7 +407,7 @@ describe("ALMLPWrapperV2 Events", () => {
 
       mockDb = mockDb.entities.UserStatsPerPool.set(
         createMockUserStatsPerPool({
-          userAddress: recipientAddress,
+          userAddress: userA,
           poolAddress: poolAddress,
           chainId: chainId,
           almLpAmount: 2000n * TEN_TO_THE_18_BI, // Recipient has 2000 tokens
@@ -416,8 +416,8 @@ describe("ALMLPWrapperV2 Events", () => {
 
       const transferAmount = 1000n * TEN_TO_THE_18_BI;
       const mockEvent = ALMLPWrapperV2.Transfer.createMockEvent({
-        from: senderAddress,
-        to: recipientAddress,
+        from: userB,
+        to: userA,
         value: transferAmount,
         mockEventData,
       });
@@ -468,10 +468,10 @@ describe("ALMLPWrapperV2 Events", () => {
       });
 
       // Pre-populate only sender's user stats
-      const userStatsFromId = `${toChecksumAddress(senderAddress)}_${toChecksumAddress(poolAddress)}_${chainId}`;
+      const userStatsFromId = `${toChecksumAddress(userB)}_${toChecksumAddress(poolAddress)}_${chainId}`;
       mockDb = mockDb.entities.UserStatsPerPool.set(
         createMockUserStatsPerPool({
-          userAddress: senderAddress,
+          userAddress: userB,
           poolAddress: poolAddress,
           chainId: chainId,
           almLpAmount: 3000n * TEN_TO_THE_18_BI,
@@ -480,8 +480,8 @@ describe("ALMLPWrapperV2 Events", () => {
 
       const transferAmount = 500n * TEN_TO_THE_18_BI;
       const mockEvent = ALMLPWrapperV2.Transfer.createMockEvent({
-        from: senderAddress,
-        to: recipientAddress,
+        from: userB,
+        to: userA,
         value: transferAmount,
         mockEventData,
       });
@@ -497,7 +497,7 @@ describe("ALMLPWrapperV2 Events", () => {
       expect(userStatsFrom?.almLpAmount).toBe(2500n * TEN_TO_THE_18_BI); // 3000 - 500
 
       // Verify recipient's almLpAmount was created and set to transfer amount
-      const userStatsToId = `${toChecksumAddress(recipientAddress)}_${toChecksumAddress(poolAddress)}_${chainId}`;
+      const userStatsToId = `${toChecksumAddress(userA)}_${toChecksumAddress(poolAddress)}_${chainId}`;
       const userStatsTo = result.entities.UserStatsPerPool.get(userStatsToId);
       expect(userStatsTo).toBeDefined();
       expect(userStatsTo?.almLpAmount).toBe(500n * TEN_TO_THE_18_BI); // 0 + 500
@@ -513,8 +513,8 @@ describe("ALMLPWrapperV2 Events", () => {
       const mockDb = MockDb.createMockDb();
 
       const mockEvent = ALMLPWrapperV2.Transfer.createMockEvent({
-        from: senderAddress,
-        to: recipientAddress,
+        from: userB,
+        to: userA,
         value: 1000n * TEN_TO_THE_18_BI,
         mockEventData,
       });
@@ -530,8 +530,8 @@ describe("ALMLPWrapperV2 Events", () => {
       expect(wrapper).toBeUndefined();
 
       // Verify that no user stats were created or updated
-      const userStatsFromId = `${toChecksumAddress(senderAddress)}_${toChecksumAddress(poolAddress)}_${chainId}`;
-      const userStatsToId = `${toChecksumAddress(recipientAddress)}_${toChecksumAddress(poolAddress)}_${chainId}`;
+      const userStatsFromId = `${toChecksumAddress(userB)}_${toChecksumAddress(poolAddress)}_${chainId}`;
+      const userStatsToId = `${toChecksumAddress(userA)}_${toChecksumAddress(poolAddress)}_${chainId}`;
       const userStatsFrom =
         result.entities.UserStatsPerPool.get(userStatsFromId);
       const userStatsTo = result.entities.UserStatsPerPool.get(userStatsToId);
@@ -556,7 +556,7 @@ describe("ALMLPWrapperV2 Events", () => {
       // Deposit/Withdraw events already handle mints/burns correctly
       const mintEvent = ALMLPWrapperV2.Transfer.createMockEvent({
         from: zeroAddress,
-        to: recipientAddress,
+        to: userA,
         value: transferAmount,
         mockEventData,
       });
@@ -566,7 +566,7 @@ describe("ALMLPWrapperV2 Events", () => {
         mockDb,
       });
 
-      const toUserStatsId = `${toChecksumAddress(recipientAddress)}_${toChecksumAddress(poolAddress)}_${chainId}`;
+      const toUserStatsId = `${toChecksumAddress(userA)}_${toChecksumAddress(poolAddress)}_${chainId}`;
       const toUserStats =
         mintResult.entities.UserStatsPerPool.get(toUserStatsId);
 
@@ -575,7 +575,7 @@ describe("ALMLPWrapperV2 Events", () => {
 
       // Burn: to zero address - handler should return early without updating UserStatsPerPool
       // Pre-populate with user stats for the burner
-      const burnerAddress = senderAddress;
+      const burnerAddress = userB;
       const burnerUserStatsId = `${toChecksumAddress(burnerAddress)}_${toChecksumAddress(poolAddress)}_${chainId}`;
       mockDb = mockDb.entities.UserStatsPerPool.set(
         createMockUserStatsPerPool({
@@ -623,7 +623,7 @@ describe("ALMLPWrapperV2 Events", () => {
       // V2: Deposit event has sender, recipient, pool, amount0, amount1, lpAmount, totalSupply
       // The handler only uses recipient (not sender), so we only need to provide recipient in the mock
       const mockEvent = ALMLPWrapperV2.Deposit.createMockEvent({
-        recipient: recipientAddress,
+        recipient: userA,
         pool: poolAddress,
         lpAmount: 0n,
         amount0: 0n,
@@ -662,7 +662,7 @@ describe("ALMLPWrapperV2 Events", () => {
       // V2: Deposit event has sender, recipient, pool, amount0, amount1, lpAmount, totalSupply
       // The handler only uses recipient (not sender), so we only need to provide recipient in the mock
       let mockEvent = ALMLPWrapperV2.Deposit.createMockEvent({
-        recipient: recipientAddress,
+        recipient: userA,
         pool: poolAddress,
         lpAmount: 1000n * TEN_TO_THE_18_BI,
         amount0: 500n * TEN_TO_THE_18_BI,
@@ -725,7 +725,7 @@ describe("ALMLPWrapperV2 Events", () => {
       ); // 2000 + 1000 + 2000 = 5000
 
       // Both users should have their individual stats
-      const userStats1Id = `${toChecksumAddress(recipientAddress)}_${toChecksumAddress(poolAddress)}_${chainId}`;
+      const userStats1Id = `${toChecksumAddress(userA)}_${toChecksumAddress(poolAddress)}_${chainId}`;
       const userStats2Id = `${toChecksumAddress(recipient2)}_${toChecksumAddress(poolAddress)}_${chainId}`;
 
       const userStats1 = result.entities.UserStatsPerPool.get(userStats1Id);
@@ -761,7 +761,7 @@ describe("ALMLPWrapperV2 Events", () => {
       // V2: Deposit event has sender, recipient, pool, amount0, amount1, lpAmount, totalSupply
       // The handler only uses recipient (not sender), so we only need to provide recipient in the mock
       let mockEvent = ALMLPWrapperV2.Deposit.createMockEvent({
-        recipient: recipientAddress,
+        recipient: userA,
         pool: poolAddress,
         lpAmount: 1000n * TEN_TO_THE_18_BI,
         amount0: 500n * TEN_TO_THE_18_BI,
@@ -778,9 +778,9 @@ describe("ALMLPWrapperV2 Events", () => {
 
       // Then withdraw
       // V2: Withdraw event has sender, recipient, pool, amount0, amount1, lpAmount
-      // The handler only uses recipient (not sender), so we only need to provide recipient in the mock
+      // The handler uses sender (not recipient), so we need to provide sender in the mock
       mockEvent = ALMLPWrapperV2.Withdraw.createMockEvent({
-        recipient: recipientAddress,
+        sender: userA,
         pool: poolAddress,
         lpAmount: 500n * TEN_TO_THE_18_BI,
         amount0: 250n * TEN_TO_THE_18_BI,


### PR DESCRIPTION
closes #499 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented burn-transfer matching for V1 LP Wrapper withdrawals to accurately calculate actual withdrawn amounts.
  * Added distinction between V1 and V2 wrapper behaviors for improved withdrawal processing.

* **Refactor**
  * Updated withdrawal and transfer event handling to support both V1 and V2 wrapper versions with proper transaction tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->