### PR TITLE
Renaming effect back to `getCurrentFee` due to deployment cache

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1139,8 +1139,8 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
-  caniuse-lite@1.0.30001775:
-    resolution: {integrity: sha512-s3Qv7Lht9zbVKE9XoTyRG6wVDCKdtOFIjBGg3+Yhn6JaytuNKPIjBMTMIY1AnOH3seL5mvF+x33oGAyK3hVt3A==}
+  caniuse-lite@1.0.30001776:
+    resolution: {integrity: sha512-sg01JDPzZ9jGshqKSckOQthXnYwOEP50jeVFhaSFbZcOy05TiuuaffDOfcwtCisJ9kNQuLBFibYywv2Bgm9osw==}
 
   cfonts@3.3.1:
     resolution: {integrity: sha512-ZGEmN3W9mViWEDjsuPo4nK4h39sfh6YtoneFYp9WLPI/rw8BaSSrfQC6jkrGW3JMvV3ZnExJB/AEqXc/nHYxkw==}
@@ -1336,8 +1336,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  electron-to-chromium@1.5.302:
-    resolution: {integrity: sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==}
+  electron-to-chromium@1.5.307:
+    resolution: {integrity: sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==}
 
   elliptic@6.6.1:
     resolution: {integrity: sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==}
@@ -2108,8 +2108,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+  postcss@8.5.8:
+    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres@3.4.8:
@@ -3877,8 +3877,8 @@ snapshots:
   browserslist@4.28.1:
     dependencies:
       baseline-browser-mapping: 2.10.0
-      caniuse-lite: 1.0.30001775
-      electron-to-chromium: 1.5.302
+      caniuse-lite: 1.0.30001776
+      electron-to-chromium: 1.5.307
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
@@ -3905,7 +3905,7 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  caniuse-lite@1.0.30001775: {}
+  caniuse-lite@1.0.30001776: {}
 
   cfonts@3.3.1:
     dependencies:
@@ -4062,7 +4062,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  electron-to-chromium@1.5.302: {}
+  electron-to-chromium@1.5.307: {}
 
   elliptic@6.6.1:
     dependencies:
@@ -4936,7 +4936,7 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.5.6:
+  postcss@8.5.8:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -5433,7 +5433,7 @@ snapshots:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
-      postcss: 8.5.6
+      postcss: 8.5.8
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:

--- a/scripts/smoke-effects.ts
+++ b/scripts/smoke-effects.ts
@@ -144,9 +144,9 @@ async function main(): Promise<void> {
     );
   });
 
-  await run("getSwapFee", async () => {
+  await run("getCurrentFee", async () => {
     const r = await callRpcGateway(context, {
-      type: EffectType.GET_SWAP_FEE,
+      type: EffectType.GET_CURRENT_FEE,
       poolAddress: POOL_OPTIMISM,
       factoryAddress: CL_FACTORY_OPTIMISM,
       chainId: CHAIN_ID,

--- a/src/Aggregators/LiquidityPoolAggregator.ts
+++ b/src/Aggregators/LiquidityPoolAggregator.ts
@@ -9,7 +9,7 @@ import {
   PoolId,
   TokenId,
 } from "../Constants";
-import { getSwapFee, roundBlockToInterval } from "../Effects/Index";
+import { getCurrentFee, roundBlockToInterval } from "../Effects/Index";
 import { generatePoolName } from "../Helpers";
 import { refreshTokenPrice } from "../PriceOracle";
 import {
@@ -166,7 +166,7 @@ export async function updateDynamicFeePools(
     return liquidityPoolAggregator;
   }
 
-  const currentFee = await context.effect(getSwapFee, {
+  const currentFee = await context.effect(getCurrentFee, {
     poolAddress,
     factoryAddress,
     chainId,

--- a/src/Effects/CurrentFee.ts
+++ b/src/Effects/CurrentFee.ts
@@ -14,9 +14,9 @@ export { fetchSwapFee } from "./fetchers/SwapFee";
  * @param input.blockNumber - Block at which to read the fee.
  * @returns Promise resolving to swap fee (bigint) or undefined when the gateway handles an RPC/contract error.
  */
-export const getSwapFee = createEffect(
+export const getCurrentFee = createEffect(
   {
-    name: EffectType.GET_SWAP_FEE,
+    name: EffectType.GET_CURRENT_FEE,
     input: {
       poolAddress: S.string,
       factoryAddress: S.string,
@@ -29,7 +29,7 @@ export const getSwapFee = createEffect(
   },
   async ({ input, context }) => {
     const result = await callRpcGateway(context, {
-      type: EffectType.GET_SWAP_FEE,
+      type: EffectType.GET_CURRENT_FEE,
       poolAddress: input.poolAddress,
       factoryAddress: input.factoryAddress,
       chainId: input.chainId,

--- a/src/Effects/Index.ts
+++ b/src/Effects/Index.ts
@@ -5,8 +5,8 @@ export {
   roundBlockToInterval,
 } from "./Token";
 
-// Swap fee-related effects (e.g. CLFactory.getSwapFee for CL pools)
-export { getSwapFee } from "./SwapFee";
+// Current fee effect (CLFactory.getSwapFee for CL pools; cache key getCurrentFee)
+export { getCurrentFee } from "./CurrentFee";
 
 // Voter-related effects
 export { getTokensDeposited } from "./Voter";

--- a/src/Effects/RpcGateway.ts
+++ b/src/Effects/RpcGateway.ts
@@ -27,7 +27,7 @@ export enum EffectType {
   GET_TOKEN_DETAILS = "getTokenDetails",
   GET_TOKEN_PRICE = "getTokenPrice",
   GET_TOKENS_DEPOSITED = "getTokensDeposited",
-  GET_SWAP_FEE = "getSwapFee",
+  GET_CURRENT_FEE = "getCurrentFee",
   GET_ROOT_POOL_ADDRESS = "getRootPoolAddress",
 }
 
@@ -85,9 +85,9 @@ const RPC_GATEWAY_OPERATIONS = {
       value: S.optional(S.bigint),
     },
   },
-  [EffectType.GET_SWAP_FEE]: {
+  [EffectType.GET_CURRENT_FEE]: {
     inputSchema: {
-      type: S.schema(EffectType.GET_SWAP_FEE),
+      type: S.schema(EffectType.GET_CURRENT_FEE),
       poolAddress: S.string,
       factoryAddress: S.string,
       chainId: S.number,
@@ -119,7 +119,7 @@ const RPC_GATEWAY_INPUT_SCHEMA = S.union([
   RPC_GATEWAY_OPERATIONS[EffectType.GET_TOKEN_DETAILS].inputSchema,
   RPC_GATEWAY_OPERATIONS[EffectType.GET_TOKEN_PRICE].inputSchema,
   RPC_GATEWAY_OPERATIONS[EffectType.GET_TOKENS_DEPOSITED].inputSchema,
-  RPC_GATEWAY_OPERATIONS[EffectType.GET_SWAP_FEE].inputSchema,
+  RPC_GATEWAY_OPERATIONS[EffectType.GET_CURRENT_FEE].inputSchema,
   RPC_GATEWAY_OPERATIONS[EffectType.GET_ROOT_POOL_ADDRESS].inputSchema,
 ]);
 
@@ -127,7 +127,7 @@ const RPC_GATEWAY_OUTPUT_SCHEMA = S.union([
   RPC_GATEWAY_OPERATIONS[EffectType.GET_TOKEN_DETAILS].outputSchema,
   RPC_GATEWAY_OPERATIONS[EffectType.GET_TOKEN_PRICE].outputSchema,
   RPC_GATEWAY_OPERATIONS[EffectType.GET_TOKENS_DEPOSITED].outputSchema,
-  RPC_GATEWAY_OPERATIONS[EffectType.GET_SWAP_FEE].outputSchema,
+  RPC_GATEWAY_OPERATIONS[EffectType.GET_CURRENT_FEE].outputSchema,
   RPC_GATEWAY_OPERATIONS[EffectType.GET_ROOT_POOL_ADDRESS].outputSchema,
 ]);
 
@@ -148,7 +148,7 @@ type RpcGatewayInputPayloadByType = {
     blockNumber: number;
     chainId: number;
   };
-  [EffectType.GET_SWAP_FEE]: {
+  [EffectType.GET_CURRENT_FEE]: {
     poolAddress: string;
     factoryAddress: string;
     chainId: number;
@@ -190,7 +190,7 @@ export type RpcGatewayOutputByType = {
     priceOracleType: string;
   };
   [EffectType.GET_TOKENS_DEPOSITED]: { value: bigint | undefined };
-  [EffectType.GET_SWAP_FEE]: { value: bigint | undefined };
+  [EffectType.GET_CURRENT_FEE]: { value: bigint | undefined };
   [EffectType.GET_ROOT_POOL_ADDRESS]: { value: string };
 };
 
@@ -239,8 +239,8 @@ export const rpcGateway = createEffect(
         return await handleGetTokenPrice(i, ctx);
       case EffectType.GET_TOKENS_DEPOSITED:
         return await handleGetTokensDeposited(i, ctx);
-      case EffectType.GET_SWAP_FEE:
-        return await handleGetSwapFee(i, ctx);
+      case EffectType.GET_CURRENT_FEE:
+        return await handleGetCurrentFee(i, ctx);
       case EffectType.GET_ROOT_POOL_ADDRESS:
         return await handleGetRootPoolAddress(i, ctx);
       default: {
@@ -474,16 +474,16 @@ async function handleGetTokensDeposited(
 }
 
 /**
- * Handles the GET_SWAP_FEE effect.
+ * Handles the GET_CURRENT_FEE effect.
  * @param i - The input for the effect.
  * @param context - The context for the effect.
- * @returns The swap fee.
+ * @returns The current swap fee.
  */
-async function handleGetSwapFee(
-  i: RpcGatewayInputByType[EffectType.GET_SWAP_FEE],
+async function handleGetCurrentFee(
+  i: RpcGatewayInputByType[EffectType.GET_CURRENT_FEE],
   context: RpcGatewayHandlerContext,
-): Promise<RpcGatewayOutputByType[EffectType.GET_SWAP_FEE]> {
-  const operationName = rpcGatewayOpName(EffectType.GET_SWAP_FEE);
+): Promise<RpcGatewayOutputByType[EffectType.GET_CURRENT_FEE]> {
+  const operationName = rpcGatewayOpName(EffectType.GET_CURRENT_FEE);
   const logDetails = {
     poolAddress: i.poolAddress,
     factoryAddress: i.factoryAddress,

--- a/test/Aggregators/LiquidityPoolAggregator.test.ts
+++ b/test/Aggregators/LiquidityPoolAggregator.test.ts
@@ -12,7 +12,7 @@ import {
   RootPoolLeafPoolId,
   toChecksumAddress,
 } from "../../src/Constants";
-import { getSwapFee } from "../../src/Effects/SwapFee";
+import { getCurrentFee } from "../../src/Effects/CurrentFee";
 import * as PriceOracle from "../../src/PriceOracle";
 import { setLiquidityPoolAggregatorSnapshot } from "../../src/Snapshots/LiquidityPoolAggregatorSnapshot";
 import { getSnapshotEpoch } from "../../src/Snapshots/Shared";
@@ -94,7 +94,7 @@ describe("LiquidityPoolAggregator Functions", () => {
             scalingFactor: 10000000n,
           };
         }
-        if (effectFn.name === "getSwapFee") {
+        if (effectFn.name === "getCurrentFee") {
           return 1900n;
         }
         return {};
@@ -203,7 +203,7 @@ describe("LiquidityPoolAggregator Functions", () => {
       // Verify that the effect was called with the expected arguments
       // biome-ignore lint/style/noNonNullAssertion: effect is verified to be defined above
       const effectMock = vi.mocked(mockContext.effect!);
-      expect(effectMock).toHaveBeenCalledWith(getSwapFee, {
+      expect(effectMock).toHaveBeenCalledWith(getCurrentFee, {
         poolAddress: liquidityPoolAggregator.poolAddress,
         factoryAddress: toChecksumAddress(
           "0x548118C7E0B865C2CfA94D15EC86B666468ac758",
@@ -352,7 +352,7 @@ describe("LiquidityPoolAggregator Functions", () => {
 
       // For non-CL pools, updateDynamicFeePools should NOT be called
       const effectCalls = effectSpy.mock.calls.filter(
-        (call) => call[0] === getSwapFee,
+        (call) => call[0] === getCurrentFee,
       );
       expect(effectCalls.length).toBe(0);
     });
@@ -392,7 +392,7 @@ describe("LiquidityPoolAggregator Functions", () => {
 
       // For CL pools, updateDynamicFeePools should be called
       const effectCalls = effectSpy.mock.calls.filter(
-        (call) => call[0] === getSwapFee,
+        (call) => call[0] === getCurrentFee,
       );
       expect(effectCalls.length).toBe(1);
     });

--- a/test/Effects/CurrentFee.test.ts
+++ b/test/Effects/CurrentFee.test.ts
@@ -1,8 +1,8 @@
 import type { logger as Envio_logger } from "envio/src/Envio.gen";
 import type { PublicClient } from "viem";
 import { CHAIN_CONSTANTS, toChecksumAddress } from "../../src/Constants";
+import { fetchSwapFee, getCurrentFee } from "../../src/Effects/CurrentFee";
 import * as HelpersModule from "../../src/Effects/Helpers";
-import { fetchSwapFee, getSwapFee } from "../../src/Effects/SwapFee";
 
 type MockEffect = {
   name: string;
@@ -78,7 +78,7 @@ const CHAIN_CONFIGS = [
   },
 ];
 
-describe("Swap Fee Effects", () => {
+describe("Current Fee Effects", () => {
   let mockContext: {
     effect: (effect: MockEffect, input: unknown) => unknown;
     ethClient: PublicClient;
@@ -125,10 +125,10 @@ describe("Swap Fee Effects", () => {
     vi.restoreAllMocks();
   });
 
-  describe("getSwapFee", () => {
+  describe("getCurrentFee", () => {
     it("should be a valid effect object", () => {
-      expect(typeof getSwapFee).toBe("object");
-      expect(getSwapFee).toHaveProperty("name", "getSwapFee");
+      expect(typeof getCurrentFee).toBe("object");
+      expect(getCurrentFee).toHaveProperty("name", "getCurrentFee");
     });
 
     it("should return undefined on error", async () => {
@@ -137,7 +137,7 @@ describe("Swap Fee Effects", () => {
       );
 
       const result = await mockContext.effect(
-        getSwapFee as unknown as MockEffect,
+        getCurrentFee as unknown as MockEffect,
         {
           poolAddress: TEST_POOL_ADDRESS,
           factoryAddress: TEST_CL_FACTORY_ADDRESS,
@@ -154,7 +154,7 @@ describe("Swap Fee Effects", () => {
       vi.mocked(mockEthClient.readContract).mockResolvedValue(TEST_FEE_VALUE);
 
       const result = await mockContext.effect(
-        getSwapFee as unknown as MockEffect,
+        getCurrentFee as unknown as MockEffect,
         {
           poolAddress: TEST_POOL_ADDRESS,
           factoryAddress: TEST_CL_FACTORY_ADDRESS,


### PR DESCRIPTION
Deployment cache has `getCurrentFee` naming and it's hard to currently change it

Therefore, we change `getSwapFee` to `getCurrentFee`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed internal fee-related operations from "SwapFee" to "CurrentFee" across the effects system and aggregator modules.
  * Updated corresponding RPC gateway operation types and handlers to reflect the new naming convention.
  * Updated tests to align with refactored internal APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->