### PR TITLE
Removing redundant amount0/1 calculation from Core.ts LPWrapper

### DIFF
--- a/src/EventHandlers/ALM/Core.ts
+++ b/src/EventHandlers/ALM/Core.ts
@@ -1,6 +1,5 @@
 import { ALMCore, type ALM_LP_Wrapper } from "generated";
 import { updateALMLPWrapper } from "../../Aggregators/ALMLPWrapper";
-import { calculatePositionAmountsFromLiquidity } from "../../Helpers";
 
 ALMCore.Rebalance.handler(async ({ event, context }) => {
   const [
@@ -31,16 +30,7 @@ ALMCore.Rebalance.handler(async ({ event, context }) => {
   // Since there's exactly 1 wrapper per pool, take the first one
   const lpWrapper = wrappers[0];
 
-  // Recalculate amount0 and amount1 from liquidity and current price
-  // This ensures amounts reflect the current pool price, not stale values
-  const recalculatedAmounts = calculatePositionAmountsFromLiquidity(
-    liquidity,
-    sqrtPriceX96,
-    tickLower,
-    tickUpper,
-  );
-
-  // Update the wrapper's strategy position state with new amounts from Rebalance
+  // Update the wrapper's strategy position state with new amounts from Rebalance (amount0/amount1 from event)
   const lpWrapperDiff: Partial<ALM_LP_Wrapper> = {
     tokenId: ammPositionIdAfter,
     tickLower: tickLower,
@@ -48,9 +38,8 @@ ALMCore.Rebalance.handler(async ({ event, context }) => {
     property: property,
     liquidity: liquidity,
     ammStateIsDerived: false,
-    // Recalculate wrapper-level amounts from current liquidity and price
-    amount0: recalculatedAmounts.amount0,
-    amount1: recalculatedAmounts.amount1,
+    amount0: amount0,
+    amount1: amount1,
     lastUpdatedTimestamp: timestamp,
   };
 

--- a/test/EventHandlers/ALM/Core.test.ts
+++ b/test/EventHandlers/ALM/Core.test.ts
@@ -1,7 +1,6 @@
 import { ALMCore, MockDb } from "../../../generated/src/TestHelpers.gen";
 import type { ALM_LP_Wrapper } from "../../../generated/src/Types.gen";
 import { toChecksumAddress } from "../../../src/Constants";
-import { calculatePositionAmountsFromLiquidity } from "../../../src/Helpers";
 import { setupCommon } from "../Pool/common";
 
 describe("ALMCore Rebalance Event", () => {
@@ -66,14 +65,6 @@ describe("ALMCore Rebalance Event", () => {
       const newProperty = 3000n;
       const sqrtPriceX96 = 79228162514264337593543950336n; // sqrt(1) * 2^96
 
-      // Calculate expected recalculated amounts from liquidity and price
-      const expectedRecalculatedAmounts = calculatePositionAmountsFromLiquidity(
-        newLiquidity,
-        sqrtPriceX96,
-        newTickLower,
-        newTickUpper,
-      );
-
       const mockEvent = ALMCore.Rebalance.createMockEvent({
         rebalanceEventParams: [
           poolAddress,
@@ -102,9 +93,8 @@ describe("ALMCore Rebalance Event", () => {
       const updatedWrapper = result.entities.ALM_LP_Wrapper.get(wrapperId);
 
       expect(updatedWrapper).toBeDefined();
-      // amount0 and amount1 are recalculated from liquidity and price, not from event amounts
-      expect(updatedWrapper?.amount0).toBe(expectedRecalculatedAmounts.amount0);
-      expect(updatedWrapper?.amount1).toBe(expectedRecalculatedAmounts.amount1);
+      expect(updatedWrapper?.amount0).toBe(newAmount0);
+      expect(updatedWrapper?.amount1).toBe(newAmount1);
       expect(updatedWrapper?.liquidity).toBe(newLiquidity);
       expect(updatedWrapper?.tokenId).toBe(newTokenId);
       expect(updatedWrapper?.tickLower).toBe(newTickLower);


### PR DESCRIPTION
closes #509 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved LP wrapper state updates in automated liquidity management to directly use values from rebalance events instead of recalculating amounts. This simplifies state management and ensures more accurate data handling during rebalancing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->