### PR TITLE
fix(snapshot): include nfpmAddress in NonFungiblePositionSnapshot ID (#620)

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -350,7 +350,7 @@ type NonFungiblePosition {
 
 # Snapshot of NonFungiblePosition at an epoch (full state for historical queries / recomputation)
 type NonFungiblePositionSnapshot {
-  id: ID! # Format: {chainId}-{tokenId}-{epochMs} (NonFungiblePositionSnapshotId)
+  id: ID! # Format: {chainId}-{nfpmAddress}-{tokenId}-{epochMs} (NonFungiblePositionSnapshotId). nfpmAddress disambiguates intra-chain tokenId collisions across multiple NFPMs (e.g. Optimism has two).
   chainId: Int!
   tokenId: BigInt! @index
   nfpmAddress: String! @index

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -1085,17 +1085,26 @@ export const UserStatsPerPoolSnapshotId = (
   epochMs: number,
 ) => `${chainId}-${userAddress}-${poolAddress}-${epochMs}`;
 
-/** Snapshot ID for NonFungiblePositionSnapshot. epochMs = getSnapshotEpoch(timestamp).getTime()
+/** Snapshot ID for NonFungiblePositionSnapshot.
+ * Format: {chainId}-{nfpmAddress}-{tokenId}-{epochMs}. epochMs = getSnapshotEpoch(timestamp).getTime().
+ *
+ * Includes nfpmAddress because tokenIds are only unique within a single NFPM contract's
+ * counter. Optimism has two NFPMs so two positions can share (chainId, tokenId) with
+ * different pools; without nfpmAddress in the ID their snapshots would collide in the
+ * same epoch and overwrite each other. See #620.
+ *
  * @param chainId - Chain ID of the non-fungible position
+ * @param nfpmAddress - Address of the NFPM contract that owns the position
  * @param tokenId - ID of the non-fungible position
  * @param epochMs - Epoch timestamp in milliseconds
- * @returns string Combined non-fungible position ID.
+ * @returns string Combined non-fungible position snapshot ID.
  */
 export const NonFungiblePositionSnapshotId = (
   chainId: number,
+  nfpmAddress: string,
   tokenId: bigint,
   epochMs: number,
-) => `${chainId}-${tokenId}-${epochMs}`;
+) => `${chainId}-${nfpmAddress}-${tokenId}-${epochMs}`;
 
 /** Snapshot ID for ALM_LP_WrapperSnapshot. Format: {chainId}-{wrapperAddress}-{epochMs}. epochMs = getSnapshotEpoch(timestamp).getTime()
  * @param chainId - Chain ID of the wrapper

--- a/src/Snapshots/NonFungiblePositionSnapshot.ts
+++ b/src/Snapshots/NonFungiblePositionSnapshot.ts
@@ -25,6 +25,7 @@ export function createNonFungiblePositionSnapshot(
   const epoch = getSnapshotEpoch(timestamp);
   const snapshotId = NonFungiblePositionSnapshotId(
     entity.chainId,
+    entity.nfpmAddress,
     entity.tokenId,
     epoch.getTime(),
   );

--- a/test/EventHandlers/NFPM/NFPMDecreaseLiquidityLogic.test.ts
+++ b/test/EventHandlers/NFPM/NFPMDecreaseLiquidityLogic.test.ts
@@ -46,7 +46,12 @@ describe("NFPMDecreaseLiquidityLogic", () => {
     expect(context.NonFungiblePositionSnapshot.set).toHaveBeenCalledTimes(1);
     expect(context.NonFungiblePositionSnapshot.set).toHaveBeenCalledWith(
       expect.objectContaining({
-        id: NonFungiblePositionSnapshotId(chainId, tokenId, epoch.getTime()),
+        id: NonFungiblePositionSnapshotId(
+          chainId,
+          mockPosition.nfpmAddress,
+          tokenId,
+          epoch.getTime(),
+        ),
         chainId,
         tokenId,
         nfpmAddress: mockPosition.nfpmAddress,

--- a/test/Snapshots/NonFungiblePositionSnapshot.test.ts
+++ b/test/Snapshots/NonFungiblePositionSnapshot.test.ts
@@ -1,6 +1,7 @@
 import {
   NonFungiblePositionSnapshotId,
   SNAPSHOT_INTERVAL_IN_MS,
+  toChecksumAddress,
 } from "../../src/Constants";
 import {
   createNonFungiblePositionSnapshot,
@@ -99,19 +100,23 @@ describe("NonFungiblePositionSnapshot", () => {
   // #620 regression: two NFPMs on the same chain can mint positions that share (chainId, tokenId).
   // Before this fix, their snapshots collided in the same epoch and overwrote each other.
   it("should produce distinct snapshot rows for two positions sharing (chainId, tokenId) under different NFPMs", () => {
-    const NFPM_A = "0xbB5DFE1380333CEE4c2EeBd7202c80dE2256AdF4";
-    const NFPM_B = "0x416b433906b1B72FA758e166e239c43d68dC6F29";
+    const NFPM_A = toChecksumAddress(
+      "0xbB5DFE1380333CEE4c2EeBd7202c80dE2256AdF4",
+    );
+    const NFPM_B = toChecksumAddress(
+      "0x416b433906b1B72FA758e166e239c43d68dC6F29",
+    );
     const sharedTokenId = 42n;
 
     const entityA = common.createMockNonFungiblePosition({
       nfpmAddress: NFPM_A,
       tokenId: sharedTokenId,
-      pool: "0xAaAa000000000000000000000000000000000001",
+      pool: toChecksumAddress("0xAaAa000000000000000000000000000000000001"),
     });
     const entityB = common.createMockNonFungiblePosition({
       nfpmAddress: NFPM_B,
       tokenId: sharedTokenId,
-      pool: "0xBbBb000000000000000000000000000000000002",
+      pool: toChecksumAddress("0xBbBb000000000000000000000000000000000002"),
     });
 
     const snapshotA = createNonFungiblePositionSnapshot(entityA, baseTimestamp);

--- a/test/Snapshots/NonFungiblePositionSnapshot.test.ts
+++ b/test/Snapshots/NonFungiblePositionSnapshot.test.ts
@@ -28,6 +28,7 @@ describe("NonFungiblePositionSnapshot", () => {
       expect(snapshot.id).toBe(
         NonFungiblePositionSnapshotId(
           entity.chainId,
+          entity.nfpmAddress,
           entity.tokenId,
           expectedEpochMs,
         ),
@@ -86,12 +87,40 @@ describe("NonFungiblePositionSnapshot", () => {
       expect.objectContaining({
         id: NonFungiblePositionSnapshotId(
           entity.chainId,
+          entity.nfpmAddress,
           entity.tokenId,
           expectedEpochMs,
         ),
         timestamp: new Date(expectedEpochMs),
       }),
     );
+  });
+
+  // #620 regression: two NFPMs on the same chain can mint positions that share (chainId, tokenId).
+  // Before this fix, their snapshots collided in the same epoch and overwrote each other.
+  it("should produce distinct snapshot rows for two positions sharing (chainId, tokenId) under different NFPMs", () => {
+    const NFPM_A = "0xbB5DFE1380333CEE4c2EeBd7202c80dE2256AdF4";
+    const NFPM_B = "0x416b433906b1B72FA758e166e239c43d68dC6F29";
+    const sharedTokenId = 42n;
+
+    const entityA = common.createMockNonFungiblePosition({
+      nfpmAddress: NFPM_A,
+      tokenId: sharedTokenId,
+      pool: "0xAaAa000000000000000000000000000000000001",
+    });
+    const entityB = common.createMockNonFungiblePosition({
+      nfpmAddress: NFPM_B,
+      tokenId: sharedTokenId,
+      pool: "0xBbBb000000000000000000000000000000000002",
+    });
+
+    const snapshotA = createNonFungiblePositionSnapshot(entityA, baseTimestamp);
+    const snapshotB = createNonFungiblePositionSnapshot(entityB, baseTimestamp);
+
+    expect(snapshotA.chainId).toBe(snapshotB.chainId);
+    expect(snapshotA.tokenId).toBe(snapshotB.tokenId);
+    expect(snapshotA.timestamp.getTime()).toBe(snapshotB.timestamp.getTime());
+    expect(snapshotA.id).not.toBe(snapshotB.id);
   });
 
   it("should spread entity fields into the snapshot", () => {
@@ -107,6 +136,7 @@ describe("NonFungiblePositionSnapshot", () => {
       expect.objectContaining({
         id: NonFungiblePositionSnapshotId(
           entity.chainId,
+          entity.nfpmAddress,
           entity.tokenId,
           expectedEpochMs,
         ),


### PR DESCRIPTION
## Summary

Two `NonFungiblePosition` entities that share `(chainId, tokenId)` under different NFPM contracts — already a real case on Optimism — currently overwrite each other's snapshots in the same epoch. This changes the snapshot ID to `{chainId}-{nfpmAddress}-{tokenId}-{epochMs}` so each NFPM gets its own row.

Independent of the entity-ID redesign (#621): the position entity already carries `nfpmAddress` after #611, so the snapshot writer plumbs it through directly.

Parent PRD: #618
Closes #620

## Envio re-sync note

`NonFungiblePositionSnapshot` ID format changed. Existing snapshot rows are dropped on reindex and new rows repopulate from the snapshot path. No backfill needed.

## Test plan

- [x] New regression test: two positions sharing `(chainId, tokenId)` under different NFPMs produce distinct snapshot rows in the same epoch.
- [x] Existing `NonFungiblePositionSnapshot.test.ts` and `NFPMDecreaseLiquidityLogic.test.ts` updated to use the 4-arg helper signature.
- [x] `schema.graphql` comment updated to reflect the new format.
- [x] `pnpm qa --write` clean, `pnpm test` green (1050/1050 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed snapshot identification for non-fungible positions by including the NFT manager contract address as a disambiguator. This ensures unique identification of positions with identical token IDs across multiple contracts on the same blockchain network.

* **Tests**
  * Updated test expectations to reflect the enhanced snapshot ID format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->