### PR TITLE
Effects API - changing back to `getSwapFee`

### DIFF
--- a/scripts/smoke-effects.ts
+++ b/scripts/smoke-effects.ts
@@ -144,9 +144,9 @@ async function main(): Promise<void> {
     );
   });
 
-  await run("getCurrentFee", async () => {
+  await run("getSwapFee", async () => {
     const r = await callRpcGateway(context, {
-      type: EffectType.GET_CURRENT_FEE,
+      type: EffectType.GET_SWAP_FEE,
       poolAddress: POOL_OPTIMISM,
       factoryAddress: CL_FACTORY_OPTIMISM,
       chainId: CHAIN_ID,

--- a/src/Aggregators/LiquidityPoolAggregator.ts
+++ b/src/Aggregators/LiquidityPoolAggregator.ts
@@ -4,12 +4,8 @@ import type {
   Token,
   handlerContext,
 } from "generated";
-import {
-  LiquidityPoolAggregatorSnapshotId,
-  PoolId,
-  TokenId,
-} from "../Constants";
-import { getCurrentFee, roundBlockToInterval } from "../Effects/Index";
+import { PoolId, TokenId } from "../Constants";
+import { getSwapFee, roundBlockToInterval } from "../Effects/Index";
 import { generatePoolName } from "../Helpers";
 import { refreshTokenPrice } from "../PriceOracle";
 import {
@@ -166,7 +162,7 @@ export async function updateDynamicFeePools(
     return liquidityPoolAggregator;
   }
 
-  const currentFee = await context.effect(getCurrentFee, {
+  const currentFee = await context.effect(getSwapFee, {
     poolAddress,
     factoryAddress,
     chainId,

--- a/src/Effects/Index.ts
+++ b/src/Effects/Index.ts
@@ -5,8 +5,7 @@ export {
   roundBlockToInterval,
 } from "./Token";
 
-// Current fee effect (CLFactory.getSwapFee for CL pools; cache key getCurrentFee)
-export { getCurrentFee } from "./CurrentFee";
+export { getSwapFee } from "./SwapFee";
 
 // Voter-related effects
 export { getTokensDeposited } from "./Voter";

--- a/src/Effects/RpcGateway.ts
+++ b/src/Effects/RpcGateway.ts
@@ -27,7 +27,7 @@ export enum EffectType {
   GET_TOKEN_DETAILS = "getTokenDetails",
   GET_TOKEN_PRICE = "getTokenPrice",
   GET_TOKENS_DEPOSITED = "getTokensDeposited",
-  GET_CURRENT_FEE = "getCurrentFee",
+  GET_SWAP_FEE = "getSwapFee",
   GET_ROOT_POOL_ADDRESS = "getRootPoolAddress",
 }
 
@@ -85,9 +85,9 @@ const RPC_GATEWAY_OPERATIONS = {
       value: S.optional(S.bigint),
     },
   },
-  [EffectType.GET_CURRENT_FEE]: {
+  [EffectType.GET_SWAP_FEE]: {
     inputSchema: {
-      type: S.schema(EffectType.GET_CURRENT_FEE),
+      type: S.schema(EffectType.GET_SWAP_FEE),
       poolAddress: S.string,
       factoryAddress: S.string,
       chainId: S.number,
@@ -119,7 +119,7 @@ const RPC_GATEWAY_INPUT_SCHEMA = S.union([
   RPC_GATEWAY_OPERATIONS[EffectType.GET_TOKEN_DETAILS].inputSchema,
   RPC_GATEWAY_OPERATIONS[EffectType.GET_TOKEN_PRICE].inputSchema,
   RPC_GATEWAY_OPERATIONS[EffectType.GET_TOKENS_DEPOSITED].inputSchema,
-  RPC_GATEWAY_OPERATIONS[EffectType.GET_CURRENT_FEE].inputSchema,
+  RPC_GATEWAY_OPERATIONS[EffectType.GET_SWAP_FEE].inputSchema,
   RPC_GATEWAY_OPERATIONS[EffectType.GET_ROOT_POOL_ADDRESS].inputSchema,
 ]);
 
@@ -127,7 +127,7 @@ const RPC_GATEWAY_OUTPUT_SCHEMA = S.union([
   RPC_GATEWAY_OPERATIONS[EffectType.GET_TOKEN_DETAILS].outputSchema,
   RPC_GATEWAY_OPERATIONS[EffectType.GET_TOKEN_PRICE].outputSchema,
   RPC_GATEWAY_OPERATIONS[EffectType.GET_TOKENS_DEPOSITED].outputSchema,
-  RPC_GATEWAY_OPERATIONS[EffectType.GET_CURRENT_FEE].outputSchema,
+  RPC_GATEWAY_OPERATIONS[EffectType.GET_SWAP_FEE].outputSchema,
   RPC_GATEWAY_OPERATIONS[EffectType.GET_ROOT_POOL_ADDRESS].outputSchema,
 ]);
 
@@ -148,7 +148,7 @@ type RpcGatewayInputPayloadByType = {
     blockNumber: number;
     chainId: number;
   };
-  [EffectType.GET_CURRENT_FEE]: {
+  [EffectType.GET_SWAP_FEE]: {
     poolAddress: string;
     factoryAddress: string;
     chainId: number;
@@ -190,7 +190,7 @@ export type RpcGatewayOutputByType = {
     priceOracleType: string;
   };
   [EffectType.GET_TOKENS_DEPOSITED]: { value: bigint | undefined };
-  [EffectType.GET_CURRENT_FEE]: { value: bigint | undefined };
+  [EffectType.GET_SWAP_FEE]: { value: bigint | undefined };
   [EffectType.GET_ROOT_POOL_ADDRESS]: { value: string };
 };
 
@@ -239,8 +239,8 @@ export const rpcGateway = createEffect(
         return await handleGetTokenPrice(i, ctx);
       case EffectType.GET_TOKENS_DEPOSITED:
         return await handleGetTokensDeposited(i, ctx);
-      case EffectType.GET_CURRENT_FEE:
-        return await handleGetCurrentFee(i, ctx);
+      case EffectType.GET_SWAP_FEE:
+        return await handleGetSwapFee(i, ctx);
       case EffectType.GET_ROOT_POOL_ADDRESS:
         return await handleGetRootPoolAddress(i, ctx);
       default: {
@@ -474,16 +474,16 @@ async function handleGetTokensDeposited(
 }
 
 /**
- * Handles the GET_CURRENT_FEE effect.
+ * Handles the GET_SWAP_FEE effect.
  * @param i - The input for the effect.
  * @param context - The context for the effect.
  * @returns The current swap fee.
  */
-async function handleGetCurrentFee(
-  i: RpcGatewayInputByType[EffectType.GET_CURRENT_FEE],
+async function handleGetSwapFee(
+  i: RpcGatewayInputByType[EffectType.GET_SWAP_FEE],
   context: RpcGatewayHandlerContext,
-): Promise<RpcGatewayOutputByType[EffectType.GET_CURRENT_FEE]> {
-  const operationName = rpcGatewayOpName(EffectType.GET_CURRENT_FEE);
+): Promise<RpcGatewayOutputByType[EffectType.GET_SWAP_FEE]> {
+  const operationName = rpcGatewayOpName(EffectType.GET_SWAP_FEE);
   const logDetails = {
     poolAddress: i.poolAddress,
     factoryAddress: i.factoryAddress,

--- a/src/Effects/SwapFee.ts
+++ b/src/Effects/SwapFee.ts
@@ -14,9 +14,9 @@ export { fetchSwapFee } from "./fetchers/SwapFee";
  * @param input.blockNumber - Block at which to read the fee.
  * @returns Promise resolving to swap fee (bigint) or undefined when the gateway handles an RPC/contract error.
  */
-export const getCurrentFee = createEffect(
+export const getSwapFee = createEffect(
   {
-    name: EffectType.GET_CURRENT_FEE,
+    name: EffectType.GET_SWAP_FEE,
     input: {
       poolAddress: S.string,
       factoryAddress: S.string,
@@ -29,7 +29,7 @@ export const getCurrentFee = createEffect(
   },
   async ({ input, context }) => {
     const result = await callRpcGateway(context, {
-      type: EffectType.GET_CURRENT_FEE,
+      type: EffectType.GET_SWAP_FEE,
       poolAddress: input.poolAddress,
       factoryAddress: input.factoryAddress,
       chainId: input.chainId,

--- a/test/Aggregators/LiquidityPoolAggregator.test.ts
+++ b/test/Aggregators/LiquidityPoolAggregator.test.ts
@@ -12,7 +12,7 @@ import {
   RootPoolLeafPoolId,
   toChecksumAddress,
 } from "../../src/Constants";
-import { getCurrentFee } from "../../src/Effects/CurrentFee";
+import { getSwapFee } from "../../src/Effects/SwapFee";
 import * as PriceOracle from "../../src/PriceOracle";
 import { setLiquidityPoolAggregatorSnapshot } from "../../src/Snapshots/LiquidityPoolAggregatorSnapshot";
 import { getSnapshotEpoch } from "../../src/Snapshots/Shared";
@@ -94,7 +94,7 @@ describe("LiquidityPoolAggregator Functions", () => {
             scalingFactor: 10000000n,
           };
         }
-        if (effectFn.name === "getCurrentFee") {
+        if (effectFn.name === "getSwapFee") {
           return 1900n;
         }
         return {};
@@ -203,7 +203,7 @@ describe("LiquidityPoolAggregator Functions", () => {
       // Verify that the effect was called with the expected arguments
       // biome-ignore lint/style/noNonNullAssertion: effect is verified to be defined above
       const effectMock = vi.mocked(mockContext.effect!);
-      expect(effectMock).toHaveBeenCalledWith(getCurrentFee, {
+      expect(effectMock).toHaveBeenCalledWith(getSwapFee, {
         poolAddress: liquidityPoolAggregator.poolAddress,
         factoryAddress: toChecksumAddress(
           "0x548118C7E0B865C2CfA94D15EC86B666468ac758",
@@ -352,7 +352,7 @@ describe("LiquidityPoolAggregator Functions", () => {
 
       // For non-CL pools, updateDynamicFeePools should NOT be called
       const effectCalls = effectSpy.mock.calls.filter(
-        (call) => call[0] === getCurrentFee,
+        (call) => call[0] === getSwapFee,
       );
       expect(effectCalls.length).toBe(0);
     });
@@ -392,7 +392,7 @@ describe("LiquidityPoolAggregator Functions", () => {
 
       // For CL pools, updateDynamicFeePools should be called
       const effectCalls = effectSpy.mock.calls.filter(
-        (call) => call[0] === getCurrentFee,
+        (call) => call[0] === getSwapFee,
       );
       expect(effectCalls.length).toBe(1);
     });

--- a/test/Effects/SwapFee.test.ts
+++ b/test/Effects/SwapFee.test.ts
@@ -1,8 +1,8 @@
 import type { logger as Envio_logger } from "envio/src/Envio.gen";
 import type { PublicClient } from "viem";
 import { CHAIN_CONSTANTS, toChecksumAddress } from "../../src/Constants";
-import { fetchSwapFee, getCurrentFee } from "../../src/Effects/CurrentFee";
 import * as HelpersModule from "../../src/Effects/Helpers";
+import { fetchSwapFee, getSwapFee } from "../../src/Effects/SwapFee";
 
 type MockEffect = {
   name: string;
@@ -78,7 +78,7 @@ const CHAIN_CONFIGS = [
   },
 ];
 
-describe("Current Fee Effects", () => {
+describe("Swap Fee Effects", () => {
   let mockContext: {
     effect: (effect: MockEffect, input: unknown) => unknown;
     ethClient: PublicClient;
@@ -125,10 +125,10 @@ describe("Current Fee Effects", () => {
     vi.restoreAllMocks();
   });
 
-  describe("getCurrentFee", () => {
+  describe("getSwapFee", () => {
     it("should be a valid effect object", () => {
-      expect(typeof getCurrentFee).toBe("object");
-      expect(getCurrentFee).toHaveProperty("name", "getCurrentFee");
+      expect(typeof getSwapFee).toBe("object");
+      expect(getSwapFee).toHaveProperty("name", "getSwapFee");
     });
 
     it("should return undefined on error", async () => {
@@ -137,7 +137,7 @@ describe("Current Fee Effects", () => {
       );
 
       const result = await mockContext.effect(
-        getCurrentFee as unknown as MockEffect,
+        getSwapFee as unknown as MockEffect,
         {
           poolAddress: TEST_POOL_ADDRESS,
           factoryAddress: TEST_CL_FACTORY_ADDRESS,
@@ -154,7 +154,7 @@ describe("Current Fee Effects", () => {
       vi.mocked(mockEthClient.readContract).mockResolvedValue(TEST_FEE_VALUE);
 
       const result = await mockContext.effect(
-        getCurrentFee as unknown as MockEffect,
+        getSwapFee as unknown as MockEffect,
         {
           poolAddress: TEST_POOL_ADDRESS,
           factoryAddress: TEST_CL_FACTORY_ADDRESS,


### PR DESCRIPTION
The current cache on deployment for `getCurrentFee` will never be hit because it was using addressses from `dynamicFeeModule`. Now we use each pool's factory as the input value.

So, to have a new clean cache, I decided to change to `getSwapFee`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Renamed the fee-fetching operation from `getCurrentFee` to `getSwapFee` across all public interfaces and system components for improved terminology consistency.
  * Updated associated gateway operations and effect types to align with the new naming convention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->