### PR TITLE
perf: skip empty CLGaugeConfig query and thread poolData into snapshot

### DIFF
--- a/src/Aggregators/UserStatsPerPool.ts
+++ b/src/Aggregators/UserStatsPerPool.ts
@@ -8,6 +8,7 @@ import {
 import { computeNonCLStakedUSD, concentratedLiquidityToUSD } from "../Helpers";
 import { getSnapshotEpoch, shouldSnapshot } from "../Snapshots/Shared";
 import { setUserStatsPerPoolSnapshot } from "../Snapshots/UserStatsPerPoolSnapshot";
+import type { PoolData } from "./LiquidityPoolAggregator";
 
 export interface UserStatsPerPoolDiff {
   incrementalCurrentLiquidityUSD: bigint;
@@ -196,6 +197,7 @@ export async function updateUserStatsPerPool(
   current: UserStatsPerPool,
   context: handlerContext,
   timestamp: Date,
+  preloadedPoolData?: PoolData,
 ): Promise<UserStatsPerPool> {
   let updated: UserStatsPerPool = {
     ...current,
@@ -399,13 +401,23 @@ export async function updateUserStatsPerPool(
     if (updated.currentLiquidityStaked === 0n) {
       updated = { ...updated, currentLiquidityStakedUSD: 0n };
     } else if (updated.currentLiquidityStaked > 0n) {
-      const poolId = PoolId(updated.chainId, updated.poolAddress);
-      const poolEntity = await context.LiquidityPoolAggregator.get(poolId);
+      // Reuse caller-provided poolData when available (saves 3 redundant entity loads
+      // per snapshot when the caller already loaded pool + token0 + token1).
+      let poolEntity = preloadedPoolData?.liquidityPoolAggregator;
+      let token0Instance = preloadedPoolData?.token0Instance;
+      let token1Instance = preloadedPoolData?.token1Instance;
+      if (!poolEntity) {
+        const poolId = PoolId(updated.chainId, updated.poolAddress);
+        poolEntity =
+          (await context.LiquidityPoolAggregator.get(poolId)) ?? undefined;
+        if (poolEntity) {
+          [token0Instance, token1Instance] = await Promise.all([
+            context.Token.get(poolEntity.token0_id),
+            context.Token.get(poolEntity.token1_id),
+          ]);
+        }
+      }
       if (poolEntity) {
-        const [token0Instance, token1Instance] = await Promise.all([
-          context.Token.get(poolEntity.token0_id),
-          context.Token.get(poolEntity.token1_id),
-        ]);
         const poolData = {
           liquidityPoolAggregator: poolEntity,
           token0Instance: token0Instance ?? undefined,

--- a/src/EventHandlers/CLFactory.ts
+++ b/src/EventHandlers/CLFactory.ts
@@ -16,14 +16,17 @@ CLFactory.PoolCreated.contractRegister(({ event, context }) => {
 });
 
 CLFactory.PoolCreated.handler(async ({ event, context }) => {
+  const newCLGaugeFactoryAddress =
+    CHAIN_CONSTANTS[event.chainId].newCLGaugeFactoryAddress;
+
   // Load token instances efficiently
   const [poolToken0, poolToken1, CLGaugeConfig, feeToTickSpacingMapping] =
     await Promise.all([
       context.Token.get(TokenId(event.chainId, event.params.token0)),
       context.Token.get(TokenId(event.chainId, event.params.token1)),
-      context.CLGaugeConfig.get(
-        CHAIN_CONSTANTS[event.chainId].newCLGaugeFactoryAddress,
-      ),
+      newCLGaugeFactoryAddress
+        ? context.CLGaugeConfig.get(newCLGaugeFactoryAddress)
+        : Promise.resolve(undefined),
       context.FeeToTickSpacingMapping.get(
         FeeToTickSpacingMappingId(event.chainId, event.params.tickSpacing),
       ),

--- a/src/EventHandlers/Gauges/GaugeSharedLogic.ts
+++ b/src/EventHandlers/Gauges/GaugeSharedLogic.ts
@@ -328,7 +328,7 @@ export async function processGaugeDeposit(
       data.chainId,
       data.blockNumber,
     ),
-    updateUserStatsPerPool(userDiff, userData, context, timestamp),
+    updateUserStatsPerPool(userDiff, userData, context, timestamp, poolData),
   ]);
 }
 
@@ -442,7 +442,7 @@ export async function processGaugeWithdraw(
       data.chainId,
       data.blockNumber,
     ),
-    updateUserStatsPerPool(userDiff, userData, context, timestamp),
+    updateUserStatsPerPool(userDiff, userData, context, timestamp, poolData),
   ]);
 }
 
@@ -538,6 +538,6 @@ export async function processGaugeClaimRewards(
       data.chainId,
       data.blockNumber,
     ),
-    updateUserStatsPerPool(userDiff, userData, context, timestamp),
+    updateUserStatsPerPool(userDiff, userData, context, timestamp, poolData),
   ]);
 }


### PR DESCRIPTION
## Summary

Two small, low-risk preload optimizations surfaced by the April 2026 metrics analysis in #589.

### 1. Skip `CLGaugeConfig` query when factory address is empty — closes #590

`CLFactory.PoolCreated` previously queried `context.CLGaugeConfig.get(newCLGaugeFactoryAddress)` on every pool-creation event. On 10 of 12 chains that address is `""`, so the query was a guaranteed miss. Guarded behind a truthiness check while preserving `Promise.all` parallelism for the other three loads.

Metrics impact: ~770s preload savings (~0.25% of the 308k s preload). Trivially safe — downstream already accepts `CLGaugeConfig | undefined`.

### 2. Thread `poolData` into `updateUserStatsPerPool` snapshot path — partial #592

`processGaugeDeposit`, `processGaugeWithdraw`, and `processGaugeClaimRewards` already `loadPoolData()` (fetching `LiquidityPoolAggregator` + `Token0` + `Token1`). The hourly-snapshot branch of `updateUserStatsPerPool` was re-fetching all three. Added an optional `preloadedPoolData?: PoolData` parameter and plumbed it through the three gauge handlers. Fallback path preserved for the 30 other callers.

Metrics impact: low thousands to ~10k seconds saved on preload (a few %). Problem 2 from the original #592 description is obsolete — `computeCLStakedUSDFromPositions` was already removed in #588, and the proposed proportional-share formula is a correctness regression for CL pools (positions have different tick ranges → share of liquidity units ≠ share of USD value). Issue #592 should be updated to close out once this lands.

## What changed

- `src/EventHandlers/CLFactory.ts` — ternary guard around `CLGaugeConfig.get` inside the `Promise.all`
- `src/Aggregators/UserStatsPerPool.ts` — new optional `preloadedPoolData` parameter; snapshot branch prefers it over re-fetching
- `src/EventHandlers/Gauges/GaugeSharedLogic.ts` — three call sites now pass `poolData` through

## Test plan

- [x] `pnpm envio codegen` — regenerated
- [x] `tsc --noEmit` — no new errors (pre-existing `Effect` type errors are unrelated)
- [x] `pnpm qa --write` — clean (Biome auto-formatted one file)
- [x] `pnpm test` — 1023 passed, 32 skipped, 0 failed
- [ ] Smoke-test against a real chain after merge to confirm the measured delta matches prediction

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized data loading patterns to reduce redundant operations in pool and gauge processing
  * Improved async operation efficiency in configuration initialization
  * Enhanced data reuse mechanisms across related operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->