### PR TITLE
Lowering RPC rps (Alchemy)

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -62,10 +62,10 @@ export const ROOT_POOL_FACTORY_ADDRESS_OPTIMISM = toChecksumAddress(
 
 // Effect rate limit constants (calls per second)
 export const EFFECT_RATE_LIMITS = {
-  TOKEN_EFFECTS: 5000, // Token details and price fetching effects
-  VOTER_EFFECTS: 5000, // Voter-related effects
-  DYNAMIC_FEE_EFFECTS: 5000, // Dynamic fee effects
-  ROOT_POOL_EFFECTS: 5000, // Root pool effects
+  TOKEN_EFFECTS: 500, // Token details and price fetching effects
+  VOTER_EFFECTS: 500, // Voter-related effects
+  DYNAMIC_FEE_EFFECTS: 500, // Dynamic fee effects
+  ROOT_POOL_EFFECTS: 500, // Root pool effects
 } as const;
 
 export const OUSDT_ADDRESS = "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189";


### PR DESCRIPTION
close #513 

Should close the above issue

Implements:
- Lower RPS limits

This is based on the 10,000 CU/s limit that PAYG accounts have. Since each `eth_call` is ~26 CU, we get max ~384RPS. Fixed it at 500 RPS, slightly above the limit, because there can be occasions where the throughput limit can be higher, depending on availability. Previously, even with the retry logic (as seen in the issue's screenshot) after 60s we still get rate limited

Reference docs: 
- https://www.alchemy.com/docs/reference/throughput
- https://www.alchemy.com/docs/reference/pricing-plans
- https://www.alchemy.com/docs/reference/compute-unit-costs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted effect application rate limits to enhance system performance and stability across multiple components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->