### PR TITLE
fix(nfpm): scope position lookups by NFPM address to fix orphaned positions (#603)

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -331,6 +331,7 @@ type NonFungiblePosition {
   id: ID! # Format: {chainId}-{poolAddress}-{tokenId} (NonFungiblePositionId)
   chainId: Int! # Chain ID where the NFT exists
   tokenId: BigInt! @index # Token ID of the NFT (from Transfer event)
+  nfpmAddress: String! @index # Address of the NFPM contract that emitted the Transfer; disambiguates intra-chain tokenId collisions across multiple NFPMs (e.g. Optimism has two)
   owner: String! @index # Checksum address of the current owner (from Transfer event)
   pool: String! @index # Address of the CL pool this position belongs to
   tickUpper: BigInt! @config(precision: 24) # Upper tick of the position range
@@ -350,6 +351,7 @@ type NonFungiblePositionSnapshot {
   id: ID! # Format: {chainId}-{tokenId}-{epochMs} (NonFungiblePositionSnapshotId)
   chainId: Int!
   tokenId: BigInt! @index
+  nfpmAddress: String! @index
   owner: String! @index
   pool: String! @index
   tickLower: BigInt! @config(precision: 24)

--- a/src/EventHandlers/NFPM/NFPMCommonLogic.ts
+++ b/src/EventHandlers/NFPM/NFPMCommonLogic.ts
@@ -21,18 +21,24 @@ export enum LiquidityChangeType {
 }
 
 /**
- * Finds a NonFungiblePosition entity by tokenId, filtering by chainId to avoid cross-chain collisions.
- * Uses a single-field getWhere (tokenId) then filters by chainId in memory because Envio's getWhere
- * supports only one filter field per call.
+ * Finds a NonFungiblePosition entity by tokenId, scoped to a specific chain AND NFPM contract.
+ *
+ * Uses a single-field getWhere (tokenId) then narrows in memory because Envio's getWhere supports
+ * only one filter field per call. Filtering by (chainId, nfpmAddress) is required because tokenIds
+ * are only unique within a single NFPM contract's counter — cross-chain and intra-chain (multiple
+ * NFPMs on the same chain, e.g. Optimism) collisions would otherwise leak the wrong position and
+ * silently misattribute liquidity, ownership, and stake state.
  *
  * @param tokenId - The token ID to search for
  * @param chainId - The chain ID to filter by
+ * @param nfpmAddress - The NFPM contract address (event.srcAddress) to filter by
  * @param context - The handler context for database operations
- * @returns Array of matching positions (should be 0 or 1), filtered by chainId
+ * @returns Array of matching positions (should be 0 or 1)
  */
 export async function findPositionByTokenId(
   tokenId: bigint,
   chainId: number,
+  nfpmAddress: string,
   context: handlerContext,
 ): Promise<NonFungiblePosition[]> {
   const positions = await context.NonFungiblePosition.getWhere({
@@ -43,9 +49,9 @@ export async function findPositionByTokenId(
     return [];
   }
 
-  // Filter by chainId to ensure we get the position from the correct chain
   return positions.filter(
-    (pos: NonFungiblePosition) => pos.chainId === chainId,
+    (pos: NonFungiblePosition) =>
+      pos.chainId === chainId && pos.nfpmAddress === nfpmAddress,
   );
 }
 

--- a/src/EventHandlers/NFPM/NFPMDecreaseLiquidityLogic.ts
+++ b/src/EventHandlers/NFPM/NFPMDecreaseLiquidityLogic.ts
@@ -52,10 +52,12 @@ export async function processNFPMDecreaseLiquidity(
 ): Promise<void> {
   // Get position by tokenId
   // Transfer should have already run and updated the placeholder, so position should exist when a DecreaseLiquidity event is processed
-  // Filter by chainId to avoid cross-chain collisions (same tokenId can exist on different chains)
+  // Filter by chainId AND nfpmAddress to avoid collisions: same tokenId can exist on different chains,
+  // and on chains with multiple NFPM contracts (e.g. Optimism) each NFPM has its own tokenId counter.
   const positions = await findPositionByTokenId(
     event.params.tokenId,
     event.chainId,
+    event.srcAddress,
     context,
   );
 

--- a/src/EventHandlers/NFPM/NFPMIncreaseLiquidityLogic.ts
+++ b/src/EventHandlers/NFPM/NFPMIncreaseLiquidityLogic.ts
@@ -57,10 +57,12 @@ export async function processNFPMIncreaseLiquidity(
 ): Promise<void> {
   // Get position by tokenId
   // Transfer (i.e. relative to mint) should have already run and updated the placeholder, so position should exist when an IncreaseLiquidity event is processed
-  // Filter by chainId to avoid cross-chain collisions (same tokenId can exist on different chains)
+  // Filter by chainId AND nfpmAddress to avoid collisions: same tokenId can exist on different chains,
+  // and on chains with multiple NFPM contracts (e.g. Optimism) each NFPM has its own tokenId counter.
   const positions = await findPositionByTokenId(
     event.params.tokenId,
     event.chainId,
+    event.srcAddress,
     context,
   );
 

--- a/src/EventHandlers/NFPM/NFPMTransferLogic.ts
+++ b/src/EventHandlers/NFPM/NFPMTransferLogic.ts
@@ -33,6 +33,7 @@ export async function createPositionFromCLPoolMint(
   mintEvent: CLPoolMintEvent,
   tokenId: bigint,
   owner: string,
+  nfpmAddress: string,
   chainId: number,
   blockTimestamp: number,
   context: handlerContext,
@@ -45,6 +46,7 @@ export async function createPositionFromCLPoolMint(
     id: stableId,
     chainId: mintEvent.chainId,
     tokenId: tokenId,
+    nfpmAddress: nfpmAddress,
     owner: owner,
     pool: mintEvent.pool,
     tickUpper: mintEvent.tickUpper,
@@ -132,6 +134,7 @@ export async function handleMintTransfer(
       mintEvent,
       event.params.tokenId,
       event.params.to,
+      event.srcAddress,
       event.chainId,
       event.block.timestamp,
       context,
@@ -350,6 +353,7 @@ export async function processNFPMTransfer(
   const positions = await findPositionByTokenId(
     event.params.tokenId,
     event.chainId,
+    event.srcAddress,
     context,
   );
 

--- a/src/Snapshots/NonFungiblePositionSnapshot.ts
+++ b/src/Snapshots/NonFungiblePositionSnapshot.ts
@@ -32,6 +32,7 @@ export function createNonFungiblePositionSnapshot(
     id: snapshotId,
     chainId: entity.chainId,
     tokenId: entity.tokenId,
+    nfpmAddress: entity.nfpmAddress,
     owner: entity.owner,
     pool: entity.pool,
     tickLower: entity.tickLower,

--- a/test/Aggregators/NonFungiblePosition.test.ts
+++ b/test/Aggregators/NonFungiblePosition.test.ts
@@ -10,10 +10,14 @@ describe("NonFungiblePosition", () => {
   const poolAddress = toChecksumAddress(
     "0x0000000000000000000000000000000000000001",
   );
+  const nfpmAddress = toChecksumAddress(
+    "0xbB5DFE1380333CEE4c2EeBd7202c80dE2256AdF4",
+  );
   const mockNonFungiblePosition: NonFungiblePosition = {
     id: NonFungiblePositionId(10, poolAddress, 1n),
     chainId: 10,
     tokenId: 1n,
+    nfpmAddress: nfpmAddress,
     owner: toChecksumAddress("0x1111111111111111111111111111111111111111"),
     pool: poolAddress,
     tickUpper: 100n,

--- a/test/Aggregators/NonFungiblePosition.test.ts
+++ b/test/Aggregators/NonFungiblePosition.test.ts
@@ -2,6 +2,7 @@ import type { NonFungiblePosition, handlerContext } from "generated";
 import { updateNonFungiblePosition } from "../../src/Aggregators/NonFungiblePosition";
 import { NonFungiblePositionId, toChecksumAddress } from "../../src/Constants";
 import { getSnapshotEpoch } from "../../src/Snapshots/Shared";
+import { NFPM_ADDRESS } from "../EventHandlers/Pool/common";
 
 describe("NonFungiblePosition", () => {
   let mockContext: Partial<handlerContext>;
@@ -10,9 +11,7 @@ describe("NonFungiblePosition", () => {
   const poolAddress = toChecksumAddress(
     "0x0000000000000000000000000000000000000001",
   );
-  const nfpmAddress = toChecksumAddress(
-    "0xbB5DFE1380333CEE4c2EeBd7202c80dE2256AdF4",
-  );
+  const nfpmAddress = NFPM_ADDRESS;
   const mockNonFungiblePosition: NonFungiblePosition = {
     id: NonFungiblePositionId(10, poolAddress, 1n),
     chainId: 10,

--- a/test/EventHandlers/ALM/DeployFactoryV1.test.ts
+++ b/test/EventHandlers/ALM/DeployFactoryV1.test.ts
@@ -33,6 +33,9 @@ describe("ALMDeployFactoryV1 StrategyCreated Event", () => {
   const blockTimestamp = 1000000;
   const blockNumber = 123456;
   const tokenId = 42n;
+  const nfpmAddress = toChecksumAddress(
+    "0xbB5DFE1380333CEE4c2EeBd7202c80dE2256AdF4",
+  );
 
   // sqrtPriceX96 is constant (calculated from tick 0 in setupCommon)
   const sqrtPriceX96 = mockLiquidityPoolData.sqrtPriceX96;
@@ -64,6 +67,7 @@ describe("ALMDeployFactoryV1 StrategyCreated Event", () => {
         id: NonFungiblePositionId(chainId, poolAddress, tokenId),
         chainId,
         tokenId,
+        nfpmAddress: nfpmAddress,
         owner: callerAddress,
         pool: poolAddress,
         tickUpper: 1000n,
@@ -266,6 +270,7 @@ describe("ALMDeployFactoryV1 StrategyCreated Event", () => {
         id: NonFungiblePositionId(chainId, poolAddress, tokenId),
         chainId,
         tokenId,
+        nfpmAddress: nfpmAddress,
         owner: callerAddress,
         pool: poolAddress,
         tickUpper: 1000n,
@@ -284,6 +289,7 @@ describe("ALMDeployFactoryV1 StrategyCreated Event", () => {
         id: NonFungiblePositionId(chainId, poolAddress, tokenId + 1n),
         chainId,
         tokenId: tokenId + 1n,
+        nfpmAddress: nfpmAddress,
         owner: callerAddress,
         pool: poolAddress,
         tickUpper: 2000n, // Different tickUpper
@@ -359,6 +365,7 @@ describe("ALMDeployFactoryV1 StrategyCreated Event", () => {
         id: NonFungiblePositionId(chainId, poolAddress, tokenId),
         chainId,
         tokenId,
+        nfpmAddress: nfpmAddress,
         owner: callerAddress,
         pool: poolAddress,
         tickUpper: 1000n,
@@ -377,6 +384,7 @@ describe("ALMDeployFactoryV1 StrategyCreated Event", () => {
         id: NonFungiblePositionId(chainId, poolAddress, tokenId + 1n),
         chainId,
         tokenId: tokenId + 1n,
+        nfpmAddress: nfpmAddress,
         owner: callerAddress,
         pool: poolAddress,
         tickUpper: 1000n,

--- a/test/EventHandlers/ALM/DeployFactoryV1.test.ts
+++ b/test/EventHandlers/ALM/DeployFactoryV1.test.ts
@@ -15,7 +15,7 @@ import {
 import { setupCommon } from "../Pool/common";
 
 describe("ALMDeployFactoryV1 StrategyCreated Event", () => {
-  const { mockLiquidityPoolData, mockToken0Data, mockToken1Data } =
+  const { mockLiquidityPoolData, mockToken0Data, mockToken1Data, nfpmAddress } =
     setupCommon();
   const chainId = mockLiquidityPoolData.chainId;
   const poolAddress = mockLiquidityPoolData.poolAddress;
@@ -33,9 +33,6 @@ describe("ALMDeployFactoryV1 StrategyCreated Event", () => {
   const blockTimestamp = 1000000;
   const blockNumber = 123456;
   const tokenId = 42n;
-  const nfpmAddress = toChecksumAddress(
-    "0xbB5DFE1380333CEE4c2EeBd7202c80dE2256AdF4",
-  );
 
   // sqrtPriceX96 is constant (calculated from tick 0 in setupCommon)
   const sqrtPriceX96 = mockLiquidityPoolData.sqrtPriceX96;

--- a/test/EventHandlers/ALM/DeployFactoryV2.test.ts
+++ b/test/EventHandlers/ALM/DeployFactoryV2.test.ts
@@ -30,6 +30,9 @@ describe("ALMDeployFactoryV2 StrategyCreated Event", () => {
   const blockTimestamp = 1000000;
   const blockNumber = 123456;
   const tokenId = 42n;
+  const nfpmAddress = toChecksumAddress(
+    "0xbB5DFE1380333CEE4c2EeBd7202c80dE2256AdF4",
+  );
 
   // sqrtPriceX96 is constant (calculated from tick 0 in setupCommon)
   const sqrtPriceX96 = mockLiquidityPoolData.sqrtPriceX96 ?? 0n;
@@ -56,6 +59,7 @@ describe("ALMDeployFactoryV2 StrategyCreated Event", () => {
         id: NonFungiblePositionId(chainId, poolAddress, tokenId),
         chainId,
         tokenId,
+        nfpmAddress: nfpmAddress,
         owner: callerAddress,
         pool: poolAddress,
         tickUpper: 1000n,
@@ -303,6 +307,7 @@ describe("ALMDeployFactoryV2 StrategyCreated Event", () => {
         id: NonFungiblePositionId(chainId, poolAddress, tokenId),
         chainId,
         tokenId,
+        nfpmAddress: nfpmAddress,
         owner: callerAddress,
         pool: poolAddress,
         tickUpper: 1000n,
@@ -418,6 +423,7 @@ describe("ALMDeployFactoryV2 StrategyCreated Event", () => {
         id: NonFungiblePositionId(chainId, poolAddress, tokenId),
         chainId,
         tokenId,
+        nfpmAddress: nfpmAddress,
         owner: callerAddress,
         pool: poolAddress,
         tickUpper: 1000n,
@@ -477,6 +483,7 @@ describe("ALMDeployFactoryV2 StrategyCreated Event", () => {
         id: NonFungiblePositionId(chainId, poolAddress, tokenId),
         chainId,
         tokenId,
+        nfpmAddress: nfpmAddress,
         owner: callerAddress,
         pool: poolAddress,
         tickUpper: 1000n,
@@ -536,6 +543,7 @@ describe("ALMDeployFactoryV2 StrategyCreated Event", () => {
         id: NonFungiblePositionId(chainId, poolAddress, tokenId),
         chainId,
         tokenId,
+        nfpmAddress: nfpmAddress,
         owner: callerAddress,
         pool: poolAddress,
         tickUpper: 2000n, // Different tickUpper (tickLower matches)
@@ -595,6 +603,7 @@ describe("ALMDeployFactoryV2 StrategyCreated Event", () => {
         id: NonFungiblePositionId(chainId, poolAddress, tokenId),
         chainId,
         tokenId,
+        nfpmAddress: nfpmAddress,
         owner: callerAddress,
         pool: poolAddress,
         tickUpper: 1000n,
@@ -654,6 +663,7 @@ describe("ALMDeployFactoryV2 StrategyCreated Event", () => {
         id: NonFungiblePositionId(chainId, poolAddress, tokenId),
         chainId,
         tokenId,
+        nfpmAddress: nfpmAddress,
         owner: callerAddress,
         pool: poolAddress,
         tickUpper: 1000n,
@@ -723,6 +733,7 @@ describe("ALMDeployFactoryV2 StrategyCreated Event", () => {
         id: NonFungiblePositionId(chainId, poolAddress, tokenId),
         chainId,
         tokenId,
+        nfpmAddress: nfpmAddress,
         owner: callerAddress,
         pool: poolAddress,
         tickUpper: 1000n,

--- a/test/EventHandlers/ALM/DeployFactoryV2.test.ts
+++ b/test/EventHandlers/ALM/DeployFactoryV2.test.ts
@@ -15,7 +15,7 @@ import {
 import { setupCommon } from "../Pool/common";
 
 describe("ALMDeployFactoryV2 StrategyCreated Event", () => {
-  const { mockLiquidityPoolData, mockToken0Data, mockToken1Data } =
+  const { mockLiquidityPoolData, mockToken0Data, mockToken1Data, nfpmAddress } =
     setupCommon();
   const chainId = mockLiquidityPoolData.chainId;
   const poolAddress = mockLiquidityPoolData.poolAddress;
@@ -30,9 +30,6 @@ describe("ALMDeployFactoryV2 StrategyCreated Event", () => {
   const blockTimestamp = 1000000;
   const blockNumber = 123456;
   const tokenId = 42n;
-  const nfpmAddress = toChecksumAddress(
-    "0xbB5DFE1380333CEE4c2EeBd7202c80dE2256AdF4",
-  );
 
   // sqrtPriceX96 is constant (calculated from tick 0 in setupCommon)
   const sqrtPriceX96 = mockLiquidityPoolData.sqrtPriceX96 ?? 0n;

--- a/test/EventHandlers/NFPM/NFPM.test.ts
+++ b/test/EventHandlers/NFPM/NFPM.test.ts
@@ -8,7 +8,7 @@ import {
   TokenId,
   toChecksumAddress,
 } from "../../../src/Constants";
-import { setupCommon } from "../Pool/common";
+import { NFPM_ADDRESS, setupCommon } from "../Pool/common";
 
 describe("NFPM Events", () => {
   const {
@@ -24,9 +24,7 @@ describe("NFPM Events", () => {
   const token0Address = mockToken0Data.address;
   const token1Address = mockToken1Data.address;
   const tokenId = 1n;
-  const nfpmAddress = toChecksumAddress(
-    "0xbB5DFE1380333CEE4c2EeBd7202c80dE2256AdF4",
-  );
+  const nfpmAddress = NFPM_ADDRESS;
 
   const transactionHash =
     "0x1234567890123456789012345678901234567890123456789012345678901234";

--- a/test/EventHandlers/NFPM/NFPM.test.ts
+++ b/test/EventHandlers/NFPM/NFPM.test.ts
@@ -24,6 +24,9 @@ describe("NFPM Events", () => {
   const token0Address = mockToken0Data.address;
   const token1Address = mockToken1Data.address;
   const tokenId = 1n;
+  const nfpmAddress = toChecksumAddress(
+    "0xbB5DFE1380333CEE4c2EeBd7202c80dE2256AdF4",
+  );
 
   const transactionHash =
     "0x1234567890123456789012345678901234567890123456789012345678901234";
@@ -33,6 +36,7 @@ describe("NFPM Events", () => {
     id: NonFungiblePositionId(chainId, poolAddress, tokenId),
     chainId,
     tokenId: tokenId,
+    nfpmAddress: nfpmAddress,
     owner: toChecksumAddress("0x1111111111111111111111111111111111111111"),
     pool: poolAddress,
     tickUpper: 100n,
@@ -74,9 +78,7 @@ describe("NFPM Events", () => {
         },
         chainId: 10,
         logIndex: 1,
-        srcAddress: toChecksumAddress(
-          "0x3333333333333333333333333333333333333333",
-        ),
+        srcAddress: nfpmAddress,
       },
     };
 
@@ -179,9 +181,7 @@ describe("NFPM Events", () => {
           },
           chainId: 10,
           logIndex: transferLogIndex,
-          srcAddress: toChecksumAddress(
-            "0x3333333333333333333333333333333333333333",
-          ),
+          srcAddress: nfpmAddress,
           transaction: {
             hash: transactionHash,
           },
@@ -222,9 +222,7 @@ describe("NFPM Events", () => {
         },
         chainId: 10,
         logIndex: 1,
-        srcAddress: toChecksumAddress(
-          "0x3333333333333333333333333333333333333333",
-        ),
+        srcAddress: nfpmAddress,
         transaction: {
           hash: transactionHash,
         },
@@ -440,9 +438,7 @@ describe("NFPM Events", () => {
         },
         chainId: 10,
         logIndex: 1,
-        srcAddress: toChecksumAddress(
-          "0x3333333333333333333333333333333333333333",
-        ),
+        srcAddress: nfpmAddress,
       },
     };
 
@@ -491,9 +487,7 @@ describe("NFPM Events", () => {
           },
           chainId: 10,
           logIndex: 1,
-          srcAddress: toChecksumAddress(
-            "0x3333333333333333333333333333333333333333",
-          ),
+          srcAddress: nfpmAddress,
           transaction: {
             hash: transactionHash,
           },
@@ -548,9 +542,7 @@ describe("NFPM Events", () => {
           },
           chainId: 10,
           logIndex: 1,
-          srcAddress: toChecksumAddress(
-            "0x3333333333333333333333333333333333333333",
-          ),
+          srcAddress: nfpmAddress,
           transaction: {
             hash: transactionHash,
           },
@@ -585,6 +577,7 @@ describe("NFPM Events", () => {
       id: NonFungiblePositionId(chainIdBase, poolAddressBase, sameTokenId),
       chainId: chainIdBase,
       tokenId: sameTokenId,
+      nfpmAddress: nfpmAddress,
       owner: toChecksumAddress("0x1111111111111111111111111111111111111111"),
       pool: poolAddressBase,
       tickUpper: 100n,
@@ -604,6 +597,7 @@ describe("NFPM Events", () => {
       id: NonFungiblePositionId(chainIdLisk, poolAddressLisk, sameTokenId),
       chainId: chainIdLisk,
       tokenId: sameTokenId,
+      nfpmAddress: nfpmAddress,
       owner: toChecksumAddress("0x2222222222222222222222222222222222222222"),
       pool: poolAddressLisk,
       tickUpper: 200n,
@@ -763,9 +757,7 @@ describe("NFPM Events", () => {
           },
           chainId: chainIdBase, // Event is on Base chain
           logIndex: 1,
-          srcAddress: toChecksumAddress(
-            "0x3333333333333333333333333333333333333333",
-          ),
+          srcAddress: nfpmAddress,
         },
       });
 
@@ -865,9 +857,7 @@ describe("NFPM Events", () => {
           },
           chainId: chainIdBase, // Event is on Base chain
           logIndex: 1,
-          srcAddress: toChecksumAddress(
-            "0x3333333333333333333333333333333333333333",
-          ),
+          srcAddress: nfpmAddress,
           transaction: {
             hash: transactionHash,
           },
@@ -967,9 +957,7 @@ describe("NFPM Events", () => {
           },
           chainId: chainIdLisk, // Event is on Lisk chain
           logIndex: 1,
-          srcAddress: toChecksumAddress(
-            "0x3333333333333333333333333333333333333333",
-          ),
+          srcAddress: nfpmAddress,
           transaction: {
             hash: transactionHash,
           },
@@ -1070,9 +1058,7 @@ describe("NFPM Events", () => {
           },
           chainId: chainIdBase, // Event is on Base chain (8453)
           logIndex: 1,
-          srcAddress: toChecksumAddress(
-            "0x3333333333333333333333333333333333333333",
-          ),
+          srcAddress: nfpmAddress,
           transaction: {
             hash: transactionHash,
           },

--- a/test/EventHandlers/NFPM/NFPMCommonLogic.test.ts
+++ b/test/EventHandlers/NFPM/NFPMCommonLogic.test.ts
@@ -40,6 +40,15 @@ describe("NFPMCommonLogic", () => {
   const poolAddress = toChecksumAddress(
     "0x00cd0AbB6c2964F7Dfb5169dD94A9F004C35F458",
   );
+  const nfpmAddressA = toChecksumAddress(
+    "0xbB5DFE1380333CEE4c2EeBd7202c80dE2256AdF4",
+  );
+  const nfpmAddressB = toChecksumAddress(
+    "0x416b433906b1B72FA758e166e239c43d68dC6F29",
+  );
+  const poolAddressB = toChecksumAddress(
+    "0x00cd0AbB6c2964F7Dfb5169dD94A9F004C35F459",
+  );
 
   const mockPosition: NonFungiblePosition = {
     id: NonFungiblePositionId(chainId, poolAddress, tokenId),
@@ -47,6 +56,7 @@ describe("NFPMCommonLogic", () => {
     tokenId: tokenId,
     owner: toChecksumAddress("0x1DFAb7699121fEF702d07932a447868dCcCFb029"),
     pool: poolAddress,
+    nfpmAddress: nfpmAddressA,
     tickUpper: 0n,
     tickLower: -4n,
     token0: toChecksumAddress("0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85"),
@@ -66,6 +76,16 @@ describe("NFPMCommonLogic", () => {
     chainId: 8453, // Different chain
   };
 
+  // Same chain (chainId=10) and same tokenId as mockPosition, but different NFPM and pool.
+  // Reproduces the intra-chain multi-NFPM collision: Optimism has two NFPM contracts,
+  // each with its own tokenId counter, so tokenId 540 can exist on both.
+  const mockPositionSameTokenDifferentNfpm: NonFungiblePosition = {
+    ...mockPosition,
+    id: NonFungiblePositionId(chainId, poolAddressB, tokenId),
+    pool: poolAddressB,
+    nfpmAddress: nfpmAddressB,
+  };
+
   let mockDb: ReturnType<typeof MockDb.createMockDb>;
   let mockContext: handlerContext;
 
@@ -75,6 +95,7 @@ describe("NFPMCommonLogic", () => {
     const storedPositions: NonFungiblePosition[] = [
       mockPosition,
       mockPositionDifferentChain,
+      mockPositionSameTokenDifferentNfpm,
     ];
 
     const getWhereNonFungiblePosition = vi
@@ -113,22 +134,25 @@ describe("NFPMCommonLogic", () => {
   });
 
   describe("findPositionByTokenId", () => {
-    it("should find position by tokenId on correct chain", async () => {
+    it("should find position by tokenId on correct chain and NFPM", async () => {
       const positions = await findPositionByTokenId(
         tokenId,
         chainId,
+        nfpmAddressA,
         mockContext,
       );
 
       expect(positions).toHaveLength(1);
       expect(positions[0]?.id).toBe(mockPosition.id);
       expect(positions[0]?.chainId).toBe(chainId);
+      expect(positions[0]?.nfpmAddress).toBe(nfpmAddressA);
     });
 
     it("should filter by chainId to avoid cross-chain collisions", async () => {
       const positions = await findPositionByTokenId(
         tokenId,
         8453, // Different chain
+        nfpmAddressA,
         mockContext,
       );
 
@@ -137,10 +161,26 @@ describe("NFPMCommonLogic", () => {
       expect(positions[0]?.chainId).toBe(8453);
     });
 
+    it("should filter by nfpmAddress to avoid intra-chain multi-NFPM collisions", async () => {
+      // Same chain, same tokenId, but a different NFPM contract (Optimism has two)
+      const positions = await findPositionByTokenId(
+        tokenId,
+        chainId,
+        nfpmAddressB,
+        mockContext,
+      );
+
+      expect(positions).toHaveLength(1);
+      expect(positions[0]?.id).toBe(mockPositionSameTokenDifferentNfpm.id);
+      expect(positions[0]?.nfpmAddress).toBe(nfpmAddressB);
+      expect(positions[0]?.pool).toBe(poolAddressB);
+    });
+
     it("should return empty array when no position exists", async () => {
       const positions = await findPositionByTokenId(
         999n, // Non-existent tokenId
         chainId,
+        nfpmAddressA,
         mockContext,
       );
 
@@ -151,6 +191,24 @@ describe("NFPMCommonLogic", () => {
       const positions = await findPositionByTokenId(
         tokenId,
         1, // Chain where position doesn't exist
+        nfpmAddressA,
+        mockContext,
+      );
+
+      expect(positions).toHaveLength(0);
+    });
+
+    it("should return empty array when the tokenId exists on same chain but under a different NFPM", async () => {
+      // Querying for an NFPM that has no position for this tokenId on this chain:
+      // previous behavior would leak the other NFPM's position and corrupt it.
+      const unknownNfpm = toChecksumAddress(
+        "0x0000000000000000000000000000000000000123",
+      );
+
+      const positions = await findPositionByTokenId(
+        tokenId,
+        chainId,
+        unknownNfpm,
         mockContext,
       );
 

--- a/test/EventHandlers/NFPM/NFPMCommonLogic.test.ts
+++ b/test/EventHandlers/NFPM/NFPMCommonLogic.test.ts
@@ -27,7 +27,7 @@ import {
   calculatePositionAmountsFromLiquidity,
   calculateTotalUSD,
 } from "../../../src/Helpers";
-import { setupCommon } from "../Pool/common";
+import { NFPM_ADDRESS, setupCommon } from "../Pool/common";
 
 vi.mock("../../../src/Aggregators/CLStakedLiquidity");
 vi.mock("../../../src/Aggregators/LiquidityPoolAggregator");
@@ -40,9 +40,7 @@ describe("NFPMCommonLogic", () => {
   const poolAddress = toChecksumAddress(
     "0x00cd0AbB6c2964F7Dfb5169dD94A9F004C35F458",
   );
-  const nfpmAddressA = toChecksumAddress(
-    "0xbB5DFE1380333CEE4c2EeBd7202c80dE2256AdF4",
-  );
+  const nfpmAddressA = NFPM_ADDRESS;
   const nfpmAddressB = toChecksumAddress(
     "0x416b433906b1B72FA758e166e239c43d68dC6F29",
   );

--- a/test/EventHandlers/NFPM/NFPMDecreaseLiquidityLogic.test.ts
+++ b/test/EventHandlers/NFPM/NFPMDecreaseLiquidityLogic.test.ts
@@ -37,6 +37,9 @@ describe("NFPMDecreaseLiquidityLogic", () => {
   const poolAddress = toChecksumAddress(
     "0x00cd0AbB6c2964F7Dfb5169dD94A9F004C35F458",
   );
+  const nfpmAddress = toChecksumAddress(
+    "0xbB5DFE1380333CEE4c2EeBd7202c80dE2256AdF4",
+  );
   const blockTimestamp = new Date(1712065791 * 1000);
 
   function expectSnapshotSet(context: handlerContext, liquidity: bigint): void {
@@ -60,6 +63,7 @@ describe("NFPMDecreaseLiquidityLogic", () => {
     id: NonFungiblePositionId(chainId, poolAddress, tokenId),
     chainId: chainId,
     tokenId: tokenId,
+    nfpmAddress: nfpmAddress,
     owner: toChecksumAddress("0x1DFAb7699121fEF702d07932a447868dCcCFb029"),
     pool: poolAddress,
     tickUpper: 0n,

--- a/test/EventHandlers/NFPM/NFPMDecreaseLiquidityLogic.test.ts
+++ b/test/EventHandlers/NFPM/NFPMDecreaseLiquidityLogic.test.ts
@@ -18,6 +18,7 @@ import {
   processNFPMDecreaseLiquidity,
 } from "../../../src/EventHandlers/NFPM/NFPMDecreaseLiquidityLogic";
 import { getSnapshotEpoch } from "../../../src/Snapshots/Shared";
+import { NFPM_ADDRESS } from "../Pool/common";
 
 vi.mock("../../../src/Aggregators/LiquidityPoolAggregator", async () => ({
   ...(await vi.importActual(
@@ -37,9 +38,7 @@ describe("NFPMDecreaseLiquidityLogic", () => {
   const poolAddress = toChecksumAddress(
     "0x00cd0AbB6c2964F7Dfb5169dD94A9F004C35F458",
   );
-  const nfpmAddress = toChecksumAddress(
-    "0xbB5DFE1380333CEE4c2EeBd7202c80dE2256AdF4",
-  );
+  const nfpmAddress = NFPM_ADDRESS;
   const blockTimestamp = new Date(1712065791 * 1000);
 
   function expectSnapshotSet(context: handlerContext, liquidity: bigint): void {
@@ -50,6 +49,7 @@ describe("NFPMDecreaseLiquidityLogic", () => {
         id: NonFungiblePositionSnapshotId(chainId, tokenId, epoch.getTime()),
         chainId,
         tokenId,
+        nfpmAddress: mockPosition.nfpmAddress,
         owner: mockPosition.owner,
         pool: poolAddress,
         liquidity,
@@ -168,9 +168,7 @@ describe("NFPMDecreaseLiquidityLogic", () => {
           },
           chainId: chainId,
           logIndex: 96,
-          srcAddress: toChecksumAddress(
-            "0xbB5DFE1380333CEE4c2EeBd7202c80dE2256AdF4",
-          ),
+          srcAddress: nfpmAddress,
         },
       });
 
@@ -194,9 +192,7 @@ describe("NFPMDecreaseLiquidityLogic", () => {
           },
           chainId: chainId,
           logIndex: 96,
-          srcAddress: toChecksumAddress(
-            "0xbB5DFE1380333CEE4c2EeBd7202c80dE2256AdF4",
-          ),
+          srcAddress: nfpmAddress,
         },
       });
 
@@ -221,9 +217,7 @@ describe("NFPMDecreaseLiquidityLogic", () => {
           },
           chainId: chainId,
           logIndex: 96,
-          srcAddress: toChecksumAddress(
-            "0xbB5DFE1380333CEE4c2EeBd7202c80dE2256AdF4",
-          ),
+          srcAddress: nfpmAddress,
         },
       });
 
@@ -259,9 +253,7 @@ describe("NFPMDecreaseLiquidityLogic", () => {
           },
           chainId: chainId,
           logIndex: 96,
-          srcAddress: toChecksumAddress(
-            "0xbB5DFE1380333CEE4c2EeBd7202c80dE2256AdF4",
-          ),
+          srcAddress: nfpmAddress,
         },
       });
 
@@ -294,9 +286,7 @@ describe("NFPMDecreaseLiquidityLogic", () => {
           },
           chainId: chainId,
           logIndex: 96,
-          srcAddress: toChecksumAddress(
-            "0xbB5DFE1380333CEE4c2EeBd7202c80dE2256AdF4",
-          ),
+          srcAddress: nfpmAddress,
         },
       });
 
@@ -330,9 +320,7 @@ describe("NFPMDecreaseLiquidityLogic", () => {
           },
           chainId: chainId,
           logIndex: 96,
-          srcAddress: toChecksumAddress(
-            "0xbB5DFE1380333CEE4c2EeBd7202c80dE2256AdF4",
-          ),
+          srcAddress: nfpmAddress,
         },
       });
 
@@ -366,9 +354,7 @@ describe("NFPMDecreaseLiquidityLogic", () => {
           },
           chainId: chainId,
           logIndex: 96,
-          srcAddress: toChecksumAddress(
-            "0xbB5DFE1380333CEE4c2EeBd7202c80dE2256AdF4",
-          ),
+          srcAddress: nfpmAddress,
         },
       });
 

--- a/test/EventHandlers/NFPM/NFPMIncreaseLiquidityLogic.test.ts
+++ b/test/EventHandlers/NFPM/NFPMIncreaseLiquidityLogic.test.ts
@@ -59,6 +59,7 @@ describe("NFPMIncreaseLiquidityLogic", () => {
     id: NonFungiblePositionId(chainId, poolAddress, tokenId),
     chainId: chainId,
     tokenId: tokenId,
+    nfpmAddress: nfpmAddress,
     owner: ownerAddress,
     pool: poolAddress,
     tickUpper: 0n,

--- a/test/EventHandlers/NFPM/NFPMIncreaseLiquidityLogic.test.ts
+++ b/test/EventHandlers/NFPM/NFPMIncreaseLiquidityLogic.test.ts
@@ -21,6 +21,7 @@ import {
   calculateIncreaseLiquidityDiff,
   processNFPMIncreaseLiquidity,
 } from "../../../src/EventHandlers/NFPM/NFPMIncreaseLiquidityLogic";
+import { NFPM_ADDRESS } from "../Pool/common";
 
 vi.mock("../../../src/Aggregators/LiquidityPoolAggregator", async () => ({
   ...(await vi.importActual(
@@ -51,9 +52,7 @@ describe("NFPMIncreaseLiquidityLogic", () => {
   const token1Address = toChecksumAddress(
     "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
   );
-  const nfpmAddress = toChecksumAddress(
-    "0xbB5DFE1380333CEE4c2EeBd7202c80dE2256AdF4",
-  );
+  const nfpmAddress = NFPM_ADDRESS;
 
   const mockPosition: NonFungiblePosition = {
     id: NonFungiblePositionId(chainId, poolAddress, tokenId),

--- a/test/EventHandlers/NFPM/NFPMTransferLogic.test.ts
+++ b/test/EventHandlers/NFPM/NFPMTransferLogic.test.ts
@@ -23,6 +23,7 @@ import {
   isGaugeTransfer,
   processNFPMTransfer,
 } from "../../../src/EventHandlers/NFPM/NFPMTransferLogic";
+import { NFPM_ADDRESS } from "../Pool/common";
 
 vi.mock("../../../src/Aggregators/LiquidityPoolAggregator", async () => ({
   ...(await vi.importActual(
@@ -58,9 +59,7 @@ describe("NFPMTransferLogic", () => {
   const token1Address = toChecksumAddress(
     "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
   );
-  const nfpmAddress = toChecksumAddress(
-    "0xbB5DFE1380333CEE4c2EeBd7202c80dE2256AdF4",
-  );
+  const nfpmAddress = NFPM_ADDRESS;
   const zeroAddress = toChecksumAddress(
     "0x0000000000000000000000000000000000000000",
   );

--- a/test/EventHandlers/NFPM/NFPMTransferLogic.test.ts
+++ b/test/EventHandlers/NFPM/NFPMTransferLogic.test.ts
@@ -162,6 +162,7 @@ describe("NFPMTransferLogic", () => {
     id: getStableId(),
     chainId: chainId,
     tokenId: tokenId,
+    nfpmAddress: nfpmAddress,
     owner: originalOwnerAddress,
     pool: poolAddress,
     tickUpper: 0n,
@@ -437,6 +438,7 @@ describe("NFPMTransferLogic", () => {
         mockCLPoolMintEvent,
         tokenId,
         owner,
+        nfpmAddress,
         chainId,
         blockTimestamp,
         mockContext,
@@ -449,6 +451,7 @@ describe("NFPMTransferLogic", () => {
       if (!position) return;
       expect(position.id).toBe(stableId);
       expect(position.tokenId).toBe(tokenId);
+      expect(position.nfpmAddress).toBe(nfpmAddress);
       expect(position.owner.toLowerCase()).toBe(owner.toLowerCase());
       expect(position.pool).toBe(poolAddress);
       expect(position.tickUpper).toBe(mockCLPoolMintEvent.tickUpper);
@@ -1052,6 +1055,65 @@ describe("NFPMTransferLogic", () => {
 
       const position = mockDb.entities.NonFungiblePosition.get(getStableId());
       expect(position).toBeUndefined();
+    });
+
+    // Regression: Optimism has two NFPM contracts, each with its own tokenId counter.
+    // Before the fix, findPositionByTokenId(tokenId, chainId) returned positions from
+    // BOTH NFPMs, so handleMintTransfer's existingPositions guard silently skipped
+    // creation of NFPM-B's position — orphaning all downstream events for that tokenId.
+    it("creates a position for NFPM-B even when NFPM-A already owns same (chainId, tokenId)", async () => {
+      const nfpmAddressB = toChecksumAddress(
+        "0x416b433906b1B72FA758e166e239c43d68dC6F29",
+      );
+      const poolAddressB = toChecksumAddress(
+        "0x00cd0AbB6c2964F7Dfb5169dD94A9F004C35F459",
+      );
+
+      // NFPM-A position already exists on chain 10, tokenId 540.
+      setPosition(mockPosition);
+
+      // NFPM-B emits its own CLPool.Mint for the SAME tokenId, on a different pool.
+      const nfpmBMintEvent: CLPoolMintEvent = {
+        ...mockCLPoolMintEvent,
+        id: CLPoolMintEventId(
+          chainId,
+          poolAddressB,
+          transactionHash,
+          mintLogIndex,
+        ),
+        pool: poolAddressB,
+      };
+      setMintEvent(nfpmBMintEvent);
+
+      // NFPM-B's Transfer(mint) fires. srcAddress = NFPM-B.
+      const nfpmBTransferEvent = createMockTransferEvent(
+        zeroAddress,
+        ownerAddress,
+        {
+          mockEventData: {
+            ...defaultMintTransferEventData,
+            srcAddress: nfpmAddressB,
+          },
+        },
+      );
+
+      await processNFPMTransfer(nfpmBTransferEvent, mockContext);
+
+      // NFPM-A's position must be untouched.
+      const positionA = storedPositions.find((p) => p.id === mockPosition.id);
+      expect(positionA).toBeDefined();
+      expect(positionA?.nfpmAddress).toBe(nfpmAddress);
+      expect(positionA?.pool).toBe(poolAddress);
+
+      // NFPM-B's position must have been created.
+      const positionB = storedPositions.find(
+        (p) =>
+          p.pool === poolAddressB &&
+          p.tokenId === tokenId &&
+          p.chainId === chainId,
+      );
+      expect(positionB).toBeDefined();
+      expect(positionB?.nfpmAddress).toBe(nfpmAddressB);
     });
   });
 });

--- a/test/EventHandlers/Pool/common.ts
+++ b/test/EventHandlers/Pool/common.ts
@@ -23,6 +23,12 @@ import {
 } from "../../../src/Constants";
 import { calculateTokenAmountUSD } from "../../../src/Helpers";
 
+// Primary Optimism NFPM address. Exported so test files that do not call
+// setupCommon() can still share a single source of truth for the NFPM literal.
+export const NFPM_ADDRESS = toChecksumAddress(
+  "0xbB5DFE1380333CEE4c2EeBd7202c80dE2256AdF4",
+);
+
 export function setupCommon() {
   const CHAIN_ID = 10;
   const POOL_ADDRESS = toChecksumAddress(
@@ -36,9 +42,7 @@ export function setupCommon() {
   const TOKEN1_ADDRESS = toChecksumAddress(
     "0x2222222222222222222222222222222222222222",
   );
-  const nfpmAddress = toChecksumAddress(
-    "0xbB5DFE1380333CEE4c2EeBd7202c80dE2256AdF4",
-  );
+  const nfpmAddress = NFPM_ADDRESS;
 
   const mockToken0Data: Token = {
     id: TokenId(CHAIN_ID, TOKEN0_ADDRESS),
@@ -471,6 +475,7 @@ export function setupCommon() {
     mockVeNFTStateData,
     mockVeNFTPoolVoteData,
     mockNonFungiblePositionData,
+    nfpmAddress,
     createMockToken,
     createMockUserStatsPerPool,
     createMockLiquidityPoolAggregator,

--- a/test/EventHandlers/Pool/common.ts
+++ b/test/EventHandlers/Pool/common.ts
@@ -36,6 +36,9 @@ export function setupCommon() {
   const TOKEN1_ADDRESS = toChecksumAddress(
     "0x2222222222222222222222222222222222222222",
   );
+  const nfpmAddress = toChecksumAddress(
+    "0xbB5DFE1380333CEE4c2EeBd7202c80dE2256AdF4",
+  );
 
   const mockToken0Data: Token = {
     id: TokenId(CHAIN_ID, TOKEN0_ADDRESS),
@@ -290,6 +293,7 @@ export function setupCommon() {
     id: NonFungiblePositionId(CHAIN_ID, POOL_ADDRESS, defaultNFPMTokenId),
     chainId: CHAIN_ID,
     tokenId: defaultNFPMTokenId,
+    nfpmAddress: nfpmAddress,
     owner: normalizedDefaultUserAddress,
     pool: POOL_ADDRESS,
     tickLower: -1000n,


### PR DESCRIPTION
## Summary

Fixes #603 — the 443 orphan `NonFungiblePosition … not found` errors (953 events) observed on Optimism and Superseed during the Apr 8–17 audit. Root cause is a lookup-scope bug, not a correlation race.

## Problem

`findPositionByTokenId` filtered candidates by `(tokenId, chainId)`. But tokenIds are only unique within a single NFPM contract's `_nextId` counter — not across a chain. Optimism runs **two** NFPM contracts (`0xbB5D…AdF4` and `0x416b…F29`), so both counters emit overlapping tokenIds.

Trace:

1. NFPM-A mints `tokenId=N` → `position_A` created (`{10}-{poolX}-{N}`).
2. NFPM-B mints `tokenId=N` → `handleMintTransfer` calls `findPositionByTokenId(N, 10)`, which returns `[position_A]`.
3. The `existingPositions.length > 0` guard triggers and **silently returns** — `position_B` is never created, no warning logged.
4. Every downstream `Transfer`/`IncreaseLiquidity`/`DecreaseLiquidity` for NFPM-B's `tokenId=N` either misattributes to `position_A` or, once `position_A` is burned, logs "not found". This is why only 5 "No CLPoolMintEvent found" warnings explain 953 downstream errors — the producer-side correlation was working; the consumer-side lookup was wrong.

The PRD explicitly rules out widening `getWhere` as a fix — the lookup scope itself is what's broken.

## Fix

Scope the position identity by NFPM contract, not just chain:

- Add `nfpmAddress: String! @index` to `NonFungiblePosition` (and its snapshot), populated from `event.srcAddress` at mint time.
- Update `findPositionByTokenId(tokenId, chainId, nfpmAddress, context)` to filter by all three in memory (getWhere still supports only one indexed field).
- Thread `event.srcAddress` through every call site: `processNFPMTransfer`, `processNFPMIncreaseLiquidity`, `processNFPMDecreaseLiquidity`, and `createPositionFromCLPoolMint`.

Cross-chain collision (same tokenId on two chains, both with single NFPM) was already handled by the `chainId` filter and remains covered; the new `nfpmAddress` filter composes with it cleanly.

## Tests

- `NFPMCommonLogic.test.ts` — new cases for cross-chain collision, intra-chain multi-NFPM collision, and unknown-NFPM lookup returning empty.
- `NFPMTransferLogic.test.ts` — end-to-end regression: when NFPM-A already owns `(chainId=10, tokenId=540)`, NFPM-B's mint now correctly creates its own position on `poolY` without touching NFPM-A's.
- All existing NFPM/ALM/snapshot tests updated to carry `nfpmAddress` on their mock positions.

`pnpm qa --write` clean, `pnpm test` green (1026 passing, 32 skipped).

## Schema migration note

`NonFungiblePosition` gains a required field. Existing production data lacks it, so the indexer will re-sync positions from events on next deploy (standard Envio behavior for non-nullable schema additions). No backfill script required — the mint correlation path now populates `nfpmAddress` from `event.srcAddress`.

## Post-Deploy Monitoring & Validation

- **Primary signal** — `uerror` count for `NonFungiblePosition … not found during (transfer|increase liquidity|decrease liquidity)` should drop to near zero. Baseline: 953 errors / 443 unique tokenIds over the 9-day audit window. Target: < 10 errors over an equivalent window.
- **Log query** — grep `uerror` for `NonFungiblePosition with tokenId .* not found` and `\[handleRegularTransfer\] No positions provided`.
- **Producer-side invariant** — `No CLPoolMintEvent found for NFPM.Transfer(mint)` should stay at its current baseline (~5/9d). This fix is downstream-only and should not move the producer count.
- **Positive signal** — aggregate `NonFungiblePosition` entity count on Optimism should increase by the number of previously-skipped NFPM-B mints (rough order: 400+ over the audit window).
- **Failure signal / rollback** — if new mints fail to create positions (look for `tokenId=… nfpmAddress=… not found` after a successful `CLPool.Mint`), revert this PR. No operational mitigation needed beyond revert; the old behavior is strictly worse but not catastrophic.
- **Validation window** — 24h after deploy, compare 24h rolling count of the target error classes against the same window pre-deploy.
- **Owner** — indexer maintainers (per PRD #597).

Ties to user stories 7 & 8 in #597.

---

[![Compound Engineering v2.62.0](https://img.shields.io/badge/Compound_Engineering-v2.62.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.7 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for distinguishing non-fungible positions across multiple NFPM contracts on the same chain by including contract address in position identification.

* **Bug Fixes**
  * Fixed potential token ID collision detection when the same token ID exists across different NFPM contracts on the same chain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->