### PR TITLE
Removal of amount0 and amount1 fields from LP Wrapper and User ALM fields

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 7.9.0
       '@uniswap/v3-sdk':
         specifier: ^3.26.0
-        version: 3.26.0(hardhat@2.27.0(ts-node@10.9.2(@types/node@18.19.70)(typescript@5.7.3))(typescript@5.7.3))
+        version: 3.27.0(hardhat@2.27.0(ts-node@10.9.2(@types/node@18.19.70)(typescript@5.7.3))(typescript@5.7.3))
       dotenv:
         specifier: ^16.4.5
         version: 16.4.5
@@ -870,6 +870,10 @@ packages:
     resolution: {integrity: sha512-f6UIliwBbRsgVLxIaBANF6w09tYqc6Y/qXdsrbEmXHyFA7ILiKrIwRFXe1yOg8M3cksgVsO9N7yuL2DdCGQKBA==}
     engines: {node: '>=10'}
 
+  '@uniswap/sdk-core@7.10.1':
+    resolution: {integrity: sha512-MOhGAjGMqrd95p+te6tBK8pHgHCVMRTs5imqZk2aTqLoKgu6KzEGllifHb70ME6I4Q2p9eIPpX3xjfh4MKFT2w==}
+    engines: {node: '>=10'}
+
   '@uniswap/sdk-core@7.9.0':
     resolution: {integrity: sha512-HHUFNK3LMi4KMQCAiHkdUyL62g/nrZLvNT44CY8RN4p8kWO6XYWzqdQt6OcjCsIbhMZ/Ifhe6Py5oOoccg/jUQ==}
     engines: {node: '>=10'}
@@ -877,6 +881,7 @@ packages:
   '@uniswap/swap-router-contracts@1.3.1':
     resolution: {integrity: sha512-mh/YNbwKb7Mut96VuEtL+Z5bRe0xVIbjjiryn+iMMrK2sFKhR4duk/86mEz0UO5gSx4pQIw9G5276P5heY/7Rg==}
     engines: {node: '>=10'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@uniswap/v2-core@1.0.1':
     resolution: {integrity: sha512-MtybtkUPSyysqLY2U210NBDeCHX+ltHt3oADGdjqoThZaFRDKwM6k1Nb3F0A3hk5hwuQvytFWhrWHOEq6nVJ8Q==}
@@ -894,13 +899,14 @@ packages:
     resolution: {integrity: sha512-S4+m+wh8HbWSO3DKk4LwUCPZJTpCugIsHrWR86m/OrUyvSqGDTXKFfc2sMuGXCZrD1ZqO3rhQsKgdWg3Hbb2Kw==}
     engines: {node: '>=10'}
 
-  '@uniswap/v3-sdk@3.26.0':
-    resolution: {integrity: sha512-bcoWNE7ntNNTHMOnDPscIqtIN67fUyrbBKr6eswI2gD2wm5b0YYFBDeh+Qc5Q3117o9i8S7QdftqrU8YSMQUfQ==}
+  '@uniswap/v3-sdk@3.27.0':
+    resolution: {integrity: sha512-BRgb9nWuxptXJmuQrax9XyqcuOMEuWsUjDSyus0UvOavzijbOu8jh3DWptg/15D7oL67Xmz5zvQaSPbLIL1cpA==}
     engines: {node: '>=10'}
 
   '@uniswap/v3-staker@1.0.0':
     resolution: {integrity: sha512-JV0Qc46Px5alvg6YWd+UIaGH9lDuYG/Js7ngxPit1SPaIP30AlVer1UYB7BRYeUVVxE+byUyIeN5jeQ7LLDjIw==}
     engines: {node: '>=10'}
+    deprecated: Please upgrade to 1.0.1
 
   abitype@0.7.1:
     resolution: {integrity: sha512-VBkRHTDZf9Myaek/dO3yMmOzB/y2s3Zo6nVU7yaw1G+TvCHAjwaJzNGN9yo4K5D8bU/VZXKP1EJpRhFr862PlQ==}
@@ -4073,6 +4079,18 @@ snapshots:
 
   '@uniswap/lib@4.0.1-alpha': {}
 
+  '@uniswap/sdk-core@7.10.1':
+    dependencies:
+      '@ethersproject/address': 5.8.0
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/keccak256': 5.7.0
+      '@ethersproject/strings': 5.7.0
+      big.js: 5.2.2
+      decimal.js-light: 2.5.1
+      jsbi: 3.2.5
+      tiny-invariant: 1.3.3
+      toformat: 2.0.0
+
   '@uniswap/sdk-core@7.9.0':
     dependencies:
       '@ethersproject/address': 5.8.0
@@ -4110,11 +4128,11 @@ snapshots:
       '@uniswap/v3-core': 1.0.1
       base64-sol: 1.0.1
 
-  '@uniswap/v3-sdk@3.26.0(hardhat@2.27.0(ts-node@10.9.2(@types/node@18.19.70)(typescript@5.7.3))(typescript@5.7.3))':
+  '@uniswap/v3-sdk@3.27.0(hardhat@2.27.0(ts-node@10.9.2(@types/node@18.19.70)(typescript@5.7.3))(typescript@5.7.3))':
     dependencies:
       '@ethersproject/abi': 5.8.0
       '@ethersproject/solidity': 5.8.0
-      '@uniswap/sdk-core': 7.9.0
+      '@uniswap/sdk-core': 7.10.1
       '@uniswap/swap-router-contracts': 1.3.1(hardhat@2.27.0(ts-node@10.9.2(@types/node@18.19.70)(typescript@5.7.3))(typescript@5.7.3))
       '@uniswap/v3-periphery': 1.4.4
       '@uniswap/v3-staker': 1.0.0

--- a/schema.graphql
+++ b/schema.graphql
@@ -209,9 +209,7 @@ type UserStatsPerPool {
   veNFTamountStaked: BigInt! @config(precision: 76) # amount of veNFT staked by this user for this pool
 
   # ALM metrics
-  almAddress: String!
-  almAmount0: BigInt! @config(precision: 76) # Underlying amount of token0 associated with LP tokens owned
-  almAmount1: BigInt! @config(precision: 76) # Underlying amount of token1 associated with LP tokens owned
+  almAddress: String! # Address of ALM LP Wrapper (if the user interacts with it; otherwise defaults to "")
   almLpAmount: BigInt! @config(precision: 76) # Number of LP tokens
   lastAlmActivityTimestamp: Timestamp! # last ALM related activity that changed ALM related fields on user entity
 
@@ -293,9 +291,7 @@ type ALM_LP_Wrapper {
   token0: String! # Address of token 0
   token1: String! # Address of token 1
 
-  # Wrapper-level amounts (recalculated from liquidity and current price)
-  amount0: BigInt! @config(precision: 76) # Current amount of token0 in the AMM position (recalculated from liquidity and current price)
-  amount1: BigInt! @config(precision: 76) # Current amount of token1 in the AMM position (recalculated from liquidity and current price)
+  # Wrapper-level state
   lpAmount: BigInt! @config(precision: 76) # Total number of LP tokens wrapped (aggregated across all users)
   lastUpdatedTimestamp: Timestamp! # Timestamp of the last update to this entity
 
@@ -306,17 +302,6 @@ type ALM_LP_Wrapper {
   tickUpper: BigInt! @config(precision: 24) # Upper tick bound of the position's price range (in tick units)
   property: BigInt! @config(precision: 24) # Pool property parameter from the AMM position struct
   liquidity: BigInt! @config(precision: 76) # Amount of liquidity currently in the AMM position
-
-  # Indicates whether `liquidity`, `amount0`, and `amount1` are currently derived
-  # using an external price (e.g. oracle or pool price) rather than being a
-  # direct snapshot of the on-chain AMM position.
-  #
-  # - true: State was derived from (`amount0`, `amount1`) at a specific price
-  #   without a recent Rebalance event (price-relative valuation), typically
-  #   updated during ALMLPWrapper Deposit / Withdraw events.
-  # - false: State was last synced from an on-chain AMM snapshot (e.g. via
-  #   Rebalance) and reflects protocol-level liquidity exactly.
-  ammStateIsDerived: Boolean!
 
   strategyType: BigInt! @config(precision: 24) # Type/kind of ALM strategy being used (defines the strategy behavior)
   tickNeighborhood: BigInt! @config(precision: 24) # Tick neighborhood parameter for the strategy (defines rebalancing range around current price)

--- a/src/Aggregators/ALMLPWrapper.ts
+++ b/src/Aggregators/ALMLPWrapper.ts
@@ -1,22 +1,17 @@
 import type { ALM_LP_Wrapper, handlerContext } from "generated";
 
 interface ALM_LP_WrapperDiff {
-  amount0: bigint;
-  amount1: bigint;
   incrementalLpAmount: bigint;
   liquidity: bigint;
   tickLower: bigint;
   tickUpper: bigint;
   property: bigint;
-  ammStateIsDerived: boolean;
   tokenId: bigint;
   lastUpdatedTimestamp: Date;
 }
 /**
- * Generic function to update ALM_LP_Wrapper with any combination of fields
- * - amount0, amount1: Set directly when recalculated from liquidity and price (for deposits/withdrawals/rebalances)
- * - lpAmount: Set directly (updated from aggregations in handlers)
- * - Position-level fields (liquidity, tickLower, tickUpper, etc.) are set directly (for rebalances)
+ * Generic function to update ALM_LP_Wrapper with any combination of fields.
+ * lpAmount and position-level fields (liquidity, tickLower, tickUpper, etc.) are set from handlers.
  */
 export async function updateALMLPWrapper(
   diff: Partial<ALM_LP_WrapperDiff>,
@@ -26,14 +21,10 @@ export async function updateALMLPWrapper(
 ): Promise<void> {
   const updated: ALM_LP_Wrapper = {
     ...current,
-    // Wrapper-level amounts: set directly (recalculated from liquidity and current price)
-    amount0: diff.amount0 !== undefined ? diff.amount0 : current.amount0,
-    amount1: diff.amount1 !== undefined ? diff.amount1 : current.amount1,
     lpAmount:
       diff.incrementalLpAmount !== undefined
         ? diff.incrementalLpAmount + current.lpAmount
         : current.lpAmount,
-    // Position-level state: set directly (for rebalances)
     tokenId: diff.tokenId !== undefined ? diff.tokenId : current.tokenId,
     liquidity:
       diff.liquidity !== undefined ? diff.liquidity : current.liquidity,
@@ -42,10 +33,6 @@ export async function updateALMLPWrapper(
     tickUpper:
       diff.tickUpper !== undefined ? diff.tickUpper : current.tickUpper,
     property: diff.property !== undefined ? diff.property : current.property,
-    ammStateIsDerived:
-      diff.ammStateIsDerived !== undefined
-        ? diff.ammStateIsDerived
-        : current.ammStateIsDerived,
     lastUpdatedTimestamp: timestamp,
   };
 

--- a/src/Aggregators/UserStatsPerPool.ts
+++ b/src/Aggregators/UserStatsPerPool.ts
@@ -31,8 +31,6 @@ export interface UserStatsPerPoolDiff {
   incrementalTotalFeeRewardClaimed: bigint;
   incrementalTotalFeeRewardClaimedUSD: bigint;
   almAddress: string;
-  almAmount0: bigint;
-  almAmount1: bigint;
   incrementalAlmLpAmount: bigint;
   lastAlmActivityTimestamp: Date;
   lastActivityTimestamp: Date;
@@ -168,8 +166,6 @@ export function createUserStatsPerPoolEntity(
 
     // ALM metrics - initialized to empty/zero values
     almAddress: "",
-    almAmount0: 0n,
-    almAmount1: 0n,
     almLpAmount: 0n,
     lastAlmActivityTimestamp: timestamp,
 
@@ -334,10 +330,6 @@ export async function updateUserStatsPerPool(
         : current.totalFeeRewardClaimedUSD,
 
     // ALM metrics
-    almAmount0:
-      diff.almAmount0 !== undefined ? diff.almAmount0 : current.almAmount0,
-    almAmount1:
-      diff.almAmount1 !== undefined ? diff.almAmount1 : current.almAmount1,
     almLpAmount:
       diff.incrementalAlmLpAmount !== undefined
         ? current.almLpAmount + diff.incrementalAlmLpAmount

--- a/src/EventHandlers/ALM/Core.ts
+++ b/src/EventHandlers/ALM/Core.ts
@@ -1,18 +1,10 @@
-import { ALMCore, type ALM_LP_Wrapper } from "generated";
+import { ALMCore } from "generated";
 import { updateALMLPWrapper } from "../../Aggregators/ALMLPWrapper";
 
 ALMCore.Rebalance.handler(async ({ event, context }) => {
-  const [
-    pool,
-    ammPositionInfo,
-    sqrtPriceX96,
-    amount0,
-    amount1,
-    ammPositionIdBefore,
-    ammPositionIdAfter,
-  ] = event.params.rebalanceEventParams;
-  const [token0, token1, property, tickLower, tickUpper, liquidity] =
-    ammPositionInfo;
+  const [pool, ammPositionInfo, , , , , ammPositionIdAfter] =
+    event.params.rebalanceEventParams;
+  const [, , property, tickLower, tickUpper, liquidity] = ammPositionInfo;
 
   const timestamp = new Date(event.block.timestamp * 1000);
 
@@ -30,16 +22,12 @@ ALMCore.Rebalance.handler(async ({ event, context }) => {
   // Since there's exactly 1 wrapper per pool, take the first one
   const lpWrapper = wrappers[0];
 
-  // Update the wrapper's strategy position state with new amounts from Rebalance (amount0/amount1 from event)
-  const lpWrapperDiff: Partial<ALM_LP_Wrapper> = {
+  const lpWrapperDiff = {
     tokenId: ammPositionIdAfter,
     tickLower: tickLower,
     tickUpper: tickUpper,
     property: property,
     liquidity: liquidity,
-    ammStateIsDerived: false,
-    amount0: amount0,
-    amount1: amount1,
     lastUpdatedTimestamp: timestamp,
   };
 

--- a/test/EventHandlers/ALM/DeployFactoryV1.test.ts
+++ b/test/EventHandlers/ALM/DeployFactoryV1.test.ts
@@ -4,7 +4,6 @@ import {
 } from "../../../generated/src/TestHelpers.gen";
 import type { NonFungiblePosition } from "../../../generated/src/Types.gen";
 import { toChecksumAddress } from "../../../src/Constants";
-import { calculatePositionAmountsFromLiquidity } from "../../../src/Helpers";
 import {
   extendMockDbWithGetWhere,
   setupLiquidityPoolAggregator,
@@ -133,16 +132,6 @@ describe("ALMDeployFactoryV1 StrategyCreated Event", () => {
       expect(createdWrapper?.token0).toBe(mockToken0Data.address);
       expect(createdWrapper?.token1).toBe(mockToken1Data.address);
 
-      // Wrapper-level aggregations should be initialized from NonFungiblePosition
-      // Calculate expected amounts from liquidity and sqrtPriceX96
-      const expectedAmounts = calculatePositionAmountsFromLiquidity(
-        liquidity,
-        sqrtPriceX96,
-        tickLower,
-        tickUpper,
-      );
-      expect(createdWrapper?.amount0).toBe(expectedAmounts.amount0);
-      expect(createdWrapper?.amount1).toBe(expectedAmounts.amount1);
       // lpAmount should equal liquidity (initialTotalSupply = position.liquidity in V1)
       expect(createdWrapper?.lpAmount).toBe(liquidity);
 
@@ -165,8 +154,6 @@ describe("ALMDeployFactoryV1 StrategyCreated Event", () => {
       expect(createdWrapper?.lastUpdatedTimestamp).toEqual(
         new Date(blockTimestamp * 1000),
       );
-      // Initial state from StrategyCreated is from on-chain AMM position, not derived
-      expect(createdWrapper?.ammStateIsDerived).toBe(false);
     });
 
     it("should not create entity when NonFungiblePosition not found", async () => {
@@ -355,14 +342,6 @@ describe("ALMDeployFactoryV1 StrategyCreated Event", () => {
       // Should use the matching NonFungiblePosition (tokenId = 42n)
       expect(createdWrapper?.tokenId).toBe(tokenId);
       // Calculate expected amounts from liquidity and sqrtPriceX96
-      const expectedAmounts = calculatePositionAmountsFromLiquidity(
-        liquidity,
-        sqrtPriceX96,
-        tickLower,
-        tickUpper,
-      );
-      expect(createdWrapper?.amount0).toBe(expectedAmounts.amount0);
-      expect(createdWrapper?.amount1).toBe(expectedAmounts.amount1);
     });
 
     it("should warn when multiple matching NonFungiblePositions found", async () => {
@@ -452,15 +431,7 @@ describe("ALMDeployFactoryV1 StrategyCreated Event", () => {
       expect(createdWrapper).toBeDefined();
       // Should use the first matching NonFungiblePosition
       expect(createdWrapper?.tokenId).toBe(tokenId);
-      // Calculate expected amounts from liquidity and sqrtPriceX96
-      const expectedAmounts = calculatePositionAmountsFromLiquidity(
-        liquidity,
-        sqrtPriceX96,
-        tickLower,
-        tickUpper,
-      );
-      expect(createdWrapper?.amount0).toBe(expectedAmounts.amount0);
-      expect(createdWrapper?.amount1).toBe(expectedAmounts.amount1);
+      expect(createdWrapper?.liquidity).toBe(liquidity);
     });
   });
 });

--- a/test/EventHandlers/ALM/LPWrapperV2.test.ts
+++ b/test/EventHandlers/ALM/LPWrapperV2.test.ts
@@ -67,20 +67,11 @@ describe("ALMLPWrapperV2 Events", () => {
       expect(wrapper?.id).toBe(wrapperId);
       expect(wrapper?.chainId).toBe(chainId);
       expect(wrapper?.pool).toBe(toChecksumAddress(poolAddress));
-      // amount0 and amount1 are recalculated from liquidity and price, then deposited amounts are added
-      // In test environment without mocked effects, recalculation fails and falls back to current wrapper values
-      // Then deposited amounts are added: current + deposited
-      expect(wrapper?.amount0).toBe(
-        mockALMLPWrapperData.amount0 + 500n * TEN_TO_THE_18_BI,
-      ); // 1000 + 500 = 1500
-      expect(wrapper?.amount1).toBe(
-        mockALMLPWrapperData.amount1 + 250n * TEN_TO_THE_6_BI,
-      ); // 500 + 250 = 750
+      expect(wrapper?.liquidity).toBeDefined();
       // lpAmount is incremented (aggregation from events)
       expect(wrapper?.lpAmount).toBe(
         mockALMLPWrapperData.lpAmount + 1000n * TEN_TO_THE_18_BI,
       ); // 2000 + 1000 = 3000
-      expect(wrapper?.ammStateIsDerived).toBe(true);
       expect(wrapper?.lastUpdatedTimestamp).toEqual(new Date(1000000 * 1000));
     });
 
@@ -144,10 +135,6 @@ describe("ALMLPWrapperV2 Events", () => {
       expect(userStats?.poolAddress).toBe(poolAddress);
       expect(userStats?.chainId).toBe(chainId);
       // User amounts are derived from LP share, not directly from event amounts
-      // After deposit: wrapper amount0=1500, amount1=750, lpAmount=3000
-      // User LP=1000, so user gets: amount0=(1500*1000)/3000=500, amount1=(750*1000)/3000=250
-      expect(userStats?.almAmount0).toBe(500n * TEN_TO_THE_18_BI);
-      expect(userStats?.almAmount1).toBe(250n * TEN_TO_THE_6_BI);
       expect(userStats?.almLpAmount).toBe(1000n * TEN_TO_THE_18_BI);
     });
 
@@ -168,8 +155,6 @@ describe("ALMLPWrapperV2 Events", () => {
           userAddress: userA,
           poolAddress: poolAddress,
           chainId: chainId,
-          almAmount0: 300n * TEN_TO_THE_18_BI,
-          almAmount1: 150n * TEN_TO_THE_6_BI,
           almLpAmount: 600n * TEN_TO_THE_18_BI,
         }),
       );
@@ -194,10 +179,6 @@ describe("ALMLPWrapperV2 Events", () => {
 
       expect(userStats).toBeDefined();
       // ALM amounts are derived from LP share after deposit
-      // After deposit: wrapper amount0=1500, amount1=750, lpAmount=3000
-      // User LP=1600 (600 existing + 1000 new), so user gets: amount0=(1500*1600)/3000=800, amount1=(750*1600)/3000=400
-      expect(userStats?.almAmount0).toBe(800n * TEN_TO_THE_18_BI);
-      expect(userStats?.almAmount1).toBe(400n * TEN_TO_THE_6_BI);
       expect(userStats?.almLpAmount).toBe(1600n * TEN_TO_THE_18_BI); // 600 + 1000
       expect(userStats?.lastActivityTimestamp).toEqual(
         new Date(1000000 * 1000),
@@ -237,24 +218,12 @@ describe("ALMLPWrapperV2 Events", () => {
 
       expect(wrapper).toBeDefined();
       expect(userStats).toBeDefined();
-      // amount0 and amount1 are recalculated from liquidity and price, then deposited amounts are added
-      // In test environment without mocked effects, recalculation fails and falls back to current wrapper values
-      // Then deposited amounts are added: current + deposited
-      expect(wrapper?.amount0).toBe(
-        mockALMLPWrapperData.amount0 + 500n * TEN_TO_THE_18_BI,
-      ); // 1000 + 500 = 1500
-      expect(wrapper?.amount1).toBe(
-        mockALMLPWrapperData.amount1 + 250n * TEN_TO_THE_6_BI,
-      ); // 500 + 250 = 750
+      expect(wrapper?.liquidity).toBeDefined();
       // lpAmount is incremented (aggregation from events)
       expect(wrapper?.lpAmount).toBe(
         mockALMLPWrapperData.lpAmount + 1000n * TEN_TO_THE_18_BI,
       );
       // User amounts are derived from LP share after deposit
-      // After deposit: wrapper amount0=1500, amount1=750, lpAmount=3000
-      // User LP=1000, so user gets: amount0=(1500*1000)/3000=500, amount1=(750*1000)/3000=250
-      expect(userStats?.almAmount0).toBe(500n * TEN_TO_THE_18_BI);
-      expect(userStats?.almAmount1).toBe(250n * TEN_TO_THE_6_BI);
       expect(userStats?.almLpAmount).toBe(1000n * TEN_TO_THE_18_BI);
     });
   });
@@ -289,18 +258,9 @@ describe("ALMLPWrapperV2 Events", () => {
       const wrapper = result.entities.ALM_LP_Wrapper.get(wrapperId);
 
       expect(wrapper).toBeDefined();
-      // amount0 and amount1 are recalculated from liquidity and price, then withdrawn amounts are subtracted
-      // In test environment without mocked effects, recalculation fails and falls back to current wrapper values
-      // Then withdrawn amounts are subtracted: current - withdrawn
-      expect(wrapper?.amount0).toBe(
-        mockALMLPWrapperData.amount0 - 250n * TEN_TO_THE_18_BI,
-      ); // 1000 - 250 = 750
-      expect(wrapper?.amount1).toBe(
-        mockALMLPWrapperData.amount1 - 125n * TEN_TO_THE_6_BI,
-      ); // 500 - 125 = 375
+      expect(wrapper?.liquidity).toBeDefined();
       // lpAmount is decremented (aggregation from events)
       expect(wrapper?.lpAmount).toBe(1500n * TEN_TO_THE_18_BI); // 2000 - 500
-      expect(wrapper?.ammStateIsDerived).toBe(true);
       expect(wrapper?.lastUpdatedTimestamp).toEqual(new Date(1000000 * 1000));
     });
 
@@ -346,8 +306,6 @@ describe("ALMLPWrapperV2 Events", () => {
           userAddress: userA,
           poolAddress: poolAddress,
           chainId: chainId,
-          almAmount0: 1000n * TEN_TO_THE_18_BI,
-          almAmount1: 500n * TEN_TO_THE_6_BI,
           almLpAmount: 2000n * TEN_TO_THE_18_BI,
         }),
       );
@@ -372,10 +330,6 @@ describe("ALMLPWrapperV2 Events", () => {
 
       expect(userStats).toBeDefined();
       // ALM amounts are derived from LP share after withdrawal
-      // After withdrawal: wrapper amount0=750, amount1=375, lpAmount=1500
-      // User LP=1500 (2000 - 500), so user gets: amount0=(750*1500)/1500=750, amount1=(375*1500)/1500=375
-      expect(userStats?.almAmount0).toBe(750n * TEN_TO_THE_18_BI);
-      expect(userStats?.almAmount1).toBe(375n * TEN_TO_THE_6_BI);
       expect(userStats?.almLpAmount).toBe(1500n * TEN_TO_THE_18_BI); // 2000 - 500
       expect(userStats?.lastActivityTimestamp).toEqual(
         new Date(1000000 * 1000),
@@ -432,8 +386,6 @@ describe("ALMLPWrapperV2 Events", () => {
       // Verify ALM_LP_Wrapper is unchanged (transfers don't affect pool-level liquidity)
       const wrapper = result.entities.ALM_LP_Wrapper.get(wrapperId);
       expect(wrapper).toBeDefined();
-      expect(wrapper?.amount0).toBe(mockALMLPWrapperData.amount0);
-      expect(wrapper?.amount1).toBe(mockALMLPWrapperData.amount1);
       expect(wrapper?.lpAmount).toBe(mockALMLPWrapperData.lpAmount);
 
       // Verify sender's almLpAmount decreased
@@ -441,21 +393,10 @@ describe("ALMLPWrapperV2 Events", () => {
         result.entities.UserStatsPerPool.get(userStatsFromId);
       expect(userStatsFrom).toBeDefined();
       expect(userStatsFrom?.almLpAmount).toBe(4000n * TEN_TO_THE_18_BI); // 5000 - 1000
-      // Sender's amounts are derived from LP share after transfer
-      // Wrapper: amount0=1000, amount1=500, lpAmount=2000 (unchanged in transfers)
-      // Sender LP=4000, so sender gets: amount0=(1000*4000)/2000=2000, amount1=(500*4000)/2000=1000
-      expect(userStatsFrom?.almAmount0).toBe(2000n * TEN_TO_THE_18_BI);
-      expect(userStatsFrom?.almAmount1).toBe(1000n * TEN_TO_THE_6_BI);
 
-      // Verify recipient's almLpAmount increased
       const userStatsTo = result.entities.UserStatsPerPool.get(userStatsToId);
       expect(userStatsTo).toBeDefined();
       expect(userStatsTo?.almLpAmount).toBe(3000n * TEN_TO_THE_18_BI); // 2000 + 1000
-      // Recipient's amounts are derived from LP share after transfer
-      // Wrapper: amount0=1000, amount1=500, lpAmount=2000 (unchanged in transfers)
-      // Recipient LP=3000, so recipient gets: amount0=(1000*3000)/2000=1500, amount1=(500*3000)/2000=750
-      expect(userStatsTo?.almAmount0).toBe(1500n * TEN_TO_THE_18_BI);
-      expect(userStatsTo?.almAmount1).toBe(750n * TEN_TO_THE_6_BI);
       expect(userStatsTo?.almAddress).toBe(lpWrapperAddress);
     });
 
@@ -504,10 +445,6 @@ describe("ALMLPWrapperV2 Events", () => {
       expect(userStatsTo).toBeDefined();
       expect(userStatsTo?.almLpAmount).toBe(500n * TEN_TO_THE_18_BI); // 0 + 500
       // Recipient's amounts are derived from LP share after transfer
-      // Wrapper: amount0=1000, amount1=500, lpAmount=2000 (unchanged in transfers)
-      // Recipient LP=500, so recipient gets: amount0=(1000*500)/2000=250, amount1=(500*500)/2000=125
-      expect(userStatsTo?.almAmount0).toBe(250n * TEN_TO_THE_18_BI);
-      expect(userStatsTo?.almAmount1).toBe(125n * TEN_TO_THE_6_BI);
       expect(userStatsTo?.almAddress).toBe(lpWrapperAddress);
     });
 
@@ -606,8 +543,6 @@ describe("ALMLPWrapperV2 Events", () => {
       // Handler returns early for burns, so UserStatsPerPool should remain unchanged
       expect(burnerUserStats).toBeDefined();
       expect(burnerUserStats?.almLpAmount).toBe(transferAmount); // Unchanged
-      expect(burnerUserStats?.almAmount0).toBe(0n); // Unchanged
-      expect(burnerUserStats?.almAmount1).toBe(0n); // Unchanged
     });
   });
 
@@ -643,8 +578,6 @@ describe("ALMLPWrapperV2 Events", () => {
       expect(wrapper).toBeDefined();
       // Zero amounts should add zero (no change to recalculated amounts)
       // Recalculation falls back to current, then adds 0
-      expect(wrapper?.amount0).toBe(mockALMLPWrapperData.amount0 + 0n);
-      expect(wrapper?.amount1).toBe(mockALMLPWrapperData.amount1 + 0n);
       expect(wrapper?.lpAmount).toBe(mockALMLPWrapperData.lpAmount);
     });
 
@@ -704,21 +637,7 @@ describe("ALMLPWrapperV2 Events", () => {
       const wrapper = result.entities.ALM_LP_Wrapper.get(wrapperId);
 
       expect(wrapper).toBeDefined();
-      // amount0 and amount1 are recalculated from liquidity and price, then deposited amounts are added
-      // In test environment without mocked effects, recalculation fails and falls back to current wrapper values
-      // After first deposit: current + first deposit amounts
-      // After second deposit: (current + first deposit) + second deposit amounts
-      // Since recalculation always falls back to initial current, we get: current + first + second
-      expect(wrapper?.amount0).toBe(
-        mockALMLPWrapperData.amount0 +
-          500n * TEN_TO_THE_18_BI +
-          1000n * TEN_TO_THE_18_BI,
-      ); // 1000 + 500 + 1000 = 2500
-      expect(wrapper?.amount1).toBe(
-        mockALMLPWrapperData.amount1 +
-          250n * TEN_TO_THE_6_BI +
-          500n * TEN_TO_THE_6_BI,
-      ); // 500 + 250 + 500 = 1250
+      expect(wrapper?.liquidity).toBeDefined();
       // lpAmount aggregates both deposits (incremented)
       expect(wrapper?.lpAmount).toBe(
         mockALMLPWrapperData.lpAmount +
@@ -734,15 +653,9 @@ describe("ALMLPWrapperV2 Events", () => {
       const userStats2 = result.entities.UserStatsPerPool.get(userStats2Id);
 
       expect(userStats1).toBeDefined();
-      // User1 amounts are derived from LP share after both deposits
-      // After both deposits: wrapper amount0=2500, amount1=1250, lpAmount=5000
-      // User1 LP=1000, so user1 gets: amount0=(2500*1000)/5000=500, amount1=(1250*1000)/5000=250
-      expect(userStats1?.almAmount0).toBe(500n * TEN_TO_THE_18_BI);
+      expect(userStats1?.almLpAmount).toBe(1000n * TEN_TO_THE_18_BI);
       expect(userStats2).toBeDefined();
-      // User2 amounts are derived from LP share after both deposits
-      // After both deposits: wrapper amount0=2500, amount1=1250, lpAmount=5000
-      // User2 LP=2000, so user2 gets: amount0=(2500*2000)/5000=1000, amount1=(1250*2000)/5000=500
-      expect(userStats2?.almAmount0).toBe(1000n * TEN_TO_THE_18_BI);
+      expect(userStats2?.almLpAmount).toBe(2000n * TEN_TO_THE_18_BI);
     });
 
     it("should handle deposit and withdrawal sequence correctly", async () => {
@@ -750,13 +663,9 @@ describe("ALMLPWrapperV2 Events", () => {
 
       // Pre-populate with existing wrapper
       const wrapperId = `${lpWrapperAddress}_${chainId}`;
-      const initialAmount0 = 1000n * TEN_TO_THE_18_BI;
-      const initialAmount1 = 500n * TEN_TO_THE_6_BI;
       mockDb = mockDb.entities.ALM_LP_Wrapper.set({
         ...mockALMLPWrapperData,
         id: wrapperId,
-        amount0: initialAmount0,
-        amount1: initialAmount1,
       });
 
       // First deposit
@@ -804,14 +713,13 @@ describe("ALMLPWrapperV2 Events", () => {
       const wrapper = result.entities.ALM_LP_Wrapper.get(wrapperId);
 
       expect(wrapper).toBeDefined();
-      // Initial + deposit - withdrawal
-      // Since recalculation falls back to initial, we get: initial + deposit - withdrawal
-      expect(wrapper?.amount0).toBe(
-        initialAmount0 + 500n * TEN_TO_THE_18_BI - 250n * TEN_TO_THE_18_BI,
-      ); // 1000 + 500 - 250 = 1250
-      expect(wrapper?.amount1).toBe(
-        initialAmount1 + 250n * TEN_TO_THE_6_BI - 125n * TEN_TO_THE_6_BI,
-      ); // 500 + 250 - 125 = 625
+      // lpAmount: initial 2000 + deposit 1000 - withdraw 500 = 2500
+      expect(wrapper?.lpAmount).toBe(
+        mockALMLPWrapperData.lpAmount +
+          1000n * TEN_TO_THE_18_BI -
+          500n * TEN_TO_THE_18_BI,
+      );
+      expect(wrapper?.liquidity).toBeDefined();
     });
   });
 

--- a/test/EventHandlers/Pool/common.ts
+++ b/test/EventHandlers/Pool/common.ts
@@ -150,12 +150,8 @@ export function setupCommon() {
     pool: POOL_ADDRESS,
     token0: mockToken0Data.address,
     token1: mockToken1Data.address,
-    // Wrapper-level aggregations
-    amount0: 1000n * TEN_TO_THE_18_BI,
-    amount1: 500n * TEN_TO_THE_6_BI,
     lpAmount: 2000n * TEN_TO_THE_18_BI,
     lastUpdatedTimestamp: new Date(900000 * 1000),
-    // Strategy/Position-level state
     tokenId: 1n,
     tickLower: -1000n,
     tickUpper: 1000n,
@@ -169,7 +165,6 @@ export function setupCommon() {
     creationTimestamp: new Date(900000 * 1000),
     strategyTransactionHash:
       "0x0000000000000000000000000000000000000000000000000000000000000001",
-    ammStateIsDerived: false, // Default to false (from on-chain AMM position), tests can override
   };
 
   const defaultUserAddress = "0xAbCccccccccccccccccccccccccccccccccccccc";
@@ -223,8 +218,6 @@ export function setupCommon() {
 
     // ALM metrics - initialized to empty/zero values
     almAddress: "",
-    almAmount0: 0n,
-    almAmount1: 0n,
     almLpAmount: 0n,
 
     // Timestamps


### PR DESCRIPTION
closes #485 

Amount0 and Amount1 weren't kept in these entities due to the following:
- Consistency with LP amount0 and amount1, which were also removed and probably will only be updated at snapshot level
- Requires less logic and workload in event handlers and with the same beneficial outcome -> when snapshots are implemented, if one requires the underlying amount0 and amount1 then it just needs to fetch the appropriate snapshot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added first and last activity timestamp tracking for users per pool

* **Refactor**
  - Optimized ALM LP wrapper data model and liquidity calculation methodology

<!-- end of auto-generated comment: release notes by coderabbit.ai -->