### PR TITLE
Pool `totalLiquidityUSD` derived from reserve0 and reserve1

### DIFF
--- a/src/Aggregators/LiquidityPoolAggregator.ts
+++ b/src/Aggregators/LiquidityPoolAggregator.ts
@@ -33,7 +33,6 @@ export interface LiquidityPoolAggregatorDiff {
   incrementalReserve0: bigint;
   incrementalReserve1: bigint;
   incrementalTotalLPSupply: bigint;
-  incrementalCurrentLiquidityUSD: bigint;
   incrementalTotalVolume0: bigint;
   incrementalTotalVolume1: bigint;
   incrementalTotalVolumeUSD: bigint;
@@ -62,8 +61,8 @@ export interface LiquidityPoolAggregatorDiff {
   incrementalTotalGaugeRewardsClaimedUSD: bigint;
   incrementalTotalGaugeRewardsClaimed: bigint;
   incrementalCurrentLiquidityStaked: bigint;
-  /** Non-cumulative: when set (e.g. by gauge flow), overwrites currentLiquidityStakedUSD. Same pattern as baseFee/currentFee. */
-  currentLiquidityStakedUSD?: bigint;
+  currentTotalLiquidityUSD: bigint;
+  currentLiquidityStakedUSD: bigint;
   token0Price: bigint;
   token1Price: bigint;
   gaugeIsAlive: boolean;
@@ -216,7 +215,7 @@ export async function updateLiquidityPoolAggregator(
     totalLPTokenSupply:
       (diff.incrementalTotalLPSupply ?? 0n) + current.totalLPTokenSupply,
     totalLiquidityUSD:
-      (diff.incrementalCurrentLiquidityUSD ?? 0n) + current.totalLiquidityUSD,
+      diff.currentTotalLiquidityUSD ?? current.totalLiquidityUSD,
     totalVolume0: (diff.incrementalTotalVolume0 ?? 0n) + current.totalVolume0,
     totalVolume1: (diff.incrementalTotalVolume1 ?? 0n) + current.totalVolume1,
     totalVolumeUSD:

--- a/src/EventHandlers/CLPool.ts
+++ b/src/EventHandlers/CLPool.ts
@@ -49,7 +49,12 @@ CLPool.Burn.handler(async ({ event, context }) => {
 
   const { liquidityPoolAggregator, token0Instance, token1Instance } = poolData;
 
-  const result = processCLPoolBurn(event, token0Instance, token1Instance);
+  const result = processCLPoolBurn(
+    event,
+    liquidityPoolAggregator,
+    token0Instance,
+    token1Instance,
+  );
   const timestamp = new Date(event.block.timestamp * 1000);
 
   await updateLiquidityPoolAggregator(
@@ -265,7 +270,12 @@ CLPool.Mint.handler(async ({ event, context }) => {
 
   const { liquidityPoolAggregator, token0Instance, token1Instance } = poolData;
 
-  const result = processCLPoolMint(event, token0Instance, token1Instance);
+  const result = processCLPoolMint(
+    event,
+    liquidityPoolAggregator,
+    token0Instance,
+    token1Instance,
+  );
   const timestamp = new Date(event.block.timestamp * 1000);
 
   await updateLiquidityPoolAggregator(

--- a/src/EventHandlers/CLPool/CLPoolBurnLogic.ts
+++ b/src/EventHandlers/CLPool/CLPoolBurnLogic.ts
@@ -1,4 +1,8 @@
-import type { CLPool_Burn_event, Token } from "generated";
+import type {
+  CLPool_Burn_event,
+  LiquidityPoolAggregator,
+  Token,
+} from "generated";
 import type { LiquidityPoolAggregatorDiff } from "../../Aggregators/LiquidityPoolAggregator";
 import { calculateTotalUSD } from "../../Helpers";
 
@@ -8,13 +12,15 @@ export interface CLPoolBurnResult {
 
 export function processCLPoolBurn(
   event: CLPool_Burn_event,
+  liquidityPoolAggregator: LiquidityPoolAggregator,
   token0Instance: Token,
   token1Instance: Token,
 ): CLPoolBurnResult {
-  // Calculate USD values using already-refreshed token prices from loadPoolData
-  const totalLiquidityUSD = calculateTotalUSD(
-    event.params.amount0,
-    event.params.amount1,
+  const newReserve0 = liquidityPoolAggregator.reserve0 - event.params.amount0;
+  const newReserve1 = liquidityPoolAggregator.reserve1 - event.params.amount1;
+  const currentTotalLiquidityUSD = calculateTotalUSD(
+    newReserve0,
+    newReserve1,
     token0Instance,
     token1Instance,
   );
@@ -22,7 +28,7 @@ export function processCLPoolBurn(
   const liquidityPoolDiff = {
     incrementalReserve0: -event.params.amount0,
     incrementalReserve1: -event.params.amount1,
-    incrementalCurrentLiquidityUSD: -totalLiquidityUSD,
+    currentTotalLiquidityUSD: currentTotalLiquidityUSD,
     lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
   };
 

--- a/src/EventHandlers/CLPool/CLPoolMintLogic.ts
+++ b/src/EventHandlers/CLPool/CLPoolMintLogic.ts
@@ -1,4 +1,8 @@
-import type { CLPool_Mint_event, Token } from "generated";
+import type {
+  CLPool_Mint_event,
+  LiquidityPoolAggregator,
+  Token,
+} from "generated";
 import type { LiquidityPoolAggregatorDiff } from "../../Aggregators/LiquidityPoolAggregator";
 import { calculateTotalUSD } from "../../Helpers";
 
@@ -8,13 +12,15 @@ export interface CLPoolMintResult {
 
 export function processCLPoolMint(
   event: CLPool_Mint_event,
+  liquidityPoolAggregator: LiquidityPoolAggregator,
   token0Instance: Token,
   token1Instance: Token,
 ): CLPoolMintResult {
-  // Calculate USD values using already-refreshed token prices from loadPoolData
-  const totalLiquidityUSD = calculateTotalUSD(
-    event.params.amount0,
-    event.params.amount1,
+  const newReserve0 = liquidityPoolAggregator.reserve0 + event.params.amount0;
+  const newReserve1 = liquidityPoolAggregator.reserve1 + event.params.amount1;
+  const currentTotalLiquidityUSD = calculateTotalUSD(
+    newReserve0,
+    newReserve1,
     token0Instance,
     token1Instance,
   );
@@ -22,7 +28,7 @@ export function processCLPoolMint(
   const liquidityPoolDiff = {
     incrementalReserve0: event.params.amount0,
     incrementalReserve1: event.params.amount1,
-    incrementalCurrentLiquidityUSD: totalLiquidityUSD,
+    currentTotalLiquidityUSD: currentTotalLiquidityUSD,
     lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
   };
 

--- a/src/EventHandlers/CLPool/CLPoolSwapLogic.ts
+++ b/src/EventHandlers/CLPool/CLPoolSwapLogic.ts
@@ -40,7 +40,7 @@ interface SwapVolumeAndFees {
 interface SwapLiquidityChanges {
   newReserve0: bigint;
   newReserve1: bigint;
-  deltaTotalLiquidityUSD: bigint;
+  currentTotalLiquidityUSD: bigint;
 }
 
 /**
@@ -198,28 +198,23 @@ export function calculateSwapLiquidityChanges(
   token0Instance: Token | undefined,
   token1Instance: Token | undefined,
 ): SwapLiquidityChanges {
-  // Calculate new reserves after the swap
-  // In the swap event, amount0 and amount1 can be both negative or positive, so we add either way
+  // Reserve fields represent swappable liquidity. We intentionally keep using the
+  // signed swap event deltas here and treat Collect/CollectFees/Flash as non-reserve
+  // events so CL totalLiquidityUSD can be derived from post-swap reserves.
   const newReserve0 = liquidityPoolAggregator.reserve0 + event.params.amount0;
   const newReserve1 = liquidityPoolAggregator.reserve1 + event.params.amount1;
 
-  // Calculate new total liquidity USD using already-refreshed token prices
-  const newTotalLiquidityUSD = calculateTotalUSD(
+  const currentTotalLiquidityUSD = calculateTotalUSD(
     newReserve0,
     newReserve1,
     token0Instance,
     token1Instance,
   );
 
-  // Calculate the delta in total liquidity USD
-  const currentTotalLiquidityUSD = liquidityPoolAggregator.totalLiquidityUSD;
-  const deltaTotalLiquidityUSD =
-    newTotalLiquidityUSD - currentTotalLiquidityUSD;
-
   return {
     newReserve0,
     newReserve1,
-    deltaTotalLiquidityUSD,
+    currentTotalLiquidityUSD,
   };
 }
 
@@ -246,7 +241,7 @@ export async function processCLPoolSwap(
   );
 
   // Calculate liquidity and reserve changes
-  const { deltaTotalLiquidityUSD } = calculateSwapLiquidityChanges(
+  const { currentTotalLiquidityUSD } = calculateSwapLiquidityChanges(
     event,
     liquidityPoolAggregator,
     token0Instance,
@@ -269,7 +264,7 @@ export async function processCLPoolSwap(
     incrementalNumberOfSwaps: 1n,
     incrementalReserve0: event.params.amount0, // Delta: can be positive or negative (signed int256)
     incrementalReserve1: event.params.amount1, // Delta: can be positive or negative (signed int256)
-    incrementalCurrentLiquidityUSD: deltaTotalLiquidityUSD,
+    currentTotalLiquidityUSD,
     sqrtPriceX96: event.params.sqrtPriceX96, // Store current sqrt price from Swap event
     tick: event.params.tick, // Store current tick from Swap event
     lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),

--- a/src/EventHandlers/Pool/PoolBurnAndMintLogic.ts
+++ b/src/EventHandlers/Pool/PoolBurnAndMintLogic.ts
@@ -239,7 +239,7 @@ export async function processPoolLiquidityEvent(
   );
 
   // Update pool metrics (token prices only)
-  // DO NOT update incrementalCurrentLiquidityUSD here - TVL is computed from reserves in Sync handler
+  // DO NOT update totalLiquidityUSD here - TVL is computed from reserves in Sync handler
   // No updates to reserves are needed - Sync events handle reserve updates
   // Mint and burn functions always call _update method on the contract which always emits Sync event
   const poolDiff = {

--- a/src/EventHandlers/Pool/PoolSyncLogic.ts
+++ b/src/EventHandlers/Pool/PoolSyncLogic.ts
@@ -29,18 +29,17 @@ export function processPoolSync(
   // Handle different scenarios based on token availability and amounts
   let reserve0Change: bigint;
   let reserve1Change: bigint;
-  let totalLiquidityUSDChange: bigint;
+  let currentTotalLiquidityUSD: bigint | undefined;
 
   if (!token0Instance && !token1Instance) {
     // No tokens available: keep existing values (no change)
     reserve0Change = 0n;
     reserve1Change = 0n;
-    totalLiquidityUSDChange = 0n;
   } else if (event.params.reserve0 === 0n && event.params.reserve1 === 0n) {
     // Zero amounts: set reserves to zero (snapshot behavior)
     reserve0Change = -liquidityPoolAggregator.reserve0;
     reserve1Change = -liquidityPoolAggregator.reserve1;
-    totalLiquidityUSDChange = -liquidityPoolAggregator.totalLiquidityUSD;
+    currentTotalLiquidityUSD = 0n;
   } else {
     // Normal case: Sync events set reserves to absolute values
     // Calculate the delta needed to set reserves to the exact values from the event
@@ -49,22 +48,20 @@ export function processPoolSync(
     reserve0Change = event.params.reserve0 - liquidityPoolAggregator.reserve0;
     reserve1Change = event.params.reserve1 - liquidityPoolAggregator.reserve1;
 
-    // Calculate total liquidity USD from the new total reserves using already-refreshed tokens
-    const newTotalLiquidityUSD = calculateTotalUSD(
+    // totalLiquidityUSD is non-cumulative: overwrite it using the absolute
+    // post-sync reserves rather than applying a delta from the previous value.
+    currentTotalLiquidityUSD = calculateTotalUSD(
       event.params.reserve0,
       event.params.reserve1,
       token0Instance,
       token1Instance,
     );
-
-    totalLiquidityUSDChange =
-      newTotalLiquidityUSD - liquidityPoolAggregator.totalLiquidityUSD;
   }
 
   const liquidityPoolDiff = {
     incrementalReserve0: reserve0Change,
     incrementalReserve1: reserve1Change,
-    incrementalCurrentLiquidityUSD: totalLiquidityUSDChange,
+    currentTotalLiquidityUSD,
     token0Price:
       token0Instance?.pricePerUSDNew ?? liquidityPoolAggregator.token0Price,
     token1Price:

--- a/test/Aggregators/LiquidityPoolAggregator.test.ts
+++ b/test/Aggregators/LiquidityPoolAggregator.test.ts
@@ -267,6 +267,52 @@ describe("LiquidityPoolAggregator Functions", () => {
     });
   });
 
+  describe("updateLiquidityPoolAggregator", () => {
+    it("should overwrite totalLiquidityUSD when currentTotalLiquidityUSD is provided", async () => {
+      await updateLiquidityPoolAggregator(
+        {
+          currentTotalLiquidityUSD: 777n,
+        },
+        {
+          ...(liquidityPoolAggregator as LiquidityPoolAggregator),
+          totalLiquidityUSD: 100n,
+        },
+        timestamp,
+        mockContext as handlerContext,
+        10,
+        blockNumber,
+      );
+
+      const poolStore = mockContext.LiquidityPoolAggregator;
+      if (!poolStore) {
+        throw new Error("test setup: LiquidityPoolAggregator store must exist");
+      }
+      const setCalls = vi.mocked(poolStore.set).mock.calls;
+      expect(setCalls.at(-1)?.[0]?.totalLiquidityUSD).toBe(777n);
+    });
+
+    it("should preserve totalLiquidityUSD when no overwrite is provided", async () => {
+      await updateLiquidityPoolAggregator(
+        {},
+        {
+          ...(liquidityPoolAggregator as LiquidityPoolAggregator),
+          totalLiquidityUSD: 100n,
+        },
+        timestamp,
+        mockContext as handlerContext,
+        10,
+        blockNumber,
+      );
+
+      const poolStore = mockContext.LiquidityPoolAggregator;
+      if (!poolStore) {
+        throw new Error("test setup: LiquidityPoolAggregator store must exist");
+      }
+      const setCalls = vi.mocked(poolStore.set).mock.calls;
+      expect(setCalls.at(-1)?.[0]?.totalLiquidityUSD).toBe(100n);
+    });
+  });
+
   describe("Updating the Liquidity Pool Aggregator", () => {
     let diff = {
       incrementalTotalVolume0: 0n,

--- a/test/EventHandlers/CLPool.test.ts
+++ b/test/EventHandlers/CLPool.test.ts
@@ -325,7 +325,7 @@ describe("CLPool Events", () => {
           liquidityPoolDiff: {
             incrementalReserve0: 1000n,
             incrementalReserve1: 1000n,
-            incrementalCurrentLiquidityUSD: 2000n,
+            currentTotalLiquidityUSD: 2000n,
             lastUpdatedTimestamp: new Date(1000000 * 1000),
           },
         });
@@ -388,7 +388,7 @@ describe("CLPool Events", () => {
           liquidityPoolDiff: {
             incrementalReserve0: -500n, // Negative because burning decreases reserves
             incrementalReserve1: -500n, // Negative because burning decreases reserves
-            incrementalCurrentLiquidityUSD: -1000n, // Negative because reserves decrease
+            currentTotalLiquidityUSD: 1000n,
             lastUpdatedTimestamp: new Date(1000000 * 1000),
           },
         });

--- a/test/EventHandlers/CLPool/CLPoolBurnLogic.test.ts
+++ b/test/EventHandlers/CLPool/CLPoolBurnLogic.test.ts
@@ -54,29 +54,45 @@ describe("CLPoolBurnLogic", () => {
     lastUpdatedTimestamp: new Date(1000000 * 1000),
   };
 
+  const mockLiquidityPoolAggregator: LiquidityPoolAggregator = {
+    ...mockLiquidityPoolData,
+    reserve0: 1000000n,
+    reserve1: 3000000000000000000n,
+    totalLiquidityUSD: 7000000000000000000n,
+  };
+
   describe("processCLPoolBurn", () => {
     it("should process burn event successfully with valid data", () => {
-      const result = processCLPoolBurn(mockEvent, mockToken0, mockToken1);
+      const result = processCLPoolBurn(
+        mockEvent,
+        mockLiquidityPoolAggregator,
+        mockToken0,
+        mockToken1,
+      );
 
       // Check liquidity pool diff with exact values (negative because burning decreases reserves)
       expect(result.liquidityPoolDiff.incrementalReserve0).toBe(-500000n); // -amount0 (delta)
       expect(result.liquidityPoolDiff.incrementalReserve1).toBe(-300000n); // -amount1 (delta)
 
-      // Calculate exact totalLiquidityUSD: (500000 * 1 USD) + (300000 * 2 USD) = 500000 + 600000 = 1100000 USD (negative because reserves decrease)
-      expect(result.liquidityPoolDiff.incrementalCurrentLiquidityUSD).toBe(
-        -1100000n,
-      ); // -1.1M USD in 18 decimals
+      expect(result.liquidityPoolDiff.currentTotalLiquidityUSD).toBe(
+        5999999999999900000n,
+      );
     });
 
     it("should calculate correct liquidity values for burn event", () => {
-      const result = processCLPoolBurn(mockEvent, mockToken0, mockToken1);
+      const result = processCLPoolBurn(
+        mockEvent,
+        mockLiquidityPoolAggregator,
+        mockToken0,
+        mockToken1,
+      );
 
       // The liquidity pool diff should reflect the reserve deltas (negative because burning decreases reserves)
       expect(result.liquidityPoolDiff.incrementalReserve0).toBe(-500000n); // -amount0 (delta)
       expect(result.liquidityPoolDiff.incrementalReserve1).toBe(-300000n); // -amount1 (delta)
-      expect(result.liquidityPoolDiff.incrementalCurrentLiquidityUSD).toBe(
-        -1100000n,
-      ); // Negative because reserves decrease
+      expect(result.liquidityPoolDiff.currentTotalLiquidityUSD).toBe(
+        5999999999999900000n,
+      );
     });
 
     it("should handle different token decimals correctly", () => {
@@ -87,14 +103,7 @@ describe("CLPoolBurnLogic", () => {
 
       const result = processCLPoolBurn(
         mockEvent,
-        tokenWithDifferentDecimals,
-        mockToken1,
-      );
-
-      // Calculate expected values using the same logic as processCLPoolBurn
-      const expectedTotalLiquidityUSD = calculateTotalUSD(
-        mockEvent.params.amount0,
-        mockEvent.params.amount1,
+        mockLiquidityPoolAggregator,
         tokenWithDifferentDecimals,
         mockToken1,
       );
@@ -103,7 +112,12 @@ describe("CLPoolBurnLogic", () => {
       const expectedLiquidityPoolDiff = {
         incrementalReserve0: -mockEvent.params.amount0, // -500000n
         incrementalReserve1: -mockEvent.params.amount1, // -300000n
-        incrementalCurrentLiquidityUSD: -expectedTotalLiquidityUSD,
+        currentTotalLiquidityUSD: calculateTotalUSD(
+          mockLiquidityPoolAggregator.reserve0 - mockEvent.params.amount0,
+          mockLiquidityPoolAggregator.reserve1 - mockEvent.params.amount1,
+          tokenWithDifferentDecimals,
+          mockToken1,
+        ),
       };
 
       // Assert liquidity pool diff with precise values
@@ -113,8 +127,8 @@ describe("CLPoolBurnLogic", () => {
       expect(result.liquidityPoolDiff.incrementalReserve1).toEqual(
         expectedLiquidityPoolDiff.incrementalReserve1,
       );
-      expect(result.liquidityPoolDiff.incrementalCurrentLiquidityUSD).toEqual(
-        expectedLiquidityPoolDiff.incrementalCurrentLiquidityUSD,
+      expect(result.liquidityPoolDiff.currentTotalLiquidityUSD).toEqual(
+        expectedLiquidityPoolDiff.currentTotalLiquidityUSD,
       );
     });
   });

--- a/test/EventHandlers/CLPool/CLPoolCollectFeesLogic.test.ts
+++ b/test/EventHandlers/CLPool/CLPoolCollectFeesLogic.test.ts
@@ -129,6 +129,15 @@ describe("CLPoolCollectFeesLogic", () => {
       expect(
         result.liquidityPoolDiff.incrementalTotalStakedFeesCollectedUSD,
       ).toBe(5000000000000000000n);
+      expect(result.liquidityPoolDiff).not.toHaveProperty(
+        "incrementalReserve0",
+      );
+      expect(result.liquidityPoolDiff).not.toHaveProperty(
+        "incrementalReserve1",
+      );
+      expect(result.liquidityPoolDiff).not.toHaveProperty(
+        "currentTotalLiquidityUSD",
+      );
     });
 
     it("should handle different token decimals correctly", () => {

--- a/test/EventHandlers/CLPool/CLPoolCollectLogic.test.ts
+++ b/test/EventHandlers/CLPool/CLPoolCollectLogic.test.ts
@@ -160,6 +160,15 @@ describe("CLPoolCollectLogic", () => {
       expect(result.liquidityPoolDiff).not.toHaveProperty(
         "incrementalTotalStakedFeesCollectedUSD",
       );
+      expect(result.liquidityPoolDiff).not.toHaveProperty(
+        "incrementalReserve0",
+      );
+      expect(result.liquidityPoolDiff).not.toHaveProperty(
+        "incrementalReserve1",
+      );
+      expect(result.liquidityPoolDiff).not.toHaveProperty(
+        "currentTotalLiquidityUSD",
+      );
     });
   });
 });

--- a/test/EventHandlers/CLPool/CLPoolFlashLogic.test.ts
+++ b/test/EventHandlers/CLPool/CLPoolFlashLogic.test.ts
@@ -79,6 +79,15 @@ describe("CLPoolFlashLogic", () => {
       expect(result.userFlashLoanDiff.incrementalTotalFlashLoanVolumeUSD).toBe(
         2000000n,
       );
+      expect(result.liquidityPoolDiff).not.toHaveProperty(
+        "incrementalReserve0",
+      );
+      expect(result.liquidityPoolDiff).not.toHaveProperty(
+        "incrementalReserve1",
+      );
+      expect(result.liquidityPoolDiff).not.toHaveProperty(
+        "currentTotalLiquidityUSD",
+      );
     });
 
     it("should calculate flash loan fees correctly", () => {

--- a/test/EventHandlers/CLPool/CLPoolMintLogic.test.ts
+++ b/test/EventHandlers/CLPool/CLPoolMintLogic.test.ts
@@ -1,4 +1,4 @@
-import type { Token } from "generated";
+import type { LiquidityPoolAggregator, Token } from "generated";
 import { CLPool } from "../../../generated/src/TestHelpers.gen";
 import { toChecksumAddress } from "../../../src/Constants";
 import { processCLPoolMint } from "../../../src/EventHandlers/CLPool/CLPoolMintLogic";
@@ -54,9 +54,21 @@ describe("CLPoolMintLogic", () => {
     lastUpdatedTimestamp: new Date(1000000 * 1000),
   };
 
+  const mockLiquidityPoolAggregator = {
+    ...mockLiquidityPoolData,
+    reserve0: 1000000000000000000n,
+    reserve1: 2000000000000000000n,
+    totalLiquidityUSD: 5000000000000000000n,
+  } as LiquidityPoolAggregator;
+
   describe("processCLPoolMint", () => {
     it("should process mint event successfully with valid data", () => {
-      const result = processCLPoolMint(mockEvent, mockToken0, mockToken1);
+      const result = processCLPoolMint(
+        mockEvent,
+        mockLiquidityPoolAggregator,
+        mockToken0,
+        mockToken1,
+      );
 
       // Check liquidity pool diff with exact values
       expect(result.liquidityPoolDiff.incrementalReserve0).toBe(
@@ -66,14 +78,19 @@ describe("CLPoolMintLogic", () => {
         300000000000000000n,
       ); // amount1 (0.3 token)
 
-      // Calculate exact totalLiquidityUSD: (0.5 * 1 USD) + (0.3 * 2 USD) = 0.5 + 0.6 = 1.1 USD
-      expect(result.liquidityPoolDiff.incrementalCurrentLiquidityUSD).toBe(
-        1100000000000000000n,
-      ); // 1.1 USD in 18 decimals
+      // Post-mint reserves: token0 = 1.5, token1 = 2.3 -> TVL = 1.5 + 4.6 = 6.1 USD
+      expect(result.liquidityPoolDiff.currentTotalLiquidityUSD).toBe(
+        6100000000000000000n,
+      );
     });
 
     it("should calculate correct liquidity values for mint event", () => {
-      const result = processCLPoolMint(mockEvent, mockToken0, mockToken1);
+      const result = processCLPoolMint(
+        mockEvent,
+        mockLiquidityPoolAggregator,
+        mockToken0,
+        mockToken1,
+      );
 
       // The liquidity pool diff should reflect the amounts being added with exact values
       expect(result.liquidityPoolDiff.incrementalReserve0).toBe(
@@ -82,9 +99,9 @@ describe("CLPoolMintLogic", () => {
       expect(result.liquidityPoolDiff.incrementalReserve1).toBe(
         300000000000000000n,
       ); // amount1
-      expect(result.liquidityPoolDiff.incrementalCurrentLiquidityUSD).toBe(
-        1100000000000000000n,
-      ); // 1.1 USD in 18 decimals
+      expect(result.liquidityPoolDiff.currentTotalLiquidityUSD).toBe(
+        6100000000000000000n,
+      );
     });
 
     it("should handle different token decimals correctly", () => {
@@ -95,6 +112,7 @@ describe("CLPoolMintLogic", () => {
 
       const result = processCLPoolMint(
         mockEvent,
+        mockLiquidityPoolAggregator,
         tokenWithDifferentDecimals,
         mockToken1,
       );
@@ -121,13 +139,16 @@ describe("CLPoolMintLogic", () => {
 
       const result = processCLPoolMint(
         eventWithZeroAmounts,
+        mockLiquidityPoolAggregator,
         mockToken0,
         mockToken1,
       );
 
       expect(result.liquidityPoolDiff.incrementalReserve0).toBe(0n);
       expect(result.liquidityPoolDiff.incrementalReserve1).toBe(0n);
-      expect(result.liquidityPoolDiff.incrementalCurrentLiquidityUSD).toBe(0n);
+      expect(result.liquidityPoolDiff.currentTotalLiquidityUSD).toBe(
+        5000000000000000000n,
+      );
     });
   });
 });

--- a/test/EventHandlers/CLPool/CLPoolSwapLogic.test.ts
+++ b/test/EventHandlers/CLPool/CLPoolSwapLogic.test.ts
@@ -406,8 +406,7 @@ describe("CLPoolSwapLogic", () => {
 
       // New reserves: 1 + 1 = 2 tokens0, 2 + 2 = 4 tokens1
       // New liquidity: 2 * $1 + 4 * $2 = $2 + $8 = $10
-      // Delta: $10 - $5 = $5
-      expect(result.deltaTotalLiquidityUSD).toBe(5n * TEN_TO_THE_18_BI);
+      expect(result.currentTotalLiquidityUSD).toBe(10n * TEN_TO_THE_18_BI);
     });
 
     it("should calculate liquidity delta correctly when liquidity decreases", () => {
@@ -436,8 +435,7 @@ describe("CLPoolSwapLogic", () => {
 
       // New reserves: 10 - 5 = 5 tokens0, 20 - 10 = 10 tokens1
       // New liquidity: 5 * $1 + 10 * $2 = $5 + $20 = $25
-      // Delta: $25 - $50 = -$25
-      expect(result.deltaTotalLiquidityUSD).toBe(-25n * TEN_TO_THE_18_BI);
+      expect(result.currentTotalLiquidityUSD).toBe(25n * TEN_TO_THE_18_BI);
     });
 
     it("should handle undefined tokens correctly", () => {
@@ -482,6 +480,9 @@ describe("CLPoolSwapLogic", () => {
       expect(result.liquidityPoolDiff.incrementalTotalFeesGeneratedUSD).toBe(
         3000000000000000n,
       ); // 3e15
+      expect(result.liquidityPoolDiff.currentTotalLiquidityUSD).toBe(
+        19n * TEN_TO_THE_18_BI,
+      );
 
       expect(result.userSwapDiff.incrementalNumberOfSwaps).toBe(1n);
       expect(result.userSwapDiff.incrementalTotalSwapVolumeAmount0).toBe(
@@ -510,6 +511,9 @@ describe("CLPoolSwapLogic", () => {
       expect(result.liquidityPoolDiff.incrementalTotalVolume0).toBe(0n);
       expect(result.liquidityPoolDiff.incrementalTotalVolume1).toBe(0n);
       expect(result.liquidityPoolDiff.incrementalTotalVolumeUSD).toBe(0n);
+      expect(result.liquidityPoolDiff.currentTotalLiquidityUSD).toBe(
+        22n * TEN_TO_THE_18_BI,
+      );
     });
 
     it("should handle undefined tokens with fallback to pool prices", async () => {

--- a/test/EventHandlers/Pool/PoolSyncLogic.test.ts
+++ b/test/EventHandlers/Pool/PoolSyncLogic.test.ts
@@ -118,9 +118,8 @@ describe("PoolSyncLogic", () => {
         mockToken1,
       );
 
-      // Current total: 2000n, New total: 1000000000004000n, Incremental change: 1000000000002000n
-      expect(result.liquidityPoolDiff?.incrementalCurrentLiquidityUSD).toBe(
-        1000000000002000n,
+      expect(result.liquidityPoolDiff?.currentTotalLiquidityUSD).toBe(
+        1000000000004000n,
       );
     });
 
@@ -132,9 +131,8 @@ describe("PoolSyncLogic", () => {
         undefined,
       );
 
-      // Current: 2000n, New: 1000000000000000n, Incremental change: 999999999998000n
-      expect(result.liquidityPoolDiff?.incrementalCurrentLiquidityUSD).toBe(
-        999999999998000n,
+      expect(result.liquidityPoolDiff?.currentTotalLiquidityUSD).toBe(
+        1000000000000000n,
       );
     });
 
@@ -146,15 +144,10 @@ describe("PoolSyncLogic", () => {
         mockToken1,
       );
 
-      // Current: 1000 * 10^0 * 2 USD = 2000n
-      // New: 2000 * 10^0 * 2 USD = 4000n
-      // Incremental change: 4000n - 2000n = 2000n
-      expect(result.liquidityPoolDiff?.incrementalCurrentLiquidityUSD).toBe(
-        2000n,
-      );
+      expect(result.liquidityPoolDiff?.currentTotalLiquidityUSD).toBe(4000n);
     });
 
-    it("should use existing incrementalCurrentLiquidityUSD when no tokens are available", () => {
+    it("should leave totalLiquidityUSD unchanged when no tokens are available", () => {
       const result = processPoolSync(
         mockEvent,
         mockLiquidityPoolAggregator,
@@ -163,7 +156,7 @@ describe("PoolSyncLogic", () => {
       );
 
       // No tokens available: keep existing values (no change)
-      expect(result.liquidityPoolDiff?.incrementalCurrentLiquidityUSD).toBe(0n);
+      expect(result.liquidityPoolDiff.currentTotalLiquidityUSD).toBeUndefined();
     });
 
     it("should handle different token decimals correctly", () => {
@@ -179,9 +172,8 @@ describe("PoolSyncLogic", () => {
         mockToken1,
       );
 
-      // Current: 2000n, New: 10000000004000n, Incremental change: 10000000002000n
-      expect(result.liquidityPoolDiff?.incrementalCurrentLiquidityUSD).toBe(
-        10000000002000n,
+      expect(result.liquidityPoolDiff?.currentTotalLiquidityUSD).toBe(
+        10000000004000n,
       );
     });
 
@@ -205,11 +197,7 @@ describe("PoolSyncLogic", () => {
         incrementalReserve0: -500n, // Set to zero: subtract current reserves
         incrementalReserve1: -1000n, // Set to zero: subtract current reserves
       });
-      // Zero amounts: set reserves to zero (snapshot behavior)
-      // This means subtracting current reserves to get to zero
-      expect(result.liquidityPoolDiff?.incrementalCurrentLiquidityUSD).toBe(
-        -2000n,
-      );
+      expect(result.liquidityPoolDiff?.currentTotalLiquidityUSD).toBe(0n);
     });
 
     it("should handle missing token instances gracefully", () => {


### PR DESCRIPTION
closes #555 

Implements:
- Updated logic for computation of total liquidity in USD on pool entity: instead of being based on delta from events, we derived directly from updated `reserve0` and `reserve1` fields (similar flow/logic to that of staked liquidity USD)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Liquidity tracking updated: pool operations (mint, burn, swap, sync) now report current total liquidity USD (post-change) rather than incremental deltas; explicit total overrides supported.
* **Tests**
  * Updated and added tests to validate overwrite vs incremental behaviors and to assert the new total-liquidity reporting across pool scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->