### PR TITLE
feat(cl-gauge): subscribe to V3 CLFactory + CLGaugeFactoryV3 on Base

### DIFF
--- a/abis/CLGaugeFactoryV3.json
+++ b/abis/CLGaugeFactoryV3.json
@@ -1,0 +1,131 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "_newDefaultCap",
+        "type": "uint256"
+      }
+    ],
+    "name": "SetDefaultCap",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_emissionAdmin",
+        "type": "address"
+      }
+    ],
+    "name": "SetEmissionAdmin",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_gauge",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_newEmissionCap",
+        "type": "uint256"
+      }
+    ],
+    "name": "SetEmissionCap",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_notifyAdmin",
+        "type": "address"
+      }
+    ],
+    "name": "SetNotifyAdmin",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_newRedistributor",
+        "type": "address"
+      }
+    ],
+    "name": "SetRedistributor",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_gaugeStakeManager",
+        "type": "address"
+      }
+    ],
+    "name": "SetGaugeStakeManager",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_minStakeTime",
+        "type": "uint256"
+      }
+    ],
+    "name": "SetDefaultMinStakeTime",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_pool",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_minStakeTime",
+        "type": "uint256"
+      }
+    ],
+    "name": "SetPoolMinStakeTime",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_penaltyRate",
+        "type": "uint256"
+      }
+    ],
+    "name": "SetPenaltyRate",
+    "type": "event"
+  }
+]

--- a/config.yaml
+++ b/config.yaml
@@ -111,6 +111,12 @@ contracts:
     events:
       - event: SetDefaultCap
       - event: SetEmissionCap
+  - name: CLGaugeFactoryV3
+    abi_file_path: abis/CLGaugeFactoryV3.json
+    handler: src/EventHandlers/CLGaugeFactory/CLGaugeFactoryV3.ts
+    events:
+      - event: SetDefaultCap
+      - event: SetEmissionCap
   - name: CLGauge
     abi_file_path: abis/CLGauge.json
     handler: src/EventHandlers/Gauges/CLGauge.ts
@@ -306,9 +312,13 @@ chains:
           - 0x5e7BB104d84c7CB9B682AaC2F3d509f5F406809A
           - 0xaDe65c38CD4849aDBA595a4323a8C7DdfE89716a # New CL Factory
           - 0x9592CD9B267748cbfBDe90Ac9F7DF3c437A6d51B # Another CL - abi is slightly different but has no impact on event handlers currently
+          - 0xf8f2eB4940CFE7d13603DDDD87f123820Fc061Ef # Newest CL Factory (paired with CLGaugeFactoryV3) — ABI event signatures are identical to the existing CLFactory
       - name: CLGaugeFactoryV2
         address:
           - 0xB630227a79707D517320b6c0f885806389dFcbB3
+      - name: CLGaugeFactoryV3
+        address:
+          - 0x385293CaE378C813F16f0C1334d774AdDDf56AbB
       - name: Pool
         address:
       - name: Voter

--- a/src/EventHandlers/CLGaugeFactory/CLGaugeFactorySharedLogic.ts
+++ b/src/EventHandlers/CLGaugeFactory/CLGaugeFactorySharedLogic.ts
@@ -1,0 +1,66 @@
+import type { handlerContext } from "generated";
+
+/**
+ * Upsert the chain-wide CLGaugeConfig default emissions cap.
+ * Shared by CLGaugeFactoryV2 and CLGaugeFactoryV3 — last-writer-wins per chain.
+ * @param chainId - Chain ID the event fired on (keys the CLGaugeConfig row)
+ * @param newDefaultCap - New default emissions cap from the event payload
+ * @param blockTimestampSeconds - Block timestamp (seconds) used for lastUpdatedTimestamp
+ * @param context - Handler context for entity access
+ * @returns Promise that resolves once the upsert is staged
+ */
+export async function applySetDefaultCap(
+  chainId: number,
+  newDefaultCap: bigint,
+  blockTimestampSeconds: number,
+  context: handlerContext,
+): Promise<void> {
+  const existing = await context.CLGaugeConfig.get(String(chainId));
+  context.CLGaugeConfig.set({
+    ...(existing ?? {}),
+    id: String(chainId),
+    defaultEmissionsCap: newDefaultCap,
+    lastUpdatedTimestamp: new Date(blockTimestampSeconds * 1000),
+  });
+}
+
+/**
+ * Apply a per-gauge emission cap to the matching LiquidityPoolAggregator.
+ * Shared by CLGaugeFactoryV2 and CLGaugeFactoryV3.
+ * @param gauge - Gauge address from the event payload
+ * @param newEmissionCap - New emissions cap for the gauge's pool
+ * @param blockTimestampSeconds - Block timestamp (seconds) used for lastUpdatedTimestamp
+ * @param factoryLogPrefix - Identifier used when warning about duplicate gauge matches (e.g. "CLGaugeFactoryV2")
+ * @param context - Handler context for entity access
+ * @returns Promise that resolves once the update is staged, or no-ops if no pool matches
+ */
+export async function applySetEmissionCap(
+  gauge: string,
+  newEmissionCap: bigint,
+  blockTimestampSeconds: number,
+  factoryLogPrefix: string,
+  context: handlerContext,
+): Promise<void> {
+  const poolEntityList = await context.LiquidityPoolAggregator.getWhere({
+    gaugeAddress: { _eq: gauge },
+  });
+
+  if (!poolEntityList || poolEntityList.length === 0) {
+    context.log.error(`Pool entity not found for gauge ${gauge}`);
+    return;
+  }
+
+  if (poolEntityList.length > 1) {
+    context.log.warn(
+      `[${factoryLogPrefix}] Multiple pools found for gauge ${gauge}, using first match`,
+    );
+  }
+
+  const poolEntity = poolEntityList[0];
+
+  context.LiquidityPoolAggregator.set({
+    ...poolEntity,
+    gaugeEmissionsCap: newEmissionCap,
+    lastUpdatedTimestamp: new Date(blockTimestampSeconds * 1000),
+  });
+}

--- a/src/EventHandlers/CLGaugeFactory/CLGaugeFactoryV3.ts
+++ b/src/EventHandlers/CLGaugeFactory/CLGaugeFactoryV3.ts
@@ -1,10 +1,10 @@
-import { CLGaugeFactoryV2 } from "generated";
+import { CLGaugeFactoryV3 } from "generated";
 import {
   applySetDefaultCap,
   applySetEmissionCap,
 } from "./CLGaugeFactorySharedLogic";
 
-CLGaugeFactoryV2.SetDefaultCap.handler(async ({ event, context }) => {
+CLGaugeFactoryV3.SetDefaultCap.handler(async ({ event, context }) => {
   await applySetDefaultCap(
     event.chainId,
     event.params._newDefaultCap,
@@ -13,12 +13,12 @@ CLGaugeFactoryV2.SetDefaultCap.handler(async ({ event, context }) => {
   );
 });
 
-CLGaugeFactoryV2.SetEmissionCap.handler(async ({ event, context }) => {
+CLGaugeFactoryV3.SetEmissionCap.handler(async ({ event, context }) => {
   await applySetEmissionCap(
     event.params._gauge,
     event.params._newEmissionCap,
     event.block.timestamp,
-    "CLGaugeFactoryV2",
+    "CLGaugeFactoryV3",
     context,
   );
 });

--- a/test/EventHandlers/CLGaugeFactory/CLGaugeFactoryV3.test.ts
+++ b/test/EventHandlers/CLGaugeFactory/CLGaugeFactoryV3.test.ts
@@ -1,0 +1,215 @@
+import type { LiquidityPoolAggregator } from "generated";
+import {
+  CLGaugeFactoryV2,
+  CLGaugeFactoryV3,
+  MockDb,
+} from "../../../generated/src/TestHelpers.gen";
+import { toChecksumAddress } from "../../../src/Constants";
+import { setupCommon } from "../Pool/common";
+
+describe("CLGaugeFactoryV3 Event Handlers", () => {
+  const { mockLiquidityPoolData } = setupCommon();
+  const chainId = 8453; // Base — where V3 is deployed
+  const v2FactoryAddress = toChecksumAddress(
+    "0xB630227a79707D517320b6c0f885806389dFcbB3",
+  );
+  const v3FactoryAddress = toChecksumAddress(
+    "0x385293CaE378C813F16f0C1334d774AdDDf56AbB",
+  );
+  const mockGaugeAddress = toChecksumAddress(
+    "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  );
+  const mockDefaultCap = 1000000000000000000000n; // 1000 tokens
+  const mockEmissionCap = 500000000000000000000n; // 500 tokens
+
+  let mockDb: ReturnType<typeof MockDb.createMockDb>;
+
+  beforeEach(() => {
+    mockDb = MockDb.createMockDb();
+  });
+
+  describe("SetDefaultCap", () => {
+    it("writes CLGaugeConfig keyed by chainId", async () => {
+      const event = CLGaugeFactoryV3.SetDefaultCap.createMockEvent({
+        _newDefaultCap: mockDefaultCap,
+        mockEventData: {
+          srcAddress: v3FactoryAddress,
+          chainId,
+          block: {
+            timestamp: 2_000_000,
+            number: 2,
+            hash: "0x2222222222222222222222222222222222222222222222222222222222222222",
+          },
+          logIndex: 1,
+        },
+      });
+
+      const result = await mockDb.processEvents([event]);
+
+      const config = result.entities.CLGaugeConfig.get(String(chainId));
+      expect(config).toBeDefined();
+      if (!config) return;
+      expect(config.id).toBe(String(chainId));
+      expect(config.defaultEmissionsCap).toBe(mockDefaultCap);
+      expect(config.lastUpdatedTimestamp).toEqual(new Date(2_000_000 * 1000));
+    });
+
+    it("last-writer-wins: V3 overrides an earlier V2-written row on the same chain", async () => {
+      const v2DefaultCap = 111n;
+      const v3DefaultCap = 222n;
+
+      const v2Event = CLGaugeFactoryV2.SetDefaultCap.createMockEvent({
+        _newDefaultCap: v2DefaultCap,
+        mockEventData: {
+          srcAddress: v2FactoryAddress,
+          chainId,
+          block: {
+            timestamp: 1_000_000,
+            number: 1,
+            hash: "0x1111111111111111111111111111111111111111111111111111111111111111",
+          },
+          logIndex: 1,
+        },
+      });
+
+      const afterV2 = await mockDb.processEvents([v2Event]);
+      const v2Config = afterV2.entities.CLGaugeConfig.get(String(chainId));
+      expect(v2Config?.defaultEmissionsCap).toBe(v2DefaultCap);
+
+      // Seed the V2 result into the next mockDb
+      let seeded = MockDb.createMockDb();
+      if (v2Config) {
+        seeded = seeded.entities.CLGaugeConfig.set(v2Config);
+      }
+
+      const v3Event = CLGaugeFactoryV3.SetDefaultCap.createMockEvent({
+        _newDefaultCap: v3DefaultCap,
+        mockEventData: {
+          srcAddress: v3FactoryAddress,
+          chainId,
+          block: {
+            timestamp: 2_000_000,
+            number: 2,
+            hash: "0x2222222222222222222222222222222222222222222222222222222222222222",
+          },
+          logIndex: 1,
+        },
+      });
+
+      const afterV3 = await seeded.processEvents([v3Event]);
+      const v3Config = afterV3.entities.CLGaugeConfig.get(String(chainId));
+
+      expect(v3Config).toBeDefined();
+      if (!v3Config) return;
+      expect(v3Config.defaultEmissionsCap).toBe(v3DefaultCap);
+      expect(v3Config.lastUpdatedTimestamp).toEqual(new Date(2_000_000 * 1000));
+    });
+  });
+
+  describe("SetEmissionCap", () => {
+    let mockPoolWithGauge: LiquidityPoolAggregator;
+    let mockDbWithGetWhere: typeof mockDb;
+
+    beforeEach(() => {
+      mockPoolWithGauge = {
+        ...mockLiquidityPoolData,
+        gaugeAddress: mockGaugeAddress,
+        gaugeEmissionsCap: 0n,
+      };
+
+      mockDb = mockDb.entities.LiquidityPoolAggregator.set(mockPoolWithGauge);
+
+      const storedPools = [mockPoolWithGauge];
+
+      mockDbWithGetWhere = {
+        ...mockDb,
+        entities: {
+          ...mockDb.entities,
+          LiquidityPoolAggregator: {
+            ...mockDb.entities.LiquidityPoolAggregator,
+            getWhere: {
+              gaugeAddress: {
+                eq: async (gaugeAddr: string) =>
+                  storedPools.filter(
+                    (p) =>
+                      p.gaugeAddress &&
+                      toChecksumAddress(p.gaugeAddress) ===
+                        toChecksumAddress(gaugeAddr),
+                  ),
+              },
+            },
+          },
+        },
+      } as typeof mockDb;
+    });
+
+    it("updates LiquidityPoolAggregator.gaugeEmissionsCap by gauge address", async () => {
+      const event = CLGaugeFactoryV3.SetEmissionCap.createMockEvent({
+        _gauge: mockGaugeAddress,
+        _newEmissionCap: mockEmissionCap,
+        mockEventData: {
+          srcAddress: v3FactoryAddress,
+          chainId,
+          block: {
+            timestamp: 3_000_000,
+            number: 3,
+            hash: "0x3333333333333333333333333333333333333333333333333333333333333333",
+          },
+          logIndex: 1,
+        },
+      });
+
+      const result = await mockDbWithGetWhere.processEvents([event]);
+
+      const pool = result.entities.LiquidityPoolAggregator.get(
+        mockLiquidityPoolData.id,
+      );
+      expect(pool).toBeDefined();
+      if (!pool) return;
+      expect(pool.gaugeEmissionsCap).toBe(mockEmissionCap);
+      expect(pool.lastUpdatedTimestamp).toEqual(new Date(3_000_000 * 1000));
+      expect(pool.gaugeAddress).toBe(mockGaugeAddress);
+    });
+
+    it("logs an error and leaves state unchanged when no pool matches the gauge", async () => {
+      const emptyDb = {
+        ...mockDb,
+        entities: {
+          ...mockDb.entities,
+          LiquidityPoolAggregator: {
+            ...mockDb.entities.LiquidityPoolAggregator,
+            getWhere: {
+              gaugeAddress: {
+                eq: async (_: string) => [],
+              },
+            },
+          },
+        },
+      } as typeof mockDb;
+
+      const event = CLGaugeFactoryV3.SetEmissionCap.createMockEvent({
+        _gauge: toChecksumAddress("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"),
+        _newEmissionCap: mockEmissionCap,
+        mockEventData: {
+          srcAddress: v3FactoryAddress,
+          chainId,
+          block: {
+            timestamp: 3_000_000,
+            number: 3,
+            hash: "0x3333333333333333333333333333333333333333333333333333333333333333",
+          },
+          logIndex: 1,
+        },
+      });
+
+      const result = await emptyDb.processEvents([event]);
+
+      const pool = result.entities.LiquidityPoolAggregator.get(
+        mockLiquidityPoolData.id,
+      );
+      expect(pool).toBeDefined();
+      if (!pool) return;
+      expect(pool.gaugeEmissionsCap).toBe(0n);
+    });
+  });
+});


### PR DESCRIPTION
Resolves #614. Stacked on top of #616 (#613).

## Summary

- Append `0xf8f2eB4940CFE7d13603DDDD87f123820Fc061Ef` to the existing Base `CLFactory` address list — event signatures match the existing ABI, so no new ABI/handler required.
- Subscribe `CLGaugeFactoryV3` (`0x385293CaE378C813F16f0C1334d774AdDDf56AbB`) for `SetDefaultCap` and `SetEmissionCap`. The 4 V3-specific events are present in the ABI but left unhandled here — landing in #615.
- Extract the cap write paths into `src/EventHandlers/CLGaugeFactory/shared.ts` so V2 and V3 share the chainId-keyed `CLGaugeConfig` upsert and the gauge-address-keyed `LiquidityPoolAggregator` update (last-writer-wins is the intended chain-wide default semantic).

## Test plan

- [x] `pnpm envio codegen` clean
- [x] `tsc --noEmit` clean
- [x] `biome check --write` clean on changed files
- [x] `pnpm test` — 1037 passed / 32 skipped
- [x] New tests in `test/EventHandlers/CLGaugeFactory/CLGaugeFactoryV3.test.ts` cover: V3 `SetDefaultCap` writes by chainId, V3 `SetEmissionCap` updates by gauge address, V2→V3 last-writer-wins on the chain-wide default.

> Note: after #616 merges to `main`, rebase this branch onto main with `git rebase --onto main feat/clgaugeconfig-chainid-rekey feat/clgaugefactory-v3-subscribe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for CLGaugeFactoryV3 contract on Base blockchain
  * Integrated event tracking for emission cap and default cap configuration updates
  * Enhanced gauge emission management capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->