### PR TITLE
`VeNFTState` - fixed negative `totalAmountLocked`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -54,6 +54,10 @@ contracts:
     handler: src/EventHandlers/VeNFT/VeNFT.ts
     events:
       - event: Deposit
+      - event: DepositManaged
+      - event: Merge
+      - event: Split
+      - event: WithdrawManaged
       - event: Withdraw
       - event: Transfer
   - name: Pool

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,10 +10,10 @@ importers:
     dependencies:
       '@uniswap/sdk-core':
         specifier: ^7.9.0
-        version: 7.11.0
+        version: 7.12.1
       '@uniswap/v3-sdk':
         specifier: ^3.26.0
-        version: 3.28.0(hardhat@2.28.6(ts-node@10.9.2(@types/node@22.19.13)(typescript@5.9.3))(typescript@5.9.3))
+        version: 3.29.1(hardhat@2.28.6(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))(typescript@5.9.3))
       dotenv:
         specifier: ^16.4.5
         version: 16.6.1
@@ -35,19 +35,19 @@ importers:
         version: 1.9.4
       '@types/node':
         specifier: ^22.0.0
-        version: 22.19.13
+        version: 22.19.15
       '@vitest/coverage-istanbul':
         specifier: 4.0.16
-        version: 4.0.16(vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(tsx@4.21.0))
+        version: 4.0.16(vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(tsx@4.21.0))
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.19.13)(typescript@5.9.3)
+        version: 10.9.2(@types/node@22.19.15)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
       vitest:
         specifier: 4.0.16
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(tsx@4.21.0)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(tsx@4.21.0)
     optionalDependencies:
       generated:
         specifier: link:generated
@@ -863,8 +863,8 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
-  '@types/node@22.19.13':
-    resolution: {integrity: sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==}
+  '@types/node@22.19.15':
+    resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
 
   '@types/ws@8.5.3':
     resolution: {integrity: sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==}
@@ -873,8 +873,8 @@ packages:
     resolution: {integrity: sha512-f6UIliwBbRsgVLxIaBANF6w09tYqc6Y/qXdsrbEmXHyFA7ILiKrIwRFXe1yOg8M3cksgVsO9N7yuL2DdCGQKBA==}
     engines: {node: '>=10'}
 
-  '@uniswap/sdk-core@7.11.0':
-    resolution: {integrity: sha512-wI1jz/zf23Yzoms8JsiYWN3M5r2QIlPSljRnEDc/ubk7wDlKxAmt5/AIaHbxZa4dISJKD83mtprhPQYDy2iSOg==}
+  '@uniswap/sdk-core@7.12.1':
+    resolution: {integrity: sha512-qQG6dVFIgk9x+WRQBDZms/abi+aM6J6YFLhaMnrvTSFIIL4hOjf74SpOep5wPEDZGx3iw3LqofRq+ijeVwLLBQ==}
     engines: {node: '>=10'}
 
   '@uniswap/swap-router-contracts@1.3.1':
@@ -898,8 +898,8 @@ packages:
     resolution: {integrity: sha512-S4+m+wh8HbWSO3DKk4LwUCPZJTpCugIsHrWR86m/OrUyvSqGDTXKFfc2sMuGXCZrD1ZqO3rhQsKgdWg3Hbb2Kw==}
     engines: {node: '>=10'}
 
-  '@uniswap/v3-sdk@3.28.0':
-    resolution: {integrity: sha512-nxdUMEH1EZLJRlc4OVoZAG+qN9GfDnYMXyQQPlKyWCvK1wBUVsawIryhq1HaFPQyc6hG0EoBn0ozTRgm+Qc4IA==}
+  '@uniswap/v3-sdk@3.29.1':
+    resolution: {integrity: sha512-EYCzrfCCxc9DqUguw5rX+9774jvpVIvvrnyraJenZ371JiX/VC09/6OToKReu3gJfgITaH1BynMATwGkmOb2SQ==}
     engines: {node: '>=10'}
 
   '@uniswap/v3-staker@1.0.0':
@@ -1139,8 +1139,8 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
-  caniuse-lite@1.0.30001776:
-    resolution: {integrity: sha512-sg01JDPzZ9jGshqKSckOQthXnYwOEP50jeVFhaSFbZcOy05TiuuaffDOfcwtCisJ9kNQuLBFibYywv2Bgm9osw==}
+  caniuse-lite@1.0.30001777:
+    resolution: {integrity: sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ==}
 
   cfonts@3.3.1:
     resolution: {integrity: sha512-ZGEmN3W9mViWEDjsuPo4nK4h39sfh6YtoneFYp9WLPI/rw8BaSSrfQC6jkrGW3JMvV3ZnExJB/AEqXc/nHYxkw==}
@@ -1407,8 +1407,8 @@ packages:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
 
-  es-toolkit@1.45.0:
-    resolution: {integrity: sha512-RArCX+Zea16+R1jg4mH223Z8p/ivbJjIkU3oC6ld2bdUfmDxiCkFYSi9zLOR2anucWJUeH4Djnzgd0im0nD3dw==}
+  es-toolkit@1.45.1:
+    resolution: {integrity: sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==}
 
   esbuild@0.27.3:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
@@ -1656,8 +1656,8 @@ packages:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
 
-  immutable@4.3.7:
-    resolution: {integrity: sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==}
+  immutable@4.3.8:
+    resolution: {integrity: sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==}
 
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
@@ -1995,8 +1995,8 @@ packages:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
 
-  node-releases@2.0.27:
-    resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
+  node-releases@2.0.36:
+    resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -3602,17 +3602,17 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
-  '@types/node@22.19.13':
+  '@types/node@22.19.15':
     dependencies:
       undici-types: 6.21.0
 
   '@types/ws@8.5.3':
     dependencies:
-      '@types/node': 22.19.13
+      '@types/node': 22.19.15
 
   '@uniswap/lib@4.0.1-alpha': {}
 
-  '@uniswap/sdk-core@7.11.0':
+  '@uniswap/sdk-core@7.12.1':
     dependencies:
       '@ethersproject/address': 5.8.0
       '@ethersproject/bytes': 5.8.0
@@ -3624,14 +3624,14 @@ snapshots:
       tiny-invariant: 1.3.3
       toformat: 2.0.0
 
-  '@uniswap/swap-router-contracts@1.3.1(hardhat@2.28.6(ts-node@10.9.2(@types/node@22.19.13)(typescript@5.9.3))(typescript@5.9.3))':
+  '@uniswap/swap-router-contracts@1.3.1(hardhat@2.28.6(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))(typescript@5.9.3))':
     dependencies:
       '@openzeppelin/contracts': 3.4.2-solc-0.7
       '@uniswap/v2-core': 1.0.1
       '@uniswap/v3-core': 1.0.1
       '@uniswap/v3-periphery': 1.4.4
       dotenv: 14.3.2
-      hardhat-watcher: 2.5.0(hardhat@2.28.6(ts-node@10.9.2(@types/node@22.19.13)(typescript@5.9.3))(typescript@5.9.3))
+      hardhat-watcher: 2.5.0(hardhat@2.28.6(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))(typescript@5.9.3))
     transitivePeerDependencies:
       - hardhat
 
@@ -3649,12 +3649,12 @@ snapshots:
       '@uniswap/v3-core': 1.0.1
       base64-sol: 1.0.1
 
-  '@uniswap/v3-sdk@3.28.0(hardhat@2.28.6(ts-node@10.9.2(@types/node@22.19.13)(typescript@5.9.3))(typescript@5.9.3))':
+  '@uniswap/v3-sdk@3.29.1(hardhat@2.28.6(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))(typescript@5.9.3))':
     dependencies:
       '@ethersproject/abi': 5.8.0
       '@ethersproject/solidity': 5.8.0
-      '@uniswap/sdk-core': 7.11.0
-      '@uniswap/swap-router-contracts': 1.3.1(hardhat@2.28.6(ts-node@10.9.2(@types/node@22.19.13)(typescript@5.9.3))(typescript@5.9.3))
+      '@uniswap/sdk-core': 7.12.1
+      '@uniswap/swap-router-contracts': 1.3.1(hardhat@2.28.6(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))(typescript@5.9.3))
       '@uniswap/v3-periphery': 1.4.4
       '@uniswap/v3-staker': 1.0.0
       tiny-invariant: 1.3.3
@@ -3668,7 +3668,7 @@ snapshots:
       '@uniswap/v3-core': 1.0.0
       '@uniswap/v3-periphery': 1.4.4
 
-  '@vitest/coverage-istanbul@4.0.16(vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(tsx@4.21.0))':
+  '@vitest/coverage-istanbul@4.0.16(vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(tsx@4.21.0))':
     dependencies:
       '@istanbuljs/schema': 0.1.3
       '@jridgewell/gen-mapping': 0.3.13
@@ -3681,7 +3681,7 @@ snapshots:
       magicast: 0.5.2
       obug: 2.1.1
       tinyrainbow: 3.0.3
-      vitest: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(tsx@4.21.0)
+      vitest: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -3694,13 +3694,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.16(vite@7.3.1(@types/node@22.19.13)(tsx@4.21.0))':
+  '@vitest/mocker@4.0.16(vite@7.3.1(@types/node@22.19.15)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.0.16
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@22.19.13)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@22.19.15)(tsx@4.21.0)
 
   '@vitest/pretty-format@4.0.16':
     dependencies:
@@ -3877,9 +3877,9 @@ snapshots:
   browserslist@4.28.1:
     dependencies:
       baseline-browser-mapping: 2.10.0
-      caniuse-lite: 1.0.30001776
+      caniuse-lite: 1.0.30001777
       electron-to-chromium: 1.5.307
-      node-releases: 2.0.27
+      node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
   buffer-from@1.1.2: {}
@@ -3905,7 +3905,7 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  caniuse-lite@1.0.30001776: {}
+  caniuse-lite@1.0.30001777: {}
 
   cfonts@3.3.1:
     dependencies:
@@ -4156,7 +4156,7 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
 
-  es-toolkit@1.45.0: {}
+  es-toolkit@1.45.1: {}
 
   esbuild@0.27.3:
     optionalDependencies:
@@ -4378,12 +4378,12 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  hardhat-watcher@2.5.0(hardhat@2.28.6(ts-node@10.9.2(@types/node@22.19.13)(typescript@5.9.3))(typescript@5.9.3)):
+  hardhat-watcher@2.5.0(hardhat@2.28.6(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))(typescript@5.9.3)):
     dependencies:
       chokidar: 3.6.0
-      hardhat: 2.28.6(ts-node@10.9.2(@types/node@22.19.13)(typescript@5.9.3))(typescript@5.9.3)
+      hardhat: 2.28.6(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))(typescript@5.9.3)
 
-  hardhat@2.28.6(ts-node@10.9.2(@types/node@22.19.13)(typescript@5.9.3))(typescript@5.9.3):
+  hardhat@2.28.6(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
       '@ethereumjs/util': 9.1.0
       '@ethersproject/abi': 5.8.0
@@ -4403,7 +4403,7 @@ snapshots:
       find-up: 5.0.0
       fp-ts: 1.19.3
       fs-extra: 7.0.1
-      immutable: 4.3.7
+      immutable: 4.3.8
       io-ts: 1.10.4
       json-stream-stringify: 3.1.6
       keccak: 3.0.4
@@ -4425,7 +4425,7 @@ snapshots:
       uuid: 8.3.2
       ws: 7.5.10
     optionalDependencies:
-      ts-node: 10.9.2(@types/node@22.19.13)(typescript@5.9.3)
+      ts-node: 10.9.2(@types/node@22.19.15)(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - bufferutil
@@ -4492,7 +4492,7 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  immutable@4.3.7: {}
+  immutable@4.3.8: {}
 
   indent-string@4.0.0: {}
 
@@ -4529,7 +4529,7 @@ snapshots:
       cli-cursor: 4.0.0
       cli-truncate: 5.2.0
       code-excerpt: 4.0.0
-      es-toolkit: 1.45.0
+      es-toolkit: 1.45.1
       indent-string: 5.0.0
       is-in-ci: 2.0.0
       patch-console: 2.0.0
@@ -4822,7 +4822,7 @@ snapshots:
 
   node-gyp-build@4.8.4: {}
 
-  node-releases@2.0.27: {}
+  node-releases@2.0.36: {}
 
   normalize-path@3.0.0: {}
 
@@ -5311,14 +5311,14 @@ snapshots:
 
   tr46@0.0.3: {}
 
-  ts-node@10.9.2(@types/node@22.19.13)(typescript@5.9.3):
+  ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.19.13
+      '@types/node': 22.19.15
       acorn: 8.16.0
       acorn-walk: 8.3.5
       arg: 4.1.3
@@ -5428,7 +5428,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  vite@7.3.1(@types/node@22.19.13)(tsx@4.21.0):
+  vite@7.3.1(@types/node@22.19.15)(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
@@ -5437,14 +5437,14 @@ snapshots:
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 22.19.13
+      '@types/node': 22.19.15
       fsevents: 2.3.3
       tsx: 4.21.0
 
-  vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(tsx@4.21.0):
+  vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(tsx@4.21.0):
     dependencies:
       '@vitest/expect': 4.0.16
-      '@vitest/mocker': 4.0.16(vite@7.3.1(@types/node@22.19.13)(tsx@4.21.0))
+      '@vitest/mocker': 4.0.16(vite@7.3.1(@types/node@22.19.15)(tsx@4.21.0))
       '@vitest/pretty-format': 4.0.16
       '@vitest/runner': 4.0.16
       '@vitest/snapshot': 4.0.16
@@ -5461,11 +5461,11 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@22.19.13)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@22.19.15)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-      '@types/node': 22.19.13
+      '@types/node': 22.19.15
     transitivePeerDependencies:
       - jiti
       - less

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -27,6 +27,7 @@ export const TEN_TO_THE_18_BI = BigInt(10 ** 18);
 export const SECONDS_IN_AN_HOUR = BigInt(3600);
 export const SECONDS_IN_A_DAY = BigInt(86400);
 export const SECONDS_IN_A_WEEK = BigInt(604800);
+export const SECONDS_IN_FOUR_YEARS = BigInt(126144000);
 
 /** Snapshot interval: 1 hour in milliseconds (for epoch-aligned snapshots) */
 export const SNAPSHOT_INTERVAL_IN_MS = 60 * 60 * 1000;

--- a/src/EventHandlers/VeNFT/VeNFT.ts
+++ b/src/EventHandlers/VeNFT/VeNFT.ts
@@ -3,8 +3,12 @@ import { VeNFTId, ZERO_ADDRESS } from "../../Constants";
 import {
   handleMintTransfer,
   processVeNFTDeposit,
+  processVeNFTDepositManaged,
+  processVeNFTMerge,
+  processVeNFTSplit,
   processVeNFTTransfer,
   processVeNFTWithdraw,
+  processVeNFTWithdrawManaged,
 } from "./VeNFTLogic";
 
 VeNFT.Withdraw.handler(async ({ event, context }) => {
@@ -16,7 +20,7 @@ VeNFT.Withdraw.handler(async ({ event, context }) => {
 
   if (!veNFTState) {
     context.log.error(
-      `VeNFTState ${tokenId} not found during VeNFT withdraw on chain ${event.chainId}`,
+      `[VeNFT.Withdraw] VeNFTState ${tokenId} not found during VeNFT withdraw on chain ${event.chainId}`,
     );
     return;
   }
@@ -49,11 +53,86 @@ VeNFT.Deposit.handler(async ({ event, context }) => {
   // Should exist because Transfer event typically come before Deposit event
   if (!veNFTState) {
     context.log.error(
-      `VeNFTState ${tokenId} not found during VeNFT deposit on chain ${event.chainId}`,
+      `[VeNFT.Deposit] VeNFTState ${tokenId} not found during VeNFT deposit on chain ${event.chainId}`,
     );
     return;
   }
 
   // Process deposit event using business logic
   await processVeNFTDeposit(event, veNFTState, context);
+});
+
+VeNFT.Merge.handler(async ({ event, context }) => {
+  const fromState = await context.VeNFTState.get(
+    VeNFTId(event.chainId, event.params._from),
+  );
+  const toState = await context.VeNFTState.get(
+    VeNFTId(event.chainId, event.params._to),
+  );
+
+  if (!fromState || !toState) {
+    context.log.error(
+      `[VeNFT.Merge] VeNFTState missing during VeNFT merge on chain ${event.chainId}: from=${event.params._from.toString()} exists=${Boolean(fromState)} to=${event.params._to.toString()} exists=${Boolean(toState)}`,
+    );
+    return;
+  }
+
+  await processVeNFTMerge(event, fromState, toState, context);
+});
+
+VeNFT.Split.handler(async ({ event, context }) => {
+  const fromState = await context.VeNFTState.get(
+    VeNFTId(event.chainId, event.params._from),
+  );
+  const token1State = await context.VeNFTState.get(
+    VeNFTId(event.chainId, event.params._tokenId1),
+  );
+  const token2State = await context.VeNFTState.get(
+    VeNFTId(event.chainId, event.params._tokenId2),
+  );
+
+  if (!fromState || !token1State || !token2State) {
+    context.log.error(
+      `[VeNFT.Split] VeNFTState missing during VeNFT split on chain ${event.chainId}: from=${event.params._from.toString()} exists=${Boolean(fromState)} token1=${event.params._tokenId1.toString()} exists=${Boolean(token1State)} token2=${event.params._tokenId2.toString()} exists=${Boolean(token2State)}`,
+    );
+    return;
+  }
+
+  await processVeNFTSplit(event, fromState, token1State, token2State, context);
+});
+
+VeNFT.DepositManaged.handler(async ({ event, context }) => {
+  const tokenState = await context.VeNFTState.get(
+    VeNFTId(event.chainId, event.params._tokenId),
+  );
+  const managedState = await context.VeNFTState.get(
+    VeNFTId(event.chainId, event.params._mTokenId),
+  );
+
+  if (!tokenState || !managedState) {
+    context.log.error(
+      `[VeNFT.DepositManaged] VeNFTState missing during VeNFT depositManaged on chain ${event.chainId}: token=${event.params._tokenId.toString()} exists=${Boolean(tokenState)} managed=${event.params._mTokenId.toString()} exists=${Boolean(managedState)}`,
+    );
+    return;
+  }
+
+  await processVeNFTDepositManaged(event, tokenState, managedState, context);
+});
+
+VeNFT.WithdrawManaged.handler(async ({ event, context }) => {
+  const tokenState = await context.VeNFTState.get(
+    VeNFTId(event.chainId, event.params._tokenId),
+  );
+  const managedState = await context.VeNFTState.get(
+    VeNFTId(event.chainId, event.params._mTokenId),
+  );
+
+  if (!tokenState || !managedState) {
+    context.log.error(
+      `[VeNFT.WithdrawManaged] VeNFTState missing during VeNFT withdrawManaged on chain ${event.chainId}: token=${event.params._tokenId.toString()} exists=${Boolean(tokenState)} managed=${event.params._mTokenId.toString()} exists=${Boolean(managedState)}`,
+    );
+    return;
+  }
+
+  await processVeNFTWithdrawManaged(event, tokenState, managedState, context);
 });

--- a/src/EventHandlers/VeNFT/VeNFTLogic.ts
+++ b/src/EventHandlers/VeNFT/VeNFTLogic.ts
@@ -1,7 +1,11 @@
 import type {
   VeNFTState,
+  VeNFT_DepositManaged_event,
   VeNFT_Deposit_event,
+  VeNFT_Merge_event,
+  VeNFT_Split_event,
   VeNFT_Transfer_event,
+  VeNFT_WithdrawManaged_event,
   VeNFT_Withdraw_event,
   handlerContext,
 } from "generated";
@@ -12,7 +16,12 @@ import {
 } from "../../Aggregators/UserStatsPerPool";
 import { loadPoolVotesByVeNFT } from "../../Aggregators/VeNFTPoolVote";
 import { updateVeNFTState } from "../../Aggregators/VeNFTState";
-import { VeNFTId, ZERO_ADDRESS } from "../../Constants";
+import {
+  SECONDS_IN_A_WEEK,
+  SECONDS_IN_FOUR_YEARS,
+  VeNFTId,
+  ZERO_ADDRESS,
+} from "../../Constants";
 
 /**
  * Processes a VeNFT Deposit event: updates the VeNFTState with the new locktime,
@@ -95,9 +104,246 @@ export async function processVeNFTTransfer(
 }
 
 /**
- * Handles the mint case of a VeNFT Transfer (from === zero address): creates the VeNFTState
- * entity with owner, chainId, tokenId, and initial timestamps. Returns the VeNFTState for the
- * token (existing or just created) so the caller can run processVeNFTTransfer for non-mint transfers.
+ * Reconciles a VeNFT position to an absolute target state.
+ *
+ * This helper translates an event-authoritative target TVL into the incremental
+ * diff expected by `updateVeNFTState`. It is used for flows such as `Merge`,
+ * `Split`, and managed-lock transitions where the contract emits the resulting
+ * balance directly and the indexer must correct any stale intermediate value.
+ *
+ * @param currentVeNFTState - The current persisted state for the affected token.
+ * @param timestamp - The block timestamp for the event being processed.
+ * @param context - Handler context used to persist the reconciled entity.
+ * @param target - The desired post-event state for the token. `totalValueLocked`
+ * is treated as an absolute value; the other fields override the current entity
+ * only when provided.
+ */
+function reconcileVeNFTState(
+  currentVeNFTState: VeNFTState,
+  timestamp: Date,
+  context: handlerContext,
+  target: {
+    totalValueLocked: bigint;
+    owner?: string;
+    locktime?: bigint;
+    isAlive?: boolean;
+  },
+): void {
+  const veNFTStateDiff = {
+    owner: target.owner,
+    locktime: target.locktime,
+    isAlive: target.isAlive,
+    incrementalTotalValueLocked:
+      target.totalValueLocked - currentVeNFTState.totalValueLocked,
+    lastUpdatedTimestamp: timestamp,
+  };
+
+  updateVeNFTState(veNFTStateDiff, currentVeNFTState, timestamp, context);
+}
+
+/**
+ * Reconstructs the lock end for a token leaving a managed position.
+ *
+ * The voting escrow contract restores the withdrawn token to a standard
+ * four-year lock aligned to week boundaries. The event exposes the withdrawal
+ * timestamp, so the indexer reproduces the contract's rounding logic here.
+ *
+ * @param ts - The withdrawal timestamp emitted by `WithdrawManaged`.
+ * @returns The reconstructed lock end, rounded down to the nearest week.
+ */
+function getManagedWithdrawLocktime(ts: bigint): bigint {
+  return ((ts + SECONDS_IN_FOUR_YEARS) / SECONDS_IN_A_WEEK) * SECONDS_IN_A_WEEK;
+}
+
+/**
+ * Reconciles both sides of a `Merge` into their post-event TVL state.
+ *
+ * The source token is burned by the merge and must end with zero TVL and
+ * `isAlive = false`. The destination token keeps the merged position and is
+ * reconciled to `_amountFinal` and `_locktime` from the event payload.
+ *
+ * @param event - The merge event carrying the authoritative destination amount
+ * and locktime.
+ * @param fromVeNFTState - Current state for the burned source token.
+ * @param toVeNFTState - Current state for the surviving destination token.
+ * @param context - Handler context used to persist both reconciled entities.
+ */
+export async function processVeNFTMerge(
+  event: VeNFT_Merge_event,
+  fromVeNFTState: VeNFTState,
+  toVeNFTState: VeNFTState,
+  context: handlerContext,
+): Promise<void> {
+  const timestamp = new Date(event.block.timestamp * 1000);
+
+  const fromVeNFTStateDiff = {
+    totalValueLocked: 0n,
+    locktime: 0n,
+    isAlive: false,
+  };
+
+  const toVeNFTStateDiff = {
+    totalValueLocked: event.params._amountFinal,
+    locktime: event.params._locktime,
+    isAlive: true,
+  };
+
+  reconcileVeNFTState(fromVeNFTState, timestamp, context, fromVeNFTStateDiff);
+  reconcileVeNFTState(toVeNFTState, timestamp, context, toVeNFTStateDiff);
+}
+
+/**
+ * Reconciles a `Split` into the exact balances emitted by the contract.
+ *
+ * The original token is fully consumed by the split and must end at zero TVL
+ * with `isAlive = false`. The two child tokens are reconciled to the
+ * authoritative split amounts and shared locktime provided by the event.
+ *
+ * @param event - The split event carrying both child amounts and the resulting
+ * locktime.
+ * @param fromVeNFTState - Current state for the token being split.
+ * @param token1VeNFTState - Current state for the first child token.
+ * @param token2VeNFTState - Current state for the second child token.
+ * @param context - Handler context used to persist all three reconciled entities.
+ */
+export async function processVeNFTSplit(
+  event: VeNFT_Split_event,
+  fromVeNFTState: VeNFTState,
+  token1VeNFTState: VeNFTState,
+  token2VeNFTState: VeNFTState,
+  context: handlerContext,
+): Promise<void> {
+  const timestamp = new Date(event.block.timestamp * 1000);
+
+  const originalVeNFTStateDiff = {
+    totalValueLocked: 0n,
+    locktime: 0n,
+    isAlive: false,
+  };
+
+  const token1VeNFTStateDiff = {
+    totalValueLocked: event.params._splitAmount1,
+    locktime: event.params._locktime,
+    isAlive: true,
+  };
+
+  const token2VeNFTStateDiff = {
+    totalValueLocked: event.params._splitAmount2,
+    locktime: event.params._locktime,
+    isAlive: true,
+  };
+
+  reconcileVeNFTState(
+    fromVeNFTState,
+    timestamp,
+    context,
+    originalVeNFTStateDiff,
+  );
+  reconcileVeNFTState(
+    token1VeNFTState,
+    timestamp,
+    context,
+    token1VeNFTStateDiff,
+  );
+  reconcileVeNFTState(
+    token2VeNFTState,
+    timestamp,
+    context,
+    token2VeNFTStateDiff,
+  );
+}
+
+/**
+ * Reconciles TVL movement when a standard veNFT is deposited into a managed lock.
+ *
+ * After `DepositManaged`, the source token no longer carries independent TVL,
+ * so it is reconciled to zero. The managed token absorbs the emitted `_weight`,
+ * which is added to its current TVL to reach the post-event balance.
+ *
+ * @param event - The managed-deposit event carrying the transferred weight.
+ * @param tokenVeNFTState - Current state for the deposited standard token.
+ * @param managedVeNFTState - Current state for the managed token receiving the weight.
+ * @param context - Handler context used to persist both reconciled entities.
+ */
+export async function processVeNFTDepositManaged(
+  event: VeNFT_DepositManaged_event,
+  tokenVeNFTState: VeNFTState,
+  managedVeNFTState: VeNFTState,
+  context: handlerContext,
+): Promise<void> {
+  const timestamp = new Date(event.block.timestamp * 1000);
+
+  const tokenVeNFTStateDiff = {
+    totalValueLocked: 0n,
+  };
+
+  const managedVeNFTStateDiff = {
+    totalValueLocked: managedVeNFTState.totalValueLocked + event.params._weight,
+  };
+
+  // DepositManaged moves value out of the standard token into the managed token,
+  // but it does not burn or replace the standard token ID. Keep `isAlive` unchanged:
+  // the NFT still exists on-chain, keeps its owner, and can later receive TVL again
+  // via WithdrawManaged. This differs from Merge / Split / burn flows, where the
+  // source token ID is actually destroyed and should be marked not alive.
+  reconcileVeNFTState(tokenVeNFTState, timestamp, context, tokenVeNFTStateDiff);
+  reconcileVeNFTState(
+    managedVeNFTState,
+    timestamp,
+    context,
+    managedVeNFTStateDiff,
+  );
+}
+
+/**
+ * Reconciles TVL movement when weight is withdrawn from a managed lock.
+ *
+ * The withdrawn standard token is restored with TVL equal to the emitted
+ * `_weight` and a new four-year lock derived from `_ts`. The managed token is
+ * reduced by the same amount so the pair remains consistent with contract state.
+ *
+ * @param event - The managed-withdraw event carrying the returned weight and timestamp.
+ * @param tokenVeNFTState - Current state for the token receiving the withdrawn weight.
+ * @param managedVeNFTState - Current state for the managed token losing the weight.
+ * @param context - Handler context used to persist both reconciled entities.
+ */
+export async function processVeNFTWithdrawManaged(
+  event: VeNFT_WithdrawManaged_event,
+  tokenVeNFTState: VeNFTState,
+  managedVeNFTState: VeNFTState,
+  context: handlerContext,
+): Promise<void> {
+  const timestamp = new Date(event.block.timestamp * 1000);
+
+  const tokenVeNFTStateDiff = {
+    totalValueLocked: event.params._weight,
+    locktime: getManagedWithdrawLocktime(event.params._ts),
+    isAlive: true,
+  };
+
+  const managedVeNFTStateDiff = {
+    totalValueLocked: managedVeNFTState.totalValueLocked - event.params._weight,
+  };
+
+  // WithdrawManaged restores value into an existing standard token ID. We set
+  // `isAlive = true` explicitly because the token is a live NFT position after
+  // the withdrawal; it was never burned during the managed-deposit period, only
+  // temporarily reduced to zero standalone TVL.
+  reconcileVeNFTState(tokenVeNFTState, timestamp, context, tokenVeNFTStateDiff);
+  reconcileVeNFTState(
+    managedVeNFTState,
+    timestamp,
+    context,
+    managedVeNFTStateDiff,
+  );
+}
+
+/**
+ * Ensures a VeNFT row exists for transfers involving newly minted token IDs.
+ *
+ * A mint `Transfer` is used only to create the entity shell. TVL is intentionally
+ * initialized to zero because amount-carrying events such as `Deposit` or `Split`
+ * are responsible for reconciling the actual locked balance afterward.
  *
  * @param event - The VeNFT Transfer event payload (from, to, tokenId).
  * @param context - Handler context for storage and logging.
@@ -114,9 +360,11 @@ export async function handleMintTransfer(
       chainId: event.chainId,
       tokenId: event.params.tokenId,
       owner: event.params.to,
-      locktime: 0n, // This is going to be updated in the Deposit event
+      // TVL-changing flows such as Split emit Transfer before the amount-carrying event.
+      // Create the shell here and let the follow-up VeNFT event reconcile TVL.
+      locktime: 0n,
       lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
-      totalValueLocked: 0n, // This is going to be updated in the Deposit event
+      totalValueLocked: 0n,
       isAlive: true,
       lastSnapshotTimestamp: undefined,
     });

--- a/test/EventHandlers/VeNFT.test.ts
+++ b/test/EventHandlers/VeNFT.test.ts
@@ -2,6 +2,8 @@ import "../eventHandlersRegistration";
 import { MockDb, VeNFT } from "../../generated/src/TestHelpers.gen";
 import * as VeNFTStateModule from "../../src/Aggregators/VeNFTState";
 import {
+  SECONDS_IN_A_WEEK,
+  SECONDS_IN_FOUR_YEARS,
   UserStatsPerPoolId,
   VeNFTId,
   toChecksumAddress,
@@ -656,6 +658,229 @@ describe("VeNFT Events", () => {
       expect(
         resultDB.entities.VeNFTState.get(VeNFTId(chainId, eventData.tokenId)),
       ).toBeUndefined();
+    });
+  });
+
+  describe("Split Flow Regression", () => {
+    it("reconciles child TVL before withdraw so it does not go negative", async () => {
+      const owner = toChecksumAddress(
+        "0x2222222222222222222222222222222222222222",
+      );
+      let db = MockDb.createMockDb();
+      db = db.entities.VeNFTState.set({
+        ...mockVeNFTState,
+        id: VeNFTId(chainId, 11n),
+        tokenId: 11n,
+        owner,
+        locktime: 999n,
+        totalValueLocked: 100n,
+      });
+
+      const mockEventData = (logIndex: number) => ({
+        block: {
+          timestamp: 1000000,
+          number: 123456,
+          hash: "0xsplit",
+        },
+        chainId,
+        logIndex,
+        srcAddress: owner,
+      });
+
+      const resultDB = await db.processEvents([
+        VeNFT.Transfer.createMockEvent({
+          from: owner,
+          to: toChecksumAddress("0x0000000000000000000000000000000000000000"),
+          tokenId: 11n,
+          mockEventData: mockEventData(1),
+        }),
+        VeNFT.Transfer.createMockEvent({
+          from: toChecksumAddress("0x0000000000000000000000000000000000000000"),
+          to: owner,
+          tokenId: 12n,
+          mockEventData: mockEventData(2),
+        }),
+        VeNFT.Transfer.createMockEvent({
+          from: toChecksumAddress("0x0000000000000000000000000000000000000000"),
+          to: owner,
+          tokenId: 13n,
+          mockEventData: mockEventData(3),
+        }),
+        VeNFT.Split.createMockEvent({
+          _from: 11n,
+          _tokenId1: 12n,
+          _tokenId2: 13n,
+          _sender: owner,
+          _splitAmount1: 30n,
+          _splitAmount2: 70n,
+          _locktime: 777n,
+          _ts: 555n,
+          mockEventData: mockEventData(4),
+        }),
+        VeNFT.Withdraw.createMockEvent({
+          provider: owner,
+          tokenId: 12n,
+          value: 30n,
+          ts: 556n,
+          mockEventData: mockEventData(5),
+        }),
+      ]);
+
+      expect(
+        resultDB.entities.VeNFTState.get(VeNFTId(chainId, 11n))
+          ?.totalValueLocked,
+      ).toBe(0n);
+      expect(
+        resultDB.entities.VeNFTState.get(VeNFTId(chainId, 12n))
+          ?.totalValueLocked,
+      ).toBe(0n);
+      expect(
+        resultDB.entities.VeNFTState.get(VeNFTId(chainId, 13n))
+          ?.totalValueLocked,
+      ).toBe(70n);
+    });
+  });
+
+  describe("Merge Flow Regression", () => {
+    it("reconciles destination TVL before withdraw so it does not go negative", async () => {
+      const owner = toChecksumAddress(
+        "0x2222222222222222222222222222222222222222",
+      );
+      let db = MockDb.createMockDb();
+      db = db.entities.VeNFTState.set({
+        ...mockVeNFTState,
+        id: VeNFTId(chainId, 21n),
+        tokenId: 21n,
+        owner,
+        locktime: 999n,
+        totalValueLocked: 100n,
+      });
+      db = db.entities.VeNFTState.set({
+        ...mockVeNFTState,
+        id: VeNFTId(chainId, 22n),
+        tokenId: 22n,
+        owner,
+        locktime: 999n,
+        totalValueLocked: 40n,
+      });
+
+      const mockEventData = (logIndex: number) => ({
+        block: {
+          timestamp: 1000000,
+          number: 123456,
+          hash: "0xmerge",
+        },
+        chainId,
+        logIndex,
+        srcAddress: owner,
+      });
+
+      const resultDB = await db.processEvents([
+        VeNFT.Transfer.createMockEvent({
+          from: owner,
+          to: toChecksumAddress("0x0000000000000000000000000000000000000000"),
+          tokenId: 21n,
+          mockEventData: mockEventData(1),
+        }),
+        VeNFT.Merge.createMockEvent({
+          _sender: owner,
+          _from: 21n,
+          _to: 22n,
+          _amountFrom: 100n,
+          _amountTo: 40n,
+          _amountFinal: 140n,
+          _locktime: 888n,
+          _ts: 777n,
+          mockEventData: mockEventData(2),
+        }),
+        VeNFT.Withdraw.createMockEvent({
+          provider: owner,
+          tokenId: 22n,
+          value: 140n,
+          ts: 778n,
+          mockEventData: mockEventData(3),
+        }),
+      ]);
+
+      expect(
+        resultDB.entities.VeNFTState.get(VeNFTId(chainId, 21n))
+          ?.totalValueLocked,
+      ).toBe(0n);
+      expect(
+        resultDB.entities.VeNFTState.get(VeNFTId(chainId, 22n))
+          ?.totalValueLocked,
+      ).toBe(0n);
+    });
+  });
+
+  describe("Managed Flow Regression", () => {
+    it("keeps normal and managed TVL consistent across depositManaged and withdrawManaged", async () => {
+      const owner = toChecksumAddress(
+        "0x2222222222222222222222222222222222222222",
+      );
+      let db = MockDb.createMockDb();
+      db = db.entities.VeNFTState.set({
+        ...mockVeNFTState,
+        id: VeNFTId(chainId, 31n),
+        tokenId: 31n,
+        owner,
+        locktime: 0n,
+        totalValueLocked: 80n,
+      });
+      db = db.entities.VeNFTState.set({
+        ...mockVeNFTState,
+        id: VeNFTId(chainId, 32n),
+        tokenId: 32n,
+        owner,
+        locktime: 0n,
+        totalValueLocked: 200n,
+      });
+
+      const withdrawTs = 123456n;
+      const expectedLocktime =
+        ((withdrawTs + SECONDS_IN_FOUR_YEARS) / SECONDS_IN_A_WEEK) *
+        SECONDS_IN_A_WEEK;
+      const mockEventData = (logIndex: number) => ({
+        block: {
+          timestamp: 1000000,
+          number: 123456,
+          hash: "0xmanaged",
+        },
+        chainId,
+        logIndex,
+        srcAddress: owner,
+      });
+
+      const resultDB = await db.processEvents([
+        VeNFT.DepositManaged.createMockEvent({
+          _owner: owner,
+          _tokenId: 31n,
+          _mTokenId: 32n,
+          _weight: 80n,
+          _ts: 1n,
+          mockEventData: mockEventData(1),
+        }),
+        VeNFT.WithdrawManaged.createMockEvent({
+          _owner: owner,
+          _tokenId: 31n,
+          _mTokenId: 32n,
+          _weight: 80n,
+          _ts: withdrawTs,
+          mockEventData: mockEventData(2),
+        }),
+      ]);
+
+      expect(
+        resultDB.entities.VeNFTState.get(VeNFTId(chainId, 31n))
+          ?.totalValueLocked,
+      ).toBe(80n);
+      expect(
+        resultDB.entities.VeNFTState.get(VeNFTId(chainId, 31n))?.locktime,
+      ).toBe(expectedLocktime);
+      expect(
+        resultDB.entities.VeNFTState.get(VeNFTId(chainId, 32n))
+          ?.totalValueLocked,
+      ).toBe(200n);
     });
   });
 });

--- a/test/EventHandlers/VeNFT/VeNFTLogic.test.ts
+++ b/test/EventHandlers/VeNFT/VeNFTLogic.test.ts
@@ -3,8 +3,12 @@ import type {
   UserStatsPerPool,
   VeNFTPoolVote,
   VeNFTState,
+  VeNFT_DepositManaged_event,
   VeNFT_Deposit_event,
+  VeNFT_Merge_event,
+  VeNFT_Split_event,
   VeNFT_Transfer_event,
+  VeNFT_WithdrawManaged_event,
   VeNFT_Withdraw_event,
   handlerContext,
 } from "../../../generated";
@@ -12,6 +16,8 @@ import * as UserStatsPerPoolModule from "../../../src/Aggregators/UserStatsPerPo
 import * as VeNFTPoolVoteAggregator from "../../../src/Aggregators/VeNFTPoolVote";
 import * as VeNFTStateAggregator from "../../../src/Aggregators/VeNFTState";
 import {
+  SECONDS_IN_A_WEEK,
+  SECONDS_IN_FOUR_YEARS,
   VeNFTId,
   VeNFTPoolVoteId,
   toChecksumAddress,
@@ -244,6 +250,335 @@ describe("VeNFTLogic", () => {
           lastUpdatedTimestamp: timestamp,
         },
         mockVeNFTState,
+        timestamp,
+        mockContext,
+      );
+    });
+  });
+
+  describe("processVeNFTMerge", () => {
+    it("reconciles source to zero and destination to the merged amount", async () => {
+      const fromState = {
+        ...mockVeNFTState,
+        tokenId: 1n,
+        totalValueLocked: 100n,
+      };
+      const toState = {
+        ...mockVeNFTState,
+        id: VeNFTId(10, 2n),
+        tokenId: 2n,
+        totalValueLocked: 40n,
+      };
+      const event = {
+        params: {
+          _sender: toChecksumAddress(
+            "0x9999999999999999999999999999999999999999",
+          ),
+          _from: 1n,
+          _to: 2n,
+          _amountFrom: 100n,
+          _amountTo: 40n,
+          _amountFinal: 140n,
+          _locktime: 500n,
+          _ts: 200n,
+        },
+        block: {
+          timestamp: 1000000,
+          number: 123456,
+          hash: "0x1234",
+        },
+        chainId: 10,
+        logIndex: 1,
+        srcAddress: toChecksumAddress(
+          "0x3333333333333333333333333333333333333333",
+        ),
+        transaction: { hash: "0xabcd" },
+      } as VeNFT_Merge_event;
+      const timestamp = new Date(event.block.timestamp * 1000);
+      const updateSpy = vi
+        .spyOn(VeNFTStateAggregator, "updateVeNFTState")
+        .mockImplementation(() => {});
+
+      await VeNFTLogic.processVeNFTMerge(
+        event,
+        fromState,
+        toState,
+        mockContext,
+      );
+
+      expect(updateSpy).toHaveBeenNthCalledWith(
+        1,
+        {
+          locktime: 0n,
+          isAlive: false,
+          incrementalTotalValueLocked: -100n,
+          lastUpdatedTimestamp: timestamp,
+          owner: undefined,
+        },
+        fromState,
+        timestamp,
+        mockContext,
+      );
+      expect(updateSpy).toHaveBeenNthCalledWith(
+        2,
+        {
+          locktime: 500n,
+          isAlive: true,
+          incrementalTotalValueLocked: 100n,
+          lastUpdatedTimestamp: timestamp,
+          owner: undefined,
+        },
+        toState,
+        timestamp,
+        mockContext,
+      );
+    });
+  });
+
+  describe("processVeNFTSplit", () => {
+    it("reconciles the parent to zero and children to split amounts", async () => {
+      const fromState = {
+        ...mockVeNFTState,
+        tokenId: 1n,
+        totalValueLocked: 100n,
+      };
+      const token1State = {
+        ...mockVeNFTState,
+        id: VeNFTId(10, 2n),
+        tokenId: 2n,
+        totalValueLocked: 0n,
+      };
+      const token2State = {
+        ...mockVeNFTState,
+        id: VeNFTId(10, 3n),
+        tokenId: 3n,
+        totalValueLocked: 0n,
+      };
+      const event = {
+        params: {
+          _from: 1n,
+          _tokenId1: 2n,
+          _tokenId2: 3n,
+          _sender: toChecksumAddress(
+            "0x9999999999999999999999999999999999999999",
+          ),
+          _splitAmount1: 30n,
+          _splitAmount2: 70n,
+          _locktime: 700n,
+          _ts: 200n,
+        },
+        block: {
+          timestamp: 1000000,
+          number: 123456,
+          hash: "0x1234",
+        },
+        chainId: 10,
+        logIndex: 1,
+        srcAddress: toChecksumAddress(
+          "0x3333333333333333333333333333333333333333",
+        ),
+        transaction: { hash: "0xabcd" },
+      } as VeNFT_Split_event;
+      const timestamp = new Date(event.block.timestamp * 1000);
+      const updateSpy = vi
+        .spyOn(VeNFTStateAggregator, "updateVeNFTState")
+        .mockImplementation(() => {});
+
+      await VeNFTLogic.processVeNFTSplit(
+        event,
+        fromState,
+        token1State,
+        token2State,
+        mockContext,
+      );
+
+      expect(updateSpy).toHaveBeenNthCalledWith(
+        1,
+        {
+          locktime: 0n,
+          isAlive: false,
+          incrementalTotalValueLocked: -100n,
+          lastUpdatedTimestamp: timestamp,
+          owner: undefined,
+        },
+        fromState,
+        timestamp,
+        mockContext,
+      );
+      expect(updateSpy).toHaveBeenNthCalledWith(
+        2,
+        {
+          locktime: 700n,
+          isAlive: true,
+          incrementalTotalValueLocked: 30n,
+          lastUpdatedTimestamp: timestamp,
+          owner: undefined,
+        },
+        token1State,
+        timestamp,
+        mockContext,
+      );
+      expect(updateSpy).toHaveBeenNthCalledWith(
+        3,
+        {
+          locktime: 700n,
+          isAlive: true,
+          incrementalTotalValueLocked: 70n,
+          lastUpdatedTimestamp: timestamp,
+          owner: undefined,
+        },
+        token2State,
+        timestamp,
+        mockContext,
+      );
+    });
+  });
+
+  describe("processVeNFTDepositManaged", () => {
+    it("moves weight from the normal token into the managed token", async () => {
+      const tokenState = {
+        ...mockVeNFTState,
+        tokenId: 1n,
+        totalValueLocked: 80n,
+      };
+      const managedState = {
+        ...mockVeNFTState,
+        id: VeNFTId(10, 2n),
+        tokenId: 2n,
+        totalValueLocked: 200n,
+      };
+      const event = {
+        params: {
+          _owner: mockVeNFTState.owner,
+          _tokenId: 1n,
+          _mTokenId: 2n,
+          _weight: 80n,
+          _ts: 200n,
+        },
+        block: {
+          timestamp: 1000000,
+          number: 123456,
+          hash: "0x1234",
+        },
+        chainId: 10,
+        logIndex: 1,
+        srcAddress: toChecksumAddress(
+          "0x3333333333333333333333333333333333333333",
+        ),
+        transaction: { hash: "0xabcd" },
+      } as VeNFT_DepositManaged_event;
+      const timestamp = new Date(event.block.timestamp * 1000);
+      const updateSpy = vi
+        .spyOn(VeNFTStateAggregator, "updateVeNFTState")
+        .mockImplementation(() => {});
+
+      await VeNFTLogic.processVeNFTDepositManaged(
+        event,
+        tokenState,
+        managedState,
+        mockContext,
+      );
+
+      expect(updateSpy).toHaveBeenNthCalledWith(
+        1,
+        {
+          locktime: undefined,
+          isAlive: undefined,
+          incrementalTotalValueLocked: -80n,
+          lastUpdatedTimestamp: timestamp,
+          owner: undefined,
+        },
+        tokenState,
+        timestamp,
+        mockContext,
+      );
+      expect(updateSpy).toHaveBeenNthCalledWith(
+        2,
+        {
+          locktime: undefined,
+          isAlive: undefined,
+          incrementalTotalValueLocked: 80n,
+          lastUpdatedTimestamp: timestamp,
+          owner: undefined,
+        },
+        managedState,
+        timestamp,
+        mockContext,
+      );
+    });
+  });
+
+  describe("processVeNFTWithdrawManaged", () => {
+    it("restores weight to the normal token and reduces managed TVL", async () => {
+      const tokenState = {
+        ...mockVeNFTState,
+        tokenId: 1n,
+        totalValueLocked: 0n,
+      };
+      const managedState = {
+        ...mockVeNFTState,
+        id: VeNFTId(10, 2n),
+        tokenId: 2n,
+        totalValueLocked: 280n,
+      };
+      const event = {
+        params: {
+          _owner: mockVeNFTState.owner,
+          _tokenId: 1n,
+          _mTokenId: 2n,
+          _weight: 80n,
+          _ts: 123456n,
+        },
+        block: {
+          timestamp: 1000000,
+          number: 123456,
+          hash: "0x1234",
+        },
+        chainId: 10,
+        logIndex: 1,
+        srcAddress: toChecksumAddress(
+          "0x3333333333333333333333333333333333333333",
+        ),
+        transaction: { hash: "0xabcd" },
+      } as VeNFT_WithdrawManaged_event;
+      const timestamp = new Date(event.block.timestamp * 1000);
+      const expectedLocktime =
+        ((123456n + SECONDS_IN_FOUR_YEARS) / SECONDS_IN_A_WEEK) *
+        SECONDS_IN_A_WEEK;
+      const updateSpy = vi
+        .spyOn(VeNFTStateAggregator, "updateVeNFTState")
+        .mockImplementation(() => {});
+
+      await VeNFTLogic.processVeNFTWithdrawManaged(
+        event,
+        tokenState,
+        managedState,
+        mockContext,
+      );
+
+      expect(updateSpy).toHaveBeenNthCalledWith(
+        1,
+        {
+          locktime: expectedLocktime,
+          isAlive: true,
+          incrementalTotalValueLocked: 80n,
+          lastUpdatedTimestamp: timestamp,
+          owner: undefined,
+        },
+        tokenState,
+        timestamp,
+        mockContext,
+      );
+      expect(updateSpy).toHaveBeenNthCalledWith(
+        2,
+        {
+          locktime: undefined,
+          isAlive: undefined,
+          incrementalTotalValueLocked: -80n,
+          lastUpdatedTimestamp: timestamp,
+          owner: undefined,
+        },
+        managedState,
         timestamp,
         mockContext,
       );


### PR DESCRIPTION
closes #553 

Implements:
- Additional events (`Merge`/`Split`/`DepositManaged`/`WithdrawManaged`) to correctly compute `totalAmountLocked`
    -  Ran locally indexer without only `VeNFT` contract on optimism and base. After full sync on both chains, no negative values for `totalAmountLocked` were found

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for VeNFT merge and split operations to enable flexible position management
  * Introduced managed deposit and withdrawal functionality for enhanced liquidity flexibility
  * Improved total value locked reconciliation across all VeNFT operations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->