### PR TITLE
Correct recipient of gauge deposits for non-cl pools

### DIFF
--- a/src/EventHandlers/Gauges/Gauge.ts
+++ b/src/EventHandlers/Gauges/Gauge.ts
@@ -9,7 +9,7 @@ Gauge.Deposit.handler(async ({ event, context }) => {
   await processGaugeDeposit(
     {
       gaugeAddress: event.srcAddress,
-      userAddress: event.params.from,
+      userAddress: event.params.to,
       chainId: event.chainId,
       blockNumber: event.block.number,
       timestamp: event.block.timestamp,

--- a/test/EventHandlers/Gauges/Gauge.test.ts
+++ b/test/EventHandlers/Gauges/Gauge.test.ts
@@ -16,6 +16,7 @@ describe("Gauge Event Handlers", () => {
     it("should map Gauge.Deposit event data correctly", async () => {
       const mockEvent = Gauge.Deposit.createMockEvent({
         from: mockUserAddress,
+        to: mockUserAddress, // recipient of staked position (balance owner)
         amount: 100000000000000000000n, // 100 USD
         mockEventData: {
           srcAddress: mockGaugeAddress,
@@ -28,8 +29,9 @@ describe("Gauge Event Handlers", () => {
         },
       });
 
-      // Test that the event data is correctly structured
+      // Test that the event data is correctly structured (to = balance owner for indexing)
       expect(mockEvent.params.from).toBe(mockUserAddress);
+      expect(mockEvent.params.to).toBe(mockUserAddress);
       expect(mockEvent.params.amount).toBe(100000000000000000000n);
       expect(mockEvent.srcAddress).toBe(mockGaugeAddress);
       expect(mockEvent.chainId).toBe(mockChainId);
@@ -90,6 +92,7 @@ describe("Gauge Event Handlers", () => {
     it("should call shared logic functions without errors for Deposit", async () => {
       const mockEvent = Gauge.Deposit.createMockEvent({
         from: mockUserAddress,
+        to: mockUserAddress,
         amount: 100000000000000000000n,
         mockEventData: {
           srcAddress: mockGaugeAddress,


### PR DESCRIPTION
closes #504 
(should close the above; re-open issue if this isn't the case when new deployment is made)

Implements:
- Update to the correct recipient of `Deposit` events from `Gauge.sol`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected deposit event attribution to properly credit the recipient address instead of the sender address, ensuring deposits are correctly associated with the intended user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->