### PR TITLE
fix(pool-launcher): drop reader-side .toLowerCase to match Envio checksum addresses (#633)

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -844,6 +844,7 @@ const SUPERSEED_CONSTANTS: chainConstants = {
 
 /**
  * Create a unique ID for a token on a specific chain. Should only be used for Token entities.
+ * Address must be EIP-55 checksum-cased (Envio's `event.params.*` already are).
  * @param chainId
  * @param address
  * @returns string Merged Token ID.
@@ -853,6 +854,8 @@ export const TokenId = (chainId: number, address: string) =>
 
 /**
  * Create a unique ID for a pool on a specific chain as used by LiquidityPoolAggregator.
+ * Pool address must be EIP-55 checksum-cased (Envio's `event.params.*` already are).
+ * Callers must NOT pre-lowercase — that triggers the silent miss documented in #633.
  * @param chainId
  * @param pool
  * @returns string Combined pool ID.
@@ -887,7 +890,7 @@ export const isKnownSinkRootPool = (
 
 /** Entity ID for ALM_LP_Wrapper. Format: {chainId}-{wrapperAddress}
  * @param chainId - Chain ID of the wrapper
- * @param wrapperAddress - Address of the wrapper
+ * @param wrapperAddress - Address of the wrapper (must be EIP-55 checksum-cased)
  * @returns string Combined wrapper ID.
  */
 export const ALMLPWrapperId = (chainId: number, wrapperAddress: string) =>

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -846,7 +846,7 @@ const SUPERSEED_CONSTANTS: chainConstants = {
  * Create a unique ID for a token on a specific chain. Should only be used for Token entities.
  * Address must be EIP-55 checksum-cased (Envio's `event.params.*` already are).
  * @param chainId
- * @param address
+ * @param address - Token address (must be EIP-55 checksum-cased; do not pre-lowercase)
  * @returns string Merged Token ID.
  */
 export const TokenId = (chainId: number, address: string) =>
@@ -857,7 +857,7 @@ export const TokenId = (chainId: number, address: string) =>
  * Pool address must be EIP-55 checksum-cased (Envio's `event.params.*` already are).
  * Callers must NOT pre-lowercase — that triggers the silent miss documented in #633.
  * @param chainId
- * @param pool
+ * @param pool - Pool address (must be EIP-55 checksum-cased; do not pre-lowercase)
  * @returns string Combined pool ID.
  */
 export const PoolId = (chainId: number, pool: string) => `${chainId}-${pool}`;
@@ -890,7 +890,7 @@ export const isKnownSinkRootPool = (
 
 /** Entity ID for ALM_LP_Wrapper. Format: {chainId}-{wrapperAddress}
  * @param chainId - Chain ID of the wrapper
- * @param wrapperAddress - Address of the wrapper (must be EIP-55 checksum-cased)
+ * @param wrapperAddress - Address of the wrapper (must be EIP-55 checksum-cased; do not pre-lowercase)
  * @returns string Combined wrapper ID.
  */
 export const ALMLPWrapperId = (chainId: number, wrapperAddress: string) =>
@@ -898,8 +898,8 @@ export const ALMLPWrapperId = (chainId: number, wrapperAddress: string) =>
 
 /** Entity ID for UserStatsPerPool. Format: {chainId}-{userAddress}-{poolAddress}
  * @param chainId - Chain ID of the pool
- * @param userAddress - Address of the user
- * @param poolAddress - Address of the pool
+ * @param userAddress - Address of the user (must be EIP-55 checksum-cased; do not pre-lowercase)
+ * @param poolAddress - Address of the pool (must be EIP-55 checksum-cased; do not pre-lowercase)
  * @returns string Combined user ID.
  */
 export const UserStatsPerPoolId = (
@@ -919,7 +919,7 @@ export const VeNFTId = (chainId: number, tokenId: bigint) =>
 /** Entity ID for VeNFTPoolVote. Format: {chainId}-{tokenId}-{poolAddress}
  * @param chainId - Chain ID of the veNFT
  * @param tokenId - ID of the veNFT
- * @param poolAddress - Address of the pool
+ * @param poolAddress - Address of the pool (must be EIP-55 checksum-cased; do not pre-lowercase)
  * @returns string Combined veNFT pool vote ID.
  */
 export const VeNFTPoolVoteId = (
@@ -931,8 +931,8 @@ export const VeNFTPoolVoteId = (
 /** Entity ID for RootPool_LeafPool. Format: {rootChainId}-{leafChainId}-{rootPoolAddress}-{leafPoolAddress}. rootChainId is typically 10 (Optimism).
  * @param rootChainId - Chain ID of the root pool
  * @param leafChainId - Chain ID of the leaf pool
- * @param rootPoolAddress - Address of the root pool
- * @param leafPoolAddress - Address of the leaf pool
+ * @param rootPoolAddress - Address of the root pool (must be EIP-55 checksum-cased; do not pre-lowercase)
+ * @param leafPoolAddress - Address of the leaf pool (must be EIP-55 checksum-cased; do not pre-lowercase)
  * @returns string Combined root pool leaf pool ID.
  */
 export const RootPoolLeafPoolId = (
@@ -944,7 +944,7 @@ export const RootPoolLeafPoolId = (
 
 /** Entity ID for PendingVote. Format: {chainId}-{rootPoolAddress}-{tokenId}-{txHash}-{logIndex}
  * @param chainId - Chain ID where the vote occurred
- * @param rootPoolAddress - Root pool address
+ * @param rootPoolAddress - Root pool address (must be EIP-55 checksum-cased; do not pre-lowercase)
  * @param tokenId - veNFT token ID
  * @param transactionHash - Transaction hash of the vote event (for uniqueness)
  * @param logIndex - Log index of the event (for uniqueness within same tx)
@@ -959,7 +959,7 @@ export const PendingVoteId = (
 
 /** Entity ID for PendingRootPoolMapping. Format: {rootChainId}-{rootPoolAddress}
  * @param rootChainId - Root chain ID
- * @param rootPoolAddress - Root pool address
+ * @param rootPoolAddress - Root pool address (must be EIP-55 checksum-cased; do not pre-lowercase)
  */
 export const PendingRootPoolMappingId = (
   rootChainId: number,
@@ -968,7 +968,7 @@ export const PendingRootPoolMappingId = (
 
 /** Entity ID for PendingDistribution. Format: {rootChainId}-{rootPoolAddress}-{blockNumber}-{logIndex}
  * @param rootChainId - Root chain ID
- * @param rootPoolAddress - Root pool address
+ * @param rootPoolAddress - Root pool address (must be EIP-55 checksum-cased; do not pre-lowercase)
  * @param blockNumber - Block number of the DistributeReward event
  * @param logIndex - Log index of the event (for uniqueness within block)
  */
@@ -981,7 +981,7 @@ export const PendingDistributionId = (
 
 /** Entity ID for RootGauge_RootPool. Format: {rootChainId}-{rootGaugeAddress}
  * @param rootChainId - Root chain ID (e.g. Optimism)
- * @param rootGaugeAddress - Root gauge address (RootGauge/RootCLGauge on root chain)
+ * @param rootGaugeAddress - Root gauge address (RootGauge/RootCLGauge on root chain) (must be EIP-55 checksum-cased; do not pre-lowercase)
  */
 export const RootGaugeRootPoolId = (
   rootChainId: number,
@@ -989,6 +989,10 @@ export const RootGaugeRootPoolId = (
 ) => `${rootChainId}-${rootGaugeAddress}`;
 
 /** rootPoolMatchingHash for cross-chain pool matching. Format: {leafChainId}_{token0}_{token1}_{tickSpacing}
+ * @param leafChainId - Chain ID of the leaf pool
+ * @param token0 - Token0 address (must be EIP-55 checksum-cased; do not pre-lowercase)
+ * @param token1 - Token1 address (must be EIP-55 checksum-cased; do not pre-lowercase)
+ * @param tickSpacing - Tick spacing value
  */
 export const rootPoolMatchingHash = (
   leafChainId: number,
@@ -1014,7 +1018,7 @@ export const FeeToTickSpacingMappingId = (
  * (e.g. Optimism) nfpmAddress is required to prevent silent overwrites. See #618 / #621.
  *
  * @param chainId - Chain ID of the position
- * @param nfpmAddress - Address of the NFPM contract that owns the position
+ * @param nfpmAddress - Address of the NFPM contract that owns the position (must be EIP-55 checksum-cased; do not pre-lowercase)
  * @param tokenId - Token ID of the NFT position
  * @returns string Combined non-fungible position ID.
  */
@@ -1027,7 +1031,7 @@ export const NonFungiblePositionId = (
 /**
  * Create a unique ID for a CLTickStaked entity.
  * @param chainId - Chain ID
- * @param poolAddress - Address of the CL pool
+ * @param poolAddress - Address of the CL pool (must be EIP-55 checksum-cased; do not pre-lowercase)
  * @param tickIndex - Tick index (aligned to tick spacing)
  * @returns string Combined tick staked ID.
  */
@@ -1041,7 +1045,7 @@ export const CLTickStakedId = (
  * Create a unique ID for a token on a specific chain at a specific block. Really should only be used
  * for TokenPrice Entities.
  * @param chainId
- * @param address
+ * @param address - Token address (must be EIP-55 checksum-cased; do not pre-lowercase)
  * @param blockNumber
  * @returns string Merged Token ID.
  */
@@ -1054,7 +1058,7 @@ export const TokenIdByBlock = (
 /** Entity ID for PoolTransferInTx.
  * @param chainId
  * @param txHash
- * @param poolAddress
+ * @param poolAddress - Address of the pool (must be EIP-55 checksum-cased; do not pre-lowercase)
  * @param logIndex
  */
 export const PoolTransferInTxId = (
@@ -1067,7 +1071,7 @@ export const PoolTransferInTxId = (
 /** Entity ID for ALMLPWrapperTransferInTx.
  * @param chainId
  * @param txHash
- * @param wrapperAddress
+ * @param wrapperAddress - Address of the wrapper (must be EIP-55 checksum-cased; do not pre-lowercase)
  * @param logIndex
  */
 export const ALMLPWrapperTransferInTxId = (
@@ -1079,7 +1083,7 @@ export const ALMLPWrapperTransferInTxId = (
 
 /** Entity ID for CLPoolMintEvent.
  * @param chainId
- * @param poolAddress
+ * @param poolAddress - Address of the CL pool (must be EIP-55 checksum-cased; do not pre-lowercase)
  * @param txHash
  * @param logIndex
  */
@@ -1105,6 +1109,11 @@ export const TxCLPoolMintRegistryId = (chainId: number, txHash: string) =>
 /** ID for CLPositionPendingPrincipal — tracks burned principal awaiting collection.
  * Keyed by contract-level position identity (pool + owner + tick range).
  * Mirrors Solidity's positions mapping key: keccak256(owner, tickLower, tickUpper) per pool.
+ * @param chainId - Chain ID of the position
+ * @param poolAddress - Address of the CL pool (must be EIP-55 checksum-cased; do not pre-lowercase)
+ * @param owner - Owner address (must be EIP-55 checksum-cased; do not pre-lowercase)
+ * @param tickLower - Lower tick of the position range
+ * @param tickUpper - Upper tick of the position range
  */
 export const CLPositionPendingPrincipalId = (
   chainId: number,
@@ -1116,7 +1125,7 @@ export const CLPositionPendingPrincipalId = (
 
 /** Snapshot ID for LiquidityPoolAggregatorSnapshot. epochMs = getSnapshotEpoch(timestamp).getTime()
  * @param chainId - Chain ID of the pool
- * @param poolAddress - Address of the pool
+ * @param poolAddress - Address of the pool (must be EIP-55 checksum-cased; do not pre-lowercase)
  * @param epochMs - Epoch timestamp in milliseconds
  * @returns string Combined pool ID.
  */
@@ -1160,8 +1169,8 @@ export const SuperSwapId = (messageId: string) => messageId;
 
 /** Snapshot ID for UserStatsPerPoolSnapshot. epochMs = getSnapshotEpoch(timestamp).getTime()
  * @param chainId - Chain ID of the pool
- * @param userAddress - Address of the user
- * @param poolAddress - Address of the pool
+ * @param userAddress - Address of the user (must be EIP-55 checksum-cased; do not pre-lowercase)
+ * @param poolAddress - Address of the pool (must be EIP-55 checksum-cased; do not pre-lowercase)
  * @param epochMs - Epoch timestamp in milliseconds
  * @returns string Combined user ID.
  */
@@ -1181,7 +1190,7 @@ export const UserStatsPerPoolSnapshotId = (
  * same epoch and overwrite each other. See #620.
  *
  * @param chainId - Chain ID of the non-fungible position
- * @param nfpmAddress - Address of the NFPM contract that owns the position
+ * @param nfpmAddress - Address of the NFPM contract that owns the position (must be EIP-55 checksum-cased; do not pre-lowercase)
  * @param tokenId - ID of the non-fungible position
  * @param epochMs - Epoch timestamp in milliseconds
  * @returns string Combined non-fungible position snapshot ID.
@@ -1195,7 +1204,7 @@ export const NonFungiblePositionSnapshotId = (
 
 /** Snapshot ID for ALM_LP_WrapperSnapshot. Format: {chainId}-{wrapperAddress}-{epochMs}. epochMs = getSnapshotEpoch(timestamp).getTime()
  * @param chainId - Chain ID of the wrapper
- * @param wrapperAddress - Address of the wrapper
+ * @param wrapperAddress - Address of the wrapper (must be EIP-55 checksum-cased; do not pre-lowercase)
  * @param epochMs - Epoch timestamp in milliseconds
  * @returns string Combined wrapper snapshot ID.
  */
@@ -1220,7 +1229,7 @@ export const VeNFTStateSnapshotId = (
 /** Snapshot ID for VeNFTPoolVoteSnapshot. Format: {chainId}-{tokenId}-{poolAddress}-{epochMs}
  * @param chainId - Chain ID of the veNFT state
  * @param tokenId - ID of the veNFT state
- * @param poolAddress - Address of the pool
+ * @param poolAddress - Address of the pool (must be EIP-55 checksum-cased; do not pre-lowercase)
  * @param epochMs - Epoch timestamp in milliseconds
  * @returns string Combined veNFT pool vote snapshot ID.
  */

--- a/src/EventHandlers/PoolLauncher/CLPoolLauncher.ts
+++ b/src/EventHandlers/PoolLauncher/CLPoolLauncher.ts
@@ -7,12 +7,12 @@ import {
 } from "./PoolLauncherLogic";
 
 CLPoolLauncher.Launch.handler(async ({ event, context }) => {
-  const poolAddress = event.params.pool.toLowerCase();
+  const poolAddress = event.params.pool;
   const launcherAddress = event.srcAddress;
-  const creator = event.params.sender.toLowerCase();
-  const poolLauncherToken = event.params.poolLauncherToken.toLowerCase();
+  const creator = event.params.sender;
+  const poolLauncherToken = event.params.poolLauncherToken;
   // poolLauncherPool is a tuple: [bigint, Address_t, Address_t, Address_t]
-  const pairToken = event.params.poolLauncherPool[1].toLowerCase();
+  const pairToken = event.params.poolLauncherPool[1];
   const createdAt = new Date(event.block.timestamp * 1000);
 
   // Create or update PoolLauncherPool entity
@@ -37,13 +37,13 @@ CLPoolLauncher.Launch.handler(async ({ event, context }) => {
 });
 
 CLPoolLauncher.Migrate.handler(async ({ event, context }) => {
-  const underlyingPool = event.params.underlyingPool.toLowerCase();
-  const oldLocker = event.params.locker.toLowerCase();
-  const newLocker = event.params.newLocker.toLowerCase();
+  const underlyingPool = event.params.underlyingPool;
+  const oldLocker = event.params.locker;
+  const newLocker = event.params.newLocker;
   // newPoolLauncherPool is a tuple: [bigint, Address_t, Address_t, Address_t]
-  const newPoolAddress = event.params.newPoolLauncherPool[3].toLowerCase();
-  const poolLauncherToken = event.params.newPoolLauncherPool[2].toLowerCase();
-  const pairToken = event.params.newPoolLauncherPool[1].toLowerCase();
+  const newPoolAddress = event.params.newPoolLauncherPool[3];
+  const poolLauncherToken = event.params.newPoolLauncherPool[2];
+  const pairToken = event.params.newPoolLauncherPool[1];
   const timestamp = new Date(event.block.timestamp * 1000);
 
   const poolId = PoolId(event.chainId, underlyingPool);
@@ -88,7 +88,7 @@ CLPoolLauncher.Migrate.handler(async ({ event, context }) => {
 });
 
 CLPoolLauncher.EmergingFlagged.handler(async ({ event, context }) => {
-  const poolAddress = event.params.pool.toLowerCase();
+  const poolAddress = event.params.pool;
   const timestamp = new Date(event.block.timestamp * 1000);
 
   const poolId = PoolId(event.chainId, poolAddress);
@@ -108,7 +108,7 @@ CLPoolLauncher.EmergingFlagged.handler(async ({ event, context }) => {
 });
 
 CLPoolLauncher.EmergingUnflagged.handler(async ({ event, context }) => {
-  const poolAddress = event.params.pool.toLowerCase();
+  const poolAddress = event.params.pool;
   const timestamp = new Date(event.block.timestamp * 1000);
 
   const poolId = PoolId(event.chainId, poolAddress);
@@ -130,7 +130,7 @@ CLPoolLauncher.EmergingUnflagged.handler(async ({ event, context }) => {
 });
 
 CLPoolLauncher.CreationTimestampSet.handler(async ({ event, context }) => {
-  const poolAddress = event.params.pool.toLowerCase();
+  const poolAddress = event.params.pool;
   const createdAt = new Date(Number(event.params.createdAt) * 1000);
 
   const poolId = PoolId(event.chainId, poolAddress);
@@ -151,7 +151,7 @@ CLPoolLauncher.CreationTimestampSet.handler(async ({ event, context }) => {
 });
 
 CLPoolLauncher.PairableTokenAdded.handler(async ({ event, context }) => {
-  const tokenAddress = event.params.token.toLowerCase();
+  const tokenAddress = event.params.token;
   const configId = PoolId(event.chainId, event.srcAddress);
 
   // Get or create PoolLauncherConfig
@@ -178,7 +178,7 @@ CLPoolLauncher.PairableTokenAdded.handler(async ({ event, context }) => {
 });
 
 CLPoolLauncher.PairableTokenRemoved.handler(async ({ event, context }) => {
-  const tokenAddress = event.params.token.toLowerCase();
+  const tokenAddress = event.params.token;
   const configId = PoolId(event.chainId, event.srcAddress);
 
   // Get existing PoolLauncherConfig
@@ -202,7 +202,7 @@ CLPoolLauncher.PairableTokenRemoved.handler(async ({ event, context }) => {
 });
 
 CLPoolLauncher.NewPoolLauncherSet.handler(async ({ event, context }) => {
-  const newPoolLauncher = event.params.newPoolLauncher.toLowerCase();
+  const newPoolLauncher = event.params.newPoolLauncher;
   const oldConfigId = PoolId(event.chainId, event.srcAddress);
   const newConfigId = PoolId(event.chainId, newPoolLauncher);
 

--- a/src/EventHandlers/PoolLauncher/PoolLauncherLogic.ts
+++ b/src/EventHandlers/PoolLauncher/PoolLauncherLogic.ts
@@ -25,11 +25,11 @@ export async function processPoolLauncherPool(
     poolLauncherPool = {
       id: poolId,
       chainId,
-      underlyingPool: poolAddress.toLowerCase(),
-      launcher: launcherAddress.toLowerCase(),
-      creator: creator.toLowerCase(),
-      poolLauncherToken: poolLauncherToken.toLowerCase(),
-      pairToken: pairToken.toLowerCase(),
+      underlyingPool: poolAddress,
+      launcher: launcherAddress,
+      creator,
+      poolLauncherToken,
+      pairToken,
       createdAt,
       isEmerging: false,
       lastFlagUpdateAt: createdAt,
@@ -43,7 +43,7 @@ export async function processPoolLauncherPool(
     // Update existing PoolLauncherPool
     poolLauncherPool = {
       ...poolLauncherPool,
-      launcher: launcherAddress.toLowerCase(),
+      launcher: launcherAddress,
       lastMigratedAt: createdAt,
     };
   }

--- a/src/EventHandlers/PoolLauncher/V2PoolLauncher.ts
+++ b/src/EventHandlers/PoolLauncher/V2PoolLauncher.ts
@@ -7,12 +7,12 @@ import {
 } from "./PoolLauncherLogic";
 
 V2PoolLauncher.Launch.handler(async ({ event, context }) => {
-  const poolAddress = event.params.pool.toLowerCase();
+  const poolAddress = event.params.pool;
   const launcherAddress = event.srcAddress;
-  const creator = event.params.sender.toLowerCase();
-  const poolLauncherToken = event.params.poolLauncherToken.toLowerCase();
+  const creator = event.params.sender;
+  const poolLauncherToken = event.params.poolLauncherToken;
   // poolLauncherPool is a tuple: [bigint, Address_t, Address_t, Address_t]
-  const pairToken = event.params.poolLauncherPool[1].toLowerCase();
+  const pairToken = event.params.poolLauncherPool[1];
   const createdAt = new Date(event.block.timestamp * 1000);
 
   // Create or update PoolLauncherPool entity
@@ -37,13 +37,13 @@ V2PoolLauncher.Launch.handler(async ({ event, context }) => {
 });
 
 V2PoolLauncher.Migrate.handler(async ({ event, context }) => {
-  const underlyingPool = event.params.underlyingPool.toLowerCase();
-  const oldLocker = event.params.locker.toLowerCase();
-  const newLocker = event.params.newLocker.toLowerCase();
+  const underlyingPool = event.params.underlyingPool;
+  const oldLocker = event.params.locker;
+  const newLocker = event.params.newLocker;
   // newPoolLauncherPool is a tuple: [bigint, Address_t, Address_t, Address_t]
-  const newPoolAddress = event.params.newPoolLauncherPool[3].toLowerCase();
-  const poolLauncherToken = event.params.newPoolLauncherPool[2].toLowerCase();
-  const pairToken = event.params.newPoolLauncherPool[1].toLowerCase();
+  const newPoolAddress = event.params.newPoolLauncherPool[3];
+  const poolLauncherToken = event.params.newPoolLauncherPool[2];
+  const pairToken = event.params.newPoolLauncherPool[1];
   const timestamp = new Date(event.block.timestamp * 1000);
 
   const poolId = PoolId(event.chainId, underlyingPool);
@@ -88,7 +88,7 @@ V2PoolLauncher.Migrate.handler(async ({ event, context }) => {
 });
 
 V2PoolLauncher.EmergingFlagged.handler(async ({ event, context }) => {
-  const poolAddress = event.params.pool.toLowerCase();
+  const poolAddress = event.params.pool;
   const timestamp = new Date(event.block.timestamp * 1000);
 
   const poolId = PoolId(event.chainId, poolAddress);
@@ -108,7 +108,7 @@ V2PoolLauncher.EmergingFlagged.handler(async ({ event, context }) => {
 });
 
 V2PoolLauncher.EmergingUnflagged.handler(async ({ event, context }) => {
-  const poolAddress = event.params.pool.toLowerCase();
+  const poolAddress = event.params.pool;
   const timestamp = new Date(event.block.timestamp * 1000);
 
   const poolId = PoolId(event.chainId, poolAddress);
@@ -130,7 +130,7 @@ V2PoolLauncher.EmergingUnflagged.handler(async ({ event, context }) => {
 });
 
 V2PoolLauncher.CreationTimestampSet.handler(async ({ event, context }) => {
-  const poolAddress = event.params.pool.toLowerCase();
+  const poolAddress = event.params.pool;
   const createdAt = new Date(Number(event.params.createdAt) * 1000);
 
   const poolId = PoolId(event.chainId, poolAddress);
@@ -151,7 +151,7 @@ V2PoolLauncher.CreationTimestampSet.handler(async ({ event, context }) => {
 });
 
 V2PoolLauncher.PairableTokenAdded.handler(async ({ event, context }) => {
-  const tokenAddress = event.params.token.toLowerCase();
+  const tokenAddress = event.params.token;
   const configId = PoolId(event.chainId, event.srcAddress);
 
   // Get or create PoolLauncherConfig
@@ -178,7 +178,7 @@ V2PoolLauncher.PairableTokenAdded.handler(async ({ event, context }) => {
 });
 
 V2PoolLauncher.PairableTokenRemoved.handler(async ({ event, context }) => {
-  const tokenAddress = event.params.token.toLowerCase();
+  const tokenAddress = event.params.token;
   const configId = PoolId(event.chainId, event.srcAddress);
 
   // Get existing PoolLauncherConfig
@@ -202,7 +202,7 @@ V2PoolLauncher.PairableTokenRemoved.handler(async ({ event, context }) => {
 });
 
 V2PoolLauncher.NewPoolLauncherSet.handler(async ({ event, context }) => {
-  const newPoolLauncher = event.params.newPoolLauncher.toLowerCase();
+  const newPoolLauncher = event.params.newPoolLauncher;
   const oldConfigId = PoolId(event.chainId, event.srcAddress);
   const newConfigId = PoolId(event.chainId, newPoolLauncher);
 

--- a/test/EventHandlers/PoolLauncher/PoolLauncherLogic.test.ts
+++ b/test/EventHandlers/PoolLauncher/PoolLauncherLogic.test.ts
@@ -74,21 +74,13 @@ describe("PoolLauncherLogic", () => {
 
       // Assert
       expect(result).toBeDefined();
-      expect(result.id).toBe("8453-0x1234567890123456789012345678901234567890");
+      expect(result.id).toBe(`8453-${poolAddress}`);
       expect(result.chainId).toBe(8453);
-      expect(result.underlyingPool).toBe(
-        "0x1234567890123456789012345678901234567890",
-      );
-      expect(result.launcher).toBe(
-        "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
-      );
-      expect(result.creator).toBe("0x1111111111111111111111111111111111111111");
-      expect(result.poolLauncherToken).toBe(
-        "0x2222222222222222222222222222222222222222",
-      );
-      expect(result.pairToken).toBe(
-        "0x3333333333333333333333333333333333333333",
-      );
+      expect(result.underlyingPool).toBe(poolAddress);
+      expect(result.launcher).toBe(launcherAddress);
+      expect(result.creator).toBe(creator);
+      expect(result.poolLauncherToken).toBe(poolLauncherToken);
+      expect(result.pairToken).toBe(pairToken);
       expect(result.createdAt).toEqual(createdAt);
       expect(result.isEmerging).toBe(false);
       expect(result.lastFlagUpdateAt).toEqual(createdAt);
@@ -100,12 +92,10 @@ describe("PoolLauncherLogic", () => {
 
       // Verify the entity was set in the context
       const savedEntity = mockDb.entities.PoolLauncherPool.get(
-        "8453-0x1234567890123456789012345678901234567890",
+        `8453-${poolAddress}`,
       );
       expect(savedEntity).toBeDefined();
-      expect(savedEntity?.id).toBe(
-        "8453-0x1234567890123456789012345678901234567890",
-      );
+      expect(savedEntity?.id).toBe(`8453-${poolAddress}`);
     });
 
     it("should update an existing PoolLauncherPool", async () => {
@@ -212,7 +202,9 @@ describe("PoolLauncherLogic", () => {
       expect(result.chainId).toBe(10);
     });
 
-    it("should normalize addresses to lowercase", async () => {
+    it("should preserve EIP-55 checksum-cased addresses verbatim (no internal lowercasing)", async () => {
+      // Envio's event.params.* always supplies EIP-55 addresses; storing them
+      // verbatim keeps writers and readers on the same canonical key. See #633.
       const poolAddress = toChecksumAddress(
         "0x1234567890123456789012345678901234567890",
       );
@@ -242,17 +234,14 @@ describe("PoolLauncherLogic", () => {
         mockContext,
       );
 
-      // Assert
-      expect(result.launcher).toBe(
-        "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
-      );
-      expect(result.creator).toBe("0x1111111111111111111111111111111111111111");
-      expect(result.poolLauncherToken).toBe(
-        "0x2222222222222222222222222222222222222222",
-      );
-      expect(result.pairToken).toBe(
-        "0x3333333333333333333333333333333333333333",
-      );
+      // Assert addresses are stored as-is (checksum-cased), not lowercased.
+      expect(result.launcher).toBe(launcherAddress);
+      expect(result.creator).toBe(creator);
+      expect(result.poolLauncherToken).toBe(poolLauncherToken);
+      expect(result.pairToken).toBe(pairToken);
+      // Sanity check: the checksum form differs from the all-lowercase form
+      // for at least one of these addresses (the all-A-F launcher).
+      expect(result.launcher).not.toBe(launcherAddress.toLowerCase());
     });
   });
 

--- a/test/EventHandlers/PoolLauncher/PoolLauncherLogic.test.ts
+++ b/test/EventHandlers/PoolLauncher/PoolLauncherLogic.test.ts
@@ -158,9 +158,7 @@ describe("PoolLauncherLogic", () => {
       // Assert
       expect(result).toBeDefined();
       expect(result.id).toBe("8453-0x1234567890123456789012345678901234567890");
-      expect(result.launcher?.toLowerCase()).toBe(
-        launcherAddress.toLowerCase(),
-      ); // Updated (impl may return lowercase)
+      expect(result.launcher).toBe(launcherAddress); // Updated, casing preserved verbatim
       expect(result.lastMigratedAt).toEqual(createdAt); // Updated
       expect(result.creator).toBe(creator); // Unchanged
       expect(result.isEmerging).toBe(true); // Unchanged
@@ -437,35 +435,6 @@ describe("PoolLauncherLogic", () => {
       );
       expect(updatedEntity).toBeDefined();
       expect(updatedEntity?.poolLauncherPoolId).toBe(PoolId(10, poolAddress));
-    });
-
-    it("should normalize pool address to lowercase", async () => {
-      const existingLiquidityPoolAggregator = createMockLiquidityPoolAggregator(
-        {
-          poolAddress: poolAddress,
-          chainId: chainId,
-        },
-      );
-
-      mockDb = mockDb.entities.LiquidityPoolAggregator.set(
-        existingLiquidityPoolAggregator,
-      );
-
-      await linkLiquidityPoolAggregatorToPoolLauncher(
-        poolAddress,
-        chainId,
-        mockContext,
-        "CL",
-      );
-
-      // Assert
-      const updatedEntity = mockDb.entities.LiquidityPoolAggregator.get(
-        PoolId(chainId, poolAddress),
-      );
-      expect(updatedEntity).toBeDefined();
-      expect(updatedEntity?.poolLauncherPoolId).toBe(
-        PoolId(chainId, poolAddress),
-      );
     });
   });
 });

--- a/test/EventHandlers/VeNFT/VeNFTLogic.test.ts
+++ b/test/EventHandlers/VeNFT/VeNFTLogic.test.ts
@@ -18,6 +18,7 @@ import * as VeNFTStateAggregator from "../../../src/Aggregators/VeNFTState";
 import {
   SECONDS_IN_A_WEEK,
   SECONDS_IN_FOUR_YEARS,
+  UserStatsPerPoolId,
   VeNFTId,
   VeNFTPoolVoteId,
   toChecksumAddress,
@@ -744,8 +745,16 @@ describe("VeNFTLogic", () => {
       const leafPoolAddress = toChecksumAddress(
         "0xb43F6D14FeFA510F014cf90c8Ab110803bB28778",
       );
-      const oldOwnerId = `${leafChainId}-${mockVeNFTState.owner}-${leafPoolAddress}`;
-      const newOwnerId = `${leafChainId}-${mockTransferEvent.params.to}-${leafPoolAddress}`;
+      const oldOwnerId = UserStatsPerPoolId(
+        leafChainId,
+        mockVeNFTState.owner,
+        leafPoolAddress,
+      );
+      const newOwnerId = UserStatsPerPoolId(
+        leafChainId,
+        mockTransferEvent.params.to,
+        leafPoolAddress,
+      );
       const poolVotes = [
         {
           id: VeNFTPoolVoteId(leafChainId, 1n, leafPoolAddress),

--- a/test/IdNormalization.test.ts
+++ b/test/IdNormalization.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from "vitest";
+import {
+  ALMLPWrapperId,
+  ALMLPWrapperSnapshotId,
+  ALMLPWrapperTransferInTxId,
+  CLPoolMintEventId,
+  CLPositionPendingPrincipalId,
+  CLTickStakedId,
+  LiquidityPoolAggregatorSnapshotId,
+  MailboxMessageId,
+  NonFungiblePositionId,
+  NonFungiblePositionSnapshotId,
+  OUSDTSwapsId,
+  PendingDistributionId,
+  PendingRootPoolMappingId,
+  PendingVoteId,
+  PoolId,
+  PoolTransferInTxId,
+  RootGaugeRootPoolId,
+  RootPoolLeafPoolId,
+  SuperSwapId,
+  TokenId,
+  TokenIdByBlock,
+  TxCLPoolMintRegistryId,
+  UserStatsPerPoolId,
+  UserStatsPerPoolSnapshotId,
+  VeNFTPoolVoteId,
+  VeNFTPoolVoteSnapshotId,
+  rootPoolMatchingHash,
+  toChecksumAddress,
+} from "../src/Constants";
+
+// Envio's `event.params.*` always supplies EIP-55 checksum-cased addresses.
+// These tests pin the contract: every *Id helper preserves the checksum
+// input verbatim — no internal lowercasing, no toChecksumAddress round-trip.
+// If a future refactor adds normalization inside a helper, a write at
+// checksum and a read at lowercase would silently key into different rows.
+
+const CHAIN_ID = 8453;
+const ROOT_CHAIN_ID = 10;
+const POOL = toChecksumAddress("0x4d5300C67F4b59B67281Bb2d205795c29ad07ba6");
+const POOL_2 = toChecksumAddress("0xCc0bDDB707055e04e497aB22a59c2aF4391cd12F");
+const TX_HASH =
+  "0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+const MSG_ID =
+  "0xdead0123456789abcdef0123456789abcdef0123456789abcdef0123456789be";
+const TOKEN_ID = 42n;
+const TICK_INDEX = 0n;
+const TICK_LOWER = -100n;
+const TICK_UPPER = 100n;
+const EPOCH_MS = 1700000000000;
+const BLOCK_NUMBER = 12345678;
+const LOG_INDEX = 7;
+const TICK_SPACING = 60n;
+const AMOUNT_IN = 1000n;
+const AMOUNT_OUT = 999n;
+
+describe("ID helpers preserve EIP-55 checksum input (issue #633)", () => {
+  it("PoolId preserves checksum-cased pool address", () => {
+    expect(PoolId(CHAIN_ID, POOL)).toBe(`${CHAIN_ID}-${POOL}`);
+  });
+
+  it("TokenId preserves checksum-cased token address", () => {
+    expect(TokenId(CHAIN_ID, POOL)).toBe(`${CHAIN_ID}-${POOL}`);
+  });
+
+  it("TokenIdByBlock preserves checksum-cased token address", () => {
+    expect(TokenIdByBlock(CHAIN_ID, POOL, BLOCK_NUMBER)).toBe(
+      `${CHAIN_ID}-${POOL}-${BLOCK_NUMBER}`,
+    );
+  });
+
+  it("ALMLPWrapperId preserves checksum-cased wrapper address", () => {
+    expect(ALMLPWrapperId(CHAIN_ID, POOL)).toBe(`${CHAIN_ID}-${POOL}`);
+  });
+
+  it("UserStatsPerPoolId preserves both checksum-cased addresses", () => {
+    expect(UserStatsPerPoolId(CHAIN_ID, POOL, POOL_2)).toBe(
+      `${CHAIN_ID}-${POOL}-${POOL_2}`,
+    );
+  });
+
+  it("VeNFTPoolVoteId preserves checksum-cased pool address", () => {
+    expect(VeNFTPoolVoteId(CHAIN_ID, TOKEN_ID, POOL)).toBe(
+      `${CHAIN_ID}-${TOKEN_ID}-${POOL}`,
+    );
+  });
+
+  it("RootPoolLeafPoolId preserves both checksum-cased pool addresses", () => {
+    expect(RootPoolLeafPoolId(ROOT_CHAIN_ID, CHAIN_ID, POOL, POOL_2)).toBe(
+      `${ROOT_CHAIN_ID}-${CHAIN_ID}-${POOL}-${POOL_2}`,
+    );
+  });
+
+  it("PendingVoteId preserves checksum-cased root pool address and tx hash", () => {
+    expect(PendingVoteId(CHAIN_ID, POOL, TOKEN_ID, TX_HASH, LOG_INDEX)).toBe(
+      `${CHAIN_ID}-${POOL}-${TOKEN_ID}-${TX_HASH}-${LOG_INDEX}`,
+    );
+  });
+
+  it("PendingRootPoolMappingId preserves checksum-cased root pool address", () => {
+    expect(PendingRootPoolMappingId(ROOT_CHAIN_ID, POOL)).toBe(
+      `${ROOT_CHAIN_ID}-${POOL}`,
+    );
+  });
+
+  it("PendingDistributionId preserves checksum-cased root pool address", () => {
+    expect(
+      PendingDistributionId(ROOT_CHAIN_ID, POOL, BLOCK_NUMBER, LOG_INDEX),
+    ).toBe(`${ROOT_CHAIN_ID}-${POOL}-${BLOCK_NUMBER}-${LOG_INDEX}`);
+  });
+
+  it("RootGaugeRootPoolId preserves checksum-cased root gauge address", () => {
+    expect(RootGaugeRootPoolId(ROOT_CHAIN_ID, POOL)).toBe(
+      `${ROOT_CHAIN_ID}-${POOL}`,
+    );
+  });
+
+  it("rootPoolMatchingHash preserves both checksum-cased token addresses", () => {
+    expect(rootPoolMatchingHash(CHAIN_ID, POOL, POOL_2, TICK_SPACING)).toBe(
+      `${CHAIN_ID}_${POOL}_${POOL_2}_${TICK_SPACING}`,
+    );
+  });
+
+  it("NonFungiblePositionId preserves checksum-cased nfpm address", () => {
+    expect(NonFungiblePositionId(CHAIN_ID, POOL, TOKEN_ID)).toBe(
+      `${CHAIN_ID}-${POOL}-${TOKEN_ID}`,
+    );
+  });
+
+  it("CLTickStakedId preserves checksum-cased pool address", () => {
+    expect(CLTickStakedId(CHAIN_ID, POOL, TICK_INDEX)).toBe(
+      `${CHAIN_ID}-${POOL}-${TICK_INDEX}`,
+    );
+  });
+
+  it("PoolTransferInTxId preserves checksum-cased tx hash and pool address", () => {
+    expect(PoolTransferInTxId(CHAIN_ID, TX_HASH, POOL, LOG_INDEX)).toBe(
+      `${CHAIN_ID}-${TX_HASH}-${POOL}-${LOG_INDEX}`,
+    );
+  });
+
+  it("ALMLPWrapperTransferInTxId preserves checksum-cased tx hash and wrapper address", () => {
+    expect(ALMLPWrapperTransferInTxId(CHAIN_ID, TX_HASH, POOL, LOG_INDEX)).toBe(
+      `${CHAIN_ID}-${TX_HASH}-${POOL}-${LOG_INDEX}`,
+    );
+  });
+
+  it("CLPoolMintEventId preserves checksum-cased pool address and tx hash", () => {
+    expect(CLPoolMintEventId(CHAIN_ID, POOL, TX_HASH, LOG_INDEX)).toBe(
+      `${CHAIN_ID}-${POOL}-${TX_HASH}-${LOG_INDEX}`,
+    );
+  });
+
+  it("TxCLPoolMintRegistryId preserves checksum-cased tx hash", () => {
+    expect(TxCLPoolMintRegistryId(CHAIN_ID, TX_HASH)).toBe(
+      `${CHAIN_ID}-${TX_HASH}`,
+    );
+  });
+
+  it("CLPositionPendingPrincipalId preserves checksum-cased pool and owner addresses", () => {
+    expect(
+      CLPositionPendingPrincipalId(
+        CHAIN_ID,
+        POOL,
+        POOL_2,
+        TICK_LOWER,
+        TICK_UPPER,
+      ),
+    ).toBe(`${CHAIN_ID}-${POOL}-${POOL_2}-${TICK_LOWER}-${TICK_UPPER}`);
+  });
+
+  it("LiquidityPoolAggregatorSnapshotId preserves checksum-cased pool address", () => {
+    expect(LiquidityPoolAggregatorSnapshotId(CHAIN_ID, POOL, EPOCH_MS)).toBe(
+      `${CHAIN_ID}-${POOL}-${EPOCH_MS}`,
+    );
+  });
+
+  it("MailboxMessageId preserves checksum-cased tx hash and message id", () => {
+    expect(MailboxMessageId(TX_HASH, CHAIN_ID, MSG_ID)).toBe(
+      `${TX_HASH}-${CHAIN_ID}-${MSG_ID}`,
+    );
+  });
+
+  it("OUSDTSwapsId preserves checksum-cased tx hash and both pool addresses", () => {
+    expect(
+      OUSDTSwapsId(TX_HASH, CHAIN_ID, POOL, AMOUNT_IN, POOL_2, AMOUNT_OUT),
+    ).toBe(
+      `${TX_HASH}-${CHAIN_ID}-${POOL}-${AMOUNT_IN}-${POOL_2}-${AMOUNT_OUT}`,
+    );
+  });
+
+  it("SuperSwapId preserves the message id verbatim", () => {
+    expect(SuperSwapId(MSG_ID)).toBe(MSG_ID);
+  });
+
+  it("UserStatsPerPoolSnapshotId preserves checksum-cased addresses", () => {
+    expect(UserStatsPerPoolSnapshotId(CHAIN_ID, POOL, POOL_2, EPOCH_MS)).toBe(
+      `${CHAIN_ID}-${POOL}-${POOL_2}-${EPOCH_MS}`,
+    );
+  });
+
+  it("NonFungiblePositionSnapshotId preserves checksum-cased nfpm address", () => {
+    expect(
+      NonFungiblePositionSnapshotId(CHAIN_ID, POOL, TOKEN_ID, EPOCH_MS),
+    ).toBe(`${CHAIN_ID}-${POOL}-${TOKEN_ID}-${EPOCH_MS}`);
+  });
+
+  it("ALMLPWrapperSnapshotId preserves checksum-cased wrapper address", () => {
+    expect(ALMLPWrapperSnapshotId(CHAIN_ID, POOL, EPOCH_MS)).toBe(
+      `${CHAIN_ID}-${POOL}-${EPOCH_MS}`,
+    );
+  });
+
+  it("VeNFTPoolVoteSnapshotId preserves checksum-cased pool address", () => {
+    expect(VeNFTPoolVoteSnapshotId(CHAIN_ID, TOKEN_ID, POOL, EPOCH_MS)).toBe(
+      `${CHAIN_ID}-${TOKEN_ID}-${POOL}-${EPOCH_MS}`,
+    );
+  });
+
+  it("CLFactory writer and CLPoolLauncher reader resolve to the same key when both consume event.params.pool unchanged (issue #633 regression)", () => {
+    // Both handlers receive the same EIP-55 checksum address from
+    // Envio's event.params.pool. Once the launcher stops calling
+    // .toLowerCase() before PoolId(), both paths land on the same key.
+    const writerId = PoolId(8453, POOL);
+    const readerId = PoolId(8453, POOL);
+    expect(writerId).toBe(readerId);
+    expect(writerId).toBe(`8453-${POOL}`);
+    // Sanity: a stale lowercased reader would have produced a different key.
+    expect(writerId).not.toBe(`8453-${POOL.toLowerCase()}`);
+  });
+});

--- a/test/IdNormalization.test.ts
+++ b/test/IdNormalization.test.ts
@@ -56,177 +56,192 @@ const AMOUNT_IN = 1000n;
 const AMOUNT_OUT = 999n;
 
 describe("ID helpers preserve EIP-55 checksum input (issue #633)", () => {
-  it("PoolId preserves checksum-cased pool address", () => {
-    expect(PoolId(CHAIN_ID, POOL)).toBe(`${CHAIN_ID}-${POOL}`);
-  });
+  // Each row exercises one *Id helper with checksum-cased inputs and asserts
+  // the output equals the template-literal composition of those same inputs.
+  // Adding a new helper to the contract = adding a new row here.
+  const cases: ReadonlyArray<{
+    name: string;
+    actual: () => string;
+    expected: string;
+  }> = [
+    {
+      name: "PoolId",
+      actual: () => PoolId(CHAIN_ID, POOL),
+      expected: `${CHAIN_ID}-${POOL}`,
+    },
+    {
+      name: "TokenId",
+      actual: () => TokenId(CHAIN_ID, POOL),
+      expected: `${CHAIN_ID}-${POOL}`,
+    },
+    {
+      name: "TokenIdByBlock",
+      actual: () => TokenIdByBlock(CHAIN_ID, POOL, BLOCK_NUMBER),
+      expected: `${CHAIN_ID}-${POOL}-${BLOCK_NUMBER}`,
+    },
+    {
+      name: "ALMLPWrapperId",
+      actual: () => ALMLPWrapperId(CHAIN_ID, POOL),
+      expected: `${CHAIN_ID}-${POOL}`,
+    },
+    {
+      name: "UserStatsPerPoolId",
+      actual: () => UserStatsPerPoolId(CHAIN_ID, POOL, POOL_2),
+      expected: `${CHAIN_ID}-${POOL}-${POOL_2}`,
+    },
+    {
+      name: "VeNFTPoolVoteId",
+      actual: () => VeNFTPoolVoteId(CHAIN_ID, TOKEN_ID, POOL),
+      expected: `${CHAIN_ID}-${TOKEN_ID}-${POOL}`,
+    },
+    {
+      name: "RootPoolLeafPoolId",
+      actual: () => RootPoolLeafPoolId(ROOT_CHAIN_ID, CHAIN_ID, POOL, POOL_2),
+      expected: `${ROOT_CHAIN_ID}-${CHAIN_ID}-${POOL}-${POOL_2}`,
+    },
+    {
+      name: "PendingVoteId",
+      actual: () => PendingVoteId(CHAIN_ID, POOL, TOKEN_ID, TX_HASH, LOG_INDEX),
+      expected: `${CHAIN_ID}-${POOL}-${TOKEN_ID}-${TX_HASH}-${LOG_INDEX}`,
+    },
+    {
+      name: "PendingRootPoolMappingId",
+      actual: () => PendingRootPoolMappingId(ROOT_CHAIN_ID, POOL),
+      expected: `${ROOT_CHAIN_ID}-${POOL}`,
+    },
+    {
+      name: "PendingDistributionId",
+      actual: () =>
+        PendingDistributionId(ROOT_CHAIN_ID, POOL, BLOCK_NUMBER, LOG_INDEX),
+      expected: `${ROOT_CHAIN_ID}-${POOL}-${BLOCK_NUMBER}-${LOG_INDEX}`,
+    },
+    {
+      name: "RootGaugeRootPoolId",
+      actual: () => RootGaugeRootPoolId(ROOT_CHAIN_ID, POOL),
+      expected: `${ROOT_CHAIN_ID}-${POOL}`,
+    },
+    {
+      name: "rootPoolMatchingHash",
+      actual: () => rootPoolMatchingHash(CHAIN_ID, POOL, POOL_2, TICK_SPACING),
+      expected: `${CHAIN_ID}_${POOL}_${POOL_2}_${TICK_SPACING}`,
+    },
+    {
+      name: "NonFungiblePositionId",
+      actual: () => NonFungiblePositionId(CHAIN_ID, POOL, TOKEN_ID),
+      expected: `${CHAIN_ID}-${POOL}-${TOKEN_ID}`,
+    },
+    {
+      name: "CLTickStakedId",
+      actual: () => CLTickStakedId(CHAIN_ID, POOL, TICK_INDEX),
+      expected: `${CHAIN_ID}-${POOL}-${TICK_INDEX}`,
+    },
+    {
+      name: "PoolTransferInTxId",
+      actual: () => PoolTransferInTxId(CHAIN_ID, TX_HASH, POOL, LOG_INDEX),
+      expected: `${CHAIN_ID}-${TX_HASH}-${POOL}-${LOG_INDEX}`,
+    },
+    {
+      name: "ALMLPWrapperTransferInTxId",
+      actual: () =>
+        ALMLPWrapperTransferInTxId(CHAIN_ID, TX_HASH, POOL, LOG_INDEX),
+      expected: `${CHAIN_ID}-${TX_HASH}-${POOL}-${LOG_INDEX}`,
+    },
+    {
+      name: "CLPoolMintEventId",
+      actual: () => CLPoolMintEventId(CHAIN_ID, POOL, TX_HASH, LOG_INDEX),
+      expected: `${CHAIN_ID}-${POOL}-${TX_HASH}-${LOG_INDEX}`,
+    },
+    {
+      name: "TxCLPoolMintRegistryId",
+      actual: () => TxCLPoolMintRegistryId(CHAIN_ID, TX_HASH),
+      expected: `${CHAIN_ID}-${TX_HASH}`,
+    },
+    {
+      name: "CLPositionPendingPrincipalId",
+      actual: () =>
+        CLPositionPendingPrincipalId(
+          CHAIN_ID,
+          POOL,
+          POOL_2,
+          TICK_LOWER,
+          TICK_UPPER,
+        ),
+      expected: `${CHAIN_ID}-${POOL}-${POOL_2}-${TICK_LOWER}-${TICK_UPPER}`,
+    },
+    {
+      name: "LiquidityPoolAggregatorSnapshotId",
+      actual: () => LiquidityPoolAggregatorSnapshotId(CHAIN_ID, POOL, EPOCH_MS),
+      expected: `${CHAIN_ID}-${POOL}-${EPOCH_MS}`,
+    },
+    {
+      name: "MailboxMessageId",
+      actual: () => MailboxMessageId(TX_HASH, CHAIN_ID, MSG_ID),
+      expected: `${TX_HASH}-${CHAIN_ID}-${MSG_ID}`,
+    },
+    {
+      name: "OUSDTSwapsId",
+      actual: () =>
+        OUSDTSwapsId(TX_HASH, CHAIN_ID, POOL, AMOUNT_IN, POOL_2, AMOUNT_OUT),
+      expected: `${TX_HASH}-${CHAIN_ID}-${POOL}-${AMOUNT_IN}-${POOL_2}-${AMOUNT_OUT}`,
+    },
+    {
+      name: "SuperSwapId",
+      actual: () => SuperSwapId(MSG_ID),
+      expected: MSG_ID,
+    },
+    {
+      name: "UserStatsPerPoolSnapshotId",
+      actual: () =>
+        UserStatsPerPoolSnapshotId(CHAIN_ID, POOL, POOL_2, EPOCH_MS),
+      expected: `${CHAIN_ID}-${POOL}-${POOL_2}-${EPOCH_MS}`,
+    },
+    {
+      name: "NonFungiblePositionSnapshotId",
+      actual: () =>
+        NonFungiblePositionSnapshotId(CHAIN_ID, POOL, TOKEN_ID, EPOCH_MS),
+      expected: `${CHAIN_ID}-${POOL}-${TOKEN_ID}-${EPOCH_MS}`,
+    },
+    {
+      name: "ALMLPWrapperSnapshotId",
+      actual: () => ALMLPWrapperSnapshotId(CHAIN_ID, POOL, EPOCH_MS),
+      expected: `${CHAIN_ID}-${POOL}-${EPOCH_MS}`,
+    },
+    {
+      name: "VeNFTPoolVoteSnapshotId",
+      actual: () => VeNFTPoolVoteSnapshotId(CHAIN_ID, TOKEN_ID, POOL, EPOCH_MS),
+      expected: `${CHAIN_ID}-${TOKEN_ID}-${POOL}-${EPOCH_MS}`,
+    },
+  ];
 
-  it("TokenId preserves checksum-cased token address", () => {
-    expect(TokenId(CHAIN_ID, POOL)).toBe(`${CHAIN_ID}-${POOL}`);
-  });
+  it.each(cases)(
+    "$name preserves checksum-cased input",
+    ({ actual, expected }) => {
+      expect(actual()).toBe(expected);
+    },
+  );
 
-  it("TokenIdByBlock preserves checksum-cased token address", () => {
-    expect(TokenIdByBlock(CHAIN_ID, POOL, BLOCK_NUMBER)).toBe(
-      `${CHAIN_ID}-${POOL}-${BLOCK_NUMBER}`,
-    );
-  });
+  it("regression #633: stale lowercased reader keys diverge from checksum writer keys; current reader matches writer", () => {
+    // Simulate the two call sites involved in issue #633:
+    //   - CLFactory writer: stores the pool keyed by event.params.pool (checksum-cased).
+    //   - CLPoolLauncher reader: looks up that pool to link a launcher record.
+    //
+    // The bug was that the launcher reader called `.toLowerCase()` on the address
+    // before invoking PoolId(), producing a different key than the writer and
+    // silently missing the pool. The fix removes the lowercasing on the reader path.
+    const writerId = PoolId(CHAIN_ID, POOL);
 
-  it("ALMLPWrapperId preserves checksum-cased wrapper address", () => {
-    expect(ALMLPWrapperId(CHAIN_ID, POOL)).toBe(`${CHAIN_ID}-${POOL}`);
-  });
+    // Pre-fix reader path: lowercased the address before keying. This MUST diverge
+    // from the writer key — otherwise this regression test cannot fail on the bug
+    // it claims to guard.
+    const staleReaderId = PoolId(CHAIN_ID, POOL.toLowerCase());
+    expect(writerId).not.toBe(staleReaderId);
 
-  it("UserStatsPerPoolId preserves both checksum-cased addresses", () => {
-    expect(UserStatsPerPoolId(CHAIN_ID, POOL, POOL_2)).toBe(
-      `${CHAIN_ID}-${POOL}-${POOL_2}`,
-    );
-  });
+    // Post-fix reader path: consumes event.params.pool unchanged, exactly like the
+    // writer. Both call sites must land on the same key.
+    const currentReaderId = PoolId(CHAIN_ID, POOL);
+    expect(writerId).toBe(currentReaderId);
 
-  it("VeNFTPoolVoteId preserves checksum-cased pool address", () => {
-    expect(VeNFTPoolVoteId(CHAIN_ID, TOKEN_ID, POOL)).toBe(
-      `${CHAIN_ID}-${TOKEN_ID}-${POOL}`,
-    );
-  });
-
-  it("RootPoolLeafPoolId preserves both checksum-cased pool addresses", () => {
-    expect(RootPoolLeafPoolId(ROOT_CHAIN_ID, CHAIN_ID, POOL, POOL_2)).toBe(
-      `${ROOT_CHAIN_ID}-${CHAIN_ID}-${POOL}-${POOL_2}`,
-    );
-  });
-
-  it("PendingVoteId preserves checksum-cased root pool address and tx hash", () => {
-    expect(PendingVoteId(CHAIN_ID, POOL, TOKEN_ID, TX_HASH, LOG_INDEX)).toBe(
-      `${CHAIN_ID}-${POOL}-${TOKEN_ID}-${TX_HASH}-${LOG_INDEX}`,
-    );
-  });
-
-  it("PendingRootPoolMappingId preserves checksum-cased root pool address", () => {
-    expect(PendingRootPoolMappingId(ROOT_CHAIN_ID, POOL)).toBe(
-      `${ROOT_CHAIN_ID}-${POOL}`,
-    );
-  });
-
-  it("PendingDistributionId preserves checksum-cased root pool address", () => {
-    expect(
-      PendingDistributionId(ROOT_CHAIN_ID, POOL, BLOCK_NUMBER, LOG_INDEX),
-    ).toBe(`${ROOT_CHAIN_ID}-${POOL}-${BLOCK_NUMBER}-${LOG_INDEX}`);
-  });
-
-  it("RootGaugeRootPoolId preserves checksum-cased root gauge address", () => {
-    expect(RootGaugeRootPoolId(ROOT_CHAIN_ID, POOL)).toBe(
-      `${ROOT_CHAIN_ID}-${POOL}`,
-    );
-  });
-
-  it("rootPoolMatchingHash preserves both checksum-cased token addresses", () => {
-    expect(rootPoolMatchingHash(CHAIN_ID, POOL, POOL_2, TICK_SPACING)).toBe(
-      `${CHAIN_ID}_${POOL}_${POOL_2}_${TICK_SPACING}`,
-    );
-  });
-
-  it("NonFungiblePositionId preserves checksum-cased nfpm address", () => {
-    expect(NonFungiblePositionId(CHAIN_ID, POOL, TOKEN_ID)).toBe(
-      `${CHAIN_ID}-${POOL}-${TOKEN_ID}`,
-    );
-  });
-
-  it("CLTickStakedId preserves checksum-cased pool address", () => {
-    expect(CLTickStakedId(CHAIN_ID, POOL, TICK_INDEX)).toBe(
-      `${CHAIN_ID}-${POOL}-${TICK_INDEX}`,
-    );
-  });
-
-  it("PoolTransferInTxId preserves checksum-cased tx hash and pool address", () => {
-    expect(PoolTransferInTxId(CHAIN_ID, TX_HASH, POOL, LOG_INDEX)).toBe(
-      `${CHAIN_ID}-${TX_HASH}-${POOL}-${LOG_INDEX}`,
-    );
-  });
-
-  it("ALMLPWrapperTransferInTxId preserves checksum-cased tx hash and wrapper address", () => {
-    expect(ALMLPWrapperTransferInTxId(CHAIN_ID, TX_HASH, POOL, LOG_INDEX)).toBe(
-      `${CHAIN_ID}-${TX_HASH}-${POOL}-${LOG_INDEX}`,
-    );
-  });
-
-  it("CLPoolMintEventId preserves checksum-cased pool address and tx hash", () => {
-    expect(CLPoolMintEventId(CHAIN_ID, POOL, TX_HASH, LOG_INDEX)).toBe(
-      `${CHAIN_ID}-${POOL}-${TX_HASH}-${LOG_INDEX}`,
-    );
-  });
-
-  it("TxCLPoolMintRegistryId preserves checksum-cased tx hash", () => {
-    expect(TxCLPoolMintRegistryId(CHAIN_ID, TX_HASH)).toBe(
-      `${CHAIN_ID}-${TX_HASH}`,
-    );
-  });
-
-  it("CLPositionPendingPrincipalId preserves checksum-cased pool and owner addresses", () => {
-    expect(
-      CLPositionPendingPrincipalId(
-        CHAIN_ID,
-        POOL,
-        POOL_2,
-        TICK_LOWER,
-        TICK_UPPER,
-      ),
-    ).toBe(`${CHAIN_ID}-${POOL}-${POOL_2}-${TICK_LOWER}-${TICK_UPPER}`);
-  });
-
-  it("LiquidityPoolAggregatorSnapshotId preserves checksum-cased pool address", () => {
-    expect(LiquidityPoolAggregatorSnapshotId(CHAIN_ID, POOL, EPOCH_MS)).toBe(
-      `${CHAIN_ID}-${POOL}-${EPOCH_MS}`,
-    );
-  });
-
-  it("MailboxMessageId preserves checksum-cased tx hash and message id", () => {
-    expect(MailboxMessageId(TX_HASH, CHAIN_ID, MSG_ID)).toBe(
-      `${TX_HASH}-${CHAIN_ID}-${MSG_ID}`,
-    );
-  });
-
-  it("OUSDTSwapsId preserves checksum-cased tx hash and both pool addresses", () => {
-    expect(
-      OUSDTSwapsId(TX_HASH, CHAIN_ID, POOL, AMOUNT_IN, POOL_2, AMOUNT_OUT),
-    ).toBe(
-      `${TX_HASH}-${CHAIN_ID}-${POOL}-${AMOUNT_IN}-${POOL_2}-${AMOUNT_OUT}`,
-    );
-  });
-
-  it("SuperSwapId preserves the message id verbatim", () => {
-    expect(SuperSwapId(MSG_ID)).toBe(MSG_ID);
-  });
-
-  it("UserStatsPerPoolSnapshotId preserves checksum-cased addresses", () => {
-    expect(UserStatsPerPoolSnapshotId(CHAIN_ID, POOL, POOL_2, EPOCH_MS)).toBe(
-      `${CHAIN_ID}-${POOL}-${POOL_2}-${EPOCH_MS}`,
-    );
-  });
-
-  it("NonFungiblePositionSnapshotId preserves checksum-cased nfpm address", () => {
-    expect(
-      NonFungiblePositionSnapshotId(CHAIN_ID, POOL, TOKEN_ID, EPOCH_MS),
-    ).toBe(`${CHAIN_ID}-${POOL}-${TOKEN_ID}-${EPOCH_MS}`);
-  });
-
-  it("ALMLPWrapperSnapshotId preserves checksum-cased wrapper address", () => {
-    expect(ALMLPWrapperSnapshotId(CHAIN_ID, POOL, EPOCH_MS)).toBe(
-      `${CHAIN_ID}-${POOL}-${EPOCH_MS}`,
-    );
-  });
-
-  it("VeNFTPoolVoteSnapshotId preserves checksum-cased pool address", () => {
-    expect(VeNFTPoolVoteSnapshotId(CHAIN_ID, TOKEN_ID, POOL, EPOCH_MS)).toBe(
-      `${CHAIN_ID}-${TOKEN_ID}-${POOL}-${EPOCH_MS}`,
-    );
-  });
-
-  it("CLFactory writer and CLPoolLauncher reader resolve to the same key when both consume event.params.pool unchanged (issue #633 regression)", () => {
-    // Both handlers receive the same EIP-55 checksum address from
-    // Envio's event.params.pool. Once the launcher stops calling
-    // .toLowerCase() before PoolId(), both paths land on the same key.
-    const writerId = PoolId(8453, POOL);
-    const readerId = PoolId(8453, POOL);
-    expect(writerId).toBe(readerId);
-    expect(writerId).toBe(`8453-${POOL}`);
-    // Sanity: a stale lowercased reader would have produced a different key.
-    expect(writerId).not.toBe(`8453-${POOL.toLowerCase()}`);
+    // Pin the exact key shape, anchoring future refactors of PoolId().
+    expect(writerId).toBe(`${CHAIN_ID}-${POOL}`);
   });
 });


### PR DESCRIPTION
## Summary

Closes #633.

Envio's `event.params.*` always supplies [EIP-55 checksum-cased addresses](https://docs.envio.dev/docs/HyperIndex/event-handlers#additional-event-information). The CLFactory writer stores `LiquidityPoolAggregator` under that checksum string. `CLPoolLauncher.Launch` (and its V2 equivalent) was calling `.toLowerCase()` before `PoolId()` and missing — emitting `LiquidityPoolAggregator not found ... it should have been created by CLFactory` even though the row existed under the checksum key.

The fix is one-directional: **delete the reader's `.toLowerCase()` pre-calls** so both sides use Envio's checksum form unchanged.

### Files changed

- **`src/EventHandlers/PoolLauncher/CLPoolLauncher.ts` & `V2PoolLauncher.ts`** — removed every `.toLowerCase()` on `event.params.*`. Pool addresses, locker addresses, pairable tokens, and tuple unpacks now flow through verbatim.
- **`src/EventHandlers/PoolLauncher/PoolLauncherLogic.ts`** — removed `.toLowerCase()` on `underlyingPool`, `launcher`, `creator`, `poolLauncherToken`, `pairToken` field assignments. `PoolLauncherPool` entity columns now store checksum-cased addresses, matching the project convention (*"Always checksum addresses for entity storage"*, CLAUDE.md).
- **`src/Constants.ts`** — left `*Id` helpers unchanged. They pass through whatever the caller supplies, which is now consistently checksum-cased on both writer and reader paths.

### Tests

- **`test/IdNormalization.test.ts`** *(new)* — pins the contract: every `*Id` helper preserves checksum input verbatim, `SuperSwapId` returns its `messageId` unchanged, and a regression test for the literal #633 production scenario.
- **`test/EventHandlers/PoolLauncher/PoolLauncherLogic.test.ts`** — flipped the `should normalize addresses to lowercase` test (which encoded the old buggy behavior) into `should preserve EIP-55 checksum-cased addresses verbatim`.

### Out of scope

The issue's *proposed* fix (lowercase inside every `*Id` helper) was not adopted — it would contradict the project convention and the on-chain canonical form. The reader-side delete achieves the same goal (writers and readers hit the same key) without flipping the canonical case across the codebase.

## Bug being fixed

Production warn on Base block 41230500:

```
uwarn: LiquidityPoolAggregator not found for pool 8453-0x4d5300c67f4b59b67281bb2d205795c29ad07ba6
       - it should have been created by CLFactory
```

The aggregator existed under `8453-0x4d5300C67F4b59B67281Bb2d205795c29ad07ba6` (checksum). The launcher lowercased before lookup and missed.

## Test plan

- [x] `pnpm qa --write` clean (238 files)
- [x] `pnpm test` — 1091 passed, 32 skipped, 0 failed
- [x] `tsc --noEmit` clean
- [x] New `test/IdNormalization.test.ts` covers all 27 `*Id` helpers + the literal #633 reproduction
- [ ] Post-deploy: `LiquidityPoolAggregator not found ... CLFactory` and `PoolLauncherPool not found` warns drop to zero on a re-sync window
- [ ] Post-deploy: `LiquidityPoolAggregator.poolLauncherPoolId` is populated for every launched pool

## Re-sync required

Existing production rows for `PoolLauncherPool` (and its address-typed columns: `launcher`, `creator`, `underlyingPool`, `poolLauncherToken`, `pairToken`, `oldLocker`, `newLocker`, `migratedTo`, `pairableTokens`) are currently stored lowercase. After this change, new rows are written checksum-cased — old rows won't auto-migrate. **A full re-sync is required** to make the columns consistent and to populate `LiquidityPoolAggregator.poolLauncherPoolId` for previously-missed launches.

This re-sync can piggy-back on the one already required by the NFPM-ID scoping work on `perf/cl-mint-registry` (#618 / #621) if shipping in the same release window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pool launcher event/address handling now preserves EIP-55 checksum casing (no implicit lowercasing), preventing lookup and identity mismatches.

* **Documentation**
  * ID helper docs updated to require EIP-55 checksum-cased addresses for correct entity keys.

* **Tests**
  * Added and updated tests to assert checksum-cased addresses are preserved and to catch regressions from lowercasing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->