### PR TITLE
feat(config): index Base V3 NFPM for newest CLFactory

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -304,6 +304,7 @@ chains:
         address:
           - 0x827922686190790b37229fd06084350E74485b72
           - 0xa990C6a764b73BF43cee5Bb40339c3322FB9D55F
+          - 0xe1f8cd9AC4e4A65F54f38a5CdAfCA44f6dD68b53 # V3 NFPM (paired with newest CLFactory 0xf8f2eB..061Ef)
       - name: FactoryRegistry
         address:
           - 0x5C3F18F06CC09CA1910767A34a20F771039E37C0


### PR DESCRIPTION
## Summary
- Appends the Slipstream V3 NonfungiblePositionManager `0xe1f8cd9AC4e4A65F54f38a5CdAfCA44f6dD68b53` to the Base (chain `8453`) NFPM tracking list in `config.yaml`.
- Positions created against the newest CL PoolFactory (`0xf8f2eB4940CFE7d13603DDDD87f123820Fc061Ef`, paired with CLGaugeFactoryV3) are now indexed — previously `Transfer`, `IncreaseLiquidity`, and `DecreaseLiquidity` events from this NFPM were silently dropped.
- No handler changes required: `src/EventHandlers/NFPM/NFPM.ts` already handles the full event set for any registered NFPM.

## Why
Per the [Slipstream README](https://github.com/aerodrome-finance/slipstream/blob/main/README.md), the Gauges V3 Base deployment introduces a new NFPM alongside the existing Initial (`0x827922...`) and Gauge Caps (`0xa990C6...`) NFPMs. Without this entry, V3 CL positions on Base are not captured by the aggregator — closing a gap between the already-tracked V3 CLFactory and its matching position manager.

## Test plan
- [x] `pnpm envio codegen` succeeds
- [x] `tsc --noEmit` clean
- [x] `biome check` clean
- [x] `pnpm test` — 1063 passed / 32 skipped (0 failed)
- [ ] Smoke verification during local indexing: confirm at least one `Transfer` / `IncreaseLiquidity` / `DecreaseLiquidity` event from `0xe1f8cd9A...` is picked up

Closes #634

🤖 Generated with [Claude Code](https://claude.com/claude-code)