### PR TITLE
perf(rpc): collapse runWithRpcRetry intermediate logs (#598)

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -162,13 +162,6 @@ export enum PriceOracleType {
 
 export { zeroAddress as ZERO_ADDRESS } from "viem";
 
-/**
- * Slow and very slow request thresholds in milliseconds
- * Used for logging slow requests
- */
-export const SLOW_REQUEST_MS = 5000;
-export const VERY_SLOW_REQUEST_MS = 30000;
-
 // Global rate limit for all RPC requests; used in rpcGateway effect
 export const GLOBAL_REQUESTS_PER_SECOND = 20000;
 

--- a/src/Effects/RpcGateway.ts
+++ b/src/Effects/RpcGateway.ts
@@ -5,12 +5,7 @@ import {
   RPC_GATEWAY_PREFIX,
   TOKEN_DETAILS_FALLBACK,
 } from "../Constants";
-import {
-  GLOBAL_REQUESTS_PER_SECOND,
-  RPC_APP_RETRY,
-  SLOW_REQUEST_MS,
-  VERY_SLOW_REQUEST_MS,
-} from "../Constants";
+import { GLOBAL_REQUESTS_PER_SECOND, RPC_APP_RETRY } from "../Constants";
 import {
   ErrorType,
   getErrorType,
@@ -582,16 +577,7 @@ export async function executeRpcWithFallback<T>(
   fn: () => Promise<T>,
 ): Promise<T> {
   try {
-    const retryAndLoggingOptions = {
-      log: {
-        warn: context.log.warn,
-        error: (msg: string) => context.log.error(msg, new Error(msg)),
-      },
-      operationName,
-      logDetails,
-    };
-
-    return await runWithRpcRetry(retryAndLoggingOptions, fn);
+    return await runWithRpcRetry(fn);
   } catch (error) {
     return handleEffectErrorReturn(
       error,
@@ -607,59 +593,25 @@ export async function executeRpcWithFallback<T>(
  * Runs an async RPC operation with retries on retryable errors. Retries on
  * {@link ErrorType.RATE_LIMIT} and {@link ErrorType.NETWORK_ERROR} with
  * error-type-aware exponential backoff (caps from {@link RPC_APP_RETRY}).
- * Non-retryable errors or exhausted retries are rethrown for the caller to handle
- * (e.g. via {@link handleEffectErrorReturn}). Logs slow requests: >5s warn; >30s
- * very-slow successful requests as warn, very-slow failed requests as error.
+ * Non-retryable errors or exhausted retries are rethrown for the caller to
+ * convert into a single `uerror` (see {@link handleEffectErrorReturn}).
  *
- * @param options - Configuration for retry and logging.
- * @param options.log - Logger with required `warn` and optional `error` (single-arg: message string).
- * @param options.operationName - Optional name for log prefixes (use {@link rpcGatewayOpName} for gateway ops).
- * @param options.logDetails - Optional key-value pairs included in log messages.
+ * Intentionally silent: intermediate retries and per-attempt latency emit no
+ * logs. Aggregate latency is visible via the Envio `/metrics` endpoint; only
+ * the final exhausted-retries error surfaces, via the caller.
+ *
  * @param fn - Async function that performs the RPC call. Invoked on each attempt.
  * @returns The result of `fn()` when it resolves successfully.
  * @throws Rethrows the last error when retries are exhausted or the error is not retryable.
  */
-export async function runWithRpcRetry<T>(
-  options: {
-    log: { warn: (msg: string) => void; error?: (msg: string) => void };
-    operationName?: string;
-    logDetails?: Record<string, string | number>;
-  },
-  fn: () => Promise<T>,
-): Promise<T> {
+export async function runWithRpcRetry<T>(fn: () => Promise<T>): Promise<T> {
   const { maxRetries, rateLimit, network } = RPC_APP_RETRY;
-  const detailSuffix = formatDetailsSuffix(options.logDetails);
-  const prefix = getRetryLogPrefix(options.operationName);
 
   let attempt = 0;
   while (true) {
-    const startTime = Date.now();
-
     try {
-      const result = await fn();
-      // Wall-clock for this logical operation; fn() may perform one or more RPC calls (viem may batch them).
-      const durationMs = Date.now() - startTime;
-
-      logSlowRequestIfNeeded(
-        options.log,
-        prefix,
-        detailSuffix,
-        durationMs,
-        "request",
-      );
-
-      return result;
+      return await fn();
     } catch (error) {
-      const durationMs = Date.now() - startTime;
-
-      logSlowRequestIfNeeded(
-        options.log,
-        prefix,
-        detailSuffix,
-        durationMs,
-        "failed request",
-      );
-
       const errorType = getErrorType(error);
       const isRetryable =
         (errorType === ErrorType.RATE_LIMIT ||
@@ -679,70 +631,8 @@ export async function runWithRpcRetry<T>(
 
       attempt++;
 
-      options.log.warn(
-        `${prefix} ${errorType} (attempt ${attempt}/${maxRetries + 1})${detailSuffix}. Retrying in ${delayMs}ms...`,
-      );
-
       await sleep(delayMs);
     }
-  }
-}
-
-/** Builds the " key1=val1, key2=val2" suffix for retry/slow-request log lines, or "".
- *
- * @param logDetails - Details to format.
- * @returns The formatted logDetails suffix.
- */
-function formatDetailsSuffix(
-  logDetails: Record<string, string | number> | undefined,
-): string {
-  if (!logDetails) return "";
-  const part = Object.entries(logDetails)
-    .map(([k, v]) => `${k}=${v}`)
-    .join(", ");
-  return part ? ` ${part}` : "";
-}
-
-/** Log prefix for runWithRpcRetry messages.
- *
- * @param operationName - Operation name for the message.
- * @returns Log prefix for the message.
- */
-function getRetryLogPrefix(operationName: string | undefined): string {
-  return operationName
-    ? `[runWithRpcRetry:${operationName}]`
-    : "[runWithRpcRetry]";
-}
-
-/** Logs slow or very-slow request when duration exceeds thresholds.
- * Very-slow successful requests are logged as warn; very-slow failed requests as error.
- *
- * @param log - Logger with required `warn` and optional `error` (single-arg: message string).
- * @param prefix - Log prefix for the message.
- * @param detailSuffix - Details suffix for the message.
- * @param durationMs - Duration in milliseconds (wall-clock for the whole fn() invocation; may reflect one or more batched RPC calls).
- * @param kind - Kind of request ("request" or "failed request").
- * @returns void
- */
-
-function logSlowRequestIfNeeded(
-  log: { warn: (msg: string) => void; error?: (msg: string) => void },
-  prefix: string,
-  detailSuffix: string,
-  durationMs: number,
-  kind: "request" | "failed request",
-): void {
-  const label = kind === "request" ? "request" : "failed request";
-  if (
-    durationMs > VERY_SLOW_REQUEST_MS &&
-    kind === "failed request" &&
-    log.error
-  ) {
-    log.error(`${prefix} Very slow ${label}: ${durationMs}ms${detailSuffix}`);
-  } else if (durationMs > VERY_SLOW_REQUEST_MS) {
-    log.warn(`${prefix} Very slow ${label}: ${durationMs}ms${detailSuffix}`);
-  } else if (durationMs > SLOW_REQUEST_MS) {
-    log.warn(`${prefix} Slow ${label}: ${durationMs}ms${detailSuffix}`);
   }
 }
 

--- a/test/Effects/Helpers.test.ts
+++ b/test/Effects/Helpers.test.ts
@@ -162,10 +162,7 @@ describe("Helpers", () => {
   });
 
   describe("runWithRpcRetry", () => {
-    const mockLog = { warn: vi.fn() };
-
     beforeEach(() => {
-      mockLog.warn.mockClear();
       vi.mocked(sleep).mockResolvedValue(undefined);
     });
 
@@ -175,10 +172,9 @@ describe("Helpers", () => {
 
     it("should return result on first success", async () => {
       const fn = vi.fn().mockResolvedValue(42);
-      const result = await runWithRpcRetry({ log: mockLog }, fn);
+      const result = await runWithRpcRetry(fn);
       expect(result).toBe(42);
       expect(fn).toHaveBeenCalledTimes(1);
-      expect(mockLog.warn).not.toHaveBeenCalled();
     });
 
     it("should retry on RATE_LIMIT then succeed", async () => {
@@ -186,55 +182,35 @@ describe("Helpers", () => {
         .fn()
         .mockRejectedValueOnce(new Error("rate limit exceeded"))
         .mockResolvedValueOnce(100n);
-      const result = await runWithRpcRetry(
-        { log: mockLog, operationName: "testOp", logDetails: { chainId: 10 } },
-        fn,
-      );
+      const result = await runWithRpcRetry(fn);
       expect(result).toBe(100n);
       expect(fn).toHaveBeenCalledTimes(2);
-      expect(mockLog.warn).toHaveBeenCalledTimes(1);
-      expect(mockLog.warn.mock.calls[0]?.[0]).toContain("RATE_LIMIT");
-      expect(mockLog.warn.mock.calls[0]?.[0]).toContain("Retrying");
     });
 
-    it("should retry on Temporary internal error. Please retry then succeed", async () => {
+    it("should retry on NETWORK_ERROR across multiple attempts then succeed", async () => {
       const fn = vi
         .fn()
         .mockRejectedValueOnce(
           new Error("Temporary internal error. Please retry"),
         )
+        .mockRejectedValueOnce(new Error("connection error"))
+        .mockRejectedValueOnce(new Error("socket hang up"))
         .mockResolvedValueOnce(99n);
-      const result = await runWithRpcRetry(
-        {
-          log: mockLog,
-          operationName: "getSwapFee",
-          logDetails: { chainId: 10 },
-        },
-        fn,
-      );
+      const result = await runWithRpcRetry(fn);
       expect(result).toBe(99n);
-      expect(fn).toHaveBeenCalledTimes(2);
-      expect(mockLog.warn).toHaveBeenCalledTimes(1);
-      expect(mockLog.warn.mock.calls[0]?.[0]).toContain("NETWORK_ERROR");
-      expect(mockLog.warn.mock.calls[0]?.[0]).toContain("Retrying");
+      expect(fn).toHaveBeenCalledTimes(4);
     });
 
     it("should not retry on CONTRACT_REVERT", async () => {
       const fn = vi.fn().mockRejectedValue(new Error("execution reverted"));
-      await expect(runWithRpcRetry({ log: mockLog }, fn)).rejects.toThrow(
-        "execution reverted",
-      );
+      await expect(runWithRpcRetry(fn)).rejects.toThrow("execution reverted");
       expect(fn).toHaveBeenCalledTimes(1);
-      expect(mockLog.warn).not.toHaveBeenCalled();
     });
 
     it("should throw after max retries exhausted", async () => {
       const fn = vi.fn().mockRejectedValue(new Error("rate limit exceeded"));
-      await expect(runWithRpcRetry({ log: mockLog }, fn)).rejects.toThrow(
-        "rate limit exceeded",
-      );
+      await expect(runWithRpcRetry(fn)).rejects.toThrow("rate limit exceeded");
       expect(fn).toHaveBeenCalledTimes(8); // 1 initial + 7 retries (RPC_APP_RETRY.maxRetries)
-      expect(mockLog.warn).toHaveBeenCalledTimes(7);
     });
   });
 });

--- a/test/Effects/RpcGateway.test.ts
+++ b/test/Effects/RpcGateway.test.ts
@@ -1,9 +1,5 @@
 import type { PublicClient } from "viem";
-import {
-  CHAIN_CONSTANTS,
-  VERY_SLOW_REQUEST_MS,
-  toChecksumAddress,
-} from "../../src/Constants";
+import { CHAIN_CONSTANTS, toChecksumAddress } from "../../src/Constants";
 import * as Helpers from "../../src/Effects/Helpers";
 import { rpcGateway } from "../../src/Effects/RpcGateway";
 import {
@@ -130,18 +126,19 @@ describe("RpcGateway", () => {
       );
     });
 
-    it("should log very slow successful request via log.warn when getTokenDetails exceeds VERY_SLOW_REQUEST_MS", async () => {
+    it("should not log slow successful requests (latency covered by /metrics)", async () => {
       const readContract = vi.mocked(mockEthClient.readContract);
       readContract
         .mockResolvedValueOnce("Slow")
         .mockResolvedValueOnce(18)
         .mockResolvedValueOnce("TKN");
 
+      // Simulate a request that takes longer than any slow-request threshold.
       const t0 = 1000000;
-      const verySlowMs = VERY_SLOW_REQUEST_MS + 1;
+      const slowMs = 60000;
       let dateNowCalls = 0;
       vi.spyOn(Date, "now").mockImplementation(() =>
-        ++dateNowCalls === 1 ? t0 : t0 + verySlowMs,
+        ++dateNowCalls === 1 ? t0 : t0 + slowMs,
       );
 
       const result = await (
@@ -160,22 +157,85 @@ describe("RpcGateway", () => {
         decimals: 18,
         symbol: "TKN",
       });
-      expect(mockContext.log.warn).toHaveBeenCalledTimes(1);
-      expect(mockContext.log.warn).toHaveBeenCalledWith(
-        expect.stringContaining("Very slow request"),
-      );
+      expect(mockContext.log.warn).not.toHaveBeenCalled();
+      expect(mockContext.log.error).not.toHaveBeenCalled();
     });
 
-    it("should log very slow failed request via log.error when getTokenDetails exceeds VERY_SLOW_REQUEST_MS", async () => {
+    it("should emit no intermediate log for a retry that ultimately succeeds", async () => {
+      // First attempt rejects the `name` call (triggers whole-Promise.all rejection and retry).
+      // All subsequent calls succeed, so the retry returns clean results.
+      let firstNameCall = true;
+      vi.mocked(mockEthClient.readContract).mockImplementation(
+        ({ functionName }: { functionName: string }) => {
+          if (functionName === "name") {
+            if (firstNameCall) {
+              firstNameCall = false;
+              return Promise.reject(new Error("rate limit exceeded"));
+            }
+            return Promise.resolve("OkToken");
+          }
+          if (functionName === "decimals") return Promise.resolve(18);
+          if (functionName === "symbol") return Promise.resolve("OK");
+          return Promise.reject(new Error("unexpected call"));
+        },
+      );
+
+      const result = await (
+        rpcGateway as unknown as { handler: MockEffect["handler"] }
+      ).handler({
+        input: {
+          type: "getTokenDetails",
+          chainId: TEST_CHAIN_ID,
+          contractAddress: TEST_CONTRACT_ADDRESS,
+        },
+        context: mockContext,
+      });
+
+      expect(result).toMatchObject({
+        name: "OkToken",
+        decimals: 18,
+        symbol: "OK",
+      });
+      expect(mockContext.log.warn).not.toHaveBeenCalled();
+      expect(mockContext.log.error).not.toHaveBeenCalled();
+    });
+
+    it("should emit exactly one error with stack trace when retries are exhausted", async () => {
+      const err = new Error("rate limit exceeded");
+      err.stack =
+        "Error: rate limit exceeded\n    at viem/internal/rpc-call.ts:42";
+      vi.mocked(mockEthClient.readContract).mockRejectedValue(err);
+
+      const result = await (
+        rpcGateway as unknown as { handler: MockEffect["handler"] }
+      ).handler({
+        input: {
+          type: "getTokenDetails",
+          chainId: TEST_CHAIN_ID,
+          contractAddress: TEST_CONTRACT_ADDRESS,
+        },
+        context: mockContext,
+      });
+
+      expect(result).toEqual({ name: "", decimals: 18, symbol: "" });
+      expect(mockContext.log.warn).not.toHaveBeenCalled();
+      expect(mockContext.log.error).toHaveBeenCalledTimes(1);
+      const [, loggedError] = vi.mocked(mockContext.log.error).mock.calls[0];
+      expect(loggedError).toBeInstanceOf(Error);
+      expect((loggedError as Error).stack).toContain("viem/internal/rpc-call");
+    });
+
+    it("should emit no failed-slow-request log when the RPC fails", async () => {
       vi.mocked(mockEthClient.readContract).mockRejectedValue(
         new Error("execution reverted"),
       );
 
+      // Simulate a failed request that took a long time.
       const t0 = 1000000;
-      const verySlowMs = VERY_SLOW_REQUEST_MS + 1;
+      const slowMs = 60000;
       let dateNowCalls = 0;
       vi.spyOn(Date, "now").mockImplementation(() =>
-        ++dateNowCalls === 1 ? t0 : t0 + verySlowMs,
+        ++dateNowCalls === 1 ? t0 : t0 + slowMs,
       );
 
       await (
@@ -189,10 +249,16 @@ describe("RpcGateway", () => {
         context: mockContext,
       });
 
-      expect(mockContext.log.error).toHaveBeenCalledWith(
-        expect.stringContaining("Very slow failed request"),
-        expect.any(Error),
-      );
+      // Non-retryable error surfaces exactly one uerror via executeRpcWithFallback;
+      // no "Very slow failed request" extra log line.
+      expect(mockContext.log.error).toHaveBeenCalledTimes(1);
+      const errorMessages = vi
+        .mocked(mockContext.log.error)
+        .mock.calls.map((c) => c[0]);
+      expect(
+        errorMessages.some((m) => m.includes("Very slow failed request")),
+      ).toBe(false);
+      expect(mockContext.log.warn).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

Collapses per-retry log output from `runWithRpcRetry` in `src/Effects/RpcGateway.ts`. Intermediate retry attempts now emit zero log output; only the final exhausted-retries case surfaces a single `uerror` via the existing `handleEffectErrorReturn` path, which already preserves the viem `stack_trace`.

- Removes `NETWORK_ERROR (attempt N/M) … Retrying in …` intermediate warns.
- Removes `RATE_LIMIT (attempt N/M) … Retrying in …` intermediate warns.
- Removes `Slow failed request` warns (duplicative of the retry log that followed).
- Removes `Slow request` (succeeded) warns entirely — `/metrics` covers latency.
- Drops now-unused `SLOW_REQUEST_MS` / `VERY_SLOW_REQUEST_MS` constants.
- Simplifies `runWithRpcRetry` signature: since it no longer logs, it no longer takes `log` / `operationName` / `logDetails`. Single caller (`executeRpcWithFallback`) updated in the same change.

## Expected impact

Per parent PRD #597:
- `uwarn` drops from ~108,526 → ~750 per backfill (~145× reduction).
- ~130 MB of viem stack strings no longer serialized per backfill.
- Total log payload drops ~7×.

## Test plan

All tests written first (TDD red → green) against the acceptance criteria in #598:

- [x] `test/Effects/RpcGateway.test.ts` — new behavioral tests:
  - `should not log slow successful requests (latency covered by /metrics)`
  - `should emit no intermediate log for a retry that ultimately succeeds`
  - `should emit exactly one error with stack trace when retries are exhausted`
  - `should emit no failed-slow-request log when the RPC fails`
- [x] `test/Effects/Helpers.test.ts > runWithRpcRetry` — existing retry-behavior tests updated to match new silent semantics (retry + succeed, exhausted retries, non-retryable errors — all verified without log assertions since log output is no longer part of the contract).
- [x] `pnpm test`: **1025 passed / 32 skipped / 0 failed** across 90 test files.
- [x] `pnpm qa --write`: clean (Biome, 234 files, no fixes applied).
- [x] `tsc --noEmit`: clean.

## Post-Deploy Monitoring & Validation

After this ships to a fresh backfill:

**What to watch**
- Sink `uwarn` count filtered to `[runWithRpcRetry` prefix — should drop from ~108,526 → **within an order of magnitude of ~750** per backfill (acceptance criterion from #598).
- Sink `uerror` count — should remain non-zero on real outages; grep for `[rpcGateway.` to count per-operation exhausted-retries errors.
- Log payload size per backfill — expect ~7× total reduction and ~130 MB of viem stack strings eliminated.
- Envio `/metrics` latency histograms — should still show RPC duration distributions (since we removed the logs, not the measurement path at the effect layer).

**Healthy signals**
- `uwarn` volume ≤ a few thousand per 9-day backfill.
- Every remaining `uerror` from `[rpcGateway.*]` includes a viem stack trace in the attached `Error` object (spot-check first few entries).
- RPC success rate unchanged vs pre-deploy baseline.

**Failure signals / rollback trigger**
- `uwarn` volume still > 50,000 per backfill → rollback, investigate other callers.
- `uerror` entries missing stack traces → rollback; means `handleEffectErrorReturn` stopped copying the viem stack (regression).
- Spike in RPC-related downstream errors (e.g. `NonFungiblePosition not found`, price = 0) → investigate whether silencing retries masked a real RPC degradation; cross-reference `/metrics` error-rate histograms.

**Validation window**: first 24h after first full backfill on the new build.
**Owner**: @FonsSicca (indexer maintainer).

Closes #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)