### PR TITLE
Voting Reward `ClaimReward` - pool id fix

### DIFF
--- a/src/EventHandlers/VotingReward/VotingRewardSharedLogic.ts
+++ b/src/EventHandlers/VotingReward/VotingRewardSharedLogic.ts
@@ -173,10 +173,10 @@ export async function loadVotingRewardData(
   }
 
   // Load pool data and handle errors
-  const poolData = await loadPoolData(pool.id, data.chainId, context);
+  const poolData = await loadPoolData(pool.poolAddress, data.chainId, context);
   if (!poolData) {
     context.log.error(
-      `${handlerName}: Pool data not found for pool ${pool.id} on chain ${data.chainId}`,
+      `${handlerName}: Pool data not found for pool ${pool.poolAddress} on chain ${data.chainId}`,
     );
     return null;
   }
@@ -184,7 +184,7 @@ export async function loadVotingRewardData(
   // Load user data
   const userData = await loadOrCreateUserData(
     userAddress,
-    pool.id,
+    pool.poolAddress,
     data.chainId,
     context,
     new Date(data.timestamp * 1000),

--- a/test/EventHandlers/VotingReward/VotingRewardSharedLogic.test.ts
+++ b/test/EventHandlers/VotingReward/VotingRewardSharedLogic.test.ts
@@ -1,10 +1,14 @@
 import type { Token } from "generated";
+import * as LiquidityPoolAggregatorModule from "../../../src/Aggregators/LiquidityPoolAggregator";
 import { PoolAddressField } from "../../../src/Aggregators/LiquidityPoolAggregator";
+import * as UserStatsPerPoolModule from "../../../src/Aggregators/UserStatsPerPool";
 import { toChecksumAddress } from "../../../src/Constants";
 import {
   type VotingRewardClaimRewardsData,
+  loadVotingRewardData,
   processVotingRewardClaimRewards,
 } from "../../../src/EventHandlers/VotingReward/VotingRewardSharedLogic";
+import { setupCommon } from "../Pool/common";
 
 describe("VotingRewardSharedLogic", () => {
   const mockChainId = 8453;
@@ -176,6 +180,95 @@ describe("VotingRewardSharedLogic", () => {
       expect(result.userDiff?.incrementalTotalBribeClaimedUSD).toBe(
         1000000000000000000n,
       );
+    });
+  });
+
+  describe("loadVotingRewardData", () => {
+    it("should call loadPoolData and loadOrCreateUserData with pool.poolAddress not pool.id", async () => {
+      const common = setupCommon();
+      const {
+        mockToken0Data,
+        mockToken1Data,
+        createMockLiquidityPoolAggregator,
+      } = common;
+
+      const chainId = 10;
+      const pool = createMockLiquidityPoolAggregator({
+        chainId,
+        bribeVotingRewardAddress: mockVotingRewardAddress,
+      });
+
+      const loadPoolDataSpy = vi.spyOn(
+        LiquidityPoolAggregatorModule,
+        "loadPoolData",
+      );
+      const loadOrCreateUserDataSpy = vi.spyOn(
+        UserStatsPerPoolModule,
+        "loadOrCreateUserData",
+      );
+
+      const userStatsStorage = new Map<string, unknown>();
+      const context = {
+        log: { error: () => {}, warn: () => {}, info: () => {} },
+        LiquidityPoolAggregator: {
+          getWhere: async (q: {
+            bribeVotingRewardAddress?: { _eq: string };
+          }) =>
+            q.bribeVotingRewardAddress?._eq === mockVotingRewardAddress
+              ? [pool]
+              : [],
+          get: async (poolId: string) =>
+            poolId === pool.id ? pool : undefined,
+        },
+        Token: {
+          get: async (id: string) =>
+            id === pool.token0_id
+              ? mockToken0Data
+              : id === pool.token1_id
+                ? mockToken1Data
+                : undefined,
+        },
+        UserStatsPerPool: {
+          get: async (id: string) => userStatsStorage.get(id) as undefined,
+          set: (entity: { id: string }) => {
+            userStatsStorage.set(entity.id, entity);
+          },
+        },
+      } as unknown as import("generated").handlerContext;
+
+      const data = {
+        votingRewardAddress: mockVotingRewardAddress,
+        userAddress: mockUserAddress,
+        chainId,
+        blockNumber: 12345,
+        timestamp: Math.floor(mockTimestamp.getTime() / 1000),
+      };
+
+      const result = await loadVotingRewardData(
+        data,
+        context,
+        "BribesVotingReward.ClaimRewards",
+        PoolAddressField.BRIBE_VOTING_REWARD_ADDRESS,
+      );
+
+      expect(result).not.toBeNull();
+      expect(loadPoolDataSpy).toHaveBeenCalledTimes(1);
+      expect(loadPoolDataSpy).toHaveBeenCalledWith(
+        pool.poolAddress,
+        chainId,
+        context,
+      );
+      expect(loadOrCreateUserDataSpy).toHaveBeenCalledTimes(1);
+      expect(loadOrCreateUserDataSpy).toHaveBeenCalledWith(
+        mockUserAddress,
+        pool.poolAddress,
+        chainId,
+        context,
+        expect.any(Date),
+      );
+
+      loadPoolDataSpy.mockRestore();
+      loadOrCreateUserDataSpy.mockRestore();
     });
   });
 });


### PR DESCRIPTION
When running locally the indexer, found this new error. Probably came from the change of `id` of pool entity from simply pool address to chainId+pooladdress

<img width="1041" height="148" alt="image" src="https://github.com/user-attachments/assets/f1a112fb-62d7-486a-870d-3347445350b1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal consistency in how pool identifiers are referenced during voting reward data operations, reducing ambiguity in data handling.

* **Tests**
  * Added comprehensive test coverage validating voting reward data loading and related interactions to increase reliability and prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->