### PR TITLE
fix(gauge): clamp CLGauge withdraw when it exceeds indexed stake

### DIFF
--- a/src/EventHandlers/Gauges/GaugeSharedLogic.ts
+++ b/src/EventHandlers/Gauges/GaugeSharedLogic.ts
@@ -372,16 +372,29 @@ export async function processGaugeWithdraw(
 
   const { liquidityPoolAggregator } = poolData;
 
-  const newPoolStake =
-    liquidityPoolAggregator.currentLiquidityStaked - data.amount;
-  const newUserStake = userData.currentLiquidityStaked - data.amount;
+  // Clamp the pool and user decrements independently to each aggregate's
+  // current stake. On-chain reality is the source of truth: when a Withdraw
+  // exceeds the indexer's view of stake, a prior Deposit was missed
+  // (attribution gap, event ordering, cross-chain migration, etc.).
+  // Previously this branch skipped the update entirely, which left
+  // currentLiquidityStaked permanently inflated with no recovery path.
+  const poolDecrement =
+    data.amount <= liquidityPoolAggregator.currentLiquidityStaked
+      ? data.amount
+      : liquidityPoolAggregator.currentLiquidityStaked;
+  const userDecrement =
+    data.amount <= userData.currentLiquidityStaked
+      ? data.amount
+      : userData.currentLiquidityStaked;
 
-  if (newPoolStake < 0n || newUserStake < 0n) {
-    context.log.error(
-      `${handlerName}: withdraw exceeds current stake for pool ${pool.poolAddress} user ${data.userAddress}. Skipping update. This needs to be fixed.`,
+  if (poolDecrement < data.amount || userDecrement < data.amount) {
+    context.log.warn(
+      `${handlerName}: withdraw ${data.amount} exceeds indexed stake (pool=${liquidityPoolAggregator.currentLiquidityStaked}, user=${userData.currentLiquidityStaked}) for pool ${pool.poolAddress} user ${data.userAddress} on chain ${data.chainId}. Clamping to available stake.`,
     );
-    return;
   }
+
+  const newPoolStake =
+    liquidityPoolAggregator.currentLiquidityStaked - poolDecrement;
 
   let poolStakedUSD: bigint | undefined;
   let stakedLiquidityInRange: bigint | undefined;
@@ -411,7 +424,7 @@ export async function processGaugeWithdraw(
 
   const poolDiff = {
     incrementalNumberOfGaugeWithdrawals: 1n,
-    incrementalCurrentLiquidityStaked: -data.amount,
+    incrementalCurrentLiquidityStaked: -poolDecrement,
     currentLiquidityStakedUSD: poolStakedUSD,
     stakedLiquidityInRange,
     incrementalStakedReserve0,
@@ -428,7 +441,7 @@ export async function processGaugeWithdraw(
 
   const userDiff = {
     incrementalNumberOfGaugeWithdrawals: 1n,
-    incrementalCurrentLiquidityStaked: -data.amount,
+    incrementalCurrentLiquidityStaked: -userDecrement,
     stakedCLPositionTokenIds,
     lastActivityTimestamp: timestamp,
   };

--- a/test/EventHandlers/Gauges/GaugeSharedLogic.test.ts
+++ b/test/EventHandlers/Gauges/GaugeSharedLogic.test.ts
@@ -474,6 +474,100 @@ describe("GaugeSharedLogic", () => {
         200000000000000000000n,
       );
     });
+
+    describe("withdraw exceeds current stake (issue #604)", () => {
+      it("clamps to zero and records withdrawal when user has no prior indexed stake", async () => {
+        // Simulate a missed Deposit attribution: user issues a Withdraw event for an
+        // amount the indexer never saw deposited. Prior to the fix, this branch
+        // silently skipped the update, leaving aggregates stuck forever.
+        const logWarnSpy = vi.fn();
+        const logErrorSpy = vi.fn();
+        const ctx = {
+          ...mockContext,
+          log: {
+            ...mockContext.log,
+            warn: logWarnSpy,
+            error: logErrorSpy,
+          },
+        };
+
+        await processGaugeWithdraw(
+          {
+            gaugeAddress: mockGaugeAddress,
+            userAddress: mockUserAddress,
+            chainId: mockChainId,
+            blockNumber: 100,
+            timestamp: 1000000,
+            amount: 50000000000000000000n,
+          },
+          ctx,
+          "TestGaugeWithdraw",
+        );
+
+        const updatedPool = updatedDB.entities.LiquidityPoolAggregator.get(
+          mockLiquidityPoolAggregator.id,
+        );
+        const updatedUser = updatedDB.entities.UserStatsPerPool.get(
+          mockUserStatsPerPool.id,
+        );
+
+        // Pool and user staked counters are clamped to zero (not left at a
+        // dangling inflated value and not made negative).
+        expect(updatedPool?.currentLiquidityStaked).toBe(0n);
+        expect(updatedUser?.currentLiquidityStaked).toBe(0n);
+        // The withdrawal itself is recorded so downstream counters stay honest.
+        expect(updatedPool?.numberOfGaugeWithdrawals).toBe(1n);
+        expect(updatedUser?.numberOfGaugeWithdrawals).toBe(1n);
+        // Visibility: one warning, no error — event is handled, not skipped.
+        expect(logWarnSpy).toHaveBeenCalledTimes(1);
+        expect(logErrorSpy).not.toHaveBeenCalled();
+      });
+
+      it("clamps pool counter when pool is short but user has prior stake", async () => {
+        // User has stake recorded but pool aggregate is behind — simulates a
+        // partial-attribution inconsistency across the two aggregates.
+        mockUserStatsPerPool = {
+          ...mockUserStatsPerPool,
+          currentLiquidityStaked: 100000000000000000000n,
+        };
+        updatedDB =
+          updatedDB.entities.UserStatsPerPool.set(mockUserStatsPerPool);
+
+        const logWarnSpy = vi.fn();
+        const ctx = {
+          ...mockContext,
+          log: { ...mockContext.log, warn: logWarnSpy },
+        };
+
+        await processGaugeWithdraw(
+          {
+            gaugeAddress: mockGaugeAddress,
+            userAddress: mockUserAddress,
+            chainId: mockChainId,
+            blockNumber: 100,
+            timestamp: 1000000,
+            amount: 50000000000000000000n,
+          },
+          ctx,
+          "TestGaugeWithdraw",
+        );
+
+        const updatedPool = updatedDB.entities.LiquidityPoolAggregator.get(
+          mockLiquidityPoolAggregator.id,
+        );
+        const updatedUser = updatedDB.entities.UserStatsPerPool.get(
+          mockUserStatsPerPool.id,
+        );
+
+        // Pool counter was 0 — clamped to 0 (can't go below).
+        expect(updatedPool?.currentLiquidityStaked).toBe(0n);
+        // User counter debits only what the pool can actually absorb so the
+        // two aggregates stay consistent after clamping.
+        expect(updatedUser?.currentLiquidityStaked).toBe(50000000000000000000n);
+        expect(updatedPool?.numberOfGaugeWithdrawals).toBe(1n);
+        expect(logWarnSpy).toHaveBeenCalledTimes(1);
+      });
+    });
   });
 
   describe("processGaugeClaimRewards", () => {


### PR DESCRIPTION
## Summary

Resolves #604. Replace the silent-skip `"This needs to be fixed"` TODO branch in `processGaugeWithdraw` with an independent clamp on the pool and user aggregate decrements. When a `Withdraw` arrives for more liquidity than the indexer has seen deposited, the on-chain transaction is the source of truth — so the handler now clamps each aggregate to `max(0, current - amount)`, still increments the withdrawal count, and emits a single warning that captures the discrepancy.

## Why this is safe

- The CL-specific bookkeeping (tick liquidity, `stakedReserve0/1`, `stakedLiquidityInRange`) is already driven by `position.liquidity`, not the event amount, so tick/reserve accounting remains correct.
- Pool and user aggregates are clamped independently, preserving the invariant `currentLiquidityStaked >= 0` on both sides.
- `stakedCLPositionTokenIds` is still filtered for the withdrawn `tokenId` — the user no longer appears to hold a position they just withdrew.
- Previously 59 events on Superseed left `stakedLiquidity` permanently inflated with no recovery path. With the clamp, subsequent Deposit/Withdraw attribution can re-converge on the correct value.

## Root-cause diagnosis

All 59 errors share chain 5330 (Superseed) and no cross-chain signature, which points to **missed Deposit attribution** rather than an event-ordering race or bridged initial state. The silent-skip branch made this manifest as permanent overcount instead of a single diagnostic error at the first failed withdraw. Clamping converts it from "permanent corruption" to "converges once the next valid event flows through."

## Tests

Added two regression scenarios in `test/EventHandlers/Gauges/GaugeSharedLogic.test.ts` under `processGaugeWithdraw > withdraw exceeds current stake (issue #604)`:

- Withdraw with no prior indexed stake — clamps both pool and user to zero, still records the withdrawal, emits one warning, no error.
- Withdraw where only the pool aggregate is short — pool clamps to zero while user decrements normally; the two aggregates stay independently consistent.

`pnpm qa --write` clean. `pnpm test` green: 1025 passed, 32 skipped across 90 files.

## Post-Deploy Monitoring & Validation

- **Log query:** search for `withdraw .* exceeds indexed stake` on chain 5330.
  - Expected: count drops to zero for new blocks after deploy (no further missed-attribution producers on Superseed that the indexer can retroactively uncover).
  - Residual warnings on older blocks during backfill are expected (the original 59); they now clamp instead of skipping.
- **Metric to watch:** Superseed `CLGauge.Withdraw` error count in Envio `/metrics` histograms — should transition from recurring `uerror` to a bounded one-time `uwarn` set and then zero on post-deploy blocks.
- **Healthy signal:** `LiquidityPoolAggregator.currentLiquidityStaked` on affected Superseed CL pools trends toward on-chain reality rather than drifting upward.
- **Failure signal / rollback trigger:** new `uerror`-level gauge events, pool-level `currentLiquidityStaked` going negative (shouldn't be possible with the clamp), or tick-liquidity regressions on non-affected chains. Roll back by reverting this commit — the pre-existing skip behavior resumes.
- **Validation window:** 48 hours post-deploy with the first full backfill cycle.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>