### PR TITLE
fix(voter): skip known sink root pools to silence orphan mapping noise

### DIFF
--- a/src/Aggregators/LiquidityPoolAggregator.ts
+++ b/src/Aggregators/LiquidityPoolAggregator.ts
@@ -4,7 +4,7 @@ import type {
   Token,
   handlerContext,
 } from "generated";
-import { PoolId, TokenId } from "../Constants";
+import { PoolId, TokenId, isKnownSinkRootPool } from "../Constants";
 import { getSwapFee, roundBlockToInterval } from "../Effects/Index";
 import { calculateTotalUSD, generatePoolName } from "../Helpers";
 import { refreshTokenPrice } from "../PriceOracle";
@@ -103,6 +103,7 @@ export enum LoadPoolDataOrRootCLPoolFailureReason {
   MAPPING_NOT_FOUND = "MAPPING_NOT_FOUND",
   MULTIPLE_MAPPINGS = "MULTIPLE_MAPPINGS",
   LEAF_POOL_NOT_FOUND = "LEAF_POOL_NOT_FOUND",
+  SINK_ROOT_POOL = "SINK_ROOT_POOL",
 }
 
 export type LoadPoolDataOrRootCLPoolResult =
@@ -118,6 +119,10 @@ export type LoadPoolDataOrRootCLPoolResult =
   | {
       ok: false;
       reason: LoadPoolDataOrRootCLPoolFailureReason.LEAF_POOL_NOT_FOUND;
+    }
+  | {
+      ok: false;
+      reason: LoadPoolDataOrRootCLPoolFailureReason.SINK_ROOT_POOL;
     };
 
 export function isMissingRootPoolMapping(
@@ -510,6 +515,13 @@ export async function loadPoolDataOrRootCLPool(
   blockNumber?: number,
   blockTimestamp?: number,
 ): Promise<LoadPoolDataOrRootCLPoolResult> {
+  if (isKnownSinkRootPool(chainId, poolAddress)) {
+    return {
+      ok: false,
+      reason: LoadPoolDataOrRootCLPoolFailureReason.SINK_ROOT_POOL,
+    };
+  }
+
   const rootPoolLeafPools =
     (await context.RootPool_LeafPool.getWhere({
       rootPoolAddress: { _eq: poolAddress },

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -771,6 +771,32 @@ export const TokenId = (chainId: number, address: string) =>
  */
 export const PoolId = (chainId: number, pool: string) => `${chainId}-${pool}`;
 
+/**
+ * Known "sink" root pool addresses. These contracts were registered via
+ * RootPoolCreated / GaugeCreated but their on-chain bytecode is a revert-only
+ * stub (no token0/token1/factory/tickSpacing). They have no real leaf pool
+ * counterpart and can never be reconciled, so handlers short-circuit on them:
+ * Voted/Abstained/DistributeReward events are silently dropped instead of
+ * emitting noisy "mapping not found" logs or creating orphan Pending* records
+ * that would never flush. See issue #601.
+ */
+export const KNOWN_SINK_ROOT_POOLS: ReadonlySet<string> = new Set([
+  PoolId(
+    10, // Optimism — gauge 0x3B59a6B600f912260048a0f3a834C1039aEcD367
+    toChecksumAddress("0x333030A736B47D20346d82A473680658ac1C2b88"),
+  ),
+  PoolId(
+    8453, // Base — gauge 0x287C94a1fE647014317E91A0E42425D6a237081D
+    toChecksumAddress("0x97Cd4EB683E29695DC93eec95d47d4E7a35E2112"),
+  ),
+]);
+
+export const isKnownSinkRootPool = (
+  chainId: number,
+  poolAddress: string,
+): boolean =>
+  KNOWN_SINK_ROOT_POOLS.has(PoolId(chainId, toChecksumAddress(poolAddress)));
+
 /** Entity ID for ALM_LP_Wrapper. Format: {chainId}-{wrapperAddress}
  * @param chainId - Chain ID of the wrapper
  * @param wrapperAddress - Address of the wrapper

--- a/src/EventHandlers/Voter/Voter.ts
+++ b/src/EventHandlers/Voter/Voter.ts
@@ -24,6 +24,7 @@ import {
   TokenId,
   VOTER_CLPOOLS_FACTORY_LIST,
   VOTER_NONCL_POOLS_FACTORY_LIST,
+  isKnownSinkRootPool,
 } from "../../Constants";
 import { getTokenDetails } from "../../Effects/Index";
 import { refreshTokenPrice } from "../../PriceOracle";
@@ -313,6 +314,11 @@ Voter.DistributeReward.handler(async ({ event, context }) => {
         RootGaugeRootPoolId(eventChainId, event.params.gauge),
       );
       if (rootGaugeMapping) {
+        if (
+          isKnownSinkRootPool(eventChainId, rootGaugeMapping.rootPoolAddress)
+        ) {
+          return;
+        }
         const rootPoolLeafPools =
           (await context.RootPool_LeafPool.getWhere({
             rootPoolAddress: { _eq: rootGaugeMapping.rootPoolAddress },

--- a/src/EventHandlers/Voter/VoterCommonLogic.ts
+++ b/src/EventHandlers/Voter/VoterCommonLogic.ts
@@ -11,7 +11,11 @@ import {
 } from "../../Aggregators/LiquidityPoolAggregator";
 import type { UserStatsPerPoolDiff } from "../../Aggregators/UserStatsPerPool";
 import type { VeNFTPoolVoteDiff } from "../../Aggregators/VeNFTPoolVote";
-import { PendingVoteId, RootGaugeRootPoolId } from "../../Constants";
+import {
+  PendingVoteId,
+  RootGaugeRootPoolId,
+  isKnownSinkRootPool,
+} from "../../Constants";
 import { getTokensDeposited } from "../../Effects/Index";
 import { normalizeTokenAmountTo1e18 } from "../../Helpers";
 import { multiplyBase1e18 } from "../../Maths";
@@ -135,6 +139,9 @@ export async function resolveLeafPoolForRootGauge(
     return null;
   }
   const rootPoolAddress = rootGaugeMapping.rootPoolAddress;
+  if (isKnownSinkRootPool(chainId, rootPoolAddress)) {
+    return null;
+  }
   const rootPoolLeafPools =
     (await context.RootPool_LeafPool.getWhere({
       rootPoolAddress: { _eq: rootPoolAddress },

--- a/test/Aggregators/LiquidityPoolAggregator.test.ts
+++ b/test/Aggregators/LiquidityPoolAggregator.test.ts
@@ -1477,5 +1477,38 @@ describe("LiquidityPoolAggregator Functions", () => {
         ),
       ).toBe(true);
     });
+
+    it("short-circuits silently with SINK_ROOT_POOL for a known-sink address", async () => {
+      // Known sink per src/Constants.ts KNOWN_SINK_ROOT_POOLS (OP).
+      const sinkRootPoolAddress = toChecksumAddress(
+        "0x333030A736B47D20346d82A473680658ac1C2b88",
+      );
+      const sinkChainId = 10;
+
+      const mockRootPoolLeafPoolGetWhere = vi.mocked(
+        mockContext.RootPool_LeafPool?.getWhere,
+      );
+      const mockLiquidityPoolGet = vi.mocked(
+        mockContext.LiquidityPoolAggregator?.get,
+      );
+      const mockErrorLog = vi.mocked(mockContext.log?.error);
+      const mockWarnLog = vi.mocked(mockContext.log?.warn);
+
+      const result = await loadPoolDataOrRootCLPool(
+        sinkRootPoolAddress,
+        sinkChainId,
+        mockContext as handlerContext,
+      );
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe("SINK_ROOT_POOL");
+      }
+      // No DB reads and no log output for known sinks.
+      expect(mockRootPoolLeafPoolGetWhere).not.toHaveBeenCalled();
+      expect(mockLiquidityPoolGet).not.toHaveBeenCalled();
+      expect(mockErrorLog).not.toHaveBeenCalled();
+      expect(mockWarnLog).not.toHaveBeenCalled();
+    });
   });
 });

--- a/test/EventHandlers/Voter/Voter.test.ts
+++ b/test/EventHandlers/Voter/Voter.test.ts
@@ -544,6 +544,92 @@ describe("Voter Events", () => {
       });
     });
 
+    describe("when pool is a known sink root pool (issue #601)", () => {
+      // Known sink per src/Constants.ts KNOWN_SINK_ROOT_POOLS (OP). These
+      // addresses are placeholder contracts with no real leaf pool, so votes
+      // must be silently dropped instead of accumulating orphan PendingVote
+      // rows that would never flush.
+      const sinkRootPoolAddress = toChecksumAddress(
+        "0x333030A736B47D20346d82A473680658ac1C2b88",
+      );
+
+      it("drops Voted silently without creating PendingVote", async () => {
+        const { createMockVeNFTState } = setupCommon();
+        const mockVeNFTState = createMockVeNFTState({
+          id: VeNFTId(chainId, tokenId),
+          chainId,
+          tokenId,
+          owner: ownerAddress,
+        });
+        mockDb = mockDb.entities.VeNFTState.set(mockVeNFTState);
+
+        const votedEvent = Voter.Voted.createMockEvent({
+          voter: voterAddress,
+          pool: sinkRootPoolAddress,
+          tokenId,
+          weight: 100n,
+          totalWeight: 1000n,
+          mockEventData: {
+            block: {
+              number: 123456,
+              timestamp: 1000000,
+              hash: "0xsinkhash",
+            },
+            chainId,
+            logIndex: 1,
+            transaction: { hash: "0xsinkhash" },
+          },
+        });
+
+        const resultDB = await mockDb.processEvents([votedEvent]);
+
+        expect(Array.from(resultDB.entities.PendingVote.getAll())).toHaveLength(
+          0,
+        );
+        expect(
+          Array.from(resultDB.entities.LiquidityPoolAggregator.getAll()),
+        ).toHaveLength(0);
+      });
+
+      it("drops Abstained silently without creating PendingVote", async () => {
+        const { createMockVeNFTState } = setupCommon();
+        const mockVeNFTState = createMockVeNFTState({
+          id: VeNFTId(chainId, tokenId),
+          chainId,
+          tokenId,
+          owner: ownerAddress,
+        });
+        mockDb = mockDb.entities.VeNFTState.set(mockVeNFTState);
+
+        const abstainedEvent = Voter.Abstained.createMockEvent({
+          voter: voterAddress,
+          pool: sinkRootPoolAddress,
+          tokenId,
+          weight: 100n,
+          totalWeight: 1000n,
+          mockEventData: {
+            block: {
+              number: 123456,
+              timestamp: 1000000,
+              hash: "0xsinkhash",
+            },
+            chainId,
+            logIndex: 1,
+            transaction: { hash: "0xsinkhash" },
+          },
+        });
+
+        const resultDB = await mockDb.processEvents([abstainedEvent]);
+
+        expect(Array.from(resultDB.entities.PendingVote.getAll())).toHaveLength(
+          0,
+        );
+        expect(
+          Array.from(resultDB.entities.LiquidityPoolAggregator.getAll()),
+        ).toHaveLength(0);
+      });
+    });
+
     describe("cross-chain sync: RootPoolCreated then Voted/Abstained (leaf chain behind)", () => {
       const rootChainId = 10;
       const leafChainId = 252;
@@ -2607,6 +2693,73 @@ describe("Voter Events", () => {
         expect(pendingDistribution?.logIndex).toBe(logIndex);
 
         // Distribution was deferred; no pool should have been updated
+        expect(
+          Array.from(resultDB.entities.LiquidityPoolAggregator.getAll()),
+        ).toHaveLength(0);
+      });
+    });
+
+    describe("when rootPoolAddress is a known sink (issue #601)", () => {
+      it("drops DistributeReward silently without creating PendingDistribution", async () => {
+        // Seed a RootGauge_RootPool mapping whose rootPoolAddress is a
+        // known sink (OP). Known sinks are placeholder contracts with no
+        // real leaf pool; we must not accumulate orphan Pending* records.
+        const sinkRootPoolAddress = toChecksumAddress(
+          "0x333030A736B47D20346d82A473680658ac1C2b88",
+        );
+        const blockNumberForSink = 128357870;
+        const logIndex = 3;
+
+        const rewardToken: Token = {
+          id: TokenId(chainId, rewardTokenAddress),
+          address: rewardTokenAddress,
+          symbol: "VELO",
+          name: "VELO",
+          chainId: chainId,
+          decimals: 18n,
+          pricePerUSDNew: 2n * 10n ** 18n,
+          isWhitelisted: true,
+          lastUpdatedTimestamp: new Date(1000000 * 1000),
+        } as Token;
+
+        const distributeRewardEvent = Voter.DistributeReward.createMockEvent({
+          gauge: gaugeAddress,
+          amount: 1000n * 10n ** 18n,
+          mockEventData: {
+            block: {
+              number: blockNumberForSink,
+              timestamp: 1000000,
+              hash: "0xblockhash",
+            },
+            chainId: chainId,
+            logIndex,
+            srcAddress: voterAddress,
+          },
+        });
+
+        let db = MockDb.createMockDb();
+        db = db.entities.Token.set(rewardToken);
+        db = db.entities.RootGauge_RootPool.set({
+          id: RootGaugeRootPoolId(chainId, gaugeAddress),
+          rootChainId: chainId,
+          rootGaugeAddress: gaugeAddress,
+          rootPoolAddress: sinkRootPoolAddress,
+        });
+
+        const resultDB = await db.processEvents([distributeRewardEvent]);
+
+        const pendingDistribution = resultDB.entities.PendingDistribution.get(
+          PendingDistributionId(
+            chainId,
+            sinkRootPoolAddress,
+            blockNumberForSink,
+            logIndex,
+          ),
+        );
+        expect(pendingDistribution).toBeUndefined();
+        expect(
+          Array.from(resultDB.entities.PendingDistribution.getAll()),
+        ).toHaveLength(0);
         expect(
           Array.from(resultDB.entities.LiquidityPoolAggregator.getAll()),
         ).toHaveLength(0);

--- a/test/EventHandlers/Voter/VoterCommonLogic.test.ts
+++ b/test/EventHandlers/Voter/VoterCommonLogic.test.ts
@@ -539,6 +539,27 @@ describe("resolveLeafPoolForRootGauge", () => {
     expect(warns[0]).toContain(String(leafChainId));
   });
 
+  it("short-circuits silently when rootPoolAddress is a known sink", async () => {
+    // Known sink per src/Constants.ts KNOWN_SINK_ROOT_POOLS (OP).
+    const sinkRootPoolAddress = toChecksumAddress(
+      "0x333030A736B47D20346d82A473680658ac1C2b88",
+    );
+    const warns: string[] = [];
+    const context = makeResolveContext({
+      rootGaugeMapping: { rootPoolAddress: sinkRootPoolAddress },
+      warns,
+    });
+
+    const result = await runResolve(context);
+
+    expect(result).toBeNull();
+    // No warn logs and no RootPool_LeafPool lookup for known sinks.
+    expect(warns).toHaveLength(0);
+    expect(
+      vi.mocked(context.RootPool_LeafPool.getWhere),
+    ).not.toHaveBeenCalled();
+  });
+
   it("returns leaf pool and isCrossChain when resolution succeeds", async () => {
     const mockPool = {
       id: `10-${leafPoolAddress}`,


### PR DESCRIPTION
## Summary

Two root pool addresses registered via `RootPoolCreated` / `GaugeCreated` are **empty revert-only stubs** on-chain, not real pools. Every Voted/Abstained/DistributeReward against them was being silently dropped into orphan `PendingVote` / `PendingDistribution` rows that would never flush, plus ~30 ``RootPool_LeafPool mapping not found`` warnings per indexer run.

This PR adds an explicit skip-list for the two known-dead addresses and short-circuits the three load sites so the events are dropped without side effects or log noise.

Closes #601. Supersedes #610.

## Context: why these are not real pools

Bytecode inspection via direct RPC:

| Address | Chain | Bytecode |
|---|---|---|
| `0x333030A736B47D20346d82A473680658ac1C2b88` | Optimism | `0x60806040525f80fdfe…` (Solidity 0.8.25) |
| `0x97Cd4EB683E29695DC93eec95d47d4E7a35E2112` | Base | `0x6080604052600080fdfe…` (Solidity 0.8.19) |

Both contracts are `PUSH1 0x80 PUSH1 0x40 MSTORE (PUSH0|PUSH1 0) DUP1 REVERT INVALID` — a hard revert on every call. Every standard pool selector (`token0()`, `token1()`, `tickSpacing()`, `factory()`, `fee()`, `stable()`, `chainid()`, `isRootPool()`, `getRatio()`) reverts. These are placeholder/sink contracts with no real leaf pool counterpart; they cannot be reconciled because there is nothing to reconcile against.

## Approach

Add `KNOWN_SINK_ROOT_POOLS: ReadonlySet<string>` and `isKnownSinkRootPool(chainId, address)` in `src/Constants.ts`, keyed by `PoolId(chainId, checksumAddress)`.

Short-circuit at three call sites:

1. **`loadPoolDataOrRootCLPool`** → new `SINK_ROOT_POOL` failure reason on the discriminated union (distinct from `MAPPING_NOT_FOUND` so `isMissingRootPoolMapping` returns false and callers skip `PendingVote` creation for Voted/Abstained).
2. **`resolveLeafPoolForRootGauge`** → return `null` silently before the `RootPool_LeafPool.getWhere` scan.
3. **`Voter.DistributeReward` deferred branch** → skip `PendingDistribution.set` when the `RootGauge_RootPool` mapping points to a sink.

No log output, no DB reads, no entity writes for known sinks.

## What this does *not* cover

- **Missing Base root factory registration**: Aerodrome's `RootCLPoolFactory` is not registered for chainId 8453 in `config.yaml`. If the protocol team later wires up real cross-chain root pools on Base, we'll need to add that contract registration separately. The sink addressed here is a placeholder, not a signal that Base root pools are fully supported.
- **Backlog cleanup**: any `PendingVote` / `PendingDistribution` rows already in production databases for these two sink pools are not cleaned up here. They are harmless (just never flush) but could be deleted with a one-off data-surgery migration if desired.

## Testing

- `src/Constants.ts` — 2 new exports (1 Set + 1 helper)
- `src/Aggregators/LiquidityPoolAggregator.ts` — new `SINK_ROOT_POOL` enum variant, early-return in `loadPoolDataOrRootCLPool`
- `src/EventHandlers/Voter/VoterCommonLogic.ts` — early-return in `resolveLeafPoolForRootGauge`
- `src/EventHandlers/Voter/Voter.ts` — early-return in DistributeReward deferred branch
- New tests:
  - `test/Aggregators/LiquidityPoolAggregator.test.ts` — `loadPoolDataOrRootCLPool` returns `SINK_ROOT_POOL` silently with no DB calls and no log output
  - `test/EventHandlers/Voter/VoterCommonLogic.test.ts` — `resolveLeafPoolForRootGauge` returns `null` silently without querying `RootPool_LeafPool`
  - `test/EventHandlers/Voter/Voter.test.ts` — full `processEvents` flows for Voted, Abstained, and DistributeReward against a sink rootPool produce zero `PendingVote` / `PendingDistribution` / `LiquidityPoolAggregator` entities

```
pnpm qa --write   # biome clean (1 file auto-fixed — test fixture)
pnpm exec tsc --noEmit   # clean
pnpm vitest run   # 1028 passed, 0 failed
```

## Post-Deploy Monitoring & Validation

- **Log queries** (after deploy, monitor for 24h):
  - Search ``RootPool_LeafPool mapping not found`` — expect the hit rate for gauge `0x3B59a6B600f912260048a0f3a834C1039aEcD367` (OP) and `0x287C94a1fE647014317E91A0E42425D6a237081D` (Base) to drop to zero.
  - Search ``[loadPoolData] LiquidityPoolAggregator 8453-0x97Cd4EB6``  — expect zero occurrences.
- **Metrics / dashboard**: watch `PendingDistribution` and `PendingVote` table row-count deltas for the two affected root pool addresses — should remain flat, not accumulate.
- **Expected healthy signals**: the two noisy log lines disappear entirely; pending-entity counts for the sink addresses stay at their pre-deploy values.
- **Failure signals / rollback trigger**: if any legitimate cross-chain pool on OP or Base suddenly shows zero vote/emission activity that correlates with deploy time — investigate whether an address in `KNOWN_SINK_ROOT_POOLS` was added in error. Rollback = revert this commit.
- **Validation window**: 24h post-deploy. Owner: indexer oncall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added identification of known sink root pools; voting and reward distribution operations on these pools are now silently excluded from processing.
  * Pool data queries now return a specific failure indicator when encountering sink root pools.

* **Tests**
  * Added comprehensive test coverage for sink root pool handling across voting, distribution, and pool data loading operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->