### PR TITLE
perf: thread poolData into updateUserStatsPerPool on 11 more call sites

### DIFF
--- a/src/EventHandlers/CLPool.ts
+++ b/src/EventHandlers/CLPool.ts
@@ -119,7 +119,7 @@ CLPool.Collect.handler(async ({ event, context }) => {
       event.chainId,
       event.block.number,
     ),
-    updateUserStatsPerPool(userDiff, userData, context, timestamp),
+    updateUserStatsPerPool(userDiff, userData, context, timestamp, poolData),
   ]);
 });
 
@@ -176,7 +176,7 @@ CLPool.CollectFees.handler(async ({ event, context }) => {
       event.chainId,
       event.block.number,
     ),
-    updateUserStatsPerPool(userDiff, userData, context, timestamp),
+    updateUserStatsPerPool(userDiff, userData, context, timestamp, poolData),
   ]);
 });
 
@@ -224,7 +224,15 @@ CLPool.Flash.handler(async ({ event, context }) => {
       event.block.number,
     ),
     ...((userDiff.incrementalTotalFlashLoanVolumeUSD ?? 0n) > 0n
-      ? [updateUserStatsPerPool(userDiff, userData, context, timestamp)]
+      ? [
+          updateUserStatsPerPool(
+            userDiff,
+            userData,
+            context,
+            timestamp,
+            poolData,
+          ),
+        ]
       : []),
   ]);
 });
@@ -394,7 +402,7 @@ CLPool.Swap.handler(async ({ event, context }) => {
       event.chainId,
       event.block.number,
     ),
-    updateUserStatsPerPool(userDiff, userData, context, timestamp),
+    updateUserStatsPerPool(userDiff, userData, context, timestamp, poolData),
   ]);
 
   // Create OUSDTSwaps entity

--- a/src/EventHandlers/NFPM/NFPMCommonLogic.ts
+++ b/src/EventHandlers/NFPM/NFPMCommonLogic.ts
@@ -106,7 +106,13 @@ export async function attributeLiquidityChangeToUserStatsPerPool(
           lastActivityTimestamp: timestamp,
         };
 
-  await updateUserStatsPerPool(userDiff, userData, context, timestamp);
+  await updateUserStatsPerPool(
+    userDiff,
+    userData,
+    context,
+    timestamp,
+    poolData,
+  );
 }
 
 /**

--- a/src/EventHandlers/Pool.ts
+++ b/src/EventHandlers/Pool.ts
@@ -35,16 +35,12 @@ Pool.Mint.handler(async ({ event, context }) => {
     return;
   }
 
-  const { liquidityPoolAggregator, token0Instance, token1Instance } = poolData;
-
   // Process mint event using shared logic
   await processPoolLiquidityEvent(
     event,
-    liquidityPoolAggregator,
+    poolData,
     poolAddress,
     chainId,
-    token0Instance,
-    token1Instance,
     context,
     timestamp,
     event.block.number,
@@ -70,16 +66,12 @@ Pool.Burn.handler(async ({ event, context }) => {
     return;
   }
 
-  const { liquidityPoolAggregator, token0Instance, token1Instance } = poolData;
-
   // Process burn event using shared logic
   await processPoolLiquidityEvent(
     event,
-    liquidityPoolAggregator,
+    poolData,
     poolAddress,
     chainId,
-    token0Instance,
-    token1Instance,
     context,
     timestamp,
     event.block.number,
@@ -133,7 +125,7 @@ Pool.Fees.handler(async ({ event, context }) => {
         )
       : Promise.resolve(),
     userDiff
-      ? updateUserStatsPerPool(userDiff, userData, context, timestamp)
+      ? updateUserStatsPerPool(userDiff, userData, context, timestamp, poolData)
       : Promise.resolve(),
   ]);
 });
@@ -181,7 +173,13 @@ Pool.Swap.handler(async ({ event, context }) => {
       event.chainId,
       event.block.number,
     ),
-    updateUserStatsPerPool(userSwapDiff, userData, context, timestamp),
+    updateUserStatsPerPool(
+      userSwapDiff,
+      userData,
+      context,
+      timestamp,
+      poolData,
+    ),
   ]);
 
   // Create OUSDTSwaps entity only if oUSDT is involved
@@ -316,6 +314,12 @@ Pool.Claim.handler(async ({ event, context }) => {
       event.chainId,
       event.block.number,
     ),
-    updateUserStatsPerPool(result.userDiff, userData, context, timestamp),
+    updateUserStatsPerPool(
+      result.userDiff,
+      userData,
+      context,
+      timestamp,
+      poolData,
+    ),
   ]);
 });

--- a/src/EventHandlers/Pool/PoolBurnAndMintLogic.ts
+++ b/src/EventHandlers/Pool/PoolBurnAndMintLogic.ts
@@ -1,12 +1,14 @@
 import type {
-  LiquidityPoolAggregator,
   PoolTransferInTx,
   Pool_Burn_event,
   Pool_Mint_event,
   Token,
   handlerContext,
 } from "generated";
-import { updateLiquidityPoolAggregator } from "../../Aggregators/LiquidityPoolAggregator";
+import {
+  type PoolData,
+  updateLiquidityPoolAggregator,
+} from "../../Aggregators/LiquidityPoolAggregator";
 import {
   loadOrCreateUserData,
   updateUserStatsPerPool,
@@ -200,11 +202,9 @@ export async function findTransferAndAttribute(
 /**
  * Process Pool Mint or Burn event with Transfer matching and USD attribution
  * @param event - Mint or Burn event
- * @param liquidityPoolAggregator - Pool aggregator entity
+ * @param poolData - Preloaded pool data (aggregator + token instances)
  * @param poolAddress - Pool address
  * @param chainId - Chain ID
- * @param token0Instance - Token0 instance
- * @param token1Instance - Token1 instance
  * @param context - Handler context
  * @param timestamp - Event timestamp
  * @param blockNumber - Block number
@@ -212,16 +212,15 @@ export async function findTransferAndAttribute(
  */
 export async function processPoolLiquidityEvent(
   event: Pool_Mint_event | Pool_Burn_event,
-  liquidityPoolAggregator: LiquidityPoolAggregator,
+  poolData: PoolData,
   poolAddress: string,
   chainId: number,
-  token0Instance: Token,
-  token1Instance: Token,
   context: handlerContext,
   timestamp: Date,
   blockNumber: number,
   isMint: boolean,
 ): Promise<void> {
+  const { liquidityPoolAggregator, token0Instance, token1Instance } = poolData;
   const txHash = event.transaction.hash;
   const eventLogIndex = event.logIndex;
 
@@ -280,6 +279,12 @@ export async function processPoolLiquidityEvent(
           lastActivityTimestamp: timestamp,
         };
 
-    await updateUserStatsPerPool(userDiff, userData, context, timestamp);
+    await updateUserStatsPerPool(
+      userDiff,
+      userData,
+      context,
+      timestamp,
+      poolData,
+    );
   }
 }

--- a/src/EventHandlers/Voter/Voter.ts
+++ b/src/EventHandlers/Voter/Voter.ts
@@ -171,7 +171,13 @@ Voter.Voted.handler(async ({ event, context }) => {
       event.chainId,
       event.block.number,
     ),
-    updateUserStatsPerPool(userStatsPerPoolDiff, userStats, context, timestamp),
+    updateUserStatsPerPool(
+      userStatsPerPoolDiff,
+      userStats,
+      context,
+      timestamp,
+      poolData,
+    ),
     updateVeNFTPoolVote(veNFTPoolVoteDiff, veNFTPoolVote, context),
   ]);
 });
@@ -262,7 +268,13 @@ Voter.Abstained.handler(async ({ event, context }) => {
       event.chainId,
       event.block.number,
     ),
-    updateUserStatsPerPool(userStatsPerPoolDiff, userStats, context, timestamp),
+    updateUserStatsPerPool(
+      userStatsPerPoolDiff,
+      userStats,
+      context,
+      timestamp,
+      poolData,
+    ),
     updateVeNFTPoolVote(veNFTPoolVoteDiff, veNFTPoolVote, context),
   ]);
 });

--- a/test/EventHandlers/Pool/PoolBurnAndMintLogic.test.ts
+++ b/test/EventHandlers/Pool/PoolBurnAndMintLogic.test.ts
@@ -1,5 +1,4 @@
 import type {
-  LiquidityPoolAggregator,
   PoolTransferInTx,
   Pool_Burn_event,
   Pool_Mint_event,
@@ -893,8 +892,10 @@ describe("PoolBurnAndMintLogic", () => {
   });
 
   describe("processPoolLiquidityEvent", () => {
-    const mockLiquidityPoolAggregator: LiquidityPoolAggregator = {
-      ...mockLiquidityPoolData,
+    const mockPoolData = {
+      liquidityPoolAggregator: { ...mockLiquidityPoolData },
+      token0Instance: mockToken0Data,
+      token1Instance: mockToken1Data,
     };
 
     it("should process mint event and update pool token prices", async () => {
@@ -911,11 +912,9 @@ describe("PoolBurnAndMintLogic", () => {
       const event = createMockMintEvent(2);
       await processPoolLiquidityEvent(
         event,
-        mockLiquidityPoolAggregator,
+        mockPoolData,
         POOL_ADDRESS,
         CHAIN_ID,
-        mockToken0Data,
-        mockToken1Data,
         mockContext,
         TIMESTAMP_DATE,
         BLOCK_NUMBER,
@@ -939,11 +938,9 @@ describe("PoolBurnAndMintLogic", () => {
       const event = createMockBurnEvent(2);
       await processPoolLiquidityEvent(
         event,
-        mockLiquidityPoolAggregator,
+        mockPoolData,
         POOL_ADDRESS,
         CHAIN_ID,
-        mockToken0Data,
-        mockToken1Data,
         mockContext,
         TIMESTAMP_DATE,
         BLOCK_NUMBER,
@@ -959,11 +956,9 @@ describe("PoolBurnAndMintLogic", () => {
       const event = createMockMintEvent(2);
       await processPoolLiquidityEvent(
         event,
-        mockLiquidityPoolAggregator,
+        mockPoolData,
         POOL_ADDRESS,
         CHAIN_ID,
-        mockToken0Data,
-        mockToken1Data,
         mockContext,
         TIMESTAMP_DATE,
         BLOCK_NUMBER,


### PR DESCRIPTION
## Summary

Extends PR #595's snapshot-plumbing pattern to every remaining caller that already has `PoolData` (or its three components) in scope. When the snapshot branch fires for a staked user in `updateUserStatsPerPool`, the preloaded pool + token instances skip three redundant entity lookups (`LiquidityPoolAggregator.get` + 2× `Token.get`).

## Sites touched (11 total)

| File | Handler / function |
|---|---|
| `CLPool.ts` | `Collect`, `CollectFees`, `Flash`, `Swap` |
| `Pool.ts` | `Fees`, `Swap`, `Claim` |
| `NFPM/NFPMCommonLogic.ts` | `attributeLiquidityChangeToUserStatsPerPool` |
| `Pool/PoolBurnAndMintLogic.ts` | `processPoolLiquidityEvent` (constructs `PoolData` inline) |
| `Voter/Voter.ts` | `Voted`, `Abstained` |

## Why this is free

Every touched call site already loaded `poolData` (or the three fields separately). The threading just passes the existing object as the 5th arg. No new fetches, no behavioural change.

## Expected impact

The snapshot bailout only fires when `currentLiquidityStaked > 0n` for the target user. Hit rates vary:

- **NFPM + PoolBurnAndMintLogic** (liquidity add/remove by staked LPs): high hit rate
- **Swap / Fees / Claim / Collect** (swapper or fee claimer happens to be a staked user): low hit rate
- **Voter.Voted/Abstained** (voter also has staked liquidity in same pool): very low hit rate

Threading cost is a pointer pass, so this is pure upside for the cases it does hit. Magnitude is modest per-event but aggregates across the highest-frequency handlers (Swap).

## Test plan

- [x] `pnpm qa --write` — biome clean
- [x] `pnpm test` — 1023 passed, 32 skipped (all pre-existing), no regressions
- [x] `tsc --noEmit` — no new type errors introduced (the 30-ish pre-existing Effect-API errors are unrelated)

## Dependency

This PR depends on PR #595 (the `preloadedPoolData?: PoolData` parameter on `updateUserStatsPerPool`). Base is set to `perf/589-590-592-snapshot-plumbing`. After #595 merges to main, rebase onto main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal user-per-pool statistics calls now include full pool context across multiple handlers; no changes to user-facing behavior or APIs.
* **Tests**
  * Updated unit tests to reflect the updated internal data shapes and call patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->