### PR TITLE
Price connectors fix for V1/V2 price oracles

### DIFF
--- a/scripts/validate-price-connectors.ts
+++ b/scripts/validate-price-connectors.ts
@@ -1,0 +1,178 @@
+/**
+ * Validates that every price connector in price_connectors.json is a real ERC20:
+ * has contract code and a callable decimals() that returns a valid uint8.
+ *
+ * Usage:
+ *   pnpm tsx scripts/validate-price-connectors.ts
+ *
+ * Uses default RPC URLs from Constants (env vars override when set for the indexer).
+ */
+
+import "dotenv/config";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { http, createPublicClient } from "viem";
+import { RPC_HTTP_OPTIONS } from "../src/Constants";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/** Max concurrent RPCs per chain to avoid rate limits */
+const CONCURRENCY = 10;
+
+const ERC20_DECIMALS_ABI = [
+  {
+    inputs: [],
+    name: "decimals",
+    outputs: [{ internalType: "uint8", name: "", type: "uint8" }],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;
+
+/** Map price_connectors.json top-level key to chain ID */
+const CHAIN_KEY_TO_CHAIN_ID: Record<string, number> = {
+  optimism: 10,
+  base: 8453,
+  mode: 34443,
+  lisk: 1135,
+  fraxtal: 252,
+  soneium: 1868,
+  ink: 57073,
+  metal: 1750,
+  unichain: 130,
+  celo: 42220,
+  swellchain: 1923,
+};
+
+type PriceConnector = { address: string; createdBlock: number };
+type ConnectorReport = {
+  chain: string;
+  address: string;
+  status: "ok" | "no_code" | "decimals_failed";
+  decimals?: number;
+  error?: string;
+};
+
+async function validateConnector(
+  client: ReturnType<typeof createPublicClient>,
+  address: string,
+): Promise<{
+  status: "ok" | "no_code" | "decimals_failed";
+  decimals?: number;
+  error?: string;
+}> {
+  const code = await client.getBytecode({ address: address as `0x${string}` });
+  if (!code || code === "0x" || code.length <= 2) {
+    return { status: "no_code" };
+  }
+  try {
+    const decimals = await client.readContract({
+      address: address as `0x${string}`,
+      abi: ERC20_DECIMALS_ABI,
+      functionName: "decimals",
+    });
+    return { status: "ok", decimals: Number(decimals) };
+  } catch (err) {
+    return {
+      status: "decimals_failed",
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+async function main(): Promise<void> {
+  const jsonPath = path.join(
+    __dirname,
+    "..",
+    "src",
+    "constants",
+    "price_connectors.json",
+  );
+  const raw = readFileSync(jsonPath, "utf-8");
+  const connectorsByChain = JSON.parse(raw) as Record<string, PriceConnector[]>;
+
+  const reports: ConnectorReport[] = [];
+
+  for (const [chainKey, connectors] of Object.entries(connectorsByChain)) {
+    const chainId = CHAIN_KEY_TO_CHAIN_ID[chainKey];
+    if (chainId == null) {
+      console.warn(`Unknown chain key "${chainKey}", skipping.`);
+      continue;
+    }
+    const envRpcKey =
+      chainKey === "swellchain"
+        ? "ENVIO_SWELL_RPC_URL"
+        : `ENVIO_${chainKey.toUpperCase()}_RPC_URL`;
+    const rpcUrl = process.env[envRpcKey];
+    if (!rpcUrl) {
+      console.warn(
+        `No RPC URL for chain ${chainKey} (chainId ${chainId}), skipping.`,
+      );
+      continue;
+    }
+
+    const client = createPublicClient({
+      transport: http(rpcUrl, RPC_HTTP_OPTIONS),
+    });
+
+    for (let i = 0; i < connectors.length; i += CONCURRENCY) {
+      const chunk = connectors.slice(i, i + CONCURRENCY);
+      const settled = await Promise.allSettled(
+        chunk.map(({ address }) =>
+          validateConnector(client, address).then((result) => ({
+            address,
+            result,
+          })),
+        ),
+      );
+      for (let j = 0; j < settled.length; j++) {
+        const s = settled[j];
+        const address = chunk[j].address;
+        if (s.status === "fulfilled") {
+          const { result } = s.value;
+          reports.push({
+            chain: chainKey,
+            address,
+            status: result.status,
+            decimals: result.decimals,
+            error: result.error,
+          });
+        } else {
+          reports.push({
+            chain: chainKey,
+            address,
+            status: "decimals_failed",
+            error:
+              s.reason instanceof Error ? s.reason.message : String(s.reason),
+          });
+        }
+      }
+    }
+  }
+
+  const invalid = reports.filter((r) => r.status !== "ok");
+  const ok = reports.filter((r) => r.status === "ok");
+
+  console.log("--- Price connector validation report ---\n");
+  if (invalid.length > 0) {
+    console.log("INVALID (no code or decimals() failed):");
+    for (const r of invalid) {
+      console.log(
+        `  ${r.chain} ${r.address}  ${r.status}${r.error ? `  ${r.error}` : ""}`,
+      );
+    }
+    console.log("");
+  }
+  console.log(
+    `Total: ${reports.length}  OK: ${ok.length}  Invalid: ${invalid.length}\n`,
+  );
+  if (invalid.length > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/constants/price_connectors.json
+++ b/src/constants/price_connectors.json
@@ -45,10 +45,6 @@
       "createdBlock": 10
     },
     {
-      "address": "0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF",
-      "createdBlock": 1
-    },
-    {
       "address": "0x4200000000000000000000000000000000000006",
       "createdBlock": 1
     },
@@ -91,10 +87,6 @@
       "createdBlock": 2062407
     },
     {
-      "address": "0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF",
-      "createdBlock": 1
-    },
-    {
       "address": "0x4200000000000000000000000000000000000006",
       "createdBlock": 1
     },
@@ -104,10 +96,6 @@
     }
   ],
   "mode": [
-    {
-      "address": "0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF",
-      "createdBlock": 1
-    },
     {
       "address": "0x4200000000000000000000000000000000000006",
       "createdBlock": 1
@@ -126,10 +114,6 @@
     }
   ],
   "lisk": [
-    {
-      "address": "0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF",
-      "createdBlock": 1
-    },
     {
       "address": "0x05D032ac25d322df992303dCa074EE7392C117b9",
       "createdBlock": 1639961
@@ -179,17 +163,9 @@
     {
       "address": "0x4200000000000000000000000000000000000006",
       "createdBlock": 1
-    },
-    {
-      "address": "0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF",
-      "createdBlock": 1
     }
   ],
   "soneium": [
-    {
-      "address": "0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF",
-      "createdBlock": 1
-    },
     {
       "address": "0xbA9986D2381edf1DA03B0B9c1f8b00dc4AacC369",
       "createdBlock": 1
@@ -205,10 +181,6 @@
   ],
   "ink": [
     {
-      "address": "0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF",
-      "createdBlock": 1
-    },
-    {
       "address": "0xF1815bd50389c46847f0Bda824eC8da914045D14",
       "createdBlock": 1
     },
@@ -222,10 +194,6 @@
     }
   ],
   "metal": [
-    {
-      "address": "0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF",
-      "createdBlock": 1
-    },
     {
       "address": "0xb91CFCcA485C6E40E3bC622f9BFA02a8ACdEeBab",
       "createdBlock": 1
@@ -244,10 +212,6 @@
     }
   ],
   "unichain": [
-    {
-      "address": "0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF",
-      "createdBlock": 1
-    },
     {
       "address": "0x4200000000000000000000000000000000000006",
       "createdBlock": 1
@@ -271,10 +235,6 @@
   ],
   "celo": [
     {
-      "address": "0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF",
-      "createdBlock": 1
-    },
-    {
       "address": "0xD221812de1BD094f35587EE8E174B07B6167D9Af",
       "createdBlock": 1
     },
@@ -292,10 +252,6 @@
     }
   ],
   "swellchain": [
-    {
-      "address": "0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF",
-      "createdBlock": 1
-    },
     {
       "address": "0x4200000000000000000000000000000000000006",
       "createdBlock": 1


### PR DESCRIPTION
Implements:
- Removal of `0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF` from price connectors which was causing contract execution reverts (seems that only v3/v4 price oracles accept `0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF` - but even in these I've deleted because doesn't seem important)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed invalid price connector entries across multiple blockchains to improve price accuracy.

* **Chores**
  * Added connector validation that verifies listed tokens and reports invalid entries, preventing use of bad connectors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->