### PR TITLE
`CustomSwapFeeModule` address update

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -403,7 +403,7 @@ chains:
     contracts:
       - name: CustomSwapFeeModule
         address:
-          - 0x04625B046C69577EfC40e6c0Bb83CDBAfab5a55F
+          - 0x6812eefC19deB79D5191b52f4B763260d9F3C238
       - name: NFPM
         address:
           - 0x991d5546C4B442B4c5fdc4c8B8b8d131DEB24702


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CustomSwapFeeModule contract addresses on Optimism (chain ID 10) and Soneium (chain ID 1868) networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->