### PR TITLE
Base new oracle with correct function name calling

### DIFF
--- a/src/Effects/Token.ts
+++ b/src/Effects/Token.ts
@@ -99,7 +99,10 @@ export async function fetchTokenPrice(
   while (attempt <= maxRetries) {
     const attemptStartTime = Date.now();
     try {
-      if (priceOracleType === PriceOracleType.V3) {
+      if (
+        priceOracleType === PriceOracleType.V3 ||
+        priceOracleType === PriceOracleType.V4
+      ) {
         const tokenAddressArray = [
           ...connectors,
           systemTokenAddress,
@@ -138,7 +141,7 @@ export async function fetchTokenPrice(
 
         return {
           pricePerUSDNew: BigInt(result[0]),
-          priceOracleType: PriceOracleType.V3,
+          priceOracleType: priceOracleType,
         };
       }
 
@@ -372,7 +375,7 @@ export const getTokenPrice = createEffect(
     }
 
     // Fetch token details for V3 oracle decimal conversion if needed
-    const [tokenDetails, USDTokenDetails] = await Promise.all([
+    const [tokenDetails, USDCTokenDetails] = await Promise.all([
       context.effect(getTokenDetails, {
         contractAddress: tokenAddress,
         chainId,
@@ -423,12 +426,15 @@ export const getTokenPrice = createEffect(
         gasLimit,
       );
 
-      // Convert V3 oracle prices to 18 decimals
+      // Convert V3/V4 oracle prices to 18 decimals
       let currentPrice: bigint;
-      if (priceData.priceOracleType === PriceOracleType.V3) {
+      if (
+        priceData.priceOracleType === PriceOracleType.V3 ||
+        priceData.priceOracleType === PriceOracleType.V4
+      ) {
         currentPrice =
           (priceData.pricePerUSDNew * 10n ** BigInt(tokenDetails.decimals)) /
-          10n ** BigInt(USDTokenDetails.decimals);
+          10n ** BigInt(USDCTokenDetails.decimals);
       } else {
         currentPrice = priceData.pricePerUSDNew;
       }

--- a/test/Effects/Token.test.ts
+++ b/test/Effects/Token.test.ts
@@ -400,7 +400,7 @@ describe("Token Effects", () => {
       realFetchTokenPrice = actual.fetchTokenPrice;
     });
 
-    it("should fetch token price from V3 and V2 oracles", async () => {
+    it("should fetch token price from V3, V4 and V2 oracles", async () => {
       const testCases = [
         {
           oracleType: PriceOracleType.V3,
@@ -410,6 +410,15 @@ describe("Token Effects", () => {
           ],
           expectedPrice: 1n,
           expectedType: PriceOracleType.V3,
+        },
+        {
+          oracleType: PriceOracleType.V4,
+          functionName: "getManyRatesWithCustomConnectors",
+          result: [
+            "0x0000000000000000000000000000000000000000000000000000000000000003",
+          ],
+          expectedPrice: 3n,
+          expectedType: PriceOracleType.V4,
         },
         {
           oracleType: PriceOracleType.V2,


### PR DESCRIPTION
Fixes the following problem, specific to Base (since it's the only one with "V4" oracle)

<img width="763" height="96" alt="image" src="https://github.com/user-attachments/assets/6996b901-7736-4861-93d6-932316ca3200" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for V4 price oracle type in token pricing, expanding compatibility alongside V3 and V2 oracle sources.
  * Improved decimal conversion logic to ensure consistent price normalization across all supported oracle types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->