### PR TITLE
perf(cl-pool): replace CLPoolMintEvent.getWhere with TxCLPoolMintRegistry PK lookup (#628)

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -708,6 +708,16 @@ type CLPositionPendingPrincipal {
   pendingPrincipal1: BigInt! @config(precision: 76)
 }
 
+# Per-transaction registry of CLPoolMintEvent IDs, used to skip the index scan
+# on CLPoolMintEvent.getWhere({ transactionHash }) in the NFPM.Transfer(mint) consumer.
+# The consumer knows chainId + txHash; it reads this row and then PK-gets each event by id.
+# Cleaned up as events are consumed: ids are removed on consumption and the row is deleted
+# when the last id is removed.
+type TxCLPoolMintRegistry {
+  id: ID! # Format: {chainId}-{txHash}
+  mintEventIds: [String!]! # CLPoolMintEvent ids produced in this tx, in insertion order
+}
+
 # Temporary entity for matching Mint/Burn with Transfer events
 # Only stores mint/burn transfers (isMint || isBurn) to reduce storage
 type PoolTransferInTx {

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -1087,6 +1087,18 @@ export const CLPoolMintEventId = (
   logIndex: number,
 ) => `${chainId}-${poolAddress}-${txHash}-${logIndex}`;
 
+/** Entity ID for TxCLPoolMintRegistry. Format: {chainId}-{txHash}.
+ * Keyed by transaction (not pool) because the NFPM.Transfer(mint) consumer only
+ * knows chainId + txHash at lookup time; filtering by pool/logIndex happens on
+ * the CLPoolMintEvent rows fetched via the registry.
+ *
+ * @param chainId - Chain ID of the tx
+ * @param txHash - Transaction hash that produced one or more CLPool.Mint events
+ * @returns string Combined registry ID.
+ */
+export const TxCLPoolMintRegistryId = (chainId: number, txHash: string) =>
+  `${chainId}-${txHash}`;
+
 /** ID for CLPositionPendingPrincipal — tracks burned principal awaiting collection.
  * Keyed by contract-level position identity (pool + owner + tick range).
  * Mirrors Solidity's positions mapping key: keccak256(owner, tickLower, tickUpper) per pool.

--- a/src/EventHandlers/CLPool.ts
+++ b/src/EventHandlers/CLPool.ts
@@ -8,7 +8,11 @@ import {
   loadOrCreateUserData,
   updateUserStatsPerPool,
 } from "../Aggregators/UserStatsPerPool";
-import { CLPoolMintEventId, OUSDT_ADDRESS } from "../Constants";
+import {
+  CLPoolMintEventId,
+  OUSDT_ADDRESS,
+  TxCLPoolMintRegistryId,
+} from "../Constants";
 import { processCLPoolBurn } from "./CLPool/CLPoolBurnLogic";
 import { processCLPoolCollectFees } from "./CLPool/CLPoolCollectFeesLogic";
 import { processCLPoolCollect } from "./CLPool/CLPoolCollectLogic";
@@ -324,6 +328,20 @@ CLPool.Mint.handler(async ({ event, context }) => {
     logIndex: event.logIndex,
     consumedByTokenId: undefined,
     createdAt: timestamp,
+  });
+
+  // Per-tx registry so NFPM.Transfer(mint) can PK-lookup the mint ids for this
+  // tx instead of running a getWhere scan on CLPoolMintEvent.transactionHash.
+  const registryId = TxCLPoolMintRegistryId(
+    event.chainId,
+    event.transaction.hash,
+  );
+  const existingRegistry = await context.TxCLPoolMintRegistry.get(registryId);
+  context.TxCLPoolMintRegistry.set({
+    id: registryId,
+    mintEventIds: existingRegistry
+      ? [...existingRegistry.mintEventIds, mintEventId]
+      : [mintEventId],
   });
 });
 

--- a/src/EventHandlers/NFPM/NFPMIncreaseLiquidityLogic.ts
+++ b/src/EventHandlers/NFPM/NFPMIncreaseLiquidityLogic.ts
@@ -50,6 +50,7 @@ export function calculateIncreaseLiquidityDiff(
  *
  * @param event - The NFPM.IncreaseLiquidity event
  * @param context - The handler context
+ * @returns Promise that resolves once the position update, orphan-mint cleanup, and downstream attributions are staged
  */
 export async function processNFPMIncreaseLiquidity(
   event: NFPM_IncreaseLiquidity_event,

--- a/src/EventHandlers/NFPM/NFPMIncreaseLiquidityLogic.ts
+++ b/src/EventHandlers/NFPM/NFPMIncreaseLiquidityLogic.ts
@@ -9,7 +9,7 @@ import {
   type NonFungiblePositionDiff,
   updateNonFungiblePosition,
 } from "../../Aggregators/NonFungiblePosition";
-import { NonFungiblePositionId } from "../../Constants";
+import { NonFungiblePositionId, TxCLPoolMintRegistryId } from "../../Constants";
 import {
   LiquidityChangeType,
   attributeLiquidityChangeToUserStatsPerPool,
@@ -92,13 +92,21 @@ export async function processNFPMIncreaseLiquidity(
   // Therefore, if we find an unconsumed CLPoolMintEvent in the same transaction when processing
   // IncreaseLiquidity, it MUST be from an increase (Case 2), because new mints (Case 1) would
   // have already been deleted by the Transfer handler that runs before IncreaseLiquidity.
-  const mintEventsInTx = await context.CLPoolMintEvent.getWhere({
-    transactionHash: { _eq: event.transaction.hash },
-  });
+  const registryId = TxCLPoolMintRegistryId(
+    event.chainId,
+    event.transaction.hash,
+  );
+  const registry = await context.TxCLPoolMintRegistry.get(registryId);
 
-  if (mintEventsInTx && mintEventsInTx.length > 0) {
+  if (registry && registry.mintEventIds.length > 0) {
+    const mintEventsInTx = (
+      await Promise.all(
+        registry.mintEventIds.map((id) => context.CLPoolMintEvent.get(id)),
+      )
+    ).filter((m): m is CLPoolMintEvent => m !== undefined);
+
     const matchingMintEvents = mintEventsInTx.filter(
-      (m: CLPoolMintEvent) =>
+      (m) =>
         m.chainId === event.chainId &&
         m.pool === position.pool &&
         m.tickLower === position.tickLower &&
@@ -111,17 +119,27 @@ export async function processNFPMIncreaseLiquidity(
     // Select closest preceding mint by logIndex (deterministic for multiple matches)
     const matchingMintEvent =
       matchingMintEvents.length > 0
-        ? matchingMintEvents.reduce(
-            (prev: CLPoolMintEvent, curr: CLPoolMintEvent) =>
-              curr.logIndex > prev.logIndex ? curr : prev,
+        ? matchingMintEvents.reduce((prev, curr) =>
+            curr.logIndex > prev.logIndex ? curr : prev,
           )
         : undefined;
 
     if (matchingMintEvent) {
       // This matches Case 2 (INCREASE) from the explanation above.
       // The CLPoolMintEvent is orphaned because no Transfer event consumed it.
-      // Delete it to prevent accumulation of temporary entities.
+      // Delete it and prune the registry (drop the row when it empties).
       context.CLPoolMintEvent.deleteUnsafe(matchingMintEvent.id);
+      const remaining = registry.mintEventIds.filter(
+        (id) => id !== matchingMintEvent.id,
+      );
+      if (remaining.length === 0) {
+        context.TxCLPoolMintRegistry.deleteUnsafe(registryId);
+      } else {
+        context.TxCLPoolMintRegistry.set({
+          id: registryId,
+          mintEventIds: remaining,
+        });
+      }
     }
   }
 

--- a/src/EventHandlers/NFPM/NFPMTransferLogic.ts
+++ b/src/EventHandlers/NFPM/NFPMTransferLogic.ts
@@ -9,7 +9,12 @@ import {
   loadPoolData,
 } from "../../Aggregators/LiquidityPoolAggregator";
 import { updateNonFungiblePosition } from "../../Aggregators/NonFungiblePosition";
-import { NonFungiblePositionId, PoolId, ZERO_ADDRESS } from "../../Constants";
+import {
+  NonFungiblePositionId,
+  PoolId,
+  TxCLPoolMintRegistryId,
+  ZERO_ADDRESS,
+} from "../../Constants";
 import { calculatePositionAmountsFromLiquidity } from "../../Helpers";
 import {
   LiquidityChangeType,
@@ -76,10 +81,11 @@ export async function createPositionFromCLPoolMint(
  *
  * Process:
  * 1. Check if position already exists (early return if found)
- * 2. Query CLPoolMintEvent by transaction hash
+ * 2. PK-lookup TxCLPoolMintRegistry for (chainId, txHash), then PK-get each CLPoolMintEvent by id
+ *    (replaces the old CLPoolMintEvent.getWhere({ transactionHash }) index scan)
  * 3. Filter by: chainId, logIndex < transferLogIndex, not consumed
  * 4. Select closest preceding mint by logIndex (deterministic for multiple mints)
- * 5. Create definitive position and delete CLPoolMintEvent
+ * 5. Create definitive position, delete CLPoolMintEvent, prune consumed id from the registry
  *
  * @param event - The NFPM.Transfer event (mint case)
  * @param context - The handler context
@@ -95,56 +101,79 @@ export async function handleMintTransfer(
     return;
   }
 
-  const mintEvents = await context.CLPoolMintEvent.getWhere({
-    transactionHash: { _eq: event.transaction.hash },
-  });
+  const registryId = TxCLPoolMintRegistryId(
+    event.chainId,
+    event.transaction.hash,
+  );
+  const registry = await context.TxCLPoolMintRegistry.get(registryId);
 
-  const matchingEvents =
-    mintEvents?.filter(
-      (m: CLPoolMintEvent) =>
-        m.chainId === event.chainId &&
-        !m.consumedByTokenId &&
-        m.logIndex < event.logIndex,
-    ) ?? [];
-
-  if (matchingEvents.length > 0) {
-    // Select closest preceding mint by logIndex (deterministic for multiple mints)
-    //
-    // Why this selection strategy is necessary:
-    // 1. A single transaction can contain multiple CLPool.Mint events (e.g., user mints positions in multiple pools)
-    // 2. Each NFPM.Transfer (mint) event must match with the correct CLPool.Mint event
-    // 3. Events are processed in logIndex order within a transaction
-    // 4. The Transfer event should match with the most recent (closest) preceding Mint event
-    //
-    // Example transaction with multiple mints:
-    //   logIndex 10: CLPool.Mint (pool A) → creates CLPoolMintEvent A
-    //   logIndex 20: CLPool.Mint (pool B) → creates CLPoolMintEvent B
-    //   logIndex 30: NFPM.Transfer (mint, pool A) → should match CLPoolMintEvent A (logIndex 10)
-    //   logIndex 40: NFPM.Transfer (mint, pool B) → should match CLPoolMintEvent B (logIndex 20)
-    //
-    // By selecting the maximum logIndex from matchingEvents (which are already filtered to logIndex < transferLogIndex),
-    // we get the closest preceding mint, ensuring deterministic and correct matching.
-    const mintEvent = matchingEvents.reduce(
-      (prev: CLPoolMintEvent, current: CLPoolMintEvent) =>
-        current.logIndex > prev.logIndex ? current : prev,
-    );
-
-    // Create definitive position and delete CLPoolMintEvent entity
-    await createPositionFromCLPoolMint(
-      mintEvent,
-      event.params.tokenId,
-      event.params.to,
-      event.srcAddress,
-      event.chainId,
-      event.block.timestamp,
-      context,
+  if (!registry || registry.mintEventIds.length === 0) {
+    context.log.warn(
+      `No CLPoolMintEvent found for NFPM.Transfer(mint) tokenId ${event.params.tokenId} in tx ${event.transaction.hash}`,
     );
     return;
   }
 
-  context.log.warn(
-    `No CLPoolMintEvent found for NFPM.Transfer(mint) tokenId ${event.params.tokenId} in tx ${event.transaction.hash}`,
+  const mintEvents = (
+    await Promise.all(
+      registry.mintEventIds.map((id) => context.CLPoolMintEvent.get(id)),
+    )
+  ).filter((m): m is CLPoolMintEvent => m !== undefined);
+
+  const matchingEvents = mintEvents.filter(
+    (m) =>
+      m.chainId === event.chainId &&
+      !m.consumedByTokenId &&
+      m.logIndex < event.logIndex,
   );
+
+  if (matchingEvents.length === 0) {
+    context.log.warn(
+      `No CLPoolMintEvent found for NFPM.Transfer(mint) tokenId ${event.params.tokenId} in tx ${event.transaction.hash}`,
+    );
+    return;
+  }
+
+  // Select closest preceding mint by logIndex (deterministic for multiple mints)
+  //
+  // Why this selection strategy is necessary:
+  // 1. A single transaction can contain multiple CLPool.Mint events (e.g., user mints positions in multiple pools)
+  // 2. Each NFPM.Transfer (mint) event must match with the correct CLPool.Mint event
+  // 3. Events are processed in logIndex order within a transaction
+  // 4. The Transfer event should match with the most recent (closest) preceding Mint event
+  //
+  // Example transaction with multiple mints:
+  //   logIndex 10: CLPool.Mint (pool A) → creates CLPoolMintEvent A
+  //   logIndex 20: CLPool.Mint (pool B) → creates CLPoolMintEvent B
+  //   logIndex 30: NFPM.Transfer (mint, pool A) → should match CLPoolMintEvent A (logIndex 10)
+  //   logIndex 40: NFPM.Transfer (mint, pool B) → should match CLPoolMintEvent B (logIndex 20)
+  //
+  // By selecting the maximum logIndex from matchingEvents (which are already filtered to logIndex < transferLogIndex),
+  // we get the closest preceding mint, ensuring deterministic and correct matching.
+  const mintEvent = matchingEvents.reduce((prev, current) =>
+    current.logIndex > prev.logIndex ? current : prev,
+  );
+
+  await createPositionFromCLPoolMint(
+    mintEvent,
+    event.params.tokenId,
+    event.params.to,
+    event.srcAddress,
+    event.chainId,
+    event.block.timestamp,
+    context,
+  );
+
+  // Prune the consumed id from the registry; delete the row when it empties.
+  const remaining = registry.mintEventIds.filter((id) => id !== mintEvent.id);
+  if (remaining.length === 0) {
+    context.TxCLPoolMintRegistry.deleteUnsafe(registryId);
+  } else {
+    context.TxCLPoolMintRegistry.set({
+      id: registryId,
+      mintEventIds: remaining,
+    });
+  }
 }
 
 /**

--- a/src/EventHandlers/NFPM/NFPMTransferLogic.ts
+++ b/src/EventHandlers/NFPM/NFPMTransferLogic.ts
@@ -90,6 +90,7 @@ export async function createPositionFromCLPoolMint(
  * @param event - The NFPM.Transfer event (mint case)
  * @param context - The handler context
  * @param existingPosition - Existing position found via direct get() (undefined when none exists)
+ * @returns Promise that resolves once the definitive position is staged, the consumed CLPoolMintEvent deleted, and the registry row pruned
  */
 export async function handleMintTransfer(
   event: NFPM_Transfer_event,

--- a/test/EventHandlers/NFPM/NFPM.test.ts
+++ b/test/EventHandlers/NFPM/NFPM.test.ts
@@ -141,8 +141,9 @@ describe("NFPM Events", () => {
       const dbWithTokens = dbWithRegistry.entities.Token.set(mockToken0Data);
       const finalDb = dbWithTokens.entities.Token.set(mockToken1Data);
 
-      // Setup getWhere for queries
-      const storedMintEvents = [mockCLPoolMintEvent];
+      // Handler uses TxCLPoolMintRegistry PK-lookup + CLPoolMintEvent PK-get,
+      // so no CLPoolMintEvent.getWhere shim is needed. If the handler ever
+      // regresses to the scan path, the mint match below will fail.
       const mockDbWithGetWhere = {
         ...finalDb,
         entities: {
@@ -152,18 +153,6 @@ describe("NFPM Events", () => {
             getWhere: {
               tokenId: {
                 eq: async () => [], // No existing position
-              },
-            },
-          },
-          CLPoolMintEvent: {
-            ...finalDb.entities.CLPoolMintEvent,
-            getWhere: {
-              transactionHash: {
-                eq: async (txHash: string) => {
-                  return storedMintEvents.filter(
-                    (e) => e.transactionHash === txHash,
-                  );
-                },
               },
             },
           },

--- a/test/EventHandlers/NFPM/NFPM.test.ts
+++ b/test/EventHandlers/NFPM/NFPM.test.ts
@@ -6,6 +6,7 @@ import {
   CLPoolMintEventId,
   NonFungiblePositionId,
   TokenId,
+  TxCLPoolMintRegistryId,
   toChecksumAddress,
 } from "../../../src/Constants";
 import { defaultNfpmAddress, setupCommon } from "../Pool/common";
@@ -129,11 +130,15 @@ describe("NFPM Events", () => {
         createdAt: new Date(1000000 * 1000),
       };
 
-      // Setup mockDb with CLPoolMintEvent
+      // Setup mockDb with CLPoolMintEvent + matching registry row
       const mockDbWithMintEvent = MockDb.createMockDb();
       const dbWithMintEvent =
         mockDbWithMintEvent.entities.CLPoolMintEvent.set(mockCLPoolMintEvent);
-      const dbWithTokens = dbWithMintEvent.entities.Token.set(mockToken0Data);
+      const dbWithRegistry = dbWithMintEvent.entities.TxCLPoolMintRegistry.set({
+        id: TxCLPoolMintRegistryId(chainId, transactionHash),
+        mintEventIds: [mockCLPoolMintEvent.id],
+      });
+      const dbWithTokens = dbWithRegistry.entities.Token.set(mockToken0Data);
       const finalDb = dbWithTokens.entities.Token.set(mockToken1Data);
 
       // Setup getWhere for queries

--- a/test/EventHandlers/NFPM/NFPMIncreaseLiquidityLogic.test.ts
+++ b/test/EventHandlers/NFPM/NFPMIncreaseLiquidityLogic.test.ts
@@ -89,6 +89,7 @@ describe("NFPMIncreaseLiquidityLogic", () => {
   let mockContext: handlerContext;
   let storedPositions: NonFungiblePosition[];
   let storedMintEvents: CLPoolMintEvent[];
+  let registryState: Map<string, string[]>;
 
   /**
    * Helper function to create a mock context with getWhere functionality
@@ -97,6 +98,15 @@ describe("NFPMIncreaseLiquidityLogic", () => {
     positions: NonFungiblePosition[] = [mockPosition],
     mintEvents: CLPoolMintEvent[] = [],
   ): handlerContext {
+    // (Re)seed registry state from mintEvents: one row per (chainId, txHash).
+    registryState = new Map<string, string[]>();
+    for (const m of mintEvents) {
+      const key = `${m.chainId}-${m.transactionHash}`;
+      const list = registryState.get(key) ?? [];
+      list.push(m.id);
+      registryState.set(key, list);
+    }
+
     const db = MockDb.createMockDb();
     let currentDb = positions.reduce(
       (acc, pos) => acc.entities.NonFungiblePosition.set(pos),
@@ -171,20 +181,21 @@ describe("NFPMIncreaseLiquidityLogic", () => {
         // biome-ignore lint/suspicious/noExplicitAny: Mock for testing
       } as any,
       TxCLPoolMintRegistry: {
-        // Mirror producer: one registry row per tx with all mint ids in that tx.
+        // Backed by shared registryState so set/deleteUnsafe are observable.
         get: vi.fn().mockImplementation((id: string) => {
-          const byTx = new Map<string, string[]>();
-          for (const m of mintEvents) {
-            const key = `${m.chainId}-${m.transactionHash}`;
-            const list = byTx.get(key) ?? [];
-            list.push(m.id);
-            byTx.set(key, list);
-          }
-          const ids = byTx.get(id);
+          const ids = registryState.get(id);
           return Promise.resolve(ids ? { id, mintEventIds: ids } : undefined);
         }),
-        set: vi.fn(),
-        deleteUnsafe: vi.fn(),
+        set: vi
+          .fn()
+          .mockImplementation(
+            (entity: { id: string; mintEventIds: string[] }) => {
+              registryState.set(entity.id, entity.mintEventIds);
+            },
+          ),
+        deleteUnsafe: vi.fn().mockImplementation((id: string) => {
+          registryState.delete(id);
+        }),
       },
       log: {
         info: vi.fn(),
@@ -370,6 +381,15 @@ describe("NFPMIncreaseLiquidityLogic", () => {
 
       // CLPoolMintEvent should be deleted from storedMintEvents
       expect(storedMintEvents.length).toBe(0);
+
+      // Registry row should be deleted after its last id is consumed
+      const registryId = `${chainId}-${transactionHash}`;
+      expect(
+        mockContext.TxCLPoolMintRegistry.deleteUnsafe,
+      ).toHaveBeenCalledWith(registryId);
+      const registryAfter =
+        await mockContext.TxCLPoolMintRegistry.get(registryId);
+      expect(registryAfter).toBeUndefined();
     });
 
     it("should not delete any CLPoolMintEvent when mint events exist in tx but none match the increase", async () => {
@@ -520,6 +540,26 @@ describe("NFPMIncreaseLiquidityLogic", () => {
       expect(
         storedMintEvents.find((e) => e.id === mockMintEvent3.id),
       ).toBeDefined(); // Should remain
+
+      // Registry row should be updated with the remaining ids (not deleted, since 2 remain)
+      const registryId = `${chainId}-${transactionHash}`;
+      expect(mockContext.TxCLPoolMintRegistry.set).toHaveBeenCalledWith({
+        id: registryId,
+        mintEventIds: expect.arrayContaining([
+          mockMintEvent1.id,
+          mockMintEvent3.id,
+        ]),
+      });
+      expect(
+        mockContext.TxCLPoolMintRegistry.deleteUnsafe,
+      ).not.toHaveBeenCalled();
+      const registryAfter =
+        await mockContext.TxCLPoolMintRegistry.get(registryId);
+      expect(registryAfter?.mintEventIds).toEqual(
+        expect.arrayContaining([mockMintEvent1.id, mockMintEvent3.id]),
+      );
+      expect(registryAfter?.mintEventIds).toHaveLength(2);
+      expect(registryAfter?.mintEventIds).not.toContain(mockMintEvent2.id);
     });
 
     it("should log error and return early if position not found", async () => {

--- a/test/EventHandlers/NFPM/NFPMIncreaseLiquidityLogic.test.ts
+++ b/test/EventHandlers/NFPM/NFPMIncreaseLiquidityLogic.test.ts
@@ -159,16 +159,6 @@ describe("NFPMIncreaseLiquidityLogic", () => {
       },
       CLPoolMintEvent: {
         ...currentDb.entities.CLPoolMintEvent,
-        getWhere: vi
-          .fn()
-          .mockImplementation(
-            (filter: { transactionHash?: { _eq?: string } }) =>
-              Promise.resolve(
-                mintEvents.filter(
-                  (e) => e.transactionHash === filter?.transactionHash?._eq,
-                ),
-              ),
-          ),
         deleteUnsafe: (id: string) => {
           const index = mintEvents.findIndex((e) => e.id === id);
           if (index >= 0) {
@@ -180,6 +170,22 @@ describe("NFPMIncreaseLiquidityLogic", () => {
         },
         // biome-ignore lint/suspicious/noExplicitAny: Mock for testing
       } as any,
+      TxCLPoolMintRegistry: {
+        // Mirror producer: one registry row per tx with all mint ids in that tx.
+        get: vi.fn().mockImplementation((id: string) => {
+          const byTx = new Map<string, string[]>();
+          for (const m of mintEvents) {
+            const key = `${m.chainId}-${m.transactionHash}`;
+            const list = byTx.get(key) ?? [];
+            list.push(m.id);
+            byTx.set(key, list);
+          }
+          const ids = byTx.get(id);
+          return Promise.resolve(ids ? { id, mintEventIds: ids } : undefined);
+        }),
+        set: vi.fn(),
+        deleteUnsafe: vi.fn(),
+      },
       log: {
         info: vi.fn(),
         warn: vi.fn(),

--- a/test/EventHandlers/NFPM/NFPMTransferLogic.test.ts
+++ b/test/EventHandlers/NFPM/NFPMTransferLogic.test.ts
@@ -1,6 +1,7 @@
 import type {
   CLPoolMintEvent,
   NonFungiblePosition,
+  TxCLPoolMintRegistry,
   handlerContext,
 } from "generated";
 import { MockDb, NFPM } from "../../../generated/src/TestHelpers.gen";
@@ -10,6 +11,7 @@ import {
   CLPoolMintEventId,
   NonFungiblePositionId,
   PoolId,
+  TxCLPoolMintRegistryId,
   toChecksumAddress,
 } from "../../../src/Constants";
 import {
@@ -181,6 +183,7 @@ describe("NFPMTransferLogic", () => {
   let mockDbRef: { current: ReturnType<typeof MockDb.createMockDb> };
   let storedPositions: NonFungiblePosition[] = [];
   let storedMintEvents: CLPoolMintEvent[] = [];
+  let storedRegistries: TxCLPoolMintRegistry[] = [];
   let liquidityPoolEntity: { gaugeAddress?: string } | undefined;
 
   /**
@@ -189,6 +192,7 @@ describe("NFPMTransferLogic", () => {
   function createMockContext(
     positions: NonFungiblePosition[] = [],
     mintEvents: CLPoolMintEvent[] = [],
+    registries: TxCLPoolMintRegistry[] = [],
   ): handlerContext {
     const db = MockDb.createMockDb();
     let currentDb = positions.reduce(
@@ -319,16 +323,6 @@ describe("NFPMTransferLogic", () => {
       },
       CLPoolMintEvent: {
         ...currentDb.entities.CLPoolMintEvent,
-        getWhere: vi
-          .fn()
-          .mockImplementation(
-            (filter: { transactionHash?: { _eq?: string } }) =>
-              Promise.resolve(
-                mintEvents.filter(
-                  (e) => e.transactionHash === filter?.transactionHash?._eq,
-                ),
-              ),
-          ),
         set: (entity: CLPoolMintEvent) => {
           trackMintEvent(entity);
           const updatedDb =
@@ -344,6 +338,24 @@ describe("NFPMTransferLogic", () => {
           const index = mintEvents.findIndex((e) => e.id === id);
           if (index >= 0) {
             mintEvents.splice(index, 1);
+          }
+        },
+      },
+      TxCLPoolMintRegistry: {
+        get: (id: string) =>
+          Promise.resolve(registries.find((r) => r.id === id)),
+        set: (entity: TxCLPoolMintRegistry) => {
+          const index = registries.findIndex((r) => r.id === entity.id);
+          if (index >= 0) {
+            registries[index] = entity;
+          } else {
+            registries.push(entity);
+          }
+        },
+        deleteUnsafe: (id: string) => {
+          const index = registries.findIndex((r) => r.id === id);
+          if (index >= 0) {
+            registries.splice(index, 1);
           }
         },
       },
@@ -385,8 +397,13 @@ describe("NFPMTransferLogic", () => {
   beforeEach(() => {
     storedPositions = [];
     storedMintEvents = [];
+    storedRegistries = [];
     liquidityPoolEntity = {};
-    mockContext = createMockContext(storedPositions, storedMintEvents);
+    mockContext = createMockContext(
+      storedPositions,
+      storedMintEvents,
+      storedRegistries,
+    );
     mockDb = MockDb.createMockDb();
     vi.mocked(loadPoolData).mockResolvedValue(null);
     vi.mocked(attributeLiquidityChangeToUserStatsPerPool).mockClear();
@@ -416,6 +433,26 @@ describe("NFPMTransferLogic", () => {
       storedMintEvents[index] = entity;
     } else {
       storedMintEvents.push(entity);
+    }
+    // Mirror CLPool.Mint handler behavior: upsert the per-tx registry so the
+    // NFPM.Transfer(mint) consumer can PK-lookup mint event ids.
+    const registryId = TxCLPoolMintRegistryId(
+      entity.chainId,
+      entity.transactionHash,
+    );
+    const existingIndex = storedRegistries.findIndex(
+      (r) => r.id === registryId,
+    );
+    if (existingIndex >= 0) {
+      const existing = storedRegistries[existingIndex];
+      if (!existing.mintEventIds.includes(entity.id)) {
+        storedRegistries[existingIndex] = {
+          id: existing.id,
+          mintEventIds: [...existing.mintEventIds, entity.id],
+        };
+      }
+    } else {
+      storedRegistries.push({ id: registryId, mintEventIds: [entity.id] });
     }
     mockDb = mockDb.entities.CLPoolMintEvent.set(entity);
     if (mockDbRef) {
@@ -586,24 +623,29 @@ describe("NFPMTransferLogic", () => {
       expect(position.mintLogIndex).toBe(41); // Should use unconsumed event
     });
 
-    it("should handle null/undefined mintEvents from getWhere query (covers ?? [] fallback)", async () => {
-      // Create a new mock context with getWhere that returns null to test ?? [] fallback on line 95
-      const nullMockContext = {
+    it("should warn and create no position when TxCLPoolMintRegistry is missing for the tx", async () => {
+      // Registry not populated (no CLPool.Mint ran for this tx) → warn, no position.
+      const emptyMockContext = {
         ...mockContext,
-        CLPoolMintEvent: {
-          ...mockContext.CLPoolMintEvent,
-          getWhere: vi.fn().mockResolvedValue(null),
+        TxCLPoolMintRegistry: {
+          ...(
+            mockContext as unknown as {
+              TxCLPoolMintRegistry: { get: unknown };
+            }
+          ).TxCLPoolMintRegistry,
+          get: vi.fn().mockResolvedValue(undefined),
         },
       } as unknown as handlerContext;
 
       const mockEvent = createMockTransferEvent(zeroAddress, ownerAddress);
 
-      await handleMintTransfer(mockEvent, nullMockContext, undefined);
+      await handleMintTransfer(mockEvent, emptyMockContext, undefined);
 
-      // Should log warning since no events found
-      expect(nullMockContext.log.warn).toHaveBeenCalledWith(
+      expect(emptyMockContext.log.warn).toHaveBeenCalledWith(
         expect.stringContaining("No CLPoolMintEvent found"),
       );
+      const stableId = getStableId();
+      expect(storedPositions.find((p) => p.id === stableId)).toBeUndefined();
     });
 
     it("should keep prev when current.logIndex <= prev.logIndex in reduce", async () => {
@@ -665,6 +707,82 @@ describe("NFPMTransferLogic", () => {
       if (!position) return;
       // Should use the first one (prev) when logIndexes are equal
       expect(position.mintLogIndex).toBe(41);
+    });
+
+    it("multi-mint tx: each NFPM.Transfer(mint) matches its closest preceding CLPool.Mint and the registry is pruned to empty", async () => {
+      // Two pools minted in the same tx, two interleaved NFPM.Transfer(mint) events.
+      //   logIndex 10: CLPool.Mint (pool A)
+      //   logIndex 20: NFPM.Transfer (mint, tokenId 1) → should match mint A (10)
+      //   logIndex 30: CLPool.Mint (pool B)
+      //   logIndex 40: NFPM.Transfer (mint, tokenId 2) → should match mint B (30)
+      const poolB = toChecksumAddress(
+        "0x00cd0AbB6c2964F7Dfb5169dD94A9F004C35F459",
+      );
+      const tokenIdA = 1001n;
+      const tokenIdB = 1002n;
+
+      const mintA: CLPoolMintEvent = {
+        ...mockCLPoolMintEvent,
+        id: CLPoolMintEventId(chainId, poolAddress, transactionHash, 10),
+        logIndex: 10,
+      };
+      const mintB: CLPoolMintEvent = {
+        ...mockCLPoolMintEvent,
+        id: CLPoolMintEventId(chainId, poolB, transactionHash, 30),
+        pool: poolB,
+        logIndex: 30,
+      };
+
+      setMintEvent(mintA);
+      setMintEvent(mintB);
+
+      // Registry populated with both ids under the single tx key.
+      const registryId = TxCLPoolMintRegistryId(chainId, transactionHash);
+      expect(
+        storedRegistries.find((r) => r.id === registryId)?.mintEventIds,
+      ).toEqual([mintA.id, mintB.id]);
+
+      // First transfer: should bind to mintA (logIndex 10, the only preceding mint at logIndex 20).
+      const transferA = createMockTransferEvent(zeroAddress, ownerAddress, {
+        tokenId: tokenIdA,
+        mockEventData: {
+          ...defaultMintTransferEventData,
+          logIndex: 20,
+        },
+      });
+      await handleMintTransfer(transferA, mockContext, undefined);
+
+      const positionA = storedPositions.find(
+        (p) => p.id === NonFungiblePositionId(chainId, nfpmAddress, tokenIdA),
+      );
+      expect(positionA).toBeDefined();
+      expect(positionA?.mintLogIndex).toBe(10);
+      expect(positionA?.pool).toBe(poolAddress);
+
+      // Registry should now hold only mintB's id.
+      expect(
+        storedRegistries.find((r) => r.id === registryId)?.mintEventIds,
+      ).toEqual([mintB.id]);
+
+      // Second transfer: should bind to mintB (logIndex 30, closest preceding at logIndex 40).
+      const transferB = createMockTransferEvent(zeroAddress, ownerAddress, {
+        tokenId: tokenIdB,
+        mockEventData: {
+          ...defaultMintTransferEventData,
+          logIndex: 40,
+        },
+      });
+      await handleMintTransfer(transferB, mockContext, undefined);
+
+      const positionB = storedPositions.find(
+        (p) => p.id === NonFungiblePositionId(chainId, nfpmAddress, tokenIdB),
+      );
+      expect(positionB).toBeDefined();
+      expect(positionB?.mintLogIndex).toBe(30);
+      expect(positionB?.pool).toBe(poolB);
+
+      // Registry row deleted after the final consumption.
+      expect(storedRegistries.find((r) => r.id === registryId)).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Summary

- Eliminates the `CLPoolMintEvent.getWhere({ transactionHash })` index scan in `NFPM.Transfer(mint)` and `NFPM.IncreaseLiquidity` (the orphan-cleanup path) by introducing a per-tx registry entity.
- **Producer**: `CLPool.Mint` upserts `TxCLPoolMintRegistry` keyed by `{chainId}-{txHash}` with each new `CLPoolMintEvent` id.
- **Consumer**: `handleMintTransfer` + `processNFPMIncreaseLiquidity` PK-lookup the registry then PK-`get` each event by id. Matching filter (chainId, `!consumedByTokenId`, `logIndex < event.logIndex`) and closest-preceding-logIndex selection are preserved.
- **Cleanup**: consumption removes the id from the registry; the row is deleted when it empties.
- Grep-verified: zero remaining `CLPoolMintEvent.getWhere` call sites.

Contributes to #591.

## Test plan

- [x] `pnpm envio codegen`, `tsc --noEmit`, `pnpm qa --write`, `pnpm test` all green (1063 tests pass)
- [x] Existing `test/EventHandlers/NFPM/NFPMTransferLogic.test.ts` + `test/EventHandlers/CLPool/CLPoolMint.test.ts` + `test/EventHandlers/NFPM/NFPMIncreaseLiquidityLogic.test.ts` + `test/EventHandlers/NFPM/NFPM.test.ts` all pass unchanged in behavior
- [x] New test: multi-mint tx (2 pools, interleaved NFPM.Transfer events) — each Transfer matches its correct mint, registry row pruned and ultimately deleted
- [x] New test: `TxCLPoolMintRegistry` missing for tx → warn, no position created
- [ ] **Post-merge Prometheus check**: `envio_storage_load_seconds{operation="CLPoolMintEvent.getWhere.transactionHash.eq"}` drops to ~0 (tracked via #630)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized transaction-level processing to improve the efficiency of NFT position creation and related operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->