### PR TITLE
config(base): reconcile DynamicSwapFeeModule addresses with Slipstream README (#635)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -292,8 +292,11 @@ chains:
     contracts:
       - name: DynamicSwapFeeModule
         address:
-          - 0xDB45818A6db280ecfeB33cbeBd445423d0216b5D
-          - 0x00cB12a1c84dfC1b9c70734C0385E769Bc86e9Ef
+          - 0xDB45818A6db280ecfeB33cbeBd445423d0216b5D # previously tracked
+          - 0x00cB12a1c84dfC1b9c70734C0385E769Bc86e9Ef # previously tracked
+          - 0x090b2A6bb475c00e2256e2095A60887cD710803b # Slipstream README — Initial Deployment
+          - 0xF4Ecd78EBEB6d36CF7f80B5B6B41453515fe2785 # Slipstream README — Gauge Caps Deployment
+          - 0x87D8f999BBa9343E8099552426775B51C338E8CB # Slipstream README — Gauges V3 Deployment (current)
       - name: CustomSwapFeeModule
         address:
           - 0xF4171B0953b52Fa55462E4d76ecA1845Db69af00


### PR DESCRIPTION
## Summary

Resolves #635 by reconciling the Base `DynamicSwapFeeModule` entry in `config.yaml` against the on-chain reality and the [Slipstream README](https://github.com/aerodrome-finance/slipstream/blob/main/README.md).

**Before** (2 addresses, neither in the README):
- `0xDB45818A6db280ecfeB33cbeBd445423d0216b5D`
- `0x00cB12a1c84dfC1b9c70734C0385E769Bc86e9Ef`

**After** (5 addresses, all 3 eras covered):
- `0xDB458…` — pre-release build, CLFactory-initial era _(kept)_
- `0x00cB1…` — pre-release build, CLFactory-gauge-caps era _(kept)_
- `0x090b2A6…` — Slipstream README Initial Deployment _(added)_
- `0xF4Ecd7…` — Slipstream README Gauge Caps Deployment _(added)_
- `0x87D8f9…` — Slipstream README **Gauges V3 Deployment — currently active** _(added)_

## Investigation

Each candidate was probed on-chain via a `viem` public client against `base.drpc.org`: bytecode check, then `factory()` / `secondsAgo()` / `defaultFeeCap()` / `defaultScalingFactor()` reads, plus paged `getLogs` for `CustomFeeSet` / `SecondsAgoSet` / `ScalingFactorSet` / `FeeCapSet` near the deploy block.

| Addr | Bytecode | `factory()` | Era | Source |
|---|---|---|---|---|
| `0xDB458…` | 7743 B | `0x5e7BB…` | initial | config.yaml |
| `0x00cB1…` | 7743 B | `0xaDe65c…` | gauge-caps | config.yaml |
| `0x090b2A6…` | 9270 B | `0x5e7BB…` | initial | README |
| `0xF4Ecd7…` | 9270 B | `0xaDe65c…` | gauge-caps | README |
| `0x87D8f9…` | 9270 B | `0xf8f2eB…` | **gauges-v3 (current)** | README |

Key observations that drove the decision:

1. The two previously-tracked addresses are a **different bytecode** (7743 B vs 9270 B) than the README-documented modules but point to the same CLFactory eras — they're earlier pre-release deployments, not typos or wrong addresses.
2. `0xDB458…` emitted **156 `CustomFeeSet`** at its deploy block (bulk constructor init) plus a `ScalingFactorSet` + `FeeCapSet` the next day, so it is not dormant — removing it would lose historical fee state for CLFactory-initial pools.
3. The current production-era module (`0x87D8f9…`, CLFactory-gauges-v3) was **not being indexed at all**, meaning active fee changes on current pools were silently dropped.

## Rationale

- **Kept** the two original pre-release modules for historical continuity — they emitted events that affected pool fees, and dropping them would break backfills.
- **Added** all three README modules (one per deployment era) so the indexer is aligned with the official address list and, crucially, picks up events from the current production module.

## Test plan

- [x] \`pnpm envio codegen\` — clean
- [x] \`pnpm exec tsc --noEmit\` — clean
- [x] \`pnpm qa --write\` — no fixes needed
- [x] \`pnpm test\` — 91 files, 1063 passed / 32 skipped / 0 failed

Acceptance criteria from #635:
- [x] Documented rationale for which addresses are tracked vs omitted (inline comments in \`config.yaml\` + this PR body)
- [x] \`config.yaml\` reflects the agreed set of DynamicSwapFeeModule addresses for Base
- [x] \`pnpm envio codegen\` + \`tsc --noEmit\` + \`pnpm test\` + \`pnpm qa --write\` all pass
- [ ] Smoke verification: at least one fee event is indexed from the newly added addresses — **left to post-deploy validation** (see below)

## Post-Deploy Monitoring & Validation

- **What to watch:** indexed \`baseFee\` / \`scalingFactor\` / \`feeCap\` updates on \`LiquidityPoolAggregator\` rows for chainId=8453 pools. Also \`DynamicFeeGlobalConfig\` rows keyed by each new module address.
- **Expected healthy signals:**
  - New \`DynamicFeeGlobalConfig\` rows appear for \`0x090b2A6…\`, \`0xF4Ecd7…\`, \`0x87D8f9…\` once \`SecondsAgoSet\` is (re)played for each.
  - At least one \`LiquidityPoolAggregator\` row on Base has \`baseFee\`/\`scalingFactor\`/\`feeCap\` updated by the gauges-v3 module (\`0x87D8f9…\`) — this is the smoke check for issue #635's final acceptance item.
- **Failure signals:** handler warn logs \`Pool {poolId} not found for CustomFeeSet event\` spiking on the newly added modules — would imply a pool-registration mismatch; rollback by reverting this commit.
- **Validation window / owner:** first ~24h after deploy; handler logs + a spot GraphQL query on the three new DynamicFeeGlobalConfig IDs. Owner: indexer on-call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)