### PR TITLE
fix(superswaps): filter non-OUSDT CrossChainSwap events and escalate real correlation failures to uerror

### DIFF
--- a/src/EventHandlers/SuperswapsHyperlane/SuperSwapLogic.ts
+++ b/src/EventHandlers/SuperswapsHyperlane/SuperSwapLogic.ts
@@ -308,6 +308,80 @@ export async function processCrossChainSwap(
 }
 
 /**
+ * Handles a CrossChainSwap event by loading the OUSDT bridge record and related
+ * mailbox state, then delegating to processCrossChainSwap for SuperSwap entity
+ * creation.
+ *
+ * CrossChainSwap fires for every cross-chain swap through VelodromeUniversalRouter,
+ * including non-OUSDT bridges that the UniversalRouterBridge producer filtered out.
+ * To avoid spamming warnings for those non-OUSDT bridges, this function treats the
+ * absence of an OUSDTBridgedTransaction as an error ONLY when an OUSDTSwaps record
+ * for the same transaction exists (meaning OUSDT was actually swapped but the
+ * bridge correlation is missing).
+ */
+export async function handleCrossChainSwapEvent(
+  transactionHash: string,
+  chainId: number,
+  destinationDomain: bigint,
+  blockTimestamp: number,
+  context: handlerContext,
+): Promise<void> {
+  const [oUSDTBridgedTransactions, sourceChainMessageIdEntities] =
+    await Promise.all([
+      context.OUSDTBridgedTransaction.getWhere({
+        transactionHash: { _eq: transactionHash },
+      }),
+      context.DispatchId_event.getWhere({
+        transactionHash: { _eq: transactionHash },
+      }),
+    ]);
+
+  if (oUSDTBridgedTransactions.length === 0) {
+    // Symmetric filter with the UniversalRouterBridge producer: CrossChainSwap
+    // fires for any bridged token, but OUSDTBridgedTransaction is only recorded
+    // when the bridged token is OUSDT. If no OUSDT pool swap exists for this
+    // transaction, this cross-chain swap did not involve OUSDT — silently skip.
+    const sourceChainOUSDTSwaps = await context.OUSDTSwaps.getWhere({
+      transactionHash: { _eq: transactionHash },
+    });
+    if (sourceChainOUSDTSwaps.length > 0) {
+      context.log.error(
+        `No OUSDTBridgedTransaction found for OUSDT swap at chain ${chainId} tx ${transactionHash}`,
+        new Error(
+          `Missing OUSDTBridgedTransaction for transaction ${transactionHash}`,
+        ),
+      );
+    }
+    return;
+  }
+
+  const bridgedTransaction = oUSDTBridgedTransactions[0];
+
+  if (sourceChainMessageIdEntities.length === 0) {
+    return;
+  }
+
+  const processIdPromises = sourceChainMessageIdEntities.map(
+    (entity: { messageId: string }) =>
+      context.ProcessId_event.getWhere({
+        messageId: { _eq: entity.messageId },
+      }),
+  );
+  const processIdResults = await Promise.all(processIdPromises);
+
+  await processCrossChainSwap(
+    sourceChainMessageIdEntities,
+    processIdResults,
+    bridgedTransaction,
+    transactionHash,
+    chainId,
+    destinationDomain,
+    blockTimestamp,
+    context,
+  );
+}
+
+/**
  * Attempts to create a SuperSwap entity when ProcessId is available.
  * This handles the case where ProcessId is processed after CrossChainSwap.
  * Since we are running Unordered Multichain Mode, there's no deterministic

--- a/src/EventHandlers/SuperswapsHyperlane/SuperSwapLogic.ts
+++ b/src/EventHandlers/SuperswapsHyperlane/SuperSwapLogic.ts
@@ -337,10 +337,13 @@ export async function handleCrossChainSwapEvent(
     ]);
 
   if (oUSDTBridgedTransactions.length === 0) {
-    // Symmetric filter with the UniversalRouterBridge producer: CrossChainSwap
-    // fires for any bridged token, but OUSDTBridgedTransaction is only recorded
-    // when the bridged token is OUSDT. If no OUSDT pool swap exists for this
-    // transaction, this cross-chain swap did not involve OUSDT — silently skip.
+    // No OUSDTBridgedTransaction for this tx — distinguish two cases via
+    // the OUSDTSwaps lookup, preserving symmetry with the UniversalRouterBridge
+    // producer (which only records OUSDTBridgedTransaction when token === OUSDT):
+    //   - sourceChainOUSDTSwaps.length > 0: OUSDT was swapped on source chain
+    //     but the bridge record is missing → real correlation failure, uerror.
+    //   - sourceChainOUSDTSwaps.length === 0: bridged token was not OUSDT,
+    //     so neither OUSDTBridgedTransaction nor OUSDTSwaps exist → silent skip.
     const sourceChainOUSDTSwaps = await context.OUSDTSwaps.getWhere({
       transactionHash: { _eq: transactionHash },
     });

--- a/src/EventHandlers/SuperswapsHyperlane/VelodromeUniversalRouter.ts
+++ b/src/EventHandlers/SuperswapsHyperlane/VelodromeUniversalRouter.ts
@@ -3,7 +3,7 @@ import {
   VelodromeUniversalRouter,
 } from "generated";
 import { OUSDT_ADDRESS } from "../../Constants";
-import { processCrossChainSwap } from "./SuperSwapLogic";
+import { handleCrossChainSwapEvent } from "./SuperSwapLogic";
 
 VelodromeUniversalRouter.UniversalRouterBridge.handler(
   async ({ event, context }) => {
@@ -27,45 +27,7 @@ VelodromeUniversalRouter.UniversalRouterBridge.handler(
 );
 
 VelodromeUniversalRouter.CrossChainSwap.handler(async ({ event, context }) => {
-  // Load all independent data in parallel
-  const [oUSDTBridgedTransactions, sourceChainMessageIdEntities] =
-    await Promise.all([
-      context.OUSDTBridgedTransaction.getWhere({
-        transactionHash: { _eq: event.transaction.hash },
-      }),
-      context.DispatchId_event.getWhere({
-        transactionHash: { _eq: event.transaction.hash },
-      }),
-    ]);
-
-  if (oUSDTBridgedTransactions.length === 0) {
-    context.log.warn(
-      `No OUSDTBridgedTransaction found for transaction ${event.transaction.hash}`,
-    );
-    return;
-  }
-
-  // Use the first bridged transaction (all should have the same transaction hash)
-  const bridgedTransaction = oUSDTBridgedTransactions[0];
-
-  if (sourceChainMessageIdEntities.length === 0) {
-    return;
-  }
-
-  // Load all ProcessId events in parallel for all message IDs
-  // Note: Each messageId maps to exactly 1 ProcessId (1:1 relationship)
-  const processIdPromises = sourceChainMessageIdEntities.map(
-    (entity: { messageId: string }) =>
-      context.ProcessId_event.getWhere({
-        messageId: { _eq: entity.messageId },
-      }),
-  );
-  const processIdResults = await Promise.all(processIdPromises);
-
-  await processCrossChainSwap(
-    sourceChainMessageIdEntities,
-    processIdResults,
-    bridgedTransaction,
+  await handleCrossChainSwapEvent(
     event.transaction.hash,
     event.chainId,
     event.params.destinationDomain,

--- a/test/EventHandlers/SuperswapsHyperlane/SuperSwapLogic.test.ts
+++ b/test/EventHandlers/SuperswapsHyperlane/SuperSwapLogic.test.ts
@@ -17,6 +17,7 @@ import {
   createSuperSwapEntity,
   findDestinationSwapWithOUSDT,
   findSourceSwapWithOUSDT,
+  handleCrossChainSwapEvent,
   loadDestinationSwaps,
   processCrossChainSwap,
 } from "../../../src/EventHandlers/SuperswapsHyperlane/SuperSwapLogic";
@@ -1558,6 +1559,204 @@ describe("SuperSwapLogic", () => {
 
       // Restore original
       context.OUSDTSwaps.getWhere = originalGetWhere;
+    });
+  });
+
+  describe("handleCrossChainSwapEvent", () => {
+    const createHandlerMockContext = (
+      dispatchIdEvents: DispatchId_event[],
+      processIdEvents: ProcessId_event[],
+      bridgedTransactions: OUSDTBridgedTransaction[],
+      swapEvents: OUSDTSwaps[],
+    ) => {
+      const dispatchIdByTxHash = new Map<string, DispatchId_event[]>();
+      const processIdMap = new Map<string, ProcessId_event[]>();
+      const bridgedTxMap = new Map<string, OUSDTBridgedTransaction[]>();
+      const swapMap = new Map<string, OUSDTSwaps[]>();
+      const logWarnings: string[] = [];
+      const logErrors: Array<{ message: string; error?: unknown }> = [];
+      const superSwaps = new Map<string, SuperSwap>();
+
+      for (const event of dispatchIdEvents) {
+        const existing = dispatchIdByTxHash.get(event.transactionHash) || [];
+        dispatchIdByTxHash.set(event.transactionHash, [...existing, event]);
+      }
+
+      for (const event of processIdEvents) {
+        const existing = processIdMap.get(event.messageId) || [];
+        processIdMap.set(event.messageId, [...existing, event]);
+      }
+
+      for (const tx of bridgedTransactions) {
+        const existing = bridgedTxMap.get(tx.transactionHash) || [];
+        bridgedTxMap.set(tx.transactionHash, [...existing, tx]);
+      }
+
+      for (const event of swapEvents) {
+        const existing = swapMap.get(event.transactionHash) || [];
+        swapMap.set(event.transactionHash, [...existing, event]);
+      }
+
+      return {
+        DispatchId_event: {
+          // biome-ignore lint/suspicious/noExplicitAny: test mock context needs flexibility
+          getWhere: async (params: any) => {
+            if (params.transactionHash?._eq)
+              return dispatchIdByTxHash.get(params.transactionHash._eq) || [];
+            return [];
+          },
+        },
+        ProcessId_event: {
+          // biome-ignore lint/suspicious/noExplicitAny: test mock context needs flexibility
+          getWhere: async (params: any) => {
+            if (params.messageId?._eq)
+              return processIdMap.get(params.messageId._eq) || [];
+            return [];
+          },
+        },
+        OUSDTBridgedTransaction: {
+          // biome-ignore lint/suspicious/noExplicitAny: test mock context needs flexibility
+          getWhere: async (params: any) => {
+            if (params.transactionHash?._eq)
+              return bridgedTxMap.get(params.transactionHash._eq) || [];
+            return [];
+          },
+        },
+        OUSDTSwaps: {
+          // biome-ignore lint/suspicious/noExplicitAny: test mock context needs flexibility
+          getWhere: async (params: any) => {
+            if (params.transactionHash?._eq)
+              return swapMap.get(params.transactionHash._eq) || [];
+            return [];
+          },
+        },
+        SuperSwap: {
+          set: (entity: SuperSwap) => {
+            superSwaps.set(entity.id, entity);
+          },
+          get: (id: string) => superSwaps.get(id),
+        },
+        log: {
+          warn: (message: string) => {
+            logWarnings.push(message);
+          },
+          error: (message: string, error?: unknown) => {
+            logErrors.push({ message, error });
+          },
+          info: () => {},
+          debug: () => {},
+        },
+        getWarnings: () => logWarnings,
+        getErrors: () => logErrors,
+        getSuperSwaps: () => superSwaps,
+        // biome-ignore lint/suspicious/noExplicitAny: test mock context needs flexibility
+      } as any;
+    };
+
+    it("creates a SuperSwap when a bridge+swap pair exists end-to-end", async () => {
+      const dispatchIdEvent = createDispatchIdEvent(
+        transactionHash,
+        chainId,
+        messageId1,
+      );
+      const processIdEvent = createProcessIdEvent(
+        destinationTxHash,
+        Number(destinationDomain),
+        messageId1,
+      );
+      const sourceSwap = createOUSDTSwap(
+        transactionHash,
+        chainId,
+        tokenInAddress,
+        1000n,
+        oUSDTAddress,
+        oUSDTAmount,
+      );
+      const destinationSwap = createOUSDTSwap(
+        destinationTxHash,
+        Number(destinationDomain),
+        oUSDTAddress,
+        oUSDTAmount,
+        tokenOutAddress,
+        950n,
+      );
+
+      const context = createHandlerMockContext(
+        [dispatchIdEvent],
+        [processIdEvent],
+        [mockBridgedTransaction],
+        [sourceSwap, destinationSwap],
+      );
+
+      await handleCrossChainSwapEvent(
+        transactionHash,
+        chainId,
+        destinationDomain,
+        blockTimestamp,
+        context,
+      );
+
+      const superSwaps = context.getSuperSwaps();
+      expect(superSwaps.size).toBe(1);
+      const superSwap = Array.from(superSwaps.values())[0] as SuperSwap;
+      expect(superSwap.originChainId).toBe(BigInt(chainId));
+      expect(superSwap.destinationChainId).toBe(destinationDomain);
+      expect(superSwap.oUSDTamount).toBe(oUSDTAmount);
+      expect(superSwap.sourceChainToken).toBe(tokenInAddress);
+      expect(superSwap.destinationChainToken).toBe(tokenOutAddress);
+      expect(context.getErrors()).toHaveLength(0);
+      expect(context.getWarnings()).toHaveLength(0);
+    });
+
+    it("logs a uerror when an OUSDT swap exists without a bridge record", async () => {
+      // OUSDT pool swap is present on source chain but OUSDTBridgedTransaction
+      // is missing — this is a real correlation failure that must be visible.
+      const sourceSwap = createOUSDTSwap(
+        transactionHash,
+        chainId,
+        tokenInAddress,
+        1000n,
+        oUSDTAddress,
+        oUSDTAmount,
+      );
+
+      const context = createHandlerMockContext([], [], [], [sourceSwap]);
+
+      await handleCrossChainSwapEvent(
+        transactionHash,
+        chainId,
+        destinationDomain,
+        blockTimestamp,
+        context,
+      );
+
+      expect(context.getSuperSwaps().size).toBe(0);
+      const errors = context.getErrors();
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toContain("No OUSDTBridgedTransaction found");
+      expect(errors[0].message).toContain(transactionHash);
+      expect(errors[0].error).toBeInstanceOf(Error);
+      // The legacy uwarn path must not fire anymore.
+      expect(context.getWarnings()).toHaveLength(0);
+    });
+
+    it("silently skips when neither bridge nor OUSDT swap exist (non-OUSDT cross-chain swap)", async () => {
+      // CrossChainSwap fires for any bridged token; when the bridged token is
+      // not OUSDT, neither OUSDTBridgedTransaction nor OUSDTSwaps is produced.
+      // This must not log (formerly produced 709 spurious warnings on Celo).
+      const context = createHandlerMockContext([], [], [], []);
+
+      await handleCrossChainSwapEvent(
+        transactionHash,
+        chainId,
+        destinationDomain,
+        blockTimestamp,
+        context,
+      );
+
+      expect(context.getSuperSwaps().size).toBe(0);
+      expect(context.getErrors()).toHaveLength(0);
+      expect(context.getWarnings()).toHaveLength(0);
     });
   });
 });

--- a/test/EventHandlers/SuperswapsHyperlane/SuperSwapLogic.test.ts
+++ b/test/EventHandlers/SuperswapsHyperlane/SuperSwapLogic.test.ts
@@ -1653,7 +1653,7 @@ describe("SuperSwapLogic", () => {
       } as any;
     };
 
-    it("creates a SuperSwap when a bridge+swap pair exists end-to-end", async () => {
+    it("should create a SuperSwap when a bridge+swap pair exists end-to-end", async () => {
       const dispatchIdEvent = createDispatchIdEvent(
         transactionHash,
         chainId,
@@ -1708,7 +1708,7 @@ describe("SuperSwapLogic", () => {
       expect(context.getWarnings()).toHaveLength(0);
     });
 
-    it("logs a uerror when an OUSDT swap exists without a bridge record", async () => {
+    it("should log a uerror when an OUSDT swap exists without a bridge record", async () => {
       // OUSDT pool swap is present on source chain but OUSDTBridgedTransaction
       // is missing — this is a real correlation failure that must be visible.
       const sourceSwap = createOUSDTSwap(
@@ -1740,7 +1740,7 @@ describe("SuperSwapLogic", () => {
       expect(context.getWarnings()).toHaveLength(0);
     });
 
-    it("silently skips when neither bridge nor OUSDT swap exist (non-OUSDT cross-chain swap)", async () => {
+    it("should silently skip when neither bridge nor OUSDT swap exist (non-OUSDT cross-chain swap)", async () => {
       // CrossChainSwap fires for any bridged token; when the bridged token is
       // not OUSDT, neither OUSDTBridgedTransaction nor OUSDTSwaps is produced.
       // This must not log (formerly produced 709 spurious warnings on Celo).


### PR DESCRIPTION
Fixes #602 (part of PRD #597)

## Diagnosis

`VelodromeUniversalRouter.CrossChainSwap` fires on the **source chain** for every cross-chain swap, regardless of the bridged token. The companion `UniversalRouterBridge` producer only records `OUSDTBridgedTransaction` rows when the bridged token is OUSDT (filtered by `token === OUSDT_ADDRESS`). Same transaction on the same chain, but asymmetric filters.

Result: every non-OUSDT cross-chain swap fell through the consumer's bridge lookup and produced `No OUSDTBridgedTransaction found for transaction <X>`. That's the entire 709-warning spike on Celo in the April 2026 log audit — 100% chainId 42220, 709 unique tx hashes.

This matches root cause #2 from issue #602 (**Filter mismatch**). Root cause #1 (tx-hash mismatch across chains) is ruled out by the ABI: both events are emitted on the source chain in the same transaction, so `event.transaction.hash` is identical. Root cause #3 (missing source-chain registration) is ruled out by `config.yaml`: `VelodromeUniversalRouter` is registered on every indexed chain, Celo included.

## Fix

Extracted the CrossChainSwap handler body into `handleCrossChainSwapEvent` in `SuperSwapLogic.ts`. The missing-bridge branch now:

1. Checks whether an `OUSDTSwaps` record exists for the same transaction on the source chain.
2. If **yes** → real correlation failure (OUSDT pool swap happened but bridge record is missing) → `context.log.error` with an `Error` payload.
3. If **no** → non-OUSDT cross-chain swap, symmetric with the producer's filter → silently skip.

The legacy `uwarn` is gone. Error logs now count only true correlation failures, making the existing `uerror`-grep observability strategy from PRD #597 work on the OUSDT path.

## Tests

New `handleCrossChainSwapEvent` describe block in `test/EventHandlers/SuperswapsHyperlane/SuperSwapLogic.test.ts`:

- **Bridge+swap pair** (end-to-end happy path): produces a `SuperSwap`, no warn/error.
- **Swap-without-bridge**: `OUSDTSwaps` present, `OUSDTBridgedTransaction` missing → exactly one `uerror` with `Error` payload, no legacy `uwarn`, no `SuperSwap`.
- **Non-OUSDT cross-chain swap**: neither swap nor bridge → silent skip, no logs, no `SuperSwap`.

All 1026 tests pass, `pnpm qa --write` clean.

## Post-Deploy Monitoring & Validation

- **Log query (baseline)**: before deploy, note count of `"No OUSDTBridgedTransaction found"` `uwarn` entries on Celo — audit baseline was 709 per 9-day backfill.
- **Post-deploy expected healthy signal**: that `uwarn` message disappears entirely. In its place, only `"No OUSDTBridgedTransaction found for OUSDT swap"` `uerror` entries should appear — and the count on Celo should be 0 or very low. Any nonzero count is a real OUSDT correlation defect and should be triaged.
- **Failure signal / rollback trigger**: if the new `uerror` count on any chain exceeds the pre-deploy `uwarn` count, revert — the symmetric filter is too permissive. If `SuperSwap` entity creation rate drops materially on any chain vs the pre-deploy baseline, revert — happy path regressed.
- **Validation window**: 48 hours post-deploy, covering at least one full backfill cycle.
- **Owner**: indexer on-call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved cross-chain swap event handling with clearer error reporting when expected transaction data is missing and silent skipping for non-relevant transactions.
* **Refactor**
  * Consolidated cross-chain swap processing into a single handler to centralize loading, validation, and delegation for consistency.
* **Tests**
  * Added end-to-end tests covering success, missing-bridge error, and silent-skip edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->