### PR TITLE
feat(cl-gauge): index V3 staking config (min stake time + penalty rate)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -117,6 +117,9 @@ contracts:
     events:
       - event: SetDefaultCap
       - event: SetEmissionCap
+      - event: SetDefaultMinStakeTime
+      - event: SetPoolMinStakeTime
+      - event: SetPenaltyRate
   - name: CLGauge
     abi_file_path: abis/CLGauge.json
     handler: src/EventHandlers/Gauges/CLGauge.ts

--- a/schema.graphql
+++ b/schema.graphql
@@ -59,6 +59,7 @@ type LiquidityPoolAggregator {
   gaugeIsAlive: Boolean! # whether the gauge is alive
   gaugeAddress: String @index # address of the gauge for this pool
   gaugeEmissionsCap: BigInt @config(precision: 76) # Emissions cap for gauge. If not specified in an SetEmissionsCap event, set to defaultEmissionsCap as per CLGaugeConfig. If CLGaugeConfig doesn't exist, there's no emissions cap
+  minStakeTime: BigInt! @config(precision: 24) # Per-pool LP stake lockup (seconds). Seeded from CLGaugeConfig.defaultMinStakeTime at pool creation; overridden by CLGaugeFactoryV3.SetPoolMinStakeTime. 0 before V3.
   numberOfGaugeDeposits: BigInt! @config(precision: 76) # number of gauge deposits (staking)
   numberOfGaugeWithdrawals: BigInt! @config(precision: 76) # number of gauge withdrawals (unstaking)
   numberOfGaugeRewardClaims: BigInt! @config(precision: 76) # number of gauge reward claims
@@ -135,6 +136,7 @@ type LiquidityPoolAggregatorSnapshot {
   gaugeIsAlive: Boolean! # whether the gauge is alive
   gaugeAddress: String @index # address of the gauge for this pool
   gaugeEmissionsCap: BigInt @config(precision: 76) # Emissions cap for gauge
+  minStakeTime: BigInt! @config(precision: 24) # Per-pool LP stake lockup (seconds) at snapshot time
   numberOfGaugeDeposits: BigInt! @config(precision: 76) # number of gauge deposits (staking)
   numberOfGaugeWithdrawals: BigInt! @config(precision: 76) # number of gauge withdrawals (unstaking)
   numberOfGaugeRewardClaims: BigInt! @config(precision: 76) # number of gauge reward claims
@@ -565,13 +567,16 @@ type OUSDTSwaps {
   amountOut: BigInt! @config(precision: 76) # Amount of tokenOutPool being swapped out of the pool
 }
 
-# Stores chain-wide CLGauge config data such as default emissions cap.
-# Keyed by chainId so the CLFactory.PoolCreated handler can resolve it with a direct get()
-# without a per-chain lookup constant. Last-writer-wins across gauge factory generations
-# (V2, V3, ...) — the row reflects the most recent chain-wide default.
+# Stores chain-wide CLGauge config data — default emissions cap, default
+# min-stake-time, and penalty rate. Keyed by chainId so the CLFactory.PoolCreated
+# handler can resolve it with a direct get() without a per-chain lookup constant.
+# Last-writer-wins across gauge factory generations (V2, V3, ...) — the row
+# reflects the most recent chain-wide defaults.
 type CLGaugeConfig {
   id: ID! # Format: stringified chainId (e.g. "8453" for Base)
   defaultEmissionsCap: BigInt! @config(precision: 24)
+  defaultMinStakeTime: BigInt! @config(precision: 24) # Chain-wide default LP stake lockup (seconds), set via CLGaugeFactoryV3.SetDefaultMinStakeTime. 0 before V3.
+  penaltyRate: BigInt! @config(precision: 24) # Early-unstake penalty rate in basis points, set via CLGaugeFactoryV3.SetPenaltyRate. 0 before V3.
   lastUpdatedTimestamp: Timestamp! # Timestamp of the last CLGaugeConfig update
 }
 

--- a/src/Aggregators/LiquidityPoolAggregator.ts
+++ b/src/Aggregators/LiquidityPoolAggregator.ts
@@ -752,6 +752,9 @@ export function createLiquidityPoolAggregatorEntity(params: {
       : isCL
         ? undefined
         : 0n,
+    // Seed per-pool min stake lockup from the chain-wide default; 0 before CLGaugeFactoryV3's SetDefaultMinStakeTime has fired.
+    // SetPoolMinStakeTime can override this per-pool later.
+    minStakeTime: CLGaugeConfig?.defaultMinStakeTime ?? 0n,
     // Dynamic Fee fields
     baseFee: baseFee,
     feeCap: undefined,

--- a/src/EventHandlers/CLGaugeFactory/CLGaugeFactorySharedLogic.ts
+++ b/src/EventHandlers/CLGaugeFactory/CLGaugeFactorySharedLogic.ts
@@ -1,4 +1,33 @@
-import type { handlerContext } from "generated";
+import type { CLGaugeConfig, handlerContext } from "generated";
+
+/**
+ * Build a fully-populated CLGaugeConfig row for a chain, spreading an existing
+ * row if present and supplying zero defaults for any required fields not yet set.
+ * Every partial-update helper (applySetDefaultCap, applySetDefaultMinStakeTime,
+ * applySetPenaltyRate) routes through this so a first-time write never leaves
+ * required fields missing and a subsequent write never stomps sibling fields.
+ * @param chainId - Chain ID keying the CLGaugeConfig row
+ * @param existing - Current CLGaugeConfig row, if any
+ * @param override - Partial fields to apply on top of the existing row
+ * @param blockTimestampSeconds - Block timestamp (seconds) used for lastUpdatedTimestamp
+ * @returns A complete CLGaugeConfig ready to be passed to context.CLGaugeConfig.set
+ */
+function mergeCLGaugeConfig(
+  chainId: number,
+  existing: CLGaugeConfig | undefined,
+  override: Partial<CLGaugeConfig>,
+  blockTimestampSeconds: number,
+): CLGaugeConfig {
+  return {
+    id: String(chainId),
+    defaultEmissionsCap: 0n,
+    defaultMinStakeTime: 0n,
+    penaltyRate: 0n,
+    ...(existing ?? {}),
+    ...override,
+    lastUpdatedTimestamp: new Date(blockTimestampSeconds * 1000),
+  };
+}
 
 /**
  * Upsert the chain-wide CLGaugeConfig default emissions cap.
@@ -16,12 +45,66 @@ export async function applySetDefaultCap(
   context: handlerContext,
 ): Promise<void> {
   const existing = await context.CLGaugeConfig.get(String(chainId));
-  context.CLGaugeConfig.set({
-    ...(existing ?? {}),
-    id: String(chainId),
-    defaultEmissionsCap: newDefaultCap,
-    lastUpdatedTimestamp: new Date(blockTimestampSeconds * 1000),
-  });
+  context.CLGaugeConfig.set(
+    mergeCLGaugeConfig(
+      chainId,
+      existing,
+      { defaultEmissionsCap: newDefaultCap },
+      blockTimestampSeconds,
+    ),
+  );
+}
+
+/**
+ * Upsert the chain-wide CLGaugeConfig default min stake time (LP lockup in seconds).
+ * Emitted by CLGaugeFactoryV3.SetDefaultMinStakeTime.
+ * @param chainId - Chain ID the event fired on (keys the CLGaugeConfig row)
+ * @param newMinStakeTime - New default min stake time (seconds) from the event payload
+ * @param blockTimestampSeconds - Block timestamp (seconds) used for lastUpdatedTimestamp
+ * @param context - Handler context for entity access
+ * @returns Promise that resolves once the upsert is staged
+ */
+export async function applySetDefaultMinStakeTime(
+  chainId: number,
+  newMinStakeTime: bigint,
+  blockTimestampSeconds: number,
+  context: handlerContext,
+): Promise<void> {
+  const existing = await context.CLGaugeConfig.get(String(chainId));
+  context.CLGaugeConfig.set(
+    mergeCLGaugeConfig(
+      chainId,
+      existing,
+      { defaultMinStakeTime: newMinStakeTime },
+      blockTimestampSeconds,
+    ),
+  );
+}
+
+/**
+ * Upsert the chain-wide CLGaugeConfig early-unstake penalty rate (basis points).
+ * Emitted by CLGaugeFactoryV3.SetPenaltyRate.
+ * @param chainId - Chain ID the event fired on (keys the CLGaugeConfig row)
+ * @param newPenaltyRate - New penalty rate (bps) from the event payload
+ * @param blockTimestampSeconds - Block timestamp (seconds) used for lastUpdatedTimestamp
+ * @param context - Handler context for entity access
+ * @returns Promise that resolves once the upsert is staged
+ */
+export async function applySetPenaltyRate(
+  chainId: number,
+  newPenaltyRate: bigint,
+  blockTimestampSeconds: number,
+  context: handlerContext,
+): Promise<void> {
+  const existing = await context.CLGaugeConfig.get(String(chainId));
+  context.CLGaugeConfig.set(
+    mergeCLGaugeConfig(
+      chainId,
+      existing,
+      { penaltyRate: newPenaltyRate },
+      blockTimestampSeconds,
+    ),
+  );
 }
 
 /**

--- a/src/EventHandlers/CLGaugeFactory/CLGaugeFactoryV3.ts
+++ b/src/EventHandlers/CLGaugeFactory/CLGaugeFactoryV3.ts
@@ -1,7 +1,10 @@
 import { CLGaugeFactoryV3 } from "generated";
+import { PoolId } from "../../Constants";
 import {
   applySetDefaultCap,
+  applySetDefaultMinStakeTime,
   applySetEmissionCap,
+  applySetPenaltyRate,
 } from "./CLGaugeFactorySharedLogic";
 
 CLGaugeFactoryV3.SetDefaultCap.handler(async ({ event, context }) => {
@@ -19,6 +22,42 @@ CLGaugeFactoryV3.SetEmissionCap.handler(async ({ event, context }) => {
     event.params._newEmissionCap,
     event.block.timestamp,
     "CLGaugeFactoryV3",
+    context,
+  );
+});
+
+CLGaugeFactoryV3.SetDefaultMinStakeTime.handler(async ({ event, context }) => {
+  await applySetDefaultMinStakeTime(
+    event.chainId,
+    event.params._minStakeTime,
+    event.block.timestamp,
+    context,
+  );
+});
+
+CLGaugeFactoryV3.SetPoolMinStakeTime.handler(async ({ event, context }) => {
+  const poolId = PoolId(event.chainId, event.params._pool);
+  const pool = await context.LiquidityPoolAggregator.get(poolId);
+
+  if (!pool) {
+    context.log.error(
+      `[CLGaugeFactoryV3] Pool ${event.params._pool} not found on chain ${event.chainId} for SetPoolMinStakeTime`,
+    );
+    return;
+  }
+
+  context.LiquidityPoolAggregator.set({
+    ...pool,
+    minStakeTime: event.params._minStakeTime,
+    lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
+  });
+});
+
+CLGaugeFactoryV3.SetPenaltyRate.handler(async ({ event, context }) => {
+  await applySetPenaltyRate(
+    event.chainId,
+    event.params._penaltyRate,
+    event.block.timestamp,
     context,
   );
 });

--- a/src/Snapshots/LiquidityPoolAggregatorSnapshot.ts
+++ b/src/Snapshots/LiquidityPoolAggregatorSnapshot.ts
@@ -68,6 +68,7 @@ export function createLiquidityPoolAggregatorSnapshot(
     gaugeIsAlive: entity.gaugeIsAlive,
     gaugeAddress: entity.gaugeAddress,
     gaugeEmissionsCap: entity.gaugeEmissionsCap,
+    minStakeTime: entity.minStakeTime,
     numberOfGaugeDeposits: entity.numberOfGaugeDeposits,
     numberOfGaugeWithdrawals: entity.numberOfGaugeWithdrawals,
     numberOfGaugeRewardClaims: entity.numberOfGaugeRewardClaims,

--- a/test/EventHandlers/CLFactory.test.ts
+++ b/test/EventHandlers/CLFactory.test.ts
@@ -70,6 +70,8 @@ describe("CLFactory Events", () => {
     const clGaugeConfig = {
       id: String(clGaugeConfigChainId),
       defaultEmissionsCap: 0n,
+      defaultMinStakeTime: 0n,
+      penaltyRate: 0n,
       lastUpdatedTimestamp: new Date(1000000 * 1000),
     } satisfies CLGaugeConfig;
     updated = updated.entities.CLGaugeConfig.set(clGaugeConfig);
@@ -467,6 +469,8 @@ describe("CLFactory Events", () => {
         const clGaugeConfig = {
           id: String(leafChain),
           defaultEmissionsCap: 0n,
+          defaultMinStakeTime: 0n,
+          penaltyRate: 0n,
           lastUpdatedTimestamp: new Date(1000000 * 1000),
         } satisfies CLGaugeConfig;
         updated = updated.entities.CLGaugeConfig.set(clGaugeConfig);

--- a/test/EventHandlers/CLFactory/CLFactoryPoolCreatedLogic.test.ts
+++ b/test/EventHandlers/CLFactory/CLFactoryPoolCreatedLogic.test.ts
@@ -481,6 +481,8 @@ describe("CLFactoryPoolCreatedLogic", () => {
       const mockCLGaugeConfig: CLGaugeConfig = {
         id: String(mockEvent.chainId),
         defaultEmissionsCap: mockDefaultEmissionsCap,
+        defaultMinStakeTime: 0n,
+        penaltyRate: 0n,
         lastUpdatedTimestamp: new Date(1000000 * 1000),
       };
 
@@ -497,6 +499,45 @@ describe("CLFactoryPoolCreatedLogic", () => {
       expect(result.liquidityPoolAggregator.gaugeEmissionsCap).toBe(
         mockDefaultEmissionsCap,
       );
+    });
+
+    it("should seed minStakeTime from CLGaugeConfig.defaultMinStakeTime when CLGaugeConfig exists", async () => {
+      const mockDefaultMinStakeTime = 86_400n; // 1 day
+      const mockCLGaugeConfig: CLGaugeConfig = {
+        id: String(mockEvent.chainId),
+        defaultEmissionsCap: 0n,
+        defaultMinStakeTime: mockDefaultMinStakeTime,
+        penaltyRate: 0n,
+        lastUpdatedTimestamp: new Date(1000000 * 1000),
+      };
+
+      const result = await processCLFactoryPoolCreated(
+        mockEvent,
+        mockEvent.srcAddress,
+        mockToken0Data,
+        mockToken1Data,
+        mockCLGaugeConfig,
+        mockFeeToTickSpacingMapping,
+        mockContext,
+      );
+
+      expect(result.liquidityPoolAggregator.minStakeTime).toBe(
+        mockDefaultMinStakeTime,
+      );
+    });
+
+    it("should fall back to 0n minStakeTime when CLGaugeConfig does not exist", async () => {
+      const result = await processCLFactoryPoolCreated(
+        mockEvent,
+        mockEvent.srcAddress,
+        mockToken0Data,
+        mockToken1Data,
+        undefined,
+        mockFeeToTickSpacingMapping,
+        mockContext,
+      );
+
+      expect(result.liquidityPoolAggregator.minStakeTime).toBe(0n);
     });
 
     it("should set baseFee and currentFee from FeeToTickSpacingMapping when mapping exists", async () => {

--- a/test/EventHandlers/CLGaugeFactory/CLGaugeFactoryV3.test.ts
+++ b/test/EventHandlers/CLGaugeFactory/CLGaugeFactoryV3.test.ts
@@ -1,10 +1,10 @@
-import type { LiquidityPoolAggregator } from "generated";
+import type { CLGaugeConfig, LiquidityPoolAggregator } from "generated";
 import {
   CLGaugeFactoryV2,
   CLGaugeFactoryV3,
   MockDb,
 } from "../../../generated/src/TestHelpers.gen";
-import { toChecksumAddress } from "../../../src/Constants";
+import { PoolId, toChecksumAddress } from "../../../src/Constants";
 import { setupCommon } from "../Pool/common";
 
 describe("CLGaugeFactoryV3 Event Handlers", () => {
@@ -210,6 +210,202 @@ describe("CLGaugeFactoryV3 Event Handlers", () => {
       expect(pool).toBeDefined();
       if (!pool) return;
       expect(pool.gaugeEmissionsCap).toBe(0n);
+    });
+  });
+
+  describe("SetDefaultMinStakeTime", () => {
+    const mockMinStakeTime = 86_400n; // 1 day
+
+    it("creates a CLGaugeConfig with defaultMinStakeTime and zero defaults for siblings", async () => {
+      const event = CLGaugeFactoryV3.SetDefaultMinStakeTime.createMockEvent({
+        _minStakeTime: mockMinStakeTime,
+        mockEventData: {
+          srcAddress: v3FactoryAddress,
+          chainId,
+          block: {
+            timestamp: 4_000_000,
+            number: 4,
+            hash: "0x4444444444444444444444444444444444444444444444444444444444444444",
+          },
+          logIndex: 1,
+        },
+      });
+
+      const result = await mockDb.processEvents([event]);
+
+      const config = result.entities.CLGaugeConfig.get(String(chainId));
+      expect(config).toBeDefined();
+      if (!config) return;
+      expect(config.defaultMinStakeTime).toBe(mockMinStakeTime);
+      expect(config.defaultEmissionsCap).toBe(0n);
+      expect(config.penaltyRate).toBe(0n);
+      expect(config.lastUpdatedTimestamp).toEqual(new Date(4_000_000 * 1000));
+    });
+
+    it("updates defaultMinStakeTime without stomping existing defaultEmissionsCap or penaltyRate", async () => {
+      const existing: CLGaugeConfig = {
+        id: String(chainId),
+        defaultEmissionsCap: mockDefaultCap,
+        defaultMinStakeTime: 0n,
+        penaltyRate: 250n,
+        lastUpdatedTimestamp: new Date(3_000_000 * 1000),
+      };
+      const seeded = mockDb.entities.CLGaugeConfig.set(existing);
+
+      const event = CLGaugeFactoryV3.SetDefaultMinStakeTime.createMockEvent({
+        _minStakeTime: mockMinStakeTime,
+        mockEventData: {
+          srcAddress: v3FactoryAddress,
+          chainId,
+          block: {
+            timestamp: 4_000_000,
+            number: 4,
+            hash: "0x4444444444444444444444444444444444444444444444444444444444444444",
+          },
+          logIndex: 1,
+        },
+      });
+
+      const result = await seeded.processEvents([event]);
+
+      const config = result.entities.CLGaugeConfig.get(String(chainId));
+      expect(config).toBeDefined();
+      if (!config) return;
+      expect(config.defaultEmissionsCap).toBe(mockDefaultCap);
+      expect(config.defaultMinStakeTime).toBe(mockMinStakeTime);
+      expect(config.penaltyRate).toBe(250n);
+    });
+  });
+
+  describe("SetPoolMinStakeTime", () => {
+    const poolAddress = toChecksumAddress(
+      "0xcccccccccccccccccccccccccccccccccccccccc",
+    );
+    const poolOnBaseId = PoolId(chainId, poolAddress);
+
+    it("sets minStakeTime on the matching LiquidityPoolAggregator", async () => {
+      const existingPool: LiquidityPoolAggregator = {
+        ...mockLiquidityPoolData,
+        id: poolOnBaseId,
+        chainId,
+        poolAddress: poolAddress as `0x${string}`,
+        minStakeTime: 0n,
+      };
+      const seeded = mockDb.entities.LiquidityPoolAggregator.set(existingPool);
+
+      const event = CLGaugeFactoryV3.SetPoolMinStakeTime.createMockEvent({
+        _pool: poolAddress,
+        _minStakeTime: 3_600n,
+        mockEventData: {
+          srcAddress: v3FactoryAddress,
+          chainId,
+          block: {
+            timestamp: 5_000_000,
+            number: 5,
+            hash: "0x5555555555555555555555555555555555555555555555555555555555555555",
+          },
+          logIndex: 1,
+        },
+      });
+
+      const result = await seeded.processEvents([event]);
+
+      const pool = result.entities.LiquidityPoolAggregator.get(poolOnBaseId);
+      expect(pool).toBeDefined();
+      if (!pool) return;
+      expect(pool.minStakeTime).toBe(3_600n);
+      expect(pool.lastUpdatedTimestamp).toEqual(new Date(5_000_000 * 1000));
+    });
+
+    it("returns cleanly when no pool is found for the given pool address", async () => {
+      const event = CLGaugeFactoryV3.SetPoolMinStakeTime.createMockEvent({
+        _pool: toChecksumAddress("0xdddddddddddddddddddddddddddddddddddddddd"),
+        _minStakeTime: 3_600n,
+        mockEventData: {
+          srcAddress: v3FactoryAddress,
+          chainId,
+          block: {
+            timestamp: 5_000_000,
+            number: 5,
+            hash: "0x5555555555555555555555555555555555555555555555555555555555555555",
+          },
+          logIndex: 1,
+        },
+      });
+
+      const result = await mockDb.processEvents([event]);
+
+      // Verify no pool entity was created for the missing pool — handler short-circuits.
+      const missingPool = result.entities.LiquidityPoolAggregator.get(
+        PoolId(
+          chainId,
+          toChecksumAddress("0xdddddddddddddddddddddddddddddddddddddddd"),
+        ),
+      );
+      expect(missingPool).toBeUndefined();
+    });
+  });
+
+  describe("SetPenaltyRate", () => {
+    const mockPenaltyRate = 250n; // 2.5% in bps
+
+    it("creates a CLGaugeConfig with penaltyRate and zero defaults for siblings", async () => {
+      const event = CLGaugeFactoryV3.SetPenaltyRate.createMockEvent({
+        _penaltyRate: mockPenaltyRate,
+        mockEventData: {
+          srcAddress: v3FactoryAddress,
+          chainId,
+          block: {
+            timestamp: 6_000_000,
+            number: 6,
+            hash: "0x6666666666666666666666666666666666666666666666666666666666666666",
+          },
+          logIndex: 1,
+        },
+      });
+
+      const result = await mockDb.processEvents([event]);
+
+      const config = result.entities.CLGaugeConfig.get(String(chainId));
+      expect(config).toBeDefined();
+      if (!config) return;
+      expect(config.penaltyRate).toBe(mockPenaltyRate);
+      expect(config.defaultEmissionsCap).toBe(0n);
+      expect(config.defaultMinStakeTime).toBe(0n);
+    });
+
+    it("updates penaltyRate without stomping defaultEmissionsCap or defaultMinStakeTime", async () => {
+      const existing: CLGaugeConfig = {
+        id: String(chainId),
+        defaultEmissionsCap: mockDefaultCap,
+        defaultMinStakeTime: 86_400n,
+        penaltyRate: 0n,
+        lastUpdatedTimestamp: new Date(4_000_000 * 1000),
+      };
+      const seeded = mockDb.entities.CLGaugeConfig.set(existing);
+
+      const event = CLGaugeFactoryV3.SetPenaltyRate.createMockEvent({
+        _penaltyRate: mockPenaltyRate,
+        mockEventData: {
+          srcAddress: v3FactoryAddress,
+          chainId,
+          block: {
+            timestamp: 6_000_000,
+            number: 6,
+            hash: "0x6666666666666666666666666666666666666666666666666666666666666666",
+          },
+          logIndex: 1,
+        },
+      });
+
+      const result = await seeded.processEvents([event]);
+
+      const config = result.entities.CLGaugeConfig.get(String(chainId));
+      expect(config).toBeDefined();
+      if (!config) return;
+      expect(config.defaultEmissionsCap).toBe(mockDefaultCap);
+      expect(config.defaultMinStakeTime).toBe(86_400n);
+      expect(config.penaltyRate).toBe(mockPenaltyRate);
     });
   });
 });

--- a/test/EventHandlers/Pool/common.ts
+++ b/test/EventHandlers/Pool/common.ts
@@ -138,6 +138,7 @@ export function setupCommon() {
     totalFlashLoanVolumeUSD: 0n,
     numberOfFlashLoans: 0n,
     // Gauge fields
+    minStakeTime: 0n,
     numberOfGaugeDeposits: 0n,
     numberOfGaugeWithdrawals: 0n,
     numberOfGaugeRewardClaims: 0n,


### PR DESCRIPTION
Resolves #615. Stacked on #617 (#614) and #616 (#613).

## Summary

Index the three staking-config events introduced by `CLGaugeFactoryV3`:

- **`SetDefaultMinStakeTime(uint256)`** — chain-wide default LP stake lockup (seconds)
- **`SetPoolMinStakeTime(address, uint256)`** — per-pool override
- **`SetPenaltyRate(uint256)`** — chain-wide early-unstake penalty (bps)

(`SetGaugeStakeManager` is out of scope.)

## Schema shape

- `CLGaugeConfig`: adds `defaultMinStakeTime: BigInt!` and `penaltyRate: BigInt!`.
- `LiquidityPoolAggregator` (+ snapshot): adds `minStakeTime: BigInt!`, seeded at pool creation from `CLGaugeConfig.defaultMinStakeTime` (same pattern as `gaugeEmissionsCap`), overridden per-pool by `SetPoolMinStakeTime`.

## Implementation

- New merge helper in `src/EventHandlers/CLGaugeFactory/shared.ts` so every partial upsert on `CLGaugeConfig` (`SetDefaultCap`, `SetDefaultMinStakeTime`, `SetPenaltyRate`) fills required fields on first write and preserves siblings on subsequent writes.
- `SetPoolMinStakeTime` resolves the pool via direct `get(PoolId(chainId, pool))` — no `getWhere`.

## Test plan

- [x] `pnpm envio codegen` clean
- [x] `tsc --noEmit` clean
- [x] `biome check --write` clean on changed files
- [x] `pnpm test` — 1045 passed / 32 skipped
- [x] Tests cover each V3 staking handler + pool-creation seeding of `minStakeTime` from `CLGaugeConfig.defaultMinStakeTime` (plus fallback to `0n` when absent) + SchemaParity test for the new snapshot field

> Note: after #616 and #617 merge, rebase: `git rebase --onto main feat/clgaugefactory-v3-subscribe feat/v3-staking-config`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable minimum stake time at both chain-wide default and per-pool levels.
  * Introduced penalty rate configuration tracking for liquidity pools.
  * Enhanced gauge configuration system to track and persist additional default parameters.

* **Tests**
  * Added comprehensive test coverage for new minimum stake time and penalty rate event handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->