### PR TITLE
fix(voter): reconcile orphan PendingRootPoolMapping records on read

### DIFF
--- a/src/Aggregators/LiquidityPoolAggregator.ts
+++ b/src/Aggregators/LiquidityPoolAggregator.ts
@@ -1,10 +1,16 @@
 import type {
   CLGaugeConfig,
   LiquidityPoolAggregator,
+  RootPool_LeafPool,
   Token,
   handlerContext,
 } from "generated";
-import { PoolId, TokenId } from "../Constants";
+import {
+  PendingRootPoolMappingId,
+  PoolId,
+  RootPoolLeafPoolId,
+  TokenId,
+} from "../Constants";
 import { getSwapFee, roundBlockToInterval } from "../Effects/Index";
 import { calculateTotalUSD, generatePoolName } from "../Helpers";
 import { refreshTokenPrice } from "../PriceOracle";
@@ -493,6 +499,65 @@ export async function loadPoolData(
 }
 
 /**
+ * Attempts to reconcile a stuck PendingRootPoolMapping for the given root pool.
+ *
+ * This handles the failure mode from issue #601: RootCLPoolFactory.RootPoolCreated fires
+ * on the root chain (Optimism) and stores a PendingRootPoolMapping because no
+ * LiquidityPoolAggregator exists on the leaf chain yet. Normally CLFactory.PoolCreated
+ * on the leaf chain would consume the pending record, but if the leaf pool was created
+ * before the leaf chain's `start_block` (or by a factory not registered in config.yaml),
+ * the event is never observed and the pending record is orphaned.
+ *
+ * When a later Voted/Abstained/DistributeReward references the orphan root pool, we
+ * retry the reconciliation: if the leaf pool's LiquidityPoolAggregator has since appeared
+ * (e.g. created by a swap or other event that surfaced it), create the RootPool_LeafPool
+ * mapping, delete the pending record, and return the leaf pool info.
+ *
+ * @returns The newly-created RootPool_LeafPool row, or null if reconciliation was not possible.
+ */
+export async function tryReconcileOrphanPendingRootPoolMapping(
+  context: handlerContext,
+  rootChainId: number,
+  rootPoolAddress: string,
+): Promise<RootPool_LeafPool | null> {
+  const pending = await context.PendingRootPoolMapping.get(
+    PendingRootPoolMappingId(rootChainId, rootPoolAddress),
+  );
+  if (!pending) {
+    return null;
+  }
+
+  const matchingAggregators =
+    (await context.LiquidityPoolAggregator.getWhere({
+      rootPoolMatchingHash: { _eq: pending.rootPoolMatchingHash },
+    })) ?? [];
+  if (matchingAggregators.length !== 1) {
+    return null;
+  }
+
+  const leafAggregator = matchingAggregators[0];
+  const leafChainId = leafAggregator.chainId;
+  const leafPoolAddress = leafAggregator.poolAddress;
+
+  const rootPoolLeafPool: RootPool_LeafPool = {
+    id: RootPoolLeafPoolId(
+      rootChainId,
+      leafChainId,
+      rootPoolAddress,
+      leafPoolAddress,
+    ),
+    rootChainId,
+    rootPoolAddress,
+    leafChainId,
+    leafPoolAddress,
+  };
+  context.RootPool_LeafPool.set(rootPoolLeafPool);
+  context.PendingRootPoolMapping.deleteUnsafe(pending.id);
+
+  return rootPoolLeafPool;
+}
+
+/**
  * Attempts to load pool data, and if not found, checks if it's a RootCLPool
  * and loads the corresponding leaf pool data instead.
  *
@@ -510,28 +575,42 @@ export async function loadPoolDataOrRootCLPool(
   blockNumber?: number,
   blockTimestamp?: number,
 ): Promise<LoadPoolDataOrRootCLPoolResult> {
-  const rootPoolLeafPools =
+  let rootPoolLeafPools =
     (await context.RootPool_LeafPool.getWhere({
       rootPoolAddress: { _eq: poolAddress },
     })) ?? [];
 
   if (rootPoolLeafPools.length === 0) {
-    const poolData = await loadPoolData(
-      poolAddress,
-      chainId,
+    // Orphan reconciliation: a PendingRootPoolMapping may exist for this root pool
+    // (e.g. CLFactory.PoolCreated was never observed on the leaf chain because the pool
+    // predates start_block). If the leaf pool's LiquidityPoolAggregator is present in the
+    // DB with a matching rootPoolMatchingHash, create the RootPool_LeafPool mapping now
+    // rather than dropping votes/distributions into pending state forever. See issue #601.
+    const reconciled = await tryReconcileOrphanPendingRootPoolMapping(
       context,
-      blockNumber,
-      blockTimestamp,
+      chainId,
+      poolAddress,
     );
+    if (reconciled) {
+      rootPoolLeafPools = [reconciled];
+    } else {
+      const poolData = await loadPoolData(
+        poolAddress,
+        chainId,
+        context,
+        blockNumber,
+        blockTimestamp,
+      );
 
-    if (poolData) {
-      return { ok: true, poolData };
+      if (poolData) {
+        return { ok: true, poolData };
+      }
+
+      return {
+        ok: false,
+        reason: LoadPoolDataOrRootCLPoolFailureReason.MAPPING_NOT_FOUND,
+      };
     }
-
-    return {
-      ok: false,
-      reason: LoadPoolDataOrRootCLPoolFailureReason.MAPPING_NOT_FOUND,
-    };
   }
 
   if (rootPoolLeafPools.length !== 1) {

--- a/src/EventHandlers/Voter/VoterCommonLogic.ts
+++ b/src/EventHandlers/Voter/VoterCommonLogic.ts
@@ -7,6 +7,7 @@ import type {
 import {
   type LiquidityPoolAggregatorDiff,
   loadPoolData,
+  tryReconcileOrphanPendingRootPoolMapping,
   updateLiquidityPoolAggregator,
 } from "../../Aggregators/LiquidityPoolAggregator";
 import type { UserStatsPerPoolDiff } from "../../Aggregators/UserStatsPerPool";
@@ -135,10 +136,23 @@ export async function resolveLeafPoolForRootGauge(
     return null;
   }
   const rootPoolAddress = rootGaugeMapping.rootPoolAddress;
-  const rootPoolLeafPools =
+  let rootPoolLeafPools =
     (await context.RootPool_LeafPool.getWhere({
       rootPoolAddress: { _eq: rootPoolAddress },
     })) ?? [];
+  if (rootPoolLeafPools.length === 0) {
+    // Orphan reconciliation (issue #601): the PendingRootPoolMapping may be stuck
+    // because CLFactory.PoolCreated never fired on the leaf chain. If the leaf pool's
+    // LiquidityPoolAggregator is already in the DB, retry the mapping now.
+    const reconciled = await tryReconcileOrphanPendingRootPoolMapping(
+      context,
+      chainId,
+      rootPoolAddress,
+    );
+    if (reconciled) {
+      rootPoolLeafPools = [reconciled];
+    }
+  }
   if (rootPoolLeafPools.length !== 1) {
     context.log.warn(
       `[resolveLeafPoolForRootGauge] Root gauge ${gaugeAddress} maps to root pool ${rootPoolAddress} but RootPool_LeafPool mapping not found or ambiguous (count: ${rootPoolLeafPools.length}) on chain ${chainId}`,

--- a/test/Aggregators/LiquidityPoolAggregator.test.ts
+++ b/test/Aggregators/LiquidityPoolAggregator.test.ts
@@ -2,14 +2,17 @@ import type { LiquidityPoolAggregator, Token, handlerContext } from "generated";
 import {
   loadPoolData,
   loadPoolDataOrRootCLPool,
+  tryReconcileOrphanPendingRootPoolMapping,
   updateDynamicFeePools,
   updateLiquidityPoolAggregator,
 } from "../../src/Aggregators/LiquidityPoolAggregator";
 import {
   type CHAIN_CONSTANTS,
   LiquidityPoolAggregatorSnapshotId,
+  PendingRootPoolMappingId,
   PoolId,
   RootPoolLeafPoolId,
+  rootPoolMatchingHash,
   toChecksumAddress,
 } from "../../src/Constants";
 import { getSwapFee } from "../../src/Effects/SwapFee";
@@ -66,6 +69,14 @@ describe("LiquidityPoolAggregator Functions", () => {
       RootPool_LeafPool: {
         set: vi.fn(),
         get: vi.fn(),
+        getOrThrow: vi.fn(),
+        getOrCreate: vi.fn(),
+        deleteUnsafe: vi.fn(),
+        getWhere: vi.fn().mockResolvedValue([]),
+      },
+      PendingRootPoolMapping: {
+        set: vi.fn(),
+        get: vi.fn().mockResolvedValue(undefined),
         getOrThrow: vi.fn(),
         getOrCreate: vi.fn(),
         deleteUnsafe: vi.fn(),
@@ -1428,6 +1439,176 @@ describe("LiquidityPoolAggregator Functions", () => {
             msg.includes("Expected exactly one RootPool_LeafPool"),
         ),
       ).toBe(true);
+    });
+
+    // Issue #601: orphan PendingRootPoolMapping reconciliation during load path.
+    // See `tryReconcileOrphanPendingRootPoolMapping` for the failure mode we are
+    // recovering from (leaf CLFactory.PoolCreated never observed).
+    describe("orphan reconciliation via PendingRootPoolMapping", () => {
+      const leafChainId = 42220; // Celo — mirrors the real orphan from issue #601
+      const pendingToken0 = toChecksumAddress(
+        "0x471EcE3750Da237f93B8E339c536989b8978a438",
+      );
+      const pendingToken1 = toChecksumAddress(
+        "0x7f9AdFbd38b669F03d1d11000Bc76b9AaEA28A81",
+      );
+      const pendingTickSpacing = 2000n;
+      const pendingHash = rootPoolMatchingHash(
+        leafChainId,
+        pendingToken0,
+        pendingToken1,
+        pendingTickSpacing,
+      );
+
+      it("reconciles a stuck PendingRootPoolMapping when the leaf LiquidityPoolAggregator already exists and returns leaf pool data", async () => {
+        const leafPoolId = PoolId(leafChainId, leafPoolAddress);
+        const leafPool = createMockLiquidityPoolAggregator({
+          id: leafPoolId,
+          chainId: leafChainId,
+          poolAddress: leafPoolAddress,
+          token0_id: "token0",
+          token1_id: "token1",
+          token0_address: token0.address,
+          token1_address: token1.address,
+          rootPoolMatchingHash: pendingHash,
+        });
+
+        const pending = {
+          id: PendingRootPoolMappingId(chainId, rootPoolAddress),
+          rootChainId: chainId,
+          rootPoolAddress,
+          leafChainId,
+          token0: pendingToken0,
+          token1: pendingToken1,
+          tickSpacing: pendingTickSpacing,
+          rootPoolMatchingHash: pendingHash,
+        };
+
+        // No existing RootPool_LeafPool; root pool has no local aggregator.
+        const mockRootPoolLeafPoolGetWhere = vi.mocked(
+          mockContext.RootPool_LeafPool?.getWhere,
+        );
+        mockRootPoolLeafPoolGetWhere?.mockResolvedValue([]);
+
+        // Pending mapping is present — simulates the stuck record from production.
+        const mockPendingGet = vi.mocked(
+          mockContext.PendingRootPoolMapping?.get,
+        );
+        mockPendingGet?.mockResolvedValue(pending);
+
+        // Leaf aggregator has since appeared — reconciliation should find it by hash.
+        const mockLpaGetWhere = vi.mocked(
+          mockContext.LiquidityPoolAggregator?.getWhere,
+        );
+        mockLpaGetWhere?.mockResolvedValue([leafPool]);
+
+        const mockLpaGet = vi.mocked(mockContext.LiquidityPoolAggregator?.get);
+        mockLpaGet?.mockImplementation((id: string) => {
+          if (id === leafPoolId) return Promise.resolve(leafPool);
+          return Promise.resolve(undefined);
+        });
+
+        const mockTokenGet = vi.mocked(mockContext.Token?.get);
+        mockTokenGet?.mockImplementation((id: string) => {
+          if (id === "token0") return Promise.resolve(token0);
+          if (id === "token1") return Promise.resolve(token1);
+          return Promise.resolve(undefined);
+        });
+
+        const result = await loadPoolDataOrRootCLPool(
+          rootPoolAddress,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+          expect(result.poolData.liquidityPoolAggregator.id).toBe(leafPoolId);
+        }
+        // Reconciliation must persist the new RootPool_LeafPool and delete the pending.
+        expect(
+          vi.mocked(mockContext.RootPool_LeafPool?.set),
+        ).toHaveBeenCalledWith(
+          expect.objectContaining({
+            rootChainId: chainId,
+            rootPoolAddress,
+            leafChainId,
+            leafPoolAddress,
+          }),
+        );
+        expect(
+          vi.mocked(mockContext.PendingRootPoolMapping?.deleteUnsafe),
+        ).toHaveBeenCalledWith(pending.id);
+      });
+
+      it("does not reconcile when multiple leaf aggregators match the pending hash (ambiguous — fail safe)", async () => {
+        const leafPoolA = createMockLiquidityPoolAggregator({
+          id: PoolId(leafChainId, leafPoolAddress),
+          chainId: leafChainId,
+          poolAddress: leafPoolAddress,
+          rootPoolMatchingHash: pendingHash,
+        });
+        const leafPoolBAddress = toChecksumAddress(
+          "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        );
+        const leafPoolB = createMockLiquidityPoolAggregator({
+          id: PoolId(leafChainId, leafPoolBAddress),
+          chainId: leafChainId,
+          poolAddress: leafPoolBAddress,
+          rootPoolMatchingHash: pendingHash,
+        });
+
+        const pending = {
+          id: PendingRootPoolMappingId(chainId, rootPoolAddress),
+          rootChainId: chainId,
+          rootPoolAddress,
+          leafChainId,
+          token0: pendingToken0,
+          token1: pendingToken1,
+          tickSpacing: pendingTickSpacing,
+          rootPoolMatchingHash: pendingHash,
+        };
+
+        const resultReconcile = await tryReconcileOrphanPendingRootPoolMapping(
+          {
+            ...mockContext,
+            PendingRootPoolMapping: {
+              ...mockContext.PendingRootPoolMapping,
+              get: vi.fn().mockResolvedValue(pending),
+              deleteUnsafe: vi.fn(),
+            },
+            LiquidityPoolAggregator: {
+              ...mockContext.LiquidityPoolAggregator,
+              getWhere: vi.fn().mockResolvedValue([leafPoolA, leafPoolB]),
+            },
+            RootPool_LeafPool: {
+              ...mockContext.RootPool_LeafPool,
+              set: vi.fn(),
+            },
+          } as unknown as handlerContext,
+          chainId,
+          rootPoolAddress,
+        );
+
+        expect(resultReconcile).toBeNull();
+      });
+
+      it("returns null when no PendingRootPoolMapping exists", async () => {
+        const resultReconcile = await tryReconcileOrphanPendingRootPoolMapping(
+          {
+            ...mockContext,
+            PendingRootPoolMapping: {
+              ...mockContext.PendingRootPoolMapping,
+              get: vi.fn().mockResolvedValue(undefined),
+              deleteUnsafe: vi.fn(),
+            },
+          } as unknown as handlerContext,
+          chainId,
+          rootPoolAddress,
+        );
+
+        expect(resultReconcile).toBeNull();
+      });
     });
 
     it("should return LEAF_POOL_NOT_FOUND when leaf pool is not found", async () => {

--- a/test/EventHandlers/Voter/Voter.test.ts
+++ b/test/EventHandlers/Voter/Voter.test.ts
@@ -728,6 +728,178 @@ describe("Voter Events", () => {
       });
     });
 
+    describe("orphan PendingRootPoolMapping reconciliation (leaf pool already exists)", () => {
+      // Mirrors the issue #601 scenario: RootPoolCreated fired on Optimism producing a
+      // PendingRootPoolMapping, but CLFactory.PoolCreated was never observed on the leaf
+      // chain (e.g. created before start_block). The leaf pool's LiquidityPoolAggregator
+      // exists in the DB — a subsequent Voted on the root chain must reconcile the mapping
+      // using the pending record and the leaf aggregator, then apply the vote to the leaf
+      // pool rather than dropping it into PendingVote.
+      const rootChainId = 10; // Optimism
+      const leafChainId = 42220; // Celo
+      const rootPoolAddress = toChecksumAddress(
+        "0x333030A736B47D20346d82A473680658ac1C2b88",
+      );
+      const leafPoolAddress = toChecksumAddress(
+        "0x5555555555555555555555555555555555555555",
+      );
+      const token0 = toChecksumAddress(
+        "0x471EcE3750Da237f93B8E339c536989b8978a438",
+      );
+      const token1 = toChecksumAddress(
+        "0x7f9AdFbd38b669F03d1d11000Bc76b9AaEA28A81",
+      );
+      const tickSpacing = 2000n;
+      const voteTokenId = 42n;
+      const voteWeight = 100n;
+      const totalWeight = 1000n;
+      const blockTimestamp = 1000000;
+      const blockNumber = 123456;
+      const txHash =
+        "0xabcdef0000000000000000000000000000000000000000000000000000000001";
+
+      it("should reconcile the pending mapping, delete it, create RootPool_LeafPool, and apply the Vote to the leaf pool", async () => {
+        const {
+          createMockLiquidityPoolAggregator,
+          createMockUserStatsPerPool,
+          createMockVeNFTState,
+          mockToken0Data,
+          mockToken1Data,
+        } = setupCommon();
+
+        const leafToken0: Token = {
+          ...mockToken0Data,
+          id: TokenId(leafChainId, mockToken0Data.address),
+          chainId: leafChainId,
+        };
+        const leafToken1: Token = {
+          ...mockToken1Data,
+          id: TokenId(leafChainId, mockToken1Data.address),
+          chainId: leafChainId,
+        };
+
+        const leafPool = createMockLiquidityPoolAggregator({
+          id: PoolId(leafChainId, leafPoolAddress),
+          chainId: leafChainId,
+          poolAddress: leafPoolAddress,
+          token0_id: leafToken0.id,
+          token1_id: leafToken1.id,
+          veNFTamountStaked: 0n,
+          rootPoolMatchingHash: rootPoolMatchingHash(
+            leafChainId,
+            token0,
+            token1,
+            tickSpacing,
+          ),
+        });
+
+        const leafUserStats = createMockUserStatsPerPool({
+          userAddress: ownerAddress,
+          poolAddress: leafPoolAddress,
+          chainId: leafChainId,
+          veNFTamountStaked: 0n,
+          firstActivityTimestamp: new Date(0),
+          lastActivityTimestamp: new Date(0),
+        });
+
+        const mockVeNFTState = createMockVeNFTState({
+          id: VeNFTId(rootChainId, voteTokenId),
+          chainId: rootChainId,
+          tokenId: voteTokenId,
+          owner: ownerAddress,
+        });
+
+        const pendingMapping = {
+          id: PendingRootPoolMappingId(rootChainId, rootPoolAddress),
+          rootChainId,
+          rootPoolAddress,
+          leafChainId,
+          token0,
+          token1,
+          tickSpacing,
+          rootPoolMatchingHash: rootPoolMatchingHash(
+            leafChainId,
+            token0,
+            token1,
+            tickSpacing,
+          ),
+        };
+
+        let db = MockDb.createMockDb();
+        db = db.entities.LiquidityPoolAggregator.set(leafPool);
+        db = db.entities.UserStatsPerPool.set(leafUserStats);
+        db = db.entities.Token.set(leafToken0);
+        db = db.entities.Token.set(leafToken1);
+        db = db.entities.VeNFTState.set(mockVeNFTState);
+        db = db.entities.PendingRootPoolMapping.set(pendingMapping);
+
+        const votedEvent = Voter.Voted.createMockEvent({
+          voter: voterAddress,
+          pool: rootPoolAddress,
+          tokenId: voteTokenId,
+          weight: voteWeight,
+          totalWeight,
+          mockEventData: {
+            block: {
+              number: blockNumber,
+              timestamp: blockTimestamp,
+              hash: txHash,
+            },
+            chainId: rootChainId,
+            logIndex: 1,
+            transaction: { hash: txHash },
+          },
+        });
+
+        const resultDB = await db.processEvents([votedEvent]);
+
+        // PendingRootPoolMapping was consumed.
+        const pending = resultDB.entities.PendingRootPoolMapping.get(
+          PendingRootPoolMappingId(rootChainId, rootPoolAddress),
+        );
+        expect(pending).toBeUndefined();
+
+        // RootPool_LeafPool was created linking root pool to leaf pool.
+        const rpLp = resultDB.entities.RootPool_LeafPool.get(
+          RootPoolLeafPoolId(
+            rootChainId,
+            leafChainId,
+            rootPoolAddress,
+            leafPoolAddress,
+          ),
+        );
+        expect(rpLp).toBeDefined();
+        expect(rpLp?.leafPoolAddress).toBe(leafPoolAddress);
+        expect(rpLp?.leafChainId).toBe(leafChainId);
+
+        // Vote was applied to the leaf pool, not dropped into PendingVote.
+        const updatedLeafPool = resultDB.entities.LiquidityPoolAggregator.get(
+          PoolId(leafChainId, leafPoolAddress),
+        );
+        expect(updatedLeafPool?.veNFTamountStaked).toBe(totalWeight);
+
+        const leafUserStatsId = UserStatsPerPoolId(
+          leafChainId,
+          ownerAddress,
+          leafPoolAddress,
+        );
+        const updatedUserStats =
+          resultDB.entities.UserStatsPerPool.get(leafUserStatsId);
+        expect(updatedUserStats?.veNFTamountStaked).toBe(voteWeight);
+
+        const veNFTPoolVote = resultDB.entities.VeNFTPoolVote.get(
+          VeNFTPoolVoteId(leafChainId, voteTokenId, leafPoolAddress),
+        );
+        expect(veNFTPoolVote).toBeDefined();
+        expect(veNFTPoolVote?.veNFTamountStaked).toBe(voteWeight);
+
+        // No PendingVote should remain — the vote was applied, not deferred.
+        expect(Array.from(resultDB.entities.PendingVote.getAll())).toHaveLength(
+          0,
+        );
+      });
+    });
+
     describe("Voted processed before RootPoolCreated (sync order edge case)", () => {
       const rootChainId = 10;
       const leafChainId = 252;

--- a/test/EventHandlers/Voter/VoterCommonLogic.test.ts
+++ b/test/EventHandlers/Voter/VoterCommonLogic.test.ts
@@ -9,6 +9,7 @@ import * as LiquidityPoolAggregatorModule from "../../../src/Aggregators/Liquidi
 import {
   PendingVoteId,
   RootGaugeRootPoolId,
+  RootPoolLeafPoolId,
   toChecksumAddress,
 } from "../../../src/Constants";
 import {
@@ -435,6 +436,16 @@ describe("resolveLeafPoolForRootGauge", () => {
       },
       RootPool_LeafPool: {
         getWhere: vi.fn().mockResolvedValue(getWhereValue),
+        set: vi.fn(),
+      },
+      // tryReconcileOrphanPendingRootPoolMapping reads these entities in the
+      // zero-mapping branch; the default stubs make reconciliation a no-op.
+      PendingRootPoolMapping: {
+        get: vi.fn().mockResolvedValue(undefined),
+        deleteUnsafe: vi.fn(),
+      },
+      LiquidityPoolAggregator: {
+        getWhere: vi.fn().mockResolvedValue([]),
       },
       log: {
         warn: vi.fn((msg: unknown) => warns.push(String(msg))),
@@ -574,5 +585,55 @@ describe("resolveLeafPoolForRootGauge", () => {
     const callArgs = vi.mocked(LiquidityPoolAggregatorModule.loadPoolData).mock
       .calls[0];
     expect(callArgs).toHaveLength(3);
+  });
+
+  // Issue #601: when no RootPool_LeafPool exists but a PendingRootPoolMapping is stuck
+  // and the leaf pool's LiquidityPoolAggregator is available, the helper must reconcile
+  // the mapping on the fly rather than returning null.
+  it("reconciles a stuck PendingRootPoolMapping via tryReconcileOrphanPendingRootPoolMapping and returns the leaf pool", async () => {
+    const mockPool = {
+      id: `${leafChainId}-${leafPoolAddress}`,
+      poolAddress: leafPoolAddress,
+      chainId: leafChainId,
+    } as unknown as LiquidityPoolAggregator;
+
+    vi.spyOn(LiquidityPoolAggregatorModule, "loadPoolData").mockResolvedValue({
+      liquidityPoolAggregator: mockPool,
+      token0Instance: {} as Token,
+      token1Instance: {} as Token,
+    });
+    const reconcileSpy = vi
+      .spyOn(
+        LiquidityPoolAggregatorModule,
+        "tryReconcileOrphanPendingRootPoolMapping",
+      )
+      .mockResolvedValue({
+        id: RootPoolLeafPoolId(
+          chainId,
+          leafChainId,
+          rootPoolAddress,
+          leafPoolAddress,
+        ),
+        rootChainId: chainId,
+        rootPoolAddress,
+        leafChainId,
+        leafPoolAddress,
+      });
+
+    const context = makeResolveContext({
+      rootGaugeMapping: { rootPoolAddress },
+      rootPoolLeafPools: [],
+    });
+
+    const result = await runResolve(context);
+
+    expect(reconcileSpy).toHaveBeenCalledWith(
+      context,
+      chainId,
+      rootPoolAddress,
+    );
+    expect(result).not.toBeNull();
+    expect(result?.pool).toBe(mockPool);
+    expect(result?.isCrossChain).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Closes #601.

Votes, bribes, and emissions on two root pools (Base `0x97Cd4EB6…`, Optimism `0x333030A7…`) were being silently dropped because their `RootPool_LeafPool` mappings never materialised. The deferred reconciliation path only fires when `CLFactory.PoolCreated` is observed on the leaf chain, and that event never reached us for the Celo leaf pool underlying the Optimism orphan (pool likely predates Celo's `start_block`). The pending record stayed orphaned forever and every cross-chain event against that root pool fell through `loadPoolDataOrRootCLPool` / `resolveLeafPoolForRootGauge` as `MAPPING_NOT_FOUND`.

This PR adds a reactive reconciliation step that recovers the mapping lazily the next time the root pool is referenced, whenever the leaf `LiquidityPoolAggregator` is already in the DB.

Full root-cause write-up: velodrome-finance/indexer#601 (comment).

## Approach

New helper `tryReconcileOrphanPendingRootPoolMapping(context, rootChainId, rootPoolAddress)` in `src/Aggregators/LiquidityPoolAggregator.ts`:

1. Loads `PendingRootPoolMapping` by `${rootChainId}-${rootPoolAddress}`.
2. Looks up `LiquidityPoolAggregator.getWhere({ rootPoolMatchingHash })` on the leaf side.
3. If exactly one leaf aggregator matches, creates `RootPool_LeafPool` and deletes the pending record. Otherwise returns `null` (fail-safe on ambiguous or missing leaf state).

Wired in as a pre-`MAPPING_NOT_FOUND` fallback in two places:

- `loadPoolDataOrRootCLPool` (drives `Voter.Voted` / `Voter.Abstained` / anything that resolves a pool by address)
- `resolveLeafPoolForRootGauge` (drives `Voter.DistributeReward` cross-chain gauges)

Both callers retry the standard leaf-pool lookup with the newly-created mapping after reconciliation succeeds. When reconciliation fails (no pending, ambiguous hash match, or no leaf aggregator yet) the code falls back to the existing `PendingVote` / `PendingDistribution` deferral path, so behaviour is strictly additive.

```mermaid
flowchart TB
    A[Voter.Voted / Abstained / DistributeReward<br/>references root pool] --> B{RootPool_LeafPool<br/>exists?}
    B -->|yes| C[apply vote/distribution<br/>to leaf pool]
    B -->|no| D[tryReconcileOrphan<br/>PendingRootPoolMapping]
    D --> E{PendingRootPoolMapping<br/>exists?}
    E -->|no| F[existing MAPPING_NOT_FOUND path:<br/>create PendingVote/PendingDistribution]
    E -->|yes| G{exactly one leaf<br/>aggregator matches hash?}
    G -->|no| F
    G -->|yes| H[create RootPool_LeafPool<br/>delete PendingRootPoolMapping]
    H --> C
```

## What this does not cover

- **Base orphan `0x97Cd4EB6…`:** no `RootCLPoolFactory` is registered for Base in `config.yaml`, so no `PendingRootPoolMapping` ever exists and reconciliation has nothing to consume. Requires registering the correct Aerodrome-Base root factory address — follow-up ticket, not in this PR.
- **Celo leaf aggregator missing entirely:** if the indexer has no `LiquidityPoolAggregator` for the leaf pool (e.g. pool predates `start_block` and no subsequent event surfaced it), reconciliation cannot match. Separate data-sourcing concern.
- **Backlog flushing of already-persisted `PendingVote` / `PendingDistribution`:** the reconciliation fixes the mapping so new events flow through correctly, but previously-deferred pendings for the orphan root pool are not re-processed here. A one-off cleanup is a separate task.

## Testing

Three new tests, all following existing harnesses:

- `test/Aggregators/LiquidityPoolAggregator.test.ts` — unit tests for `tryReconcileOrphanPendingRootPoolMapping` covering: happy path (reconciles + writes `RootPool_LeafPool` + deletes pending), ambiguous leaf aggregator (no-op), missing pending (no-op).
- `test/EventHandlers/Voter/Voter.test.ts` — end-to-end `Voter.Voted` test using the real `(CELO, XVELO, 2000)` token pair from the issue: starts with `PendingRootPoolMapping` + leaf `LiquidityPoolAggregator`, ends with the vote applied to the leaf pool and the pending record gone.
- `test/EventHandlers/Voter/VoterCommonLogic.test.ts` — `resolveLeafPoolForRootGauge` test verifying the reconciliation helper is invoked on the zero-mapping branch.

Existing tests updated only to add the new `PendingRootPoolMapping` entity to mock contexts — no behavioural changes.

```
pnpm test     # 1028 passed, 32 skipped
pnpm qa       # biome clean
tsc --noEmit  # clean
```

## Post-Deploy Monitoring & Validation

This ships as a lazy read-path behaviour change. To validate after deploy:

**Log queries**
- Search `[resolveLeafPoolForRootGauge] … RootPool_LeafPool mapping not found or ambiguous` for the two orphan root pool addresses. Count should drop to zero for `0x333030A736B47D20346d82A473680658ac1C2b88` once a Celo `LiquidityPoolAggregator` exists for the matching pool. Count for the Base orphan `0x97Cd4EB683E29695DC93eec95d47d4E7a35E2112` is expected to remain unchanged (see "What this does not cover") until the follow-up factory registration ships.
- Search `[loadPoolData] LiquidityPoolAggregator 8453-0x97Cd4EB6…` and `…LiquidityPoolAggregator 10-0x333030A7…` errors — same expectation.

**Entity checks**
- `SELECT COUNT(*) FROM "PendingRootPoolMapping" WHERE "rootPoolMatchingHash" = '42220_0x471EcE3750Da237f93B8E339c536989b8978a438_0x7f9AdFbd38b669F03d1d11000Bc76b9AaEA28A81_2000';` — expected to drop to 0 after the first vote/bribe/emission on the Optimism orphan reaches the indexer (contingent on the Celo aggregator being present).
- `SELECT COUNT(*) FROM "RootPool_LeafPool" WHERE "rootPoolAddress" = '0x333030A736B47D20346d82A473680658ac1C2b88';` — expected to become 1 after reconciliation.

**Failure signals**
- Any new error like `Expected exactly one RootPool_LeafPool for pool …` would indicate the reconciliation produced a duplicate mapping; mitigation is an immediate revert and we would investigate hash collisions.
- No change in `PendingRootPoolMapping` count after a known Voted/DistributeReward against the Optimism orphan means either the Celo leaf aggregator still doesn't exist in the DB (expected — separate concern) or the hash is not matching (investigate case/checksum).

**Validation window**: 24 hours post-deploy, owner: indexer maintainers.
**Rollback**: straightforward revert of this commit; behaviour on the non-orphan path is strictly unchanged.

---

[![Compound Engineering v2.62.0](https://img.shields.io/badge/Compound_Engineering-v2.62.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.7 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)