### PR TITLE
Skip `CLGauge`/`Gauge` `Deposit`, `Withdraw`, and `ClaimRewards` for root gauges

### DIFF
--- a/src/EventHandlers/Gauges/GaugeSharedLogic.ts
+++ b/src/EventHandlers/Gauges/GaugeSharedLogic.ts
@@ -1,4 +1,4 @@
-import type { handlerContext } from "generated";
+import type { LiquidityPoolAggregator, handlerContext } from "generated";
 import {
   findPoolByGaugeAddress,
   loadPoolData,
@@ -22,6 +22,50 @@ export interface GaugeEventData {
 }
 
 /**
+ * Returns true if the gauge address is registered as a root gauge (RootGauge/RootCLGauge on the root chain).
+ * Used to skip Deposit/Withdraw/ClaimRewards for root gauges, which have no associated pool entity.
+ * @param gaugeAddress - The address of the gauge
+ * @param context - The handler context
+ * @returns True if the gauge address is registered as a root gauge, false otherwise
+ */
+export async function isRootGauge(
+  gaugeAddress: string,
+  context: handlerContext,
+): Promise<boolean> {
+  const mappings = await context.RootGauge_RootPool.getWhere({
+    rootGaugeAddress: { _eq: gaugeAddress },
+  });
+  return mappings.length > 0;
+}
+
+/**
+ * Looks up pool by gauge address; returns null silently for root gauges, logs and returns null otherwise when not found.
+ * @param gaugeAddress - The gauge address
+ * @param chainId - The chain ID
+ * @param context - The handler context
+ * @param handlerName - Handler name for error logging
+ * @returns { pool } if pool found, null if not found (root gauge = silent, else log error)
+ */
+export async function findPoolOrSkipRootGauge(
+  gaugeAddress: string,
+  chainId: number,
+  context: handlerContext,
+  handlerName: string,
+): Promise<{ pool: LiquidityPoolAggregator } | null> {
+  const pool = await findPoolByGaugeAddress(gaugeAddress, chainId, context);
+  if (pool) {
+    return { pool };
+  }
+  if (await isRootGauge(gaugeAddress, context)) {
+    return null;
+  }
+  context.log.error(
+    `${handlerName}: Pool not found for gauge address ${gaugeAddress} on chain ${chainId}`,
+  );
+  return null;
+}
+
+/**
  * Common logic for processing gauge deposit events
  */
 export async function processGaugeDeposit(
@@ -29,18 +73,14 @@ export async function processGaugeDeposit(
   context: handlerContext,
   handlerName: string,
 ): Promise<void> {
-  // Find the pool by gauge address
-  const pool = await findPoolByGaugeAddress(
+  const result = await findPoolOrSkipRootGauge(
     data.gaugeAddress,
     data.chainId,
     context,
+    handlerName,
   );
-  if (!pool) {
-    context.log.error(
-      `${handlerName}: Pool not found for gauge address ${data.gaugeAddress} on chain ${data.chainId}`,
-    );
-    return;
-  }
+  if (!result) return;
+  const { pool } = result;
 
   const timestamp = new Date(data.timestamp * 1000);
 
@@ -114,18 +154,14 @@ export async function processGaugeWithdraw(
   context: handlerContext,
   handlerName: string,
 ): Promise<void> {
-  // Find the pool by gauge address
-  const pool = await findPoolByGaugeAddress(
+  const result = await findPoolOrSkipRootGauge(
     data.gaugeAddress,
     data.chainId,
     context,
+    handlerName,
   );
-  if (!pool) {
-    context.log.error(
-      `${handlerName}: Pool not found for gauge address ${data.gaugeAddress} on chain ${data.chainId}`,
-    );
-    return;
-  }
+  if (!result) return;
+  const { pool } = result;
 
   const timestamp = new Date(data.timestamp * 1000);
 
@@ -199,18 +235,14 @@ export async function processGaugeClaimRewards(
   context: handlerContext,
   handlerName: string,
 ): Promise<void> {
-  // Find the pool by gauge address
-  const pool = await findPoolByGaugeAddress(
+  const result = await findPoolOrSkipRootGauge(
     data.gaugeAddress,
     data.chainId,
     context,
+    handlerName,
   );
-  if (!pool) {
-    context.log.error(
-      `${handlerName}: Pool not found for gauge address ${data.gaugeAddress} on chain ${data.chainId}`,
-    );
-    return;
-  }
+  if (!result) return;
+  const { pool } = result;
 
   const timestamp = new Date(data.timestamp * 1000);
 

--- a/test/EventHandlers/Gauges/GaugeSharedLogic.test.ts
+++ b/test/EventHandlers/Gauges/GaugeSharedLogic.test.ts
@@ -13,6 +13,8 @@ import {
 } from "../../../src/Constants";
 import {
   type GaugeEventData,
+  findPoolOrSkipRootGauge,
+  isRootGauge,
   processGaugeClaimRewards,
   processGaugeDeposit,
   processGaugeWithdraw,
@@ -238,6 +240,9 @@ describe("GaugeSharedLogic", () => {
       TokenPriceSnapshot: {
         set: () => {},
       },
+      RootGauge_RootPool: {
+        getWhere: async () => [],
+      },
       isPreload: false,
     };
   });
@@ -372,6 +377,227 @@ describe("GaugeSharedLogic", () => {
       expect(updatedUser?.totalGaugeRewardsClaimedUSD).toBe(
         1000000000000000000000n,
       );
+    });
+  });
+
+  describe("isRootGauge", () => {
+    it("returns true when RootGauge_RootPool has a row for the gauge address", async () => {
+      const rootGaugeAddress = toChecksumAddress(
+        "0x923EC7E98706153Ce2c984DD802230476D4722B4",
+      );
+      const contextWithRootGauge = {
+        ...mockContext,
+        RootGauge_RootPool: {
+          getWhere: async (params: { rootGaugeAddress?: { _eq: string } }) =>
+            params.rootGaugeAddress?._eq === rootGaugeAddress
+              ? [
+                  {
+                    id: "10-".concat(rootGaugeAddress),
+                    rootChainId: 10,
+                    rootGaugeAddress,
+                    rootPoolAddress: "0x",
+                  },
+                ]
+              : [],
+        },
+      };
+
+      const result = await isRootGauge(
+        rootGaugeAddress,
+        contextWithRootGauge as unknown as handlerContext,
+      );
+      expect(result).toBe(true);
+    });
+
+    it("returns false when RootGauge_RootPool has no row for the gauge address", async () => {
+      const unknownGauge = toChecksumAddress(
+        "0x9999999999999999999999999999999999999999",
+      );
+      const result = await isRootGauge(
+        unknownGauge,
+        mockContext as unknown as handlerContext,
+      );
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("findPoolOrSkipRootGauge", () => {
+    it("returns { pool } when pool exists for gauge address", async () => {
+      const result = await findPoolOrSkipRootGauge(
+        mockGaugeAddress,
+        mockChainId,
+        mockContext as unknown as handlerContext,
+        "TestHandler",
+      );
+      expect(result).not.toBeNull();
+      expect(result?.pool.id).toBe(mockLiquidityPoolAggregator.id);
+      expect(result?.pool.poolAddress).toBe(mockPoolAddress);
+    });
+
+    it("returns null without logging when gauge is root gauge", async () => {
+      const rootGaugeAddress = toChecksumAddress(
+        "0x923EC7E98706153Ce2c984DD802230476D4722B4",
+      );
+      const ctx = {
+        ...mockContext,
+        RootGauge_RootPool: {
+          getWhere: async (params: { rootGaugeAddress?: { _eq: string } }) =>
+            params.rootGaugeAddress?._eq === rootGaugeAddress
+              ? [
+                  {
+                    id: "10-".concat(rootGaugeAddress),
+                    rootChainId: 10,
+                    rootGaugeAddress,
+                    rootPoolAddress:
+                      "0x0000000000000000000000000000000000000001",
+                  },
+                ]
+              : [],
+        },
+        log: { ...mockContext.log, error: vi.fn() },
+      } as unknown as handlerContext;
+
+      const result = await findPoolOrSkipRootGauge(
+        rootGaugeAddress,
+        mockChainId,
+        ctx,
+        "TestHandler",
+      );
+      expect(result).toBeNull();
+      expect(ctx.log.error).not.toHaveBeenCalled();
+    });
+
+    it("returns null and logs when pool missing and not root gauge", async () => {
+      const unknownGauge = toChecksumAddress(
+        "0x9999999999999999999999999999999999999999",
+      );
+      const logErrorSpy = vi.fn();
+      const ctx = {
+        ...mockContext,
+        log: { ...mockContext.log, error: logErrorSpy },
+      } as unknown as handlerContext;
+
+      const result = await findPoolOrSkipRootGauge(
+        unknownGauge,
+        mockChainId,
+        ctx,
+        "TestHandler",
+      );
+      expect(result).toBeNull();
+      expect(logErrorSpy).toHaveBeenCalledTimes(1);
+      expect(logErrorSpy).toHaveBeenCalledWith(
+        `TestHandler: Pool not found for gauge address ${unknownGauge} on chain ${mockChainId}`,
+      );
+    });
+  });
+
+  describe("Root gauge skip", () => {
+    const rootGaugeAddress = toChecksumAddress(
+      "0x923EC7E98706153Ce2c984DD802230476D4722B4",
+    );
+
+    function createContextWithRootGauge() {
+      return {
+        ...mockContext,
+        RootGauge_RootPool: {
+          getWhere: async (params: { rootGaugeAddress?: { _eq: string } }) =>
+            params.rootGaugeAddress?._eq === rootGaugeAddress
+              ? [
+                  {
+                    id: "10-".concat(rootGaugeAddress),
+                    rootChainId: 10,
+                    rootGaugeAddress,
+                    rootPoolAddress:
+                      "0x0000000000000000000000000000000000000001",
+                  },
+                ]
+              : [],
+        },
+      } as unknown as handlerContext;
+    }
+
+    it("should skip deposit without error when gauge is root gauge", async () => {
+      const logErrorSpy = vi.fn();
+      const baseCtx = createContextWithRootGauge();
+      const ctx = {
+        ...baseCtx,
+        log: { ...baseCtx.log, error: logErrorSpy },
+      };
+
+      await processGaugeDeposit(
+        {
+          gaugeAddress: rootGaugeAddress,
+          userAddress: mockUserAddress,
+          chainId: mockChainId,
+          blockNumber: 100,
+          timestamp: 1000000,
+          amount: 100000000000000000000n,
+        },
+        ctx,
+        "TestGaugeDeposit",
+      );
+
+      expect(logErrorSpy).not.toHaveBeenCalled();
+      const updatedPool = updatedDB.entities.LiquidityPoolAggregator.get(
+        mockLiquidityPoolAggregator.id,
+      );
+      expect(updatedPool?.numberOfGaugeDeposits).toBe(0n);
+    });
+
+    it("should skip withdraw without error when gauge is root gauge", async () => {
+      const logErrorSpy = vi.fn();
+      const baseCtx = createContextWithRootGauge();
+      const ctx = {
+        ...baseCtx,
+        log: { ...baseCtx.log, error: logErrorSpy },
+      };
+
+      await processGaugeWithdraw(
+        {
+          gaugeAddress: rootGaugeAddress,
+          userAddress: mockUserAddress,
+          chainId: mockChainId,
+          blockNumber: 100,
+          timestamp: 1000000,
+          amount: 50000000000000000000n,
+        },
+        ctx,
+        "TestGaugeWithdraw",
+      );
+
+      expect(logErrorSpy).not.toHaveBeenCalled();
+      const updatedPool = updatedDB.entities.LiquidityPoolAggregator.get(
+        mockLiquidityPoolAggregator.id,
+      );
+      expect(updatedPool?.numberOfGaugeWithdrawals).toBe(0n);
+    });
+
+    it("should skip claim rewards without error when gauge is root gauge", async () => {
+      const logErrorSpy = vi.fn();
+      const baseCtx = createContextWithRootGauge();
+      const ctx = {
+        ...baseCtx,
+        log: { ...baseCtx.log, error: logErrorSpy },
+      };
+
+      await processGaugeClaimRewards(
+        {
+          gaugeAddress: rootGaugeAddress,
+          userAddress: mockUserAddress,
+          chainId: mockChainId,
+          blockNumber: 100,
+          timestamp: 1000000,
+          amount: 1000000000000000000000n,
+        },
+        ctx,
+        "TestGaugeClaimRewards",
+      );
+
+      expect(logErrorSpy).not.toHaveBeenCalled();
+      const updatedPool = updatedDB.entities.LiquidityPoolAggregator.get(
+        mockLiquidityPoolAggregator.id,
+      );
+      expect(updatedPool?.numberOfGaugeRewardClaims).toBe(0n);
     });
   });
 


### PR DESCRIPTION
## Problem

When indexing **CLGauge.Deposit**, **CLGauge.Withdraw**, and **CLGauge.ClaimRewards** (and the equivalent **Gauge** events), the handlers look up a pool by gauge address via `findPoolByGaugeAddress`. For **root gauges** (RootGauge / RootCLGauge on the root chain, e.g. Optimism), no `LiquidityPoolAggregator` exists with that `gaugeAddress` on the event chain, because:

- Root contracts (root pool, root gauge, root CL gauge) exist only on the root chain (Optimism).
- The root gauge maps to a root pool via `RootGauge_RootPool`, and that root pool maps to leaf pools on other chains via `RootPool_LeafPool`.
- There is no single “pool” entity to attribute deposit/withdraw/claim to on the event chain.

As a result, the indexer logged errors such as:

```
CLGauge.Withdraw: Pool not found for gauge address 0x923EC7E98706153Ce2c984DD802230476D4722B4 on chain 1868
CLGauge.Deposit: Pool not found for gauge address 0xfcD11ec7E9536e7B21C0FA98b95dAF81C0448f33 on chain 1868
CLGauge.ClaimRewards: Pool not found for gauge address 0x10A2BD31da8582231bA355EC7a6d9C2F06932a77 on chain 1868
```

These are expected situations (root gauge events on leaf or root chain), not indexing bugs. Treating them as errors was noisy and misleading.

## Solution

- **When `findPoolByGaugeAddress` returns null**, check whether the gauge is a **root gauge** by querying `RootGauge_RootPool` by `rootGaugeAddress` (lookup by address only, since the entity is keyed by root chain id and the event may be on a leaf chain).
- **If a mapping exists**, treat the event as a root-gauge event: **skip** processing (no pool/user updates) and **do not** log an error.
- **If no mapping exists**, keep the existing behaviour: log the error and return.

No new entities or cross-chain sync are introduced; this is a conditional skip so root gauge events are ignored by design.

## Changes

- **`src/EventHandlers/Gauges/GaugeSharedLogic.ts`**
  - Added **`isRootGauge(gaugeAddress, context)`**: returns `true` if `RootGauge_RootPool.getWhere({ rootGaugeAddress: { _eq: gaugeAddress } })` has at least one row. Exported for testing.
  - **`processGaugeDeposit`**, **`processGaugeWithdraw`**, **`processGaugeClaimRewards`**: when pool is null, call `isRootGauge` first; if true, return without error; otherwise log error and return as before.

- **`test/EventHandlers/Gauges/GaugeSharedLogic.test.ts`**
  - Added **`RootGauge_RootPool`** to the mock context (`getWhere` returns `[]` by default).
  - **`describe("isRootGauge")`**: tests that `isRootGauge` returns true when a row exists for the gauge address and false when it does not.
  - **`describe("Root gauge skip")`**: three tests (deposit, withdraw, claim rewards) that use a gauge address present in `RootGauge_RootPool` and assert that no error is logged and pool counters remain unchanged.

## Testing

- `pnpm test test/EventHandlers/Gauges/GaugeSharedLogic.test.ts --run` — all tests pass.
- `pnpm tsc --noEmit` — compiles successfully.

Manual verification: run the indexer over a range that previously emitted the “Pool not found for gauge address” errors for root gauges (e.g. chain 1868); those errors should no longer appear for root gauge addresses.

## Notes

- **Gauge** (non-CL) uses the same shared logic, so the fix applies to both CLGauge and Gauge handlers.
- Root gauge detection does **not** depend on cross-chain ordering: `RootGauge_RootPool` is populated when indexing the root chain (Voter.GaugeCreated); the lookup by gauge address works regardless of which chain the event is on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved root gauge handling in deposit, withdraw, and claim reward operations—root gauges are now skipped gracefully without generating errors.
  * Refined error logging to distinguish between root gauges (skipped silently) and genuinely missing pools (logged appropriately).
  * Centralized pool lookup logic to provide consistent behavior across gauge operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->