### PR TITLE
refactor(nfpm): scope NonFungiblePosition ID by NFPM, drop getWhere (#621)

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -335,7 +335,7 @@ type TokenPriceSnapshot {
 # Tracks relevant data for each NFT minted: each NFT represents a concentrated position in a pool
 # Note: amount0, amount1, amountUSD are derived fields computed on-demand from liquidity + sqrtPriceX96 + ticks
 type NonFungiblePosition {
-  id: ID! # Format: {chainId}-{poolAddress}-{tokenId} (NonFungiblePositionId)
+  id: ID! # Format: {chainId}-{nfpmAddress}-{tokenId} (NonFungiblePositionId). Natural key is (NFPM, tokenId); pool is metadata and preserved as a field. nfpmAddress disambiguates intra-chain tokenId collisions across multiple NFPMs (e.g. Optimism has two).
   chainId: Int! # Chain ID where the NFT exists
   tokenId: BigInt! @index # Token ID of the NFT (from Transfer event)
   nfpmAddress: String! @index # Address of the NFPM contract that emitted the Transfer; disambiguates intra-chain tokenId collisions across multiple NFPMs (e.g. Optimism has two)

--- a/schema.graphql
+++ b/schema.graphql
@@ -89,6 +89,11 @@ type LiquidityPoolAggregator {
   # Address of the factory that created this pool (e.g. CLFactory for CL pools, set from PoolCreated event)
   factoryAddress: String
 
+  # Address of the NFPM contract that mints positions for this CL pool. Null for V2 (non-CL) pools.
+  # Resolved from (chainId, factoryAddress) via nfpmForCLPool in Constants.ts. Used by downstream
+  # consumers (gauges, user-stats, NFPM handlers) to derive the correct NFPM without a separate scan.
+  nfpmAddress: String @index
+
   # RootPool matching - only relevant for non-OP and non-Base pools
   # For each superChain pool there's a unique rootPool
   # This is because the rootPool is created through a hash of these 4 quantities and they are a unique combination (enforced by smart contract)

--- a/src/Aggregators/LiquidityPoolAggregator.ts
+++ b/src/Aggregators/LiquidityPoolAggregator.ts
@@ -642,6 +642,10 @@ export function createLiquidityPoolAggregatorEntity(params: {
   tickSpacing?: number; // For CL pools
   CLGaugeConfig?: CLGaugeConfig | null; // For CL pools
   factoryAddress: string; // Address of the factory that created this pool (e.g. CLFactory for CL pools)
+  // Address of the NFPM contract that mints positions for this pool (CL only; null for V2).
+  // Resolved by nfpmForCLPool() at the PoolCreated handler; threaded here so downstream
+  // consumers (gauges, user-stats, NFPM handlers) can look up positions without a separate scan.
+  nfpmAddress?: string | null;
   baseFee: bigint;
   currentFee: bigint;
 }): LiquidityPoolAggregator {
@@ -658,6 +662,7 @@ export function createLiquidityPoolAggregatorEntity(params: {
     tickSpacing,
     CLGaugeConfig,
     factoryAddress,
+    nfpmAddress,
     baseFee,
     currentFee,
   } = params;
@@ -743,6 +748,8 @@ export function createLiquidityPoolAggregatorEntity(params: {
     poolLauncherPoolId: undefined,
     // Address of the factory that created this pool (e.g. CLFactory for CL pools)
     factoryAddress: factoryAddress,
+    // Address of the NFPM for this CL pool (null for V2). See nfpmForCLPool in Constants.ts.
+    nfpmAddress: nfpmAddress ?? undefined,
     // Voting fields
     gaugeAddress: "",
     // Set to undefined if CLGaugeConfig does not exist (i.e before the deployment of CLGaugeFactoryV2 which introduces emissions caps per gauge).

--- a/src/Aggregators/UserStatsPerPool.ts
+++ b/src/Aggregators/UserStatsPerPool.ts
@@ -427,17 +427,16 @@ export async function updateUserStatsPerPool(
           poolEntity.isCL &&
           poolEntity.sqrtPriceX96 &&
           poolEntity.sqrtPriceX96 !== 0n &&
-          updated.stakedCLPositionTokenIds.length > 0
+          updated.stakedCLPositionTokenIds.length > 0 &&
+          poolEntity.nfpmAddress
         ) {
-          // Fetch all staked positions in parallel — O(1) per get(), O(K) total
+          // Fetch all staked positions in parallel — O(1) per get(), O(K) total.
+          // pool.nfpmAddress is threaded onto the aggregator at PoolCreated time (see #619).
+          const nfpmAddress = poolEntity.nfpmAddress;
           const positions = await Promise.all(
             updated.stakedCLPositionTokenIds.map((tokenId) =>
               context.NonFungiblePosition.get(
-                NonFungiblePositionId(
-                  updated.chainId,
-                  updated.poolAddress,
-                  tokenId,
-                ),
+                NonFungiblePositionId(updated.chainId, nfpmAddress, tokenId),
               ),
             ),
           );

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -82,6 +82,70 @@ export const ROOT_POOL_FACTORY_ADDRESS_OPTIMISM = toChecksumAddress(
   "0x31832f2a97Fd20664D76Cc421207669b55CE4BC0",
 );
 
+/**
+ * Canonical NFPM address for each CL pool, keyed by (chainId, CLFactory address).
+ *
+ * Chains typically have a 1:1 CLFactory↔NFPM pairing, but Optimism has two of each.
+ * We disambiguate via factory-source: the CLFactory that emitted PoolCreated tells us
+ * which NFPM will mint positions in that pool. Pairings are by deployment lineage —
+ * the older factory pairs with the older NFPM, the newer factory pairs with the newer NFPM.
+ *
+ * Keys are `${chainId}-${checksumFactoryAddress}`. Values are checksummed NFPM addresses.
+ *
+ * Extracted from config.yaml — any new chain or factory must be added here for nfpmAddress
+ * to populate on newly created CL pools.
+ */
+const CL_FACTORY_TO_NFPM: Record<string, string> = {
+  // Optimism — two NFPMs, two CLFactories. Paired by deployment order.
+  [`10-${toChecksumAddress("0x548118C7E0B865C2CfA94D15EC86B666468ac758")}`]:
+    toChecksumAddress("0xbB5DFE1380333CEE4c2EeBd7202c80dE2256AdF4"),
+  [`10-${toChecksumAddress("0xCc0bDDB707055e04e497aB22a59c2aF4391cd12F")}`]:
+    toChecksumAddress("0x416b433906b1B72FA758e166e239c43d68dC6F29"),
+
+  // Base — two NFPMs, two canonical CLFactories. The third factory
+  // (0x9592CD9B...) has a slightly different ABI and currently does not
+  // drive handler behavior; we pair it with the newer NFPM for completeness.
+  [`8453-${toChecksumAddress("0x5e7BB104d84c7CB9B682AaC2F3d509f5F406809A")}`]:
+    toChecksumAddress("0x827922686190790b37229fd06084350E74485b72"),
+  [`8453-${toChecksumAddress("0xaDe65c38CD4849aDBA595a4323a8C7DdfE89716a")}`]:
+    toChecksumAddress("0xa990C6a764b73BF43cee5Bb40339c3322FB9D55F"),
+  [`8453-${toChecksumAddress("0x9592CD9B267748cbfBDe90Ac9F7DF3c437A6d51B")}`]:
+    toChecksumAddress("0xa990C6a764b73BF43cee5Bb40339c3322FB9D55F"),
+};
+
+/**
+ * All superchain leaf chains share the same CLFactory↔NFPM pair, so we match on
+ * factory alone to avoid listing every chain ID explicitly.
+ */
+const SUPERCHAIN_CL_FACTORY = toChecksumAddress(
+  "0x04625B046C69577EfC40e6c0Bb83CDBAfab5a55F",
+);
+const SUPERCHAIN_NFPM = toChecksumAddress(
+  "0x991d5546C4B442B4c5fdc4c8B8b8d131DEB24702",
+);
+
+/**
+ * Resolve the canonical NFPM address for a CL pool from its (chainId, factoryAddress) pair.
+ *
+ * The NFPM contract owns position NFTs for CL pools created by its paired CLFactory.
+ * On chains with a single NFPM/CLFactory this is trivially deterministic; on Optimism
+ * (two NFPMs) we rely on the factory that emitted PoolCreated to pick the right one.
+ *
+ * @param chainId - Chain ID where the CL pool lives
+ * @param factoryAddress - Address of the CLFactory that created the pool (event.srcAddress)
+ * @returns Checksummed NFPM address, or null if the (chainId, factory) pair is unknown
+ */
+export function nfpmForCLPool(
+  chainId: number,
+  factoryAddress: string,
+): string | null {
+  const checksummed = toChecksumAddress(factoryAddress);
+  const explicit = CL_FACTORY_TO_NFPM[`${chainId}-${checksummed}`];
+  if (explicit) return explicit;
+  if (checksummed === SUPERCHAIN_CL_FACTORY) return SUPERCHAIN_NFPM;
+  return null;
+}
+
 export const OUSDT_ADDRESS = "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189";
 export const OUSDT_DECIMALS = 6;
 

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -1004,17 +1004,22 @@ export const FeeToTickSpacingMappingId = (
   tickSpacing: bigint | number,
 ) => `${chainId}-${tickSpacing}`;
 
-/** Entity ID for NonFungiblePosition. Format: {chainId}-{poolAddress}-{tokenId} (stable id).
+/** Entity ID for NonFungiblePosition. Format: {chainId}-{nfpmAddress}-{tokenId} (stable id).
+ *
+ * The natural key is (NFPM, tokenId) — pool is metadata on the position. tokenIds are only
+ * unique within a single NFPM contract's counter, so on chains with multiple NFPMs
+ * (e.g. Optimism) nfpmAddress is required to prevent silent overwrites. See #618 / #621.
+ *
  * @param chainId - Chain ID of the position
- * @param poolAddress - Address of the pool
+ * @param nfpmAddress - Address of the NFPM contract that owns the position
  * @param tokenId - Token ID of the NFT position
  * @returns string Combined non-fungible position ID.
  */
 export const NonFungiblePositionId = (
   chainId: number,
-  poolAddress: string,
+  nfpmAddress: string,
   tokenId: bigint,
-) => `${chainId}-${poolAddress}-${tokenId}`;
+) => `${chainId}-${nfpmAddress}-${tokenId}`;
 
 /**
  * Create a unique ID for a CLTickStaked entity.

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -102,15 +102,18 @@ const CL_FACTORY_TO_NFPM: Record<string, string> = {
   [`10-${toChecksumAddress("0xCc0bDDB707055e04e497aB22a59c2aF4391cd12F")}`]:
     toChecksumAddress("0x416b433906b1B72FA758e166e239c43d68dC6F29"),
 
-  // Base — two NFPMs, two canonical CLFactories. The third factory
-  // (0x9592CD9B...) has a slightly different ABI and currently does not
-  // drive handler behavior; we pair it with the newer NFPM for completeness.
+  // Base — three CLFactories each with a dedicated NFPM, verified on-chain via
+  // NFPM.factory(). The newest Base CLFactory (0xf8f2eB49...) does not yet have
+  // a paired NFPM deployed, so pools from it fall through to null — this will
+  // resolve itself once a new NFPM is deployed and added here.
+  // TODO(nfpm): add Base V3-newest NFPM for 0xf8f2eB4940CFE7d13603DDDD87f123820Fc061Ef
+  //             once that factory ships with a paired NFPM.
   [`8453-${toChecksumAddress("0x5e7BB104d84c7CB9B682AaC2F3d509f5F406809A")}`]:
     toChecksumAddress("0x827922686190790b37229fd06084350E74485b72"),
   [`8453-${toChecksumAddress("0xaDe65c38CD4849aDBA595a4323a8C7DdfE89716a")}`]:
     toChecksumAddress("0xa990C6a764b73BF43cee5Bb40339c3322FB9D55F"),
   [`8453-${toChecksumAddress("0x9592CD9B267748cbfBDe90Ac9F7DF3c437A6d51B")}`]:
-    toChecksumAddress("0xa990C6a764b73BF43cee5Bb40339c3322FB9D55F"),
+    toChecksumAddress("0xc741beb2156827704A1466575ccA1cBf726a1178"),
 };
 
 /**

--- a/src/EventHandlers/CLFactory/CLFactoryPoolCreatedLogic.ts
+++ b/src/EventHandlers/CLFactory/CLFactoryPoolCreatedLogic.ts
@@ -7,7 +7,11 @@ import type {
   handlerContext,
 } from "generated";
 import { createLiquidityPoolAggregatorEntity } from "../../Aggregators/LiquidityPoolAggregator";
-import { RootPoolLeafPoolId, rootPoolMatchingHash } from "../../Constants";
+import {
+  RootPoolLeafPoolId,
+  nfpmForCLPool,
+  rootPoolMatchingHash,
+} from "../../Constants";
 import type { TokenEntityMapping } from "../../CustomTypes";
 import { createTokenEntity } from "../../PriceOracle";
 import { flushPendingVotesAndDistributionsForRootPool } from "../Voter/CrossChainPendingResolution";
@@ -68,6 +72,10 @@ export async function processCLFactoryPoolCreated(
       tickSpacing: Number(event.params.tickSpacing),
       CLGaugeConfig: CLGaugeConfig,
       factoryAddress: factoryAddress,
+      // Resolve the canonical NFPM that mints positions for this pool.
+      // Threaded onto the aggregator so gauge + user-stats + NFPM handlers
+      // can build the new NonFungiblePositionId() without a separate scan.
+      nfpmAddress: nfpmForCLPool(event.chainId, factoryAddress),
       // From what I've researched, there's always a TickSpacingEnabled event
       // with the appropriate tick spacing <-> fee mapping before a CL pool with the same tick spacing is created
       // CLFactoryPool constructor calls enableTickSpacing which emits TickSpacingEnabled event

--- a/src/EventHandlers/Gauges/GaugeSharedLogic.ts
+++ b/src/EventHandlers/Gauges/GaugeSharedLogic.ts
@@ -60,12 +60,13 @@ async function computeCLStakedReservesOnGaugeEvent(
 }> {
   if (data.tokenId === undefined) return {};
 
+  // Pool → NFPM is threaded onto the aggregator at PoolCreated time (see #619).
+  // For V2 pools or pools without an NFPM mapping, no position can exist — bail early.
+  const nfpmAddress = liquidityPoolAggregator.nfpmAddress;
+  if (!nfpmAddress) return {};
+
   const position = await context.NonFungiblePosition.get(
-    NonFungiblePositionId(
-      data.chainId,
-      liquidityPoolAggregator.poolAddress,
-      data.tokenId,
-    ),
+    NonFungiblePositionId(data.chainId, nfpmAddress, data.tokenId),
   );
   if (!position) return {};
 

--- a/src/EventHandlers/NFPM/NFPMCommonLogic.ts
+++ b/src/EventHandlers/NFPM/NFPMCommonLogic.ts
@@ -21,41 +21,6 @@ export enum LiquidityChangeType {
 }
 
 /**
- * Finds a NonFungiblePosition entity by tokenId, scoped to a specific chain AND NFPM contract.
- *
- * Uses a single-field getWhere (tokenId) then narrows in memory because Envio's getWhere supports
- * only one filter field per call. Filtering by (chainId, nfpmAddress) is required because tokenIds
- * are only unique within a single NFPM contract's counter — cross-chain and intra-chain (multiple
- * NFPMs on the same chain, e.g. Optimism) collisions would otherwise leak the wrong position and
- * silently misattribute liquidity, ownership, and stake state.
- *
- * @param tokenId - The token ID to search for
- * @param chainId - The chain ID to filter by
- * @param nfpmAddress - The NFPM contract address (event.srcAddress) to filter by
- * @param context - The handler context for database operations
- * @returns Array of matching positions (should be 0 or 1)
- */
-export async function findPositionByTokenId(
-  tokenId: bigint,
-  chainId: number,
-  nfpmAddress: string,
-  context: handlerContext,
-): Promise<NonFungiblePosition[]> {
-  const positions = await context.NonFungiblePosition.getWhere({
-    tokenId: { _eq: tokenId },
-  });
-
-  if (!positions || positions.length === 0) {
-    return [];
-  }
-
-  return positions.filter(
-    (pos: NonFungiblePosition) =>
-      pos.chainId === chainId && pos.nfpmAddress === nfpmAddress,
-  );
-}
-
-/**
  * Attributes a liquidity addition or removal to the UserStatsPerPool entity for a given owner and pool.
  * Calculates the total USD-equivalent value of the liquidity change, updates per-token stats,
  * and records the user's last activity timestamp.

--- a/src/EventHandlers/NFPM/NFPMDecreaseLiquidityLogic.ts
+++ b/src/EventHandlers/NFPM/NFPMDecreaseLiquidityLogic.ts
@@ -4,10 +4,10 @@ import {
   type NonFungiblePositionDiff,
   updateNonFungiblePosition,
 } from "../../Aggregators/NonFungiblePosition";
+import { NonFungiblePositionId } from "../../Constants";
 import {
   LiquidityChangeType,
   attributeLiquidityChangeToUserStatsPerPool,
-  findPositionByTokenId,
   updateStakedPositionLiquidity,
 } from "./NFPMCommonLogic";
 
@@ -50,26 +50,23 @@ export async function processNFPMDecreaseLiquidity(
   event: NFPM_DecreaseLiquidity_event,
   context: handlerContext,
 ): Promise<void> {
-  // Get position by tokenId
-  // Transfer should have already run and updated the placeholder, so position should exist when a DecreaseLiquidity event is processed
-  // Filter by chainId AND nfpmAddress to avoid collisions: same tokenId can exist on different chains,
-  // and on chains with multiple NFPM contracts (e.g. Optimism) each NFPM has its own tokenId counter.
-  const positions = await findPositionByTokenId(
-    event.params.tokenId,
-    event.chainId,
-    event.srcAddress,
-    context,
+  // Transfer runs before DecreaseLiquidity, so the stable position should already exist.
+  // Direct O(1) lookup via (chainId, nfpmAddress, tokenId).
+  const position = await context.NonFungiblePosition.get(
+    NonFungiblePositionId(
+      event.chainId,
+      event.srcAddress,
+      event.params.tokenId,
+    ),
   );
 
   // This should never happen
-  if (positions.length === 0) {
+  if (!position) {
     context.log.error(
       `NonFungiblePosition with tokenId ${event.params.tokenId} not found during decrease liquidity on chain ${event.chainId}`,
     );
     return;
   }
-
-  const position = positions[0];
 
   // Calculate decrease liquidity diff
   const nonFungiblePositionDiff = calculateDecreaseLiquidityDiff(event);

--- a/src/EventHandlers/NFPM/NFPMIncreaseLiquidityLogic.ts
+++ b/src/EventHandlers/NFPM/NFPMIncreaseLiquidityLogic.ts
@@ -9,10 +9,10 @@ import {
   type NonFungiblePositionDiff,
   updateNonFungiblePosition,
 } from "../../Aggregators/NonFungiblePosition";
+import { NonFungiblePositionId } from "../../Constants";
 import {
   LiquidityChangeType,
   attributeLiquidityChangeToUserStatsPerPool,
-  findPositionByTokenId,
   updateStakedPositionLiquidity,
 } from "./NFPMCommonLogic";
 
@@ -55,25 +55,22 @@ export async function processNFPMIncreaseLiquidity(
   event: NFPM_IncreaseLiquidity_event,
   context: handlerContext,
 ): Promise<void> {
-  // Get position by tokenId
-  // Transfer (i.e. relative to mint) should have already run and updated the placeholder, so position should exist when an IncreaseLiquidity event is processed
-  // Filter by chainId AND nfpmAddress to avoid collisions: same tokenId can exist on different chains,
-  // and on chains with multiple NFPM contracts (e.g. Optimism) each NFPM has its own tokenId counter.
-  const positions = await findPositionByTokenId(
-    event.params.tokenId,
-    event.chainId,
-    event.srcAddress,
-    context,
+  // Transfer (relative to mint) runs before IncreaseLiquidity, so the stable position
+  // should already exist. Direct O(1) lookup via (chainId, nfpmAddress, tokenId).
+  const position = await context.NonFungiblePosition.get(
+    NonFungiblePositionId(
+      event.chainId,
+      event.srcAddress,
+      event.params.tokenId,
+    ),
   );
 
-  if (positions.length === 0) {
+  if (!position) {
     context.log.error(
       `NonFungiblePosition with tokenId ${event.params.tokenId} not found during increase liquidity on chain ${event.chainId}`,
     );
     return;
   }
-
-  const position = positions[0];
 
   // Clean up any orphaned CLPoolMintEvent entities from same transaction
   //

--- a/src/EventHandlers/NFPM/NFPMTransferLogic.ts
+++ b/src/EventHandlers/NFPM/NFPMTransferLogic.ts
@@ -14,7 +14,6 @@ import { calculatePositionAmountsFromLiquidity } from "../../Helpers";
 import {
   LiquidityChangeType,
   attributeLiquidityChangeToUserStatsPerPool,
-  findPositionByTokenId,
 } from "./NFPMCommonLogic";
 
 /**
@@ -38,8 +37,9 @@ export async function createPositionFromCLPoolMint(
   blockTimestamp: number,
   context: handlerContext,
 ): Promise<void> {
-  // Create definitive NonFungiblePosition with stable ID via NonFungiblePositionId()
-  const stableId = NonFungiblePositionId(chainId, mintEvent.pool, tokenId);
+  // Create definitive NonFungiblePosition with stable ID via NonFungiblePositionId().
+  // Key is (chainId, nfpmAddress, tokenId) — pool is metadata, not part of the identity.
+  const stableId = NonFungiblePositionId(chainId, nfpmAddress, tokenId);
 
   // Create new entity with stable ID, using data from CLPoolMintEvent
   const position: NonFungiblePosition = {
@@ -83,15 +83,15 @@ export async function createPositionFromCLPoolMint(
  *
  * @param event - The NFPM.Transfer event (mint case)
  * @param context - The handler context
- * @param existingPositions - Array of existing positions found by tokenId (pre-queried)
+ * @param existingPosition - Existing position found via direct get() (undefined when none exists)
  */
 export async function handleMintTransfer(
   event: NFPM_Transfer_event,
   context: handlerContext,
-  existingPositions: NonFungiblePosition[],
+  existingPosition: NonFungiblePosition | undefined,
 ): Promise<void> {
   // If position already exists, nothing to do (shouldn't happen for new mints)
-  if (existingPositions.length > 0) {
+  if (existingPosition) {
     return;
   }
 
@@ -234,22 +234,14 @@ export async function attributeTransferToUserStatsPerPool(
  * Otherwise attributes position token0/token1 to UserStatsPerPool (remove from sender, add to recipient) then updates owner.
  *
  * @param event - The NFPM.Transfer event (regular transfer case)
- * @param positions - The existing positions. Only one position should be found.
+ * @param position - The existing position (pre-fetched via direct get() by the caller)
  * @param context - The handler context
  */
 export async function handleRegularTransfer(
   event: NFPM_Transfer_event,
-  positions: NonFungiblePosition[],
+  position: NonFungiblePosition,
   context: handlerContext,
 ): Promise<void> {
-  if (positions.length === 0) {
-    context.log.error(
-      `[handleRegularTransfer] No positions provided for transfer of tokenId ${event.params.tokenId} on chain ${event.chainId}`,
-    );
-    return;
-  }
-
-  const position = positions[0];
   const timestamp = event.block.timestamp;
   const updateTimestamp = new Date(timestamp * 1000);
 
@@ -350,11 +342,14 @@ export async function processNFPMTransfer(
   event: NFPM_Transfer_event,
   context: handlerContext,
 ): Promise<void> {
-  const positions = await findPositionByTokenId(
-    event.params.tokenId,
-    event.chainId,
-    event.srcAddress,
-    context,
+  // Direct O(1) lookup via stable ID (chainId, nfpmAddress, tokenId).
+  // event.srcAddress is the NFPM contract that emitted the Transfer.
+  const position = await context.NonFungiblePosition.get(
+    NonFungiblePositionId(
+      event.chainId,
+      event.srcAddress,
+      event.params.tokenId,
+    ),
   );
 
   const isMint = event.params.from === ZERO_ADDRESS;
@@ -363,11 +358,11 @@ export async function processNFPMTransfer(
   if (isMint) {
     // Handle mint transfer: find appropriate CLPoolMintEvent entity and
     // create NonFungiblePosition entity with stable ID
-    await handleMintTransfer(event, context, positions);
+    await handleMintTransfer(event, context, position);
     return;
   }
 
-  if (positions.length === 0) {
+  if (!position) {
     context.log.error(
       `NonFungiblePosition with tokenId ${event.params.tokenId} not found during transfer on chain ${event.chainId}`,
     );
@@ -376,11 +371,10 @@ export async function processNFPMTransfer(
 
   if (isBurn) {
     // NFT burned — liquidity is already 0 (DecreaseLiquidity precedes burn).
-    // Delete to reduce getWhere scan size for staked USD computation.
-    context.NonFungiblePosition.deleteUnsafe(positions[0].id);
+    context.NonFungiblePosition.deleteUnsafe(position.id);
     return;
   }
 
   // Handle regular transfer: gauge check, token0/token1 accounting, then update owner
-  await handleRegularTransfer(event, positions, context);
+  await handleRegularTransfer(event, position, context);
 }

--- a/test/Aggregators/NonFungiblePosition.test.ts
+++ b/test/Aggregators/NonFungiblePosition.test.ts
@@ -2,7 +2,7 @@ import type { NonFungiblePosition, handlerContext } from "generated";
 import { updateNonFungiblePosition } from "../../src/Aggregators/NonFungiblePosition";
 import { NonFungiblePositionId, toChecksumAddress } from "../../src/Constants";
 import { getSnapshotEpoch } from "../../src/Snapshots/Shared";
-import { NFPM_ADDRESS } from "../EventHandlers/Pool/common";
+import { defaultNfpmAddress } from "../EventHandlers/Pool/common";
 
 describe("NonFungiblePosition", () => {
   let mockContext: Partial<handlerContext>;
@@ -11,7 +11,7 @@ describe("NonFungiblePosition", () => {
   const poolAddress = toChecksumAddress(
     "0x0000000000000000000000000000000000000001",
   );
-  const nfpmAddress = NFPM_ADDRESS;
+  const nfpmAddress = defaultNfpmAddress;
   const mockNonFungiblePosition: NonFungiblePosition = {
     id: NonFungiblePositionId(10, poolAddress, 1n),
     chainId: 10,

--- a/test/Constants.test.ts
+++ b/test/Constants.test.ts
@@ -21,11 +21,20 @@ describe("nfpmForCLPool", () => {
   const BASE_CL_FACTORY_NEW = toChecksumAddress(
     "0xaDe65c38CD4849aDBA595a4323a8C7DdfE89716a",
   );
+  const BASE_CL_FACTORY_V3 = toChecksumAddress(
+    "0x9592CD9B267748cbfBDe90Ac9F7DF3c437A6d51B",
+  );
+  const BASE_CL_FACTORY_V3_NEWEST = toChecksumAddress(
+    "0xf8f2eB4940CFE7d13603DDDD87f123820Fc061Ef",
+  );
   const BASE_NFPM_OLD = toChecksumAddress(
     "0x827922686190790b37229fd06084350E74485b72",
   );
   const BASE_NFPM_NEW = toChecksumAddress(
     "0xa990C6a764b73BF43cee5Bb40339c3322FB9D55F",
+  );
+  const BASE_NFPM_V3 = toChecksumAddress(
+    "0xc741beb2156827704A1466575ccA1cBf726a1178",
   );
 
   const SUPERCHAIN_CL_FACTORY = toChecksumAddress(
@@ -43,6 +52,13 @@ describe("nfpmForCLPool", () => {
   it("pairs Base CLFactories with their respective NFPMs", () => {
     expect(nfpmForCLPool(8453, BASE_CL_FACTORY_OLD)).toBe(BASE_NFPM_OLD);
     expect(nfpmForCLPool(8453, BASE_CL_FACTORY_NEW)).toBe(BASE_NFPM_NEW);
+    expect(nfpmForCLPool(8453, BASE_CL_FACTORY_V3)).toBe(BASE_NFPM_V3);
+  });
+
+  it("returns null for the newest Base CLFactory pending NFPM deployment", () => {
+    // 0xf8f2eB... ships without a paired NFPM yet; callers should treat null
+    // as "unknown" and skip attribution until the mapping is filled in.
+    expect(nfpmForCLPool(8453, BASE_CL_FACTORY_V3_NEWEST)).toBeNull();
   });
 
   it("returns the superchain NFPM for any superchain leaf chain", () => {

--- a/test/Constants.test.ts
+++ b/test/Constants.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { nfpmForCLPool, toChecksumAddress } from "../src/Constants";
+
+describe("nfpmForCLPool", () => {
+  const OP_CL_FACTORY_OLD = toChecksumAddress(
+    "0x548118C7E0B865C2CfA94D15EC86B666468ac758",
+  );
+  const OP_CL_FACTORY_NEW = toChecksumAddress(
+    "0xCc0bDDB707055e04e497aB22a59c2aF4391cd12F",
+  );
+  const OP_NFPM_OLD = toChecksumAddress(
+    "0xbB5DFE1380333CEE4c2EeBd7202c80dE2256AdF4",
+  );
+  const OP_NFPM_NEW = toChecksumAddress(
+    "0x416b433906b1B72FA758e166e239c43d68dC6F29",
+  );
+
+  const BASE_CL_FACTORY_OLD = toChecksumAddress(
+    "0x5e7BB104d84c7CB9B682AaC2F3d509f5F406809A",
+  );
+  const BASE_CL_FACTORY_NEW = toChecksumAddress(
+    "0xaDe65c38CD4849aDBA595a4323a8C7DdfE89716a",
+  );
+  const BASE_NFPM_OLD = toChecksumAddress(
+    "0x827922686190790b37229fd06084350E74485b72",
+  );
+  const BASE_NFPM_NEW = toChecksumAddress(
+    "0xa990C6a764b73BF43cee5Bb40339c3322FB9D55F",
+  );
+
+  const SUPERCHAIN_CL_FACTORY = toChecksumAddress(
+    "0x04625B046C69577EfC40e6c0Bb83CDBAfab5a55F",
+  );
+  const SUPERCHAIN_NFPM = toChecksumAddress(
+    "0x991d5546C4B442B4c5fdc4c8B8b8d131DEB24702",
+  );
+
+  it("disambiguates Optimism's two CLFactories to distinct NFPMs", () => {
+    expect(nfpmForCLPool(10, OP_CL_FACTORY_OLD)).toBe(OP_NFPM_OLD);
+    expect(nfpmForCLPool(10, OP_CL_FACTORY_NEW)).toBe(OP_NFPM_NEW);
+  });
+
+  it("pairs Base CLFactories with their respective NFPMs", () => {
+    expect(nfpmForCLPool(8453, BASE_CL_FACTORY_OLD)).toBe(BASE_NFPM_OLD);
+    expect(nfpmForCLPool(8453, BASE_CL_FACTORY_NEW)).toBe(BASE_NFPM_NEW);
+  });
+
+  it("returns the superchain NFPM for any superchain leaf chain", () => {
+    // Every superchain leaf shares the same CLFactory↔NFPM pair
+    const superchainChainIds = [
+      1135, 34443, 42220, 1868, 130, 252, 57073, 1750, 1923, 5330,
+    ];
+    for (const chainId of superchainChainIds) {
+      expect(nfpmForCLPool(chainId, SUPERCHAIN_CL_FACTORY)).toBe(
+        SUPERCHAIN_NFPM,
+      );
+    }
+  });
+
+  it("accepts lowercase factory addresses (checksums internally)", () => {
+    expect(nfpmForCLPool(10, OP_CL_FACTORY_OLD.toLowerCase())).toBe(
+      OP_NFPM_OLD,
+    );
+  });
+
+  it("returns null for unknown (chainId, factory) pairs", () => {
+    expect(
+      nfpmForCLPool(10, "0x0000000000000000000000000000000000000001"),
+    ).toBeNull();
+    // Optimism factory on wrong chain
+    expect(nfpmForCLPool(8453, OP_CL_FACTORY_OLD)).toBeNull();
+  });
+});

--- a/test/Constants.test.ts
+++ b/test/Constants.test.ts
@@ -61,17 +61,15 @@ describe("nfpmForCLPool", () => {
     expect(nfpmForCLPool(8453, BASE_CL_FACTORY_V3_NEWEST)).toBeNull();
   });
 
-  it("returns the superchain NFPM for any superchain leaf chain", () => {
-    // Every superchain leaf shares the same CLFactory↔NFPM pair
-    const superchainChainIds = [
-      1135, 34443, 42220, 1868, 130, 252, 57073, 1750, 1923, 5330,
-    ];
-    for (const chainId of superchainChainIds) {
+  // Every superchain leaf shares the same CLFactory↔NFPM pair
+  it.each([1135, 34443, 42220, 1868, 130, 252, 57073, 1750, 1923, 5330])(
+    "returns the superchain NFPM for leaf chain %i",
+    (chainId) => {
       expect(nfpmForCLPool(chainId, SUPERCHAIN_CL_FACTORY)).toBe(
         SUPERCHAIN_NFPM,
       );
-    }
-  });
+    },
+  );
 
   it("accepts lowercase factory addresses (checksums internally)", () => {
     expect(nfpmForCLPool(10, OP_CL_FACTORY_OLD.toLowerCase())).toBe(
@@ -81,7 +79,10 @@ describe("nfpmForCLPool", () => {
 
   it("returns null for unknown (chainId, factory) pairs", () => {
     expect(
-      nfpmForCLPool(10, "0x0000000000000000000000000000000000000001"),
+      nfpmForCLPool(
+        10,
+        toChecksumAddress("0x0000000000000000000000000000000000000001"),
+      ),
     ).toBeNull();
     // Optimism factory on wrong chain
     expect(nfpmForCLPool(8453, OP_CL_FACTORY_OLD)).toBeNull();

--- a/test/EventHandlers/ALM/DeployFactoryV1.test.ts
+++ b/test/EventHandlers/ALM/DeployFactoryV1.test.ts
@@ -65,7 +65,7 @@ describe("ALMDeployFactoryV1 StrategyCreated Event", () => {
 
       // Pre-populate with NonFungiblePosition (created by CLPool handlers)
       const mockNFPM: NonFungiblePosition = {
-        id: NonFungiblePositionId(chainId, poolAddress, tokenId),
+        id: NonFungiblePositionId(chainId, nfpmAddress, tokenId),
         chainId,
         tokenId,
         nfpmAddress: nfpmAddress,
@@ -268,7 +268,7 @@ describe("ALMDeployFactoryV1 StrategyCreated Event", () => {
 
       // Create multiple NonFungiblePositions with different values
       const matchingNFPM: NonFungiblePosition = {
-        id: NonFungiblePositionId(chainId, poolAddress, tokenId),
+        id: NonFungiblePositionId(chainId, nfpmAddress, tokenId),
         chainId,
         tokenId,
         nfpmAddress: nfpmAddress,
@@ -287,7 +287,7 @@ describe("ALMDeployFactoryV1 StrategyCreated Event", () => {
       };
 
       const nonMatchingNFPM: NonFungiblePosition = {
-        id: NonFungiblePositionId(chainId, poolAddress, tokenId + 1n),
+        id: NonFungiblePositionId(chainId, nfpmAddress, tokenId + 1n),
         chainId,
         tokenId: tokenId + 1n,
         nfpmAddress: nfpmAddress,
@@ -363,7 +363,7 @@ describe("ALMDeployFactoryV1 StrategyCreated Event", () => {
 
       // Create two NonFungiblePositions with identical matching criteria
       const matchingNFPM1: NonFungiblePosition = {
-        id: NonFungiblePositionId(chainId, poolAddress, tokenId),
+        id: NonFungiblePositionId(chainId, nfpmAddress, tokenId),
         chainId,
         tokenId,
         nfpmAddress: nfpmAddress,
@@ -382,7 +382,7 @@ describe("ALMDeployFactoryV1 StrategyCreated Event", () => {
       };
 
       const matchingNFPM2: NonFungiblePosition = {
-        id: NonFungiblePositionId(chainId, poolAddress, tokenId + 1n),
+        id: NonFungiblePositionId(chainId, nfpmAddress, tokenId + 1n),
         chainId,
         tokenId: tokenId + 1n,
         nfpmAddress: nfpmAddress,

--- a/test/EventHandlers/ALM/DeployFactoryV1.test.ts
+++ b/test/EventHandlers/ALM/DeployFactoryV1.test.ts
@@ -15,8 +15,12 @@ import {
 import { setupCommon } from "../Pool/common";
 
 describe("ALMDeployFactoryV1 StrategyCreated Event", () => {
-  const { mockLiquidityPoolData, mockToken0Data, mockToken1Data, nfpmAddress } =
-    setupCommon();
+  const {
+    mockLiquidityPoolData,
+    mockToken0Data,
+    mockToken1Data,
+    defaultNfpmAddress: nfpmAddress,
+  } = setupCommon();
   const chainId = mockLiquidityPoolData.chainId;
   const poolAddress = mockLiquidityPoolData.poolAddress;
   const lpWrapperAddress = toChecksumAddress(

--- a/test/EventHandlers/ALM/DeployFactoryV2.test.ts
+++ b/test/EventHandlers/ALM/DeployFactoryV2.test.ts
@@ -15,8 +15,12 @@ import {
 import { setupCommon } from "../Pool/common";
 
 describe("ALMDeployFactoryV2 StrategyCreated Event", () => {
-  const { mockLiquidityPoolData, mockToken0Data, mockToken1Data, nfpmAddress } =
-    setupCommon();
+  const {
+    mockLiquidityPoolData,
+    mockToken0Data,
+    mockToken1Data,
+    defaultNfpmAddress: nfpmAddress,
+  } = setupCommon();
   const chainId = mockLiquidityPoolData.chainId;
   const poolAddress = mockLiquidityPoolData.poolAddress;
   const lpWrapperAddress = toChecksumAddress(

--- a/test/EventHandlers/ALM/DeployFactoryV2.test.ts
+++ b/test/EventHandlers/ALM/DeployFactoryV2.test.ts
@@ -57,7 +57,7 @@ describe("ALMDeployFactoryV2 StrategyCreated Event", () => {
 
       // Pre-populate with NonFungiblePosition (created by CLPool handlers)
       const mockNFPM: NonFungiblePosition = {
-        id: NonFungiblePositionId(chainId, poolAddress, tokenId),
+        id: NonFungiblePositionId(chainId, nfpmAddress, tokenId),
         chainId,
         tokenId,
         nfpmAddress: nfpmAddress,
@@ -305,7 +305,7 @@ describe("ALMDeployFactoryV2 StrategyCreated Event", () => {
 
       // Create multiple NonFungiblePositions with same transaction hash but different properties
       const matchingNFPM: NonFungiblePosition = {
-        id: NonFungiblePositionId(chainId, poolAddress, tokenId),
+        id: NonFungiblePositionId(chainId, nfpmAddress, tokenId),
         chainId,
         tokenId,
         nfpmAddress: nfpmAddress,
@@ -325,7 +325,7 @@ describe("ALMDeployFactoryV2 StrategyCreated Event", () => {
 
       const nonMatchingNFPM1: NonFungiblePosition = {
         ...matchingNFPM,
-        id: NonFungiblePositionId(chainId, poolAddress, tokenId + 1n),
+        id: NonFungiblePositionId(chainId, nfpmAddress, tokenId + 1n),
         tokenId: tokenId + 1n,
         tickLower: -2000n, // Different tickLower
         mintTransactionHash: transactionHash,
@@ -333,7 +333,7 @@ describe("ALMDeployFactoryV2 StrategyCreated Event", () => {
 
       const nonMatchingNFPM2: NonFungiblePosition = {
         ...matchingNFPM,
-        id: NonFungiblePositionId(chainId, poolAddress, tokenId + 2n),
+        id: NonFungiblePositionId(chainId, nfpmAddress, tokenId + 2n),
         tokenId: tokenId + 2n,
         liquidity: 2000000n, // Different liquidity
         mintTransactionHash: transactionHash,
@@ -421,7 +421,7 @@ describe("ALMDeployFactoryV2 StrategyCreated Event", () => {
 
       // Create NonFungiblePosition with matching properties except token0
       const nonMatchingNFPM: NonFungiblePosition = {
-        id: NonFungiblePositionId(chainId, poolAddress, tokenId),
+        id: NonFungiblePositionId(chainId, nfpmAddress, tokenId),
         chainId,
         tokenId,
         nfpmAddress: nfpmAddress,
@@ -481,7 +481,7 @@ describe("ALMDeployFactoryV2 StrategyCreated Event", () => {
 
       // Create NonFungiblePosition with matching properties except token1
       const nonMatchingNFPM: NonFungiblePosition = {
-        id: NonFungiblePositionId(chainId, poolAddress, tokenId),
+        id: NonFungiblePositionId(chainId, nfpmAddress, tokenId),
         chainId,
         tokenId,
         nfpmAddress: nfpmAddress,
@@ -541,7 +541,7 @@ describe("ALMDeployFactoryV2 StrategyCreated Event", () => {
 
       // Create NonFungiblePosition with matching tickLower but different tickUpper
       const nonMatchingNFPM: NonFungiblePosition = {
-        id: NonFungiblePositionId(chainId, poolAddress, tokenId),
+        id: NonFungiblePositionId(chainId, nfpmAddress, tokenId),
         chainId,
         tokenId,
         nfpmAddress: nfpmAddress,
@@ -601,7 +601,7 @@ describe("ALMDeployFactoryV2 StrategyCreated Event", () => {
 
       // Pre-populate with NonFungiblePosition but NOT TotalSupplyLimitUpdated event
       const mockNFPM: NonFungiblePosition = {
-        id: NonFungiblePositionId(chainId, poolAddress, tokenId),
+        id: NonFungiblePositionId(chainId, nfpmAddress, tokenId),
         chainId,
         tokenId,
         nfpmAddress: nfpmAddress,
@@ -661,7 +661,7 @@ describe("ALMDeployFactoryV2 StrategyCreated Event", () => {
 
       // Pre-populate with NonFungiblePosition
       const mockNFPM: NonFungiblePosition = {
-        id: NonFungiblePositionId(chainId, poolAddress, tokenId),
+        id: NonFungiblePositionId(chainId, nfpmAddress, tokenId),
         chainId,
         tokenId,
         nfpmAddress: nfpmAddress,
@@ -731,7 +731,7 @@ describe("ALMDeployFactoryV2 StrategyCreated Event", () => {
 
       // Create two NonFungiblePositions with identical matching properties
       const matchingNFPM1: NonFungiblePosition = {
-        id: NonFungiblePositionId(chainId, poolAddress, tokenId),
+        id: NonFungiblePositionId(chainId, nfpmAddress, tokenId),
         chainId,
         tokenId,
         nfpmAddress: nfpmAddress,
@@ -751,7 +751,7 @@ describe("ALMDeployFactoryV2 StrategyCreated Event", () => {
 
       const matchingNFPM2: NonFungiblePosition = {
         ...matchingNFPM1,
-        id: NonFungiblePositionId(chainId, poolAddress, tokenId + 1n),
+        id: NonFungiblePositionId(chainId, nfpmAddress, tokenId + 1n),
         tokenId: tokenId + 1n,
         mintLogIndex: 2,
       };

--- a/test/EventHandlers/CLFactory/CLFactoryPoolCreatedLogic.test.ts
+++ b/test/EventHandlers/CLFactory/CLFactoryPoolCreatedLogic.test.ts
@@ -125,6 +125,8 @@ describe("CLFactoryPoolCreatedLogic", () => {
       expect(result.liquidityPoolAggregator.factoryAddress).toBe(
         mockEvent.srcAddress,
       );
+      // Unknown factory in the test mock resolves to null via nfpmForCLPool
+      expect(result.liquidityPoolAggregator.nfpmAddress).toBeUndefined();
       expect(result.liquidityPoolAggregator).toMatchObject({
         id: LEAF_POOL_ID,
         chainId: 10,
@@ -355,6 +357,45 @@ describe("CLFactoryPoolCreatedLogic", () => {
           toChecksumAddress("0x3333333333333333333333333333333333333333"),
         ),
       );
+    });
+
+    // US-1 acceptance: nfpmAddress is resolved from (chainId, factoryAddress) at pool creation
+    // so downstream (#621) can build the new NonFungiblePositionId() without a separate scan.
+    it("should populate nfpmAddress from nfpmForCLPool for known Optimism CLFactories", async () => {
+      const opFactoryOld = toChecksumAddress(
+        "0x548118C7E0B865C2CfA94D15EC86B666468ac758",
+      );
+      const opNfpmOld = toChecksumAddress(
+        "0xbB5DFE1380333CEE4c2EeBd7202c80dE2256AdF4",
+      );
+      const opFactoryNew = toChecksumAddress(
+        "0xCc0bDDB707055e04e497aB22a59c2aF4391cd12F",
+      );
+      const opNfpmNew = toChecksumAddress(
+        "0x416b433906b1B72FA758e166e239c43d68dC6F29",
+      );
+
+      const resultOld = await processCLFactoryPoolCreated(
+        mockEvent,
+        opFactoryOld,
+        mockToken0Data,
+        mockToken1Data,
+        undefined,
+        mockFeeToTickSpacingMapping,
+        mockContext,
+      );
+      expect(resultOld.liquidityPoolAggregator.nfpmAddress).toBe(opNfpmOld);
+
+      const resultNew = await processCLFactoryPoolCreated(
+        mockEvent,
+        opFactoryNew,
+        mockToken0Data,
+        mockToken1Data,
+        undefined,
+        mockFeeToTickSpacingMapping,
+        mockContext,
+      );
+      expect(resultNew.liquidityPoolAggregator.nfpmAddress).toBe(opNfpmNew);
     });
 
     it("should handle different token symbols correctly", async () => {

--- a/test/EventHandlers/NFPM/NFPM.test.ts
+++ b/test/EventHandlers/NFPM/NFPM.test.ts
@@ -8,7 +8,7 @@ import {
   TokenId,
   toChecksumAddress,
 } from "../../../src/Constants";
-import { NFPM_ADDRESS, setupCommon } from "../Pool/common";
+import { defaultNfpmAddress, setupCommon } from "../Pool/common";
 
 describe("NFPM Events", () => {
   const {
@@ -24,7 +24,7 @@ describe("NFPM Events", () => {
   const token0Address = mockToken0Data.address;
   const token1Address = mockToken1Data.address;
   const tokenId = 1n;
-  const nfpmAddress = NFPM_ADDRESS;
+  const nfpmAddress = defaultNfpmAddress;
 
   const transactionHash =
     "0x1234567890123456789012345678901234567890123456789012345678901234";

--- a/test/EventHandlers/NFPM/NFPM.test.ts
+++ b/test/EventHandlers/NFPM/NFPM.test.ts
@@ -31,7 +31,7 @@ describe("NFPM Events", () => {
   // Mock position with amounts matching the IncreaseLiquidity event amounts
   // This represents a newly minted position before the IncreaseLiquidity event
   const mockNonFungiblePosition = {
-    id: NonFungiblePositionId(chainId, poolAddress, tokenId),
+    id: NonFungiblePositionId(chainId, nfpmAddress, tokenId),
     chainId,
     tokenId: tokenId,
     nfpmAddress: nfpmAddress,
@@ -92,7 +92,7 @@ describe("NFPM Events", () => {
 
     it("should update the owner", () => {
       const updatedEntity = postEventDB.entities.NonFungiblePosition.get(
-        NonFungiblePositionId(chainId, poolAddress, tokenId),
+        NonFungiblePositionId(chainId, nfpmAddress, tokenId),
       );
       expect(updatedEntity).toBeDefined();
       if (!updatedEntity) return; // Type guard
@@ -104,7 +104,7 @@ describe("NFPM Events", () => {
       // In this test, CLPool.Mint has logIndex 0, Transfer has logIndex 2
       const mintLogIndex = 0;
       const transferLogIndex = 2;
-      const stableId = NonFungiblePositionId(chainId, poolAddress, tokenId);
+      const stableId = NonFungiblePositionId(chainId, nfpmAddress, tokenId);
 
       const mockCLPoolMintEvent = {
         id: CLPoolMintEventId(
@@ -264,7 +264,7 @@ describe("NFPM Events", () => {
 
     it("should increase liquidity", () => {
       const updatedEntity = postEventDB.entities.NonFungiblePosition.get(
-        NonFungiblePositionId(chainId, poolAddress, tokenId),
+        NonFungiblePositionId(chainId, nfpmAddress, tokenId),
       );
       expect(updatedEntity).toBeDefined();
       if (!updatedEntity) return; // Type guard
@@ -278,7 +278,7 @@ describe("NFPM Events", () => {
       // Create a second position with different ticks but same transaction hash
       const position2 = {
         ...mockNonFungiblePosition,
-        id: NonFungiblePositionId(chainId, mockNonFungiblePosition.pool, 2n),
+        id: NonFungiblePositionId(chainId, nfpmAddress, 2n),
         tokenId: 2n,
         tickLower: -200n, // Different ticks - won't match IncreaseLiquidity event
         tickUpper: 200n,
@@ -311,7 +311,7 @@ describe("NFPM Events", () => {
 
       // Should match the first position, not the second
       const updatedEntity = result.entities.NonFungiblePosition.get(
-        NonFungiblePositionId(chainId, poolAddress, tokenId),
+        NonFungiblePositionId(chainId, nfpmAddress, tokenId),
       );
       expect(updatedEntity).toBeDefined();
       if (!updatedEntity) return;
@@ -350,7 +350,7 @@ describe("NFPM Events", () => {
 
       // Should not create or update any position
       const updatedEntity = result.entities.NonFungiblePosition.get(
-        NonFungiblePositionId(chainId, poolAddress, tokenId),
+        NonFungiblePositionId(chainId, nfpmAddress, tokenId),
       );
       expect(updatedEntity).toBeUndefined();
     });
@@ -361,11 +361,7 @@ describe("NFPM Events", () => {
       const differentTokenId = 999n;
       const positionWithDifferentTokenId = {
         ...mockNonFungiblePosition,
-        id: NonFungiblePositionId(
-          chainId,
-          mockNonFungiblePosition.pool,
-          differentTokenId,
-        ), // Update ID to match new tokenId
+        id: NonFungiblePositionId(chainId, nfpmAddress, differentTokenId), // Update ID to match new tokenId
         tokenId: differentTokenId, // Different tokenId so not found by tokenId query
       };
 
@@ -410,11 +406,7 @@ describe("NFPM Events", () => {
       // Should not update the position (amounts don't match, handler returns early)
       // Position should still exist in the result with original values
       const updatedEntity = result.entities.NonFungiblePosition.get(
-        NonFungiblePositionId(
-          chainId,
-          mockNonFungiblePosition.pool,
-          differentTokenId,
-        ),
+        NonFungiblePositionId(chainId, nfpmAddress, differentTokenId),
       );
       // Position exists but wasn't updated (still has original amounts)
       expect(updatedEntity).toBeDefined();
@@ -454,7 +446,7 @@ describe("NFPM Events", () => {
 
     it("should decrease liquidity", () => {
       const updatedEntity = postEventDB.entities.NonFungiblePosition.get(
-        NonFungiblePositionId(chainId, poolAddress, tokenId),
+        NonFungiblePositionId(chainId, nfpmAddress, tokenId),
       );
       expect(updatedEntity).toBeDefined();
       if (!updatedEntity) return; // Type guard
@@ -496,7 +488,7 @@ describe("NFPM Events", () => {
 
       // Should not create any position
       const updatedEntity = result.entities.NonFungiblePosition.get(
-        NonFungiblePositionId(chainId, poolAddress, tokenId),
+        NonFungiblePositionId(chainId, nfpmAddress, tokenId),
       );
       expect(updatedEntity).toBeUndefined();
     });
@@ -551,7 +543,7 @@ describe("NFPM Events", () => {
 
       // Should not create any position
       const updatedEntity = result.entities.NonFungiblePosition.get(
-        NonFungiblePositionId(chainId, poolAddress, tokenId),
+        NonFungiblePositionId(chainId, nfpmAddress, tokenId),
       );
       expect(updatedEntity).toBeUndefined();
     });
@@ -572,7 +564,7 @@ describe("NFPM Events", () => {
 
     // Position on Base (chain 8453)
     const positionBase = {
-      id: NonFungiblePositionId(chainIdBase, poolAddressBase, sameTokenId),
+      id: NonFungiblePositionId(chainIdBase, nfpmAddress, sameTokenId),
       chainId: chainIdBase,
       tokenId: sameTokenId,
       nfpmAddress: nfpmAddress,
@@ -592,7 +584,7 @@ describe("NFPM Events", () => {
 
     // Position on Lisk (chain 1135) with same tokenId
     const positionLisk = {
-      id: NonFungiblePositionId(chainIdLisk, poolAddressLisk, sameTokenId),
+      id: NonFungiblePositionId(chainIdLisk, nfpmAddress, sameTokenId),
       chainId: chainIdLisk,
       tokenId: sameTokenId,
       nfpmAddress: nfpmAddress,
@@ -765,10 +757,10 @@ describe("NFPM Events", () => {
 
       // Should only update the Base position, not the Lisk position
       const updatedBasePosition = result.entities.NonFungiblePosition.get(
-        NonFungiblePositionId(chainIdBase, poolAddressBase, sameTokenId),
+        NonFungiblePositionId(chainIdBase, nfpmAddress, sameTokenId),
       );
       const liskPosition = result.entities.NonFungiblePosition.get(
-        NonFungiblePositionId(chainIdLisk, poolAddressLisk, sameTokenId),
+        NonFungiblePositionId(chainIdLisk, nfpmAddress, sameTokenId),
       );
 
       expect(updatedBasePosition).toBeDefined();
@@ -868,10 +860,10 @@ describe("NFPM Events", () => {
 
       // Should only update the Base position
       const updatedBasePosition = result.entities.NonFungiblePosition.get(
-        NonFungiblePositionId(chainIdBase, poolAddressBase, sameTokenId),
+        NonFungiblePositionId(chainIdBase, nfpmAddress, sameTokenId),
       );
       const liskPosition = result.entities.NonFungiblePosition.get(
-        NonFungiblePositionId(chainIdLisk, poolAddressLisk, sameTokenId),
+        NonFungiblePositionId(chainIdLisk, nfpmAddress, sameTokenId),
       );
 
       expect(updatedBasePosition).toBeDefined();
@@ -968,10 +960,10 @@ describe("NFPM Events", () => {
 
       // Should only update the Lisk position
       const basePosition = result.entities.NonFungiblePosition.get(
-        NonFungiblePositionId(chainIdBase, poolAddressBase, sameTokenId),
+        NonFungiblePositionId(chainIdBase, nfpmAddress, sameTokenId),
       );
       const updatedLiskPosition = result.entities.NonFungiblePosition.get(
-        NonFungiblePositionId(chainIdLisk, poolAddressLisk, sameTokenId),
+        NonFungiblePositionId(chainIdLisk, nfpmAddress, sameTokenId),
       );
 
       expect(updatedLiskPosition).toBeDefined();
@@ -1069,7 +1061,7 @@ describe("NFPM Events", () => {
 
       // Verify: Base position should be updated (correct position was found and used)
       const updatedBasePosition = result.entities.NonFungiblePosition.get(
-        NonFungiblePositionId(chainIdBase, poolAddressBase, sameTokenId),
+        NonFungiblePositionId(chainIdBase, nfpmAddress, sameTokenId),
       );
       expect(updatedBasePosition).toBeDefined();
       if (!updatedBasePosition) return;
@@ -1080,11 +1072,43 @@ describe("NFPM Events", () => {
 
       // Verify: Lisk position should remain unchanged (wrong position was NOT used)
       const liskPosition = result.entities.NonFungiblePosition.get(
-        NonFungiblePositionId(chainIdLisk, poolAddressLisk, sameTokenId),
+        NonFungiblePositionId(chainIdLisk, nfpmAddress, sameTokenId),
       );
       expect(liskPosition).toBeDefined();
       if (!liskPosition) return;
       expect(liskPosition.liquidity).toBe(positionLisk.liquidity);
+    });
+  });
+
+  // #621 regression: two NFPMs on the same chain each have their own tokenId counter,
+  // so (chainId, tokenId) alone is NOT a natural key. Adding nfpmAddress to the entity
+  // ID guarantees the two positions live as distinct entities instead of silently
+  // overwriting each other when they happen to mint into the same pool.
+  describe("Intra-chain multi-NFPM tokenId collision prevention", () => {
+    it("keeps positions under different NFPMs distinct for the same (chainId, tokenId)", () => {
+      const OP_NFPM_A = toChecksumAddress(
+        "0xbB5DFE1380333CEE4c2EeBd7202c80dE2256AdF4",
+      );
+      const OP_NFPM_B = toChecksumAddress(
+        "0x416b433906b1B72FA758e166e239c43d68dC6F29",
+      );
+      const sharedChainId = 10;
+      const sharedTokenId = 777n;
+
+      const idA = NonFungiblePositionId(
+        sharedChainId,
+        OP_NFPM_A,
+        sharedTokenId,
+      );
+      const idB = NonFungiblePositionId(
+        sharedChainId,
+        OP_NFPM_B,
+        sharedTokenId,
+      );
+
+      expect(idA).not.toBe(idB);
+      expect(idA).toBe(`${sharedChainId}-${OP_NFPM_A}-${sharedTokenId}`);
+      expect(idB).toBe(`${sharedChainId}-${OP_NFPM_B}-${sharedTokenId}`);
     });
   });
 });

--- a/test/EventHandlers/NFPM/NFPMCommonLogic.test.ts
+++ b/test/EventHandlers/NFPM/NFPMCommonLogic.test.ts
@@ -27,7 +27,7 @@ import {
   calculatePositionAmountsFromLiquidity,
   calculateTotalUSD,
 } from "../../../src/Helpers";
-import { NFPM_ADDRESS, setupCommon } from "../Pool/common";
+import { defaultNfpmAddress, setupCommon } from "../Pool/common";
 
 vi.mock("../../../src/Aggregators/CLStakedLiquidity");
 vi.mock("../../../src/Aggregators/LiquidityPoolAggregator");
@@ -40,7 +40,7 @@ describe("NFPMCommonLogic", () => {
   const poolAddress = toChecksumAddress(
     "0x00cd0AbB6c2964F7Dfb5169dD94A9F004C35F458",
   );
-  const nfpmAddressA = NFPM_ADDRESS;
+  const nfpmAddressA = defaultNfpmAddress;
   const nfpmAddressB = toChecksumAddress(
     "0x416b433906b1B72FA758e166e239c43d68dC6F29",
   );

--- a/test/EventHandlers/NFPM/NFPMCommonLogic.test.ts
+++ b/test/EventHandlers/NFPM/NFPMCommonLogic.test.ts
@@ -20,7 +20,6 @@ import {
 import {
   LiquidityChangeType,
   attributeLiquidityChangeToUserStatsPerPool,
-  findPositionByTokenId,
   updateStakedPositionLiquidity,
 } from "../../../src/EventHandlers/NFPM/NFPMCommonLogic";
 import {
@@ -49,7 +48,7 @@ describe("NFPMCommonLogic", () => {
   );
 
   const mockPosition: NonFungiblePosition = {
-    id: NonFungiblePositionId(chainId, poolAddress, tokenId),
+    id: NonFungiblePositionId(chainId, nfpmAddressA, tokenId),
     chainId: chainId,
     tokenId: tokenId,
     owner: toChecksumAddress("0x1DFAb7699121fEF702d07932a447868dCcCFb029"),
@@ -70,7 +69,7 @@ describe("NFPMCommonLogic", () => {
 
   const mockPositionDifferentChain: NonFungiblePosition = {
     ...mockPosition,
-    id: NonFungiblePositionId(8453, poolAddress, tokenId),
+    id: NonFungiblePositionId(8453, nfpmAddressA, tokenId),
     chainId: 8453, // Different chain
   };
 
@@ -79,7 +78,7 @@ describe("NFPMCommonLogic", () => {
   // each with its own tokenId counter, so tokenId 540 can exist on both.
   const mockPositionSameTokenDifferentNfpm: NonFungiblePosition = {
     ...mockPosition,
-    id: NonFungiblePositionId(chainId, poolAddressB, tokenId),
+    id: NonFungiblePositionId(chainId, nfpmAddressB, tokenId),
     pool: poolAddressB,
     nfpmAddress: nfpmAddressB,
   };
@@ -131,86 +130,20 @@ describe("NFPMCommonLogic", () => {
     } as unknown as handlerContext;
   });
 
-  describe("findPositionByTokenId", () => {
-    it("should find position by tokenId on correct chain and NFPM", async () => {
-      const positions = await findPositionByTokenId(
-        tokenId,
-        chainId,
-        nfpmAddressA,
-        mockContext,
+  // Regression for #621: the new stable ID for NonFungiblePosition is
+  // {chainId}-{nfpmAddress}-{tokenId}, so two positions that share (chainId, tokenId)
+  // under different NFPMs live as distinct entities instead of silently overwriting
+  // each other (as they would have with the old {chainId}-{poolAddress}-{tokenId} key
+  // when both factories/NFPMs happened to mint into the same pool).
+  describe("NonFungiblePositionId identity", () => {
+    it("produces distinct IDs for two positions sharing (chainId, tokenId) under different NFPMs", () => {
+      expect(mockPosition.id).not.toBe(mockPositionSameTokenDifferentNfpm.id);
+      expect(mockPosition.chainId).toBe(
+        mockPositionSameTokenDifferentNfpm.chainId,
       );
-
-      expect(positions).toHaveLength(1);
-      expect(positions[0]?.id).toBe(mockPosition.id);
-      expect(positions[0]?.chainId).toBe(chainId);
-      expect(positions[0]?.nfpmAddress).toBe(nfpmAddressA);
-    });
-
-    it("should filter by chainId to avoid cross-chain collisions", async () => {
-      const positions = await findPositionByTokenId(
-        tokenId,
-        8453, // Different chain
-        nfpmAddressA,
-        mockContext,
+      expect(mockPosition.tokenId).toBe(
+        mockPositionSameTokenDifferentNfpm.tokenId,
       );
-
-      expect(positions).toHaveLength(1);
-      expect(positions[0]?.id).toBe(mockPositionDifferentChain.id);
-      expect(positions[0]?.chainId).toBe(8453);
-    });
-
-    it("should filter by nfpmAddress to avoid intra-chain multi-NFPM collisions", async () => {
-      // Same chain, same tokenId, but a different NFPM contract (Optimism has two)
-      const positions = await findPositionByTokenId(
-        tokenId,
-        chainId,
-        nfpmAddressB,
-        mockContext,
-      );
-
-      expect(positions).toHaveLength(1);
-      expect(positions[0]?.id).toBe(mockPositionSameTokenDifferentNfpm.id);
-      expect(positions[0]?.nfpmAddress).toBe(nfpmAddressB);
-      expect(positions[0]?.pool).toBe(poolAddressB);
-    });
-
-    it("should return empty array when no position exists", async () => {
-      const positions = await findPositionByTokenId(
-        999n, // Non-existent tokenId
-        chainId,
-        nfpmAddressA,
-        mockContext,
-      );
-
-      expect(positions).toHaveLength(0);
-    });
-
-    it("should return empty array when position exists on different chain", async () => {
-      const positions = await findPositionByTokenId(
-        tokenId,
-        1, // Chain where position doesn't exist
-        nfpmAddressA,
-        mockContext,
-      );
-
-      expect(positions).toHaveLength(0);
-    });
-
-    it("should return empty array when the tokenId exists on same chain but under a different NFPM", async () => {
-      // Querying for an NFPM that has no position for this tokenId on this chain:
-      // previous behavior would leak the other NFPM's position and corrupt it.
-      const unknownNfpm = toChecksumAddress(
-        "0x0000000000000000000000000000000000000123",
-      );
-
-      const positions = await findPositionByTokenId(
-        tokenId,
-        chainId,
-        unknownNfpm,
-        mockContext,
-      );
-
-      expect(positions).toHaveLength(0);
     });
   });
 

--- a/test/EventHandlers/NFPM/NFPMDecreaseLiquidityLogic.test.ts
+++ b/test/EventHandlers/NFPM/NFPMDecreaseLiquidityLogic.test.ts
@@ -18,7 +18,7 @@ import {
   processNFPMDecreaseLiquidity,
 } from "../../../src/EventHandlers/NFPM/NFPMDecreaseLiquidityLogic";
 import { getSnapshotEpoch } from "../../../src/Snapshots/Shared";
-import { NFPM_ADDRESS } from "../Pool/common";
+import { defaultNfpmAddress } from "../Pool/common";
 
 vi.mock("../../../src/Aggregators/LiquidityPoolAggregator", async () => ({
   ...(await vi.importActual(
@@ -38,7 +38,7 @@ describe("NFPMDecreaseLiquidityLogic", () => {
   const poolAddress = toChecksumAddress(
     "0x00cd0AbB6c2964F7Dfb5169dD94A9F004C35F458",
   );
-  const nfpmAddress = NFPM_ADDRESS;
+  const nfpmAddress = defaultNfpmAddress;
   const blockTimestamp = new Date(1712065791 * 1000);
 
   function expectSnapshotSet(context: handlerContext, liquidity: bigint): void {

--- a/test/EventHandlers/NFPM/NFPMDecreaseLiquidityLogic.test.ts
+++ b/test/EventHandlers/NFPM/NFPMDecreaseLiquidityLogic.test.ts
@@ -60,7 +60,7 @@ describe("NFPMDecreaseLiquidityLogic", () => {
   }
 
   const mockPosition: NonFungiblePosition = {
-    id: NonFungiblePositionId(chainId, poolAddress, tokenId),
+    id: NonFungiblePositionId(chainId, nfpmAddress, tokenId),
     chainId: chainId,
     tokenId: tokenId,
     nfpmAddress: nfpmAddress,

--- a/test/EventHandlers/NFPM/NFPMIncreaseLiquidityLogic.test.ts
+++ b/test/EventHandlers/NFPM/NFPMIncreaseLiquidityLogic.test.ts
@@ -21,7 +21,7 @@ import {
   calculateIncreaseLiquidityDiff,
   processNFPMIncreaseLiquidity,
 } from "../../../src/EventHandlers/NFPM/NFPMIncreaseLiquidityLogic";
-import { NFPM_ADDRESS } from "../Pool/common";
+import { defaultNfpmAddress } from "../Pool/common";
 
 vi.mock("../../../src/Aggregators/LiquidityPoolAggregator", async () => ({
   ...(await vi.importActual(
@@ -52,7 +52,7 @@ describe("NFPMIncreaseLiquidityLogic", () => {
   const token1Address = toChecksumAddress(
     "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
   );
-  const nfpmAddress = NFPM_ADDRESS;
+  const nfpmAddress = defaultNfpmAddress;
 
   const mockPosition: NonFungiblePosition = {
     id: NonFungiblePositionId(chainId, poolAddress, tokenId),

--- a/test/EventHandlers/NFPM/NFPMIncreaseLiquidityLogic.test.ts
+++ b/test/EventHandlers/NFPM/NFPMIncreaseLiquidityLogic.test.ts
@@ -55,7 +55,7 @@ describe("NFPMIncreaseLiquidityLogic", () => {
   const nfpmAddress = defaultNfpmAddress;
 
   const mockPosition: NonFungiblePosition = {
-    id: NonFungiblePositionId(chainId, poolAddress, tokenId),
+    id: NonFungiblePositionId(chainId, nfpmAddress, tokenId),
     chainId: chainId,
     tokenId: tokenId,
     nfpmAddress: nfpmAddress,

--- a/test/EventHandlers/NFPM/NFPMTransferLogic.test.ts
+++ b/test/EventHandlers/NFPM/NFPMTransferLogic.test.ts
@@ -71,9 +71,9 @@ describe("NFPMTransferLogic", () => {
   const defaultSqrtPriceX96 = 79228162514264337593543950336n;
   const positionLiquidityAmount = 26679636922854n;
 
-  // Stable ID calculation helper (chainId-poolAddress-tokenId)
+  // Stable ID calculation helper (chainId-nfpmAddress-tokenId)
   const getStableId = () =>
-    NonFungiblePositionId(chainId, poolAddress, tokenId);
+    NonFungiblePositionId(chainId, nfpmAddress, tokenId);
 
   /** Minimal PoolData stub for tests (gauge and/or sqrtPriceX96). */
   function minimalPoolData(
@@ -476,7 +476,7 @@ describe("NFPMTransferLogic", () => {
 
       const mockEvent = createMockTransferEvent(zeroAddress, ownerAddress);
 
-      await handleMintTransfer(mockEvent, mockContext, []);
+      await handleMintTransfer(mockEvent, mockContext, undefined);
 
       const stableId = getStableId();
       const position = storedPositions.find((p) => p.id === stableId);
@@ -495,11 +495,11 @@ describe("NFPMTransferLogic", () => {
 
       const mockEvent = createMockTransferEvent(zeroAddress, ownerAddress);
 
-      // Pass the position from storedPositions to match what processNFPMTransfer would do
-      const existingPositions = storedPositions.filter(
+      // Pass the existing position to match what processNFPMTransfer would do
+      const existingPosition = storedPositions.find(
         (p) => p.tokenId === tokenId,
       );
-      await handleMintTransfer(mockEvent, mockContext, existingPositions);
+      await handleMintTransfer(mockEvent, mockContext, existingPosition);
 
       // Position should still exist with same ID
       const position =
@@ -513,7 +513,7 @@ describe("NFPMTransferLogic", () => {
     it("should log warning if no CLPoolMintEvent found", async () => {
       const mockEvent = createMockTransferEvent(zeroAddress, ownerAddress);
 
-      await handleMintTransfer(mockEvent, mockContext, []);
+      await handleMintTransfer(mockEvent, mockContext, undefined);
 
       // No position should be created
       const stableId = getStableId();
@@ -549,7 +549,7 @@ describe("NFPMTransferLogic", () => {
 
       const mockEvent = createMockTransferEvent(zeroAddress, ownerAddress);
 
-      await handleMintTransfer(mockEvent, mockContext, []);
+      await handleMintTransfer(mockEvent, mockContext, undefined);
 
       const stableId = getStableId();
       const position = storedPositions.find((p) => p.id === stableId);
@@ -576,7 +576,7 @@ describe("NFPMTransferLogic", () => {
 
       const mockEvent = createMockTransferEvent(zeroAddress, ownerAddress);
 
-      await handleMintTransfer(mockEvent, mockContext, []);
+      await handleMintTransfer(mockEvent, mockContext, undefined);
 
       const stableId = getStableId();
       const position = storedPositions.find((p) => p.id === stableId);
@@ -598,7 +598,7 @@ describe("NFPMTransferLogic", () => {
 
       const mockEvent = createMockTransferEvent(zeroAddress, ownerAddress);
 
-      await handleMintTransfer(mockEvent, nullMockContext, []);
+      await handleMintTransfer(mockEvent, nullMockContext, undefined);
 
       // Should log warning since no events found
       expect(nullMockContext.log.warn).toHaveBeenCalledWith(
@@ -627,7 +627,7 @@ describe("NFPMTransferLogic", () => {
 
       const mockEvent = createMockTransferEvent(zeroAddress, ownerAddress);
 
-      await handleMintTransfer(mockEvent, mockContext, []);
+      await handleMintTransfer(mockEvent, mockContext, undefined);
 
       const stableId = getStableId();
       const position = storedPositions.find((p) => p.id === stableId);
@@ -656,7 +656,7 @@ describe("NFPMTransferLogic", () => {
 
       const mockEvent = createMockTransferEvent(zeroAddress, ownerAddress);
 
-      await handleMintTransfer(mockEvent, mockContext, []);
+      await handleMintTransfer(mockEvent, mockContext, undefined);
 
       const stableId = getStableId();
       const position = storedPositions.find((p) => p.id === stableId);
@@ -687,21 +687,6 @@ describe("NFPMTransferLogic", () => {
   });
 
   describe("handleRegularTransfer", () => {
-    it("logs error and returns when positions array is empty", async () => {
-      const mockEvent = createMockTransferEvent(userA, userB);
-
-      await handleRegularTransfer(mockEvent, [], mockContext);
-
-      expect(mockContext.log.error).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "[handleRegularTransfer] No positions provided",
-        ),
-      );
-      expect(mockContext.log.error).toHaveBeenCalledWith(
-        expect.stringContaining(`tokenId ${tokenId}`),
-      );
-    });
-
     it("should update owner of existing position", async () => {
       vi.mocked(loadPoolData).mockResolvedValue(
         minimalPoolData({ sqrtPriceX96: defaultSqrtPriceX96 }),
@@ -710,7 +695,7 @@ describe("NFPMTransferLogic", () => {
 
       setPosition(mockPosition);
 
-      await handleRegularTransfer(mockEvent, [mockPosition], mockContext);
+      await handleRegularTransfer(mockEvent, mockPosition, mockContext);
 
       const updatedPosition = mockDb.entities.NonFungiblePosition.get(
         mockPosition.id,
@@ -730,7 +715,7 @@ describe("NFPMTransferLogic", () => {
       const mockEvent = createMockTransferEvent(mockPosition.owner, userB);
       setPosition(mockPosition);
 
-      await handleRegularTransfer(mockEvent, [mockPosition], mockContext);
+      await handleRegularTransfer(mockEvent, mockPosition, mockContext);
 
       expect(mockContext.log.warn).toHaveBeenCalledWith(
         expect.stringContaining("Pool pricing data not found"),
@@ -761,7 +746,7 @@ describe("NFPMTransferLogic", () => {
         minimalPoolData({ gaugeAddress: mockEvent.params.to }),
       );
 
-      await handleRegularTransfer(mockEvent, [positionWithOwner], mockContext);
+      await handleRegularTransfer(mockEvent, positionWithOwner, mockContext);
 
       const positionAfter = getPositionAfterTransfer();
       expect(positionAfter).toBeDefined();
@@ -785,7 +770,7 @@ describe("NFPMTransferLogic", () => {
         originalOwnerAddress,
       );
 
-      await handleRegularTransfer(mockEvent, [positionWithOwner], mockContext);
+      await handleRegularTransfer(mockEvent, positionWithOwner, mockContext);
 
       const positionAfter = getPositionAfterTransfer();
       expect(positionAfter).toBeDefined();
@@ -801,7 +786,7 @@ describe("NFPMTransferLogic", () => {
       setPosition(positionOwnedByA);
       const mockEvent = createMockTransferEvent(userA, userB);
 
-      await handleRegularTransfer(mockEvent, [positionOwnedByA], mockContext);
+      await handleRegularTransfer(mockEvent, positionOwnedByA, mockContext);
 
       const updatedPosition = getPositionAfterTransfer();
       expect(updatedPosition).toBeDefined();
@@ -821,7 +806,7 @@ describe("NFPMTransferLogic", () => {
         gaugeAddress,
       );
 
-      await handleRegularTransfer(mockEvent, [positionWithOwner], mockContext);
+      await handleRegularTransfer(mockEvent, positionWithOwner, mockContext);
 
       expect(attributeLiquidityChangeToUserStatsPerPool).not.toHaveBeenCalled();
       const positionAfter = getPositionAfterTransfer();
@@ -846,7 +831,7 @@ describe("NFPMTransferLogic", () => {
         originalOwnerAddress,
       );
 
-      await handleRegularTransfer(mockEvent, [positionWithOwner], mockContext);
+      await handleRegularTransfer(mockEvent, positionWithOwner, mockContext);
 
       expect(attributeLiquidityChangeToUserStatsPerPool).not.toHaveBeenCalled();
       const positionAfter = getPositionAfterTransfer();
@@ -865,7 +850,7 @@ describe("NFPMTransferLogic", () => {
       const mockEvent = createMockTransferEvent(mockPosition.owner, userB);
       setPosition(mockPosition);
 
-      await handleRegularTransfer(mockEvent, [mockPosition], mockContext);
+      await handleRegularTransfer(mockEvent, mockPosition, mockContext);
 
       expect(mockContext.log.warn).toHaveBeenCalledWith(
         expect.stringContaining("Pool entity not found"),
@@ -888,7 +873,7 @@ describe("NFPMTransferLogic", () => {
       setPosition(pos);
       const mockEvent = createMockTransferEvent(userA, userB);
 
-      await handleRegularTransfer(mockEvent, [pos], mockContext);
+      await handleRegularTransfer(mockEvent, pos, mockContext);
 
       expect(attributeLiquidityChangeToUserStatsPerPool).toHaveBeenCalledTimes(
         2,
@@ -916,7 +901,7 @@ describe("NFPMTransferLogic", () => {
       setPosition(pos);
       const mockEvent = createMockTransferEvent(userA, zeroAddress);
 
-      await handleRegularTransfer(mockEvent, [pos], mockContext);
+      await handleRegularTransfer(mockEvent, pos, mockContext);
 
       expect(attributeLiquidityChangeToUserStatsPerPool).toHaveBeenCalledTimes(
         1,
@@ -938,7 +923,7 @@ describe("NFPMTransferLogic", () => {
       setPosition(pos);
       const mockEvent = createMockTransferEvent(userA, userB);
 
-      await handleRegularTransfer(mockEvent, [pos], mockContext);
+      await handleRegularTransfer(mockEvent, pos, mockContext);
 
       expect(attributeLiquidityChangeToUserStatsPerPool).not.toHaveBeenCalled();
       const updatedPosition = getPositionAfterTransfer();
@@ -953,7 +938,7 @@ describe("NFPMTransferLogic", () => {
       setPosition(pos);
       const mockEvent = createMockTransferEvent(userA, userA);
 
-      await handleRegularTransfer(mockEvent, [pos], mockContext);
+      await handleRegularTransfer(mockEvent, pos, mockContext);
 
       expect(attributeLiquidityChangeToUserStatsPerPool).not.toHaveBeenCalled();
       const updatedPosition = getPositionAfterTransfer();

--- a/test/EventHandlers/NFPM/NFPMTransferLogic.test.ts
+++ b/test/EventHandlers/NFPM/NFPMTransferLogic.test.ts
@@ -23,7 +23,7 @@ import {
   isGaugeTransfer,
   processNFPMTransfer,
 } from "../../../src/EventHandlers/NFPM/NFPMTransferLogic";
-import { NFPM_ADDRESS } from "../Pool/common";
+import { defaultNfpmAddress } from "../Pool/common";
 
 vi.mock("../../../src/Aggregators/LiquidityPoolAggregator", async () => ({
   ...(await vi.importActual(
@@ -59,7 +59,7 @@ describe("NFPMTransferLogic", () => {
   const token1Address = toChecksumAddress(
     "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
   );
-  const nfpmAddress = NFPM_ADDRESS;
+  const nfpmAddress = defaultNfpmAddress;
   const zeroAddress = toChecksumAddress(
     "0x0000000000000000000000000000000000000000",
   );

--- a/test/EventHandlers/Pool/common.ts
+++ b/test/EventHandlers/Pool/common.ts
@@ -159,6 +159,8 @@ export function setupCommon() {
     poolLauncherPoolId: undefined,
     // Address of the factory that created this pool (e.g. CLFactory for CL pools)
     factoryAddress: "",
+    // NFPM address for CL pools (null for V2). See nfpmForCLPool in Constants.ts.
+    nfpmAddress: undefined,
     // Voting fields
     gaugeAddress: "",
     gaugeEmissionsCap: 0n,

--- a/test/EventHandlers/Pool/common.ts
+++ b/test/EventHandlers/Pool/common.ts
@@ -297,7 +297,7 @@ export function setupCommon() {
 
   const defaultNFPMTokenId = 42n;
   const mockNonFungiblePositionData: NonFungiblePosition = {
-    id: NonFungiblePositionId(CHAIN_ID, POOL_ADDRESS, defaultNFPMTokenId),
+    id: NonFungiblePositionId(CHAIN_ID, defaultNfpmAddress, defaultNFPMTokenId),
     chainId: CHAIN_ID,
     tokenId: defaultNFPMTokenId,
     nfpmAddress: defaultNfpmAddress,
@@ -325,7 +325,11 @@ export function setupCommon() {
     const chainId = overrides.chainId ?? CHAIN_ID;
     const pool = toChecksumAddress(overrides.pool ?? POOL_ADDRESS);
     const tokenId = overrides.tokenId ?? defaultNFPMTokenId;
-    const id = overrides.id ?? NonFungiblePositionId(chainId, pool, tokenId);
+    const positionNfpm = toChecksumAddress(
+      overrides.nfpmAddress ?? defaultNfpmAddress,
+    );
+    const id =
+      overrides.id ?? NonFungiblePositionId(chainId, positionNfpm, tokenId);
     const owner = toChecksumAddress(
       overrides.owner ?? normalizedDefaultUserAddress,
     );
@@ -338,6 +342,7 @@ export function setupCommon() {
       tokenId,
       pool,
       owner,
+      nfpmAddress: positionNfpm,
     };
   }
 
@@ -393,6 +398,14 @@ export function setupCommon() {
       overrides.poolAddress ?? POOL_ADDRESS,
     );
     const id = overrides.id ?? PoolId(chainId, poolAddress);
+    // Default nfpmAddress for CL pools so tests that exercise NFPM-scoped lookups
+    // (gauges, UserStatsPerPool snapshot USD) see a valid mapping. V2 pools keep it null.
+    const nfpmAddress =
+      overrides.nfpmAddress !== undefined
+        ? overrides.nfpmAddress
+        : overrides.isCL
+          ? defaultNfpmAddress
+          : undefined;
 
     return {
       ...mockLiquidityPoolData,
@@ -400,6 +413,7 @@ export function setupCommon() {
       poolAddress,
       chainId,
       id,
+      nfpmAddress,
     };
   }
 

--- a/test/EventHandlers/Pool/common.ts
+++ b/test/EventHandlers/Pool/common.ts
@@ -23,9 +23,11 @@ import {
 } from "../../../src/Constants";
 import { calculateTokenAmountUSD } from "../../../src/Helpers";
 
-// Primary Optimism NFPM address. Exported so test files that do not call
-// setupCommon() can still share a single source of truth for the NFPM literal.
-export const NFPM_ADDRESS = toChecksumAddress(
+// Canonical NFPM used for mock NonFungiblePosition fixtures (Optimism-old NFPM).
+// Named `default*` rather than a SCREAMING_CASE module constant because it's the
+// fixture paired with the default mock position — not a general-purpose NFPM default
+// for the V2 `mockLiquidityPoolData` (which intentionally has `nfpmAddress: undefined`).
+export const defaultNfpmAddress = toChecksumAddress(
   "0xbB5DFE1380333CEE4c2EeBd7202c80dE2256AdF4",
 );
 
@@ -42,8 +44,6 @@ export function setupCommon() {
   const TOKEN1_ADDRESS = toChecksumAddress(
     "0x2222222222222222222222222222222222222222",
   );
-  const nfpmAddress = NFPM_ADDRESS;
-
   const mockToken0Data: Token = {
     id: TokenId(CHAIN_ID, TOKEN0_ADDRESS),
     address: TOKEN0_ADDRESS as `0x${string}`,
@@ -300,7 +300,7 @@ export function setupCommon() {
     id: NonFungiblePositionId(CHAIN_ID, POOL_ADDRESS, defaultNFPMTokenId),
     chainId: CHAIN_ID,
     tokenId: defaultNFPMTokenId,
-    nfpmAddress: nfpmAddress,
+    nfpmAddress: defaultNfpmAddress,
     owner: normalizedDefaultUserAddress,
     pool: POOL_ADDRESS,
     tickLower: -1000n,
@@ -478,7 +478,7 @@ export function setupCommon() {
     mockVeNFTStateData,
     mockVeNFTPoolVoteData,
     mockNonFungiblePositionData,
-    nfpmAddress,
+    defaultNfpmAddress,
     createMockToken,
     createMockUserStatsPerPool,
     createMockLiquidityPoolAggregator,

--- a/test/EventHandlers/PoolFactory.test.ts
+++ b/test/EventHandlers/PoolFactory.test.ts
@@ -167,6 +167,12 @@ describe("PoolFactory Events", () => {
       expect(pool?.factoryAddress).toBe(mockEvent.srcAddress);
     });
 
+    // US-1 acceptance: V2 (non-CL) pools do not carry an NFPM — leave nfpmAddress unset.
+    it("should leave nfpmAddress unset for non-CL (V2) pools", () => {
+      expect(createdPool?.isCL).toBe(false);
+      expect(createdPool?.nfpmAddress).toBeUndefined();
+    });
+
     it("should set baseFee and currentFee for stable pools (sAMM)", async () => {
       resetMockPriceOracle();
 

--- a/test/Snapshots/SchemaParity.test.ts
+++ b/test/Snapshots/SchemaParity.test.ts
@@ -40,6 +40,7 @@ describe("Snapshot schema parity", () => {
         "lastSnapshotTimestamp",
         "rootPoolMatchingHash",
         "factoryAddress",
+        "nfpmAddress",
         "poolLauncherPoolId",
       ],
     ],


### PR DESCRIPTION
## Summary

Makes `(chainId, nfpmAddress, tokenId)` the natural key for `NonFungiblePosition`, drops `pool` from the ID, deletes `findPositionByTokenId`, and has every reader call `context.NonFungiblePosition.get(NonFungiblePositionId(...))` directly — O(1) instead of a `getWhere` scan + in-memory filter.

Parent PRD: #618
Closes #621
**Base: #625** (depends on `pool.nfpmAddress` from #619)

## What changed

- `NonFungiblePositionId(chainId, nfpmAddress, tokenId)` — pool removed from the ID; entity still carries `pool` as a field.
- Deleted `findPositionByTokenId` from `NFPMCommonLogic.ts`.
- `processNFPMTransfer` / `processNFPMIncreaseLiquidity` / `processNFPMDecreaseLiquidity` call `context.NonFungiblePosition.get(...)` directly with `event.srcAddress` as the NFPM.
- `GaugeSharedLogic` and `UserStatsPerPool` staked-USD path read `pool.nfpmAddress` (from #619) and call `get()` with the new ID.
- `handleMintTransfer` / `handleRegularTransfer` signatures updated from `NonFungiblePosition[]` → `NonFungiblePosition | undefined` / `NonFungiblePosition` to match the direct-get path.

## Why

Two NFPMs on the same chain each have their own tokenId counter, so `(chainId, tokenId)` alone is not a natural key. Before this change, two positions that happened to mint into the same pool with the same tokenId would silently overwrite each other. PR #611 masked the symptom via an `nfpmAddress` filter after a `getWhere`; this change fixes it structurally by making the ID collision-proof and removing the scan.

## Scope notes

- ALM DeployFactory V1/V2 still use `context.NonFungiblePosition.getWhere` keyed by `mintTransactionHash` — a different query pattern (they don't know the tokenId at event time). **Not in scope for this change.**
- V2 (`Pool`) handlers unchanged per issue non-goals.

## Envio re-sync note

`NonFungiblePosition` and `NonFungiblePositionSnapshot` ID formats changed. Existing rows are dropped on reindex and repopulate from events (Transfer/Increase/Decrease path). No backfill script needed — same migration story as #611.

## Test plan

- [x] New regression test: two NFPMs with same `(chainId, tokenId)` produce distinct entity IDs.
- [x] `findPositionByTokenId` describe block replaced with identity assertion.
- [x] All NFPM handler tests updated to new signatures; `handleRegularTransfer` "no positions" test removed (caller now guards with `!position` before calling).
- [x] `createMockLiquidityPoolAggregator` defaults `nfpmAddress` when `isCL: true` so gauge + user-stats tests exercise the new lookup path.
- [x] `pnpm qa --write` clean, `pnpm test` green (1051/1051 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)