### PR TITLE
Index UnstakedFeeModule events on Base + Optimism (#636)

### DIFF
--- a/abis/CustomUnstakedFeeModule.json
+++ b/abis/CustomUnstakedFeeModule.json
@@ -1,0 +1,127 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_factory",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint24",
+        "name": "fee",
+        "type": "uint24"
+      }
+    ],
+    "name": "SetCustomFee",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_FEE",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "ZERO_FEE_INDICATOR",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "customFee",
+    "outputs": [
+      {
+        "internalType": "uint24",
+        "name": "",
+        "type": "uint24"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "factory",
+    "outputs": [
+      {
+        "internalType": "contract ICLFactory",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "getFee",
+    "outputs": [
+      {
+        "internalType": "uint24",
+        "name": "",
+        "type": "uint24"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "uint24",
+        "name": "fee",
+        "type": "uint24"
+      }
+    ],
+    "name": "setCustomFee",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/abis/UnstakedFeeModule.json
+++ b/abis/UnstakedFeeModule.json
@@ -1,0 +1,127 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_factory",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint24",
+        "name": "fee",
+        "type": "uint24"
+      }
+    ],
+    "name": "CustomFeeSet",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_FEE",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "ZERO_FEE_INDICATOR",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "customFee",
+    "outputs": [
+      {
+        "internalType": "uint24",
+        "name": "",
+        "type": "uint24"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "factory",
+    "outputs": [
+      {
+        "internalType": "contract ICLFactory",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_pool",
+        "type": "address"
+      }
+    ],
+    "name": "getFee",
+    "outputs": [
+      {
+        "internalType": "uint24",
+        "name": "",
+        "type": "uint24"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_pool",
+        "type": "address"
+      },
+      {
+        "internalType": "uint24",
+        "name": "_fee",
+        "type": "uint24"
+      }
+    ],
+    "name": "setCustomFee",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/config.yaml
+++ b/config.yaml
@@ -177,6 +177,16 @@ contracts:
     handler: src/EventHandlers/SwapFeeModule/CustomSwapFeeModule.ts
     events:
       - event: SetCustomFee
+  - name: UnstakedFeeModule
+    abi_file_path: abis/UnstakedFeeModule.json
+    handler: src/EventHandlers/SwapFeeModule/UnstakedFeeModule.ts
+    events:
+      - event: CustomFeeSet
+  - name: CustomUnstakedFeeModule
+    abi_file_path: abis/CustomUnstakedFeeModule.json
+    handler: src/EventHandlers/SwapFeeModule/CustomUnstakedFeeModule.ts
+    events:
+      - event: SetCustomFee
   - name: CLPoolLauncher
     handler: src/EventHandlers/PoolLauncher/CLPoolLauncher.ts
     abi_file_path: abis/CLPoolLauncher.json
@@ -223,6 +233,9 @@ chains:
       - name: CustomSwapFeeModule
         address:
           - 0x7361E9079920fb75496E9764A2665d8ee5049D5f
+      - name: CustomUnstakedFeeModule
+        address:
+          - 0xC565F7ba9c56b157Da983c4Db30e13F5f06C59D9 # Slipstream README (velodrome-finance fork)
       - name: VeNFT
         address:
           - 0xFAf8FD17D9840595845582fCB047DF13f006787d
@@ -300,6 +313,13 @@ chains:
       - name: CustomSwapFeeModule
         address:
           - 0xF4171B0953b52Fa55462E4d76ecA1845Db69af00
+      - name: CustomUnstakedFeeModule
+        address:
+          - 0x0AD08370c76Ff426F534bb2AFFD9b5555338ee68 # Slipstream README — Initial Deployment
+      - name: UnstakedFeeModule
+        address:
+          - 0xCCC21f4750E8B3E9C095BCB5d2fF59247A2CCD35 # Slipstream README — Gauge Caps Deployment
+          - 0xc2cc3256434AfbC36Bb5e815e1Bb2151310a1a0b # Slipstream README — Gauges V3 Deployment (current)
       - name: VeNFT
         address:
           - 0xeBf418Fe2512e7E6bd9b87a8F0f294aCDC67e6B4

--- a/schema.graphql
+++ b/schema.graphql
@@ -83,6 +83,12 @@ type LiquidityPoolAggregator {
   scalingFactor: BigInt @config(precision: 76) # Current scaling factor for pool
   currentFee: BigInt! @config(precision: 76) # Current fee for pool (base + dynamic)
 
+  # Unstaked Fee fields
+  # Raw customFee value last emitted by an UnstakedFeeModule for this pool (CL pools only).
+  # 0 = no override (factory default applies), 420 = explicit 0% fee (ZERO_FEE_INDICATOR),
+  # else fee rate with 6-decimal precision (e.g. 500_000 = 50%). Null = never set.
+  unstakedFee: BigInt @config(precision: 24)
+
   # Pool Launcher relationship
   poolLauncherPoolId: String # ID of the PoolLauncherPool entity if this pool was launched via Pool Launcher
 
@@ -181,6 +187,9 @@ type LiquidityPoolAggregatorSnapshot {
   feeCap: BigInt @config(precision: 76) # Current fee cap for pool
   scalingFactor: BigInt @config(precision: 76) # Current scaling factor for pool
   currentFee: BigInt! @config(precision: 76) # Current fee for pool (base + dynamic)
+
+  # Unstaked Fee fields
+  unstakedFee: BigInt @config(precision: 24) # Raw customFee value last emitted by an UnstakedFeeModule for this pool (see LiquidityPoolAggregator for semantics)
 }
 
 # Entity for tracking user activity and positions in specific pools

--- a/src/Aggregators/LiquidityPoolAggregator.ts
+++ b/src/Aggregators/LiquidityPoolAggregator.ts
@@ -89,6 +89,7 @@ export interface LiquidityPoolAggregatorDiff {
   feeCap: bigint;
   scalingFactor: bigint;
   currentFee: bigint;
+  unstakedFee: bigint;
   lastUpdatedTimestamp: Date;
   lastSnapshotTimestamp: Date;
 }
@@ -347,6 +348,9 @@ export async function updateLiquidityPoolAggregator(
     currentFee: diff.currentFee ?? current.currentFee,
     feeCap: diff.feeCap ?? current.feeCap,
     scalingFactor: diff.scalingFactor ?? current.scalingFactor,
+
+    // Unstaked Fee fields - non-cumulative, last-writer-wins across UnstakedFeeModule instances
+    unstakedFee: diff.unstakedFee ?? current.unstakedFee,
 
     lastUpdatedTimestamp: timestamp,
   };
@@ -767,6 +771,8 @@ export function createLiquidityPoolAggregatorEntity(params: {
     feeCap: undefined,
     scalingFactor: undefined,
     currentFee: currentFee,
+    // Unstaked Fee fields - populated by UnstakedFeeModule / CustomUnstakedFeeModule events.
+    unstakedFee: undefined,
     rootPoolMatchingHash: `${chainId}_${token0Address}_${token1Address}_${(tickSpacing ? BigInt(tickSpacing) : 0n).toString()}`,
   };
 }

--- a/src/Aggregators/LiquidityPoolAggregator.ts
+++ b/src/Aggregators/LiquidityPoolAggregator.ts
@@ -89,7 +89,10 @@ export interface LiquidityPoolAggregatorDiff {
   feeCap: bigint;
   scalingFactor: bigint;
   currentFee: bigint;
-  unstakedFee: bigint;
+  // Nullable to allow an explicit "unset" sentinel (entity field is also nullable).
+  // No clear path exists today — the module never emits a reset — but widening keeps
+  // diff nullability aligned with the entity if one is ever added.
+  unstakedFee: bigint | undefined;
   lastUpdatedTimestamp: Date;
   lastSnapshotTimestamp: Date;
 }

--- a/src/EventHandlers/SwapFeeModule/CustomUnstakedFeeModule.ts
+++ b/src/EventHandlers/SwapFeeModule/CustomUnstakedFeeModule.ts
@@ -1,0 +1,16 @@
+import { CustomUnstakedFeeModule } from "generated";
+import { applyUnstakedFee } from "./UnstakedFeeModuleSharedLogic";
+
+CustomUnstakedFeeModule.SetCustomFee.handler(async ({ event, context }) => {
+  await applyUnstakedFee(
+    {
+      poolAddress: event.params.pool,
+      fee: BigInt(event.params.fee),
+      chainId: event.chainId,
+      blockNumber: event.block.number,
+      blockTimestamp: event.block.timestamp,
+      logContext: "CustomUnstakedFeeModule.SetCustomFee",
+    },
+    context,
+  );
+});

--- a/src/EventHandlers/SwapFeeModule/UnstakedFeeModule.ts
+++ b/src/EventHandlers/SwapFeeModule/UnstakedFeeModule.ts
@@ -1,0 +1,16 @@
+import { UnstakedFeeModule } from "generated";
+import { applyUnstakedFee } from "./UnstakedFeeModuleSharedLogic";
+
+UnstakedFeeModule.CustomFeeSet.handler(async ({ event, context }) => {
+  await applyUnstakedFee(
+    {
+      poolAddress: event.params.pool,
+      fee: BigInt(event.params.fee),
+      chainId: event.chainId,
+      blockNumber: event.block.number,
+      blockTimestamp: event.block.timestamp,
+      logContext: "UnstakedFeeModule.CustomFeeSet",
+    },
+    context,
+  );
+});

--- a/src/EventHandlers/SwapFeeModule/UnstakedFeeModuleSharedLogic.ts
+++ b/src/EventHandlers/SwapFeeModule/UnstakedFeeModuleSharedLogic.ts
@@ -1,0 +1,54 @@
+import type { LiquidityPoolAggregator, handlerContext } from "generated";
+import { updateLiquidityPoolAggregator } from "../../Aggregators/LiquidityPoolAggregator";
+import { PoolId } from "../../Constants";
+
+export interface UnstakedFeeEventData {
+  poolAddress: string;
+  fee: bigint;
+  chainId: number;
+  blockNumber: number;
+  blockTimestamp: number;
+  logContext: string;
+}
+
+/**
+ * Applies a raw customFee value emitted by an UnstakedFeeModule (or CustomUnstakedFeeModule)
+ * to the target pool aggregator. Last-writer-wins across all unstaked-fee module deployments
+ * (Initial, Gauge Caps, Gauges V3) registered for the same chain.
+ *
+ * The value stored is the raw event parameter. Contract semantics of the underlying
+ * customFee[pool] mapping:
+ *   - 0   = no override, factory default applies
+ *   - 420 = ZERO_FEE_INDICATOR (explicit 0% fee)
+ *   - X in (0, 500_000] = X/1_000_000 fee rate
+ *
+ * @param data - Pool address, raw fee value, and event coordinates for the upsert.
+ * @param context - Envio handler context used to read/write the pool aggregator.
+ * @returns Promise that resolves once the pool diff has been staged; no-op if the pool
+ *   aggregator does not yet exist (warning logged).
+ */
+export async function applyUnstakedFee(
+  data: UnstakedFeeEventData,
+  context: handlerContext,
+): Promise<void> {
+  const poolId = PoolId(data.chainId, data.poolAddress);
+  const pool = await context.LiquidityPoolAggregator.get(poolId);
+
+  if (!pool) {
+    context.log.warn(`Pool ${poolId} not found for ${data.logContext} event`);
+    return;
+  }
+
+  const diff: Partial<LiquidityPoolAggregator> = {
+    unstakedFee: data.fee,
+  };
+
+  await updateLiquidityPoolAggregator(
+    diff,
+    pool,
+    new Date(data.blockTimestamp * 1000),
+    context,
+    data.chainId,
+    data.blockNumber,
+  );
+}

--- a/src/EventHandlers/SwapFeeModule/UnstakedFeeModuleSharedLogic.ts
+++ b/src/EventHandlers/SwapFeeModule/UnstakedFeeModuleSharedLogic.ts
@@ -1,5 +1,8 @@
-import type { LiquidityPoolAggregator, handlerContext } from "generated";
-import { updateLiquidityPoolAggregator } from "../../Aggregators/LiquidityPoolAggregator";
+import type { handlerContext } from "generated";
+import {
+  type LiquidityPoolAggregatorDiff,
+  updateLiquidityPoolAggregator,
+} from "../../Aggregators/LiquidityPoolAggregator";
 import { PoolId } from "../../Constants";
 
 export interface UnstakedFeeEventData {
@@ -39,7 +42,7 @@ export async function applyUnstakedFee(
     return;
   }
 
-  const diff: Partial<LiquidityPoolAggregator> = {
+  const diff: Partial<LiquidityPoolAggregatorDiff> = {
     unstakedFee: data.fee,
   };
 

--- a/src/Snapshots/LiquidityPoolAggregatorSnapshot.ts
+++ b/src/Snapshots/LiquidityPoolAggregatorSnapshot.ts
@@ -77,6 +77,7 @@ export function createLiquidityPoolAggregatorSnapshot(
     currentLiquidityStaked: entity.currentLiquidityStaked,
     currentLiquidityStakedUSD: entity.currentLiquidityStakedUSD,
     timestamp: epoch,
+    unstakedFee: entity.unstakedFee,
     feeProtocol0: entity.feeProtocol0,
     feeProtocol1: entity.feeProtocol1,
     observationCardinalityNext: entity.observationCardinalityNext,

--- a/test/EventHandlers/Pool/common.ts
+++ b/test/EventHandlers/Pool/common.ts
@@ -169,6 +169,8 @@ export function setupCommon() {
     feeCap: undefined,
     scalingFactor: undefined,
     currentFee: 0n,
+    // Unstaked Fee fields
+    unstakedFee: undefined,
     rootPoolMatchingHash: "",
     tickSpacing: 0n,
   };

--- a/test/EventHandlers/SwapFeeModule/CustomUnstakedFeeModule.test.ts
+++ b/test/EventHandlers/SwapFeeModule/CustomUnstakedFeeModule.test.ts
@@ -3,152 +3,130 @@ import {
   MockDb,
 } from "../../../generated/src/TestHelpers.gen";
 import { toChecksumAddress } from "../../../src/Constants";
+import "../../eventHandlersRegistration";
 import { setupCommon } from "../Pool/common";
 
+const BASE_INITIAL_MODULE = toChecksumAddress(
+  "0x0AD08370c76Ff426F534bb2AFFD9b5555338ee68",
+);
+const OPTIMISM_MODULE = toChecksumAddress(
+  "0xC565F7ba9c56b157Da983c4Db30e13F5f06C59D9",
+);
+
+const DEFAULT_BLOCK = {
+  timestamp: 1000000,
+  number: 123456,
+  hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
+} as const;
+
+function createSetCustomFeeEvent(params: {
+  poolAddress: string;
+  fee: bigint;
+  chainId: number;
+  srcAddress: string;
+}) {
+  return CustomUnstakedFeeModule.SetCustomFee.createMockEvent({
+    pool: params.poolAddress as `0x${string}`,
+    fee: params.fee,
+    mockEventData: {
+      block: DEFAULT_BLOCK,
+      chainId: params.chainId,
+      logIndex: 1,
+      srcAddress: params.srcAddress as `0x${string}`,
+    },
+  });
+}
+
 describe("CustomUnstakedFeeModule Events", () => {
-  const { createMockLiquidityPoolAggregator } = setupCommon();
-  const baseInitialModuleAddress = toChecksumAddress(
-    "0x0AD08370c76Ff426F534bb2AFFD9b5555338ee68",
-  );
-  const optimismModuleAddress = toChecksumAddress(
-    "0xC565F7ba9c56b157Da983c4Db30e13F5f06C59D9",
-  );
+  let common: ReturnType<typeof setupCommon>;
+
+  beforeEach(() => {
+    common = setupCommon();
+  });
+
+  describe("SetCustomFee event — chain-parameterized", () => {
+    // applyUnstakedFee routes on event.chainId, not srcAddress. These rows
+    // exercise both deployments we ship today (Base Initial + Optimism) through
+    // the same handler path.
+    const chainCases = [
+      {
+        name: "Base (Initial deployment)",
+        chainId: 8453,
+        srcAddress: BASE_INITIAL_MODULE,
+        fee: 250n,
+      },
+      {
+        name: "Optimism",
+        chainId: 10,
+        srcAddress: OPTIMISM_MODULE,
+        fee: 1000n,
+      },
+    ] as const;
+
+    it.each(chainCases)(
+      "should set unstakedFee on $name",
+      async ({ chainId, srcAddress, fee }) => {
+        const pool = common.createMockLiquidityPoolAggregator({ chainId });
+        const populatedDb =
+          MockDb.createMockDb().entities.LiquidityPoolAggregator.set(pool);
+
+        const event = createSetCustomFeeEvent({
+          poolAddress: pool.poolAddress,
+          fee,
+          chainId,
+          srcAddress,
+        });
+
+        const result = await populatedDb.processEvents([event]);
+
+        const updatedPool = result.entities.LiquidityPoolAggregator.get(
+          pool.id,
+        );
+        expect(updatedPool).toBeDefined();
+        expect(updatedPool?.unstakedFee).toBe(fee);
+        // baseFee and currentFee must be orthogonal and untouched.
+        expect(updatedPool?.baseFee).toBe(pool.baseFee);
+        expect(updatedPool?.currentFee).toBe(pool.currentFee);
+      },
+    );
+  });
 
   describe("SetCustomFee event on Base (Initial deployment)", () => {
     const chainId = 8453;
-    const mockLiquidityPoolAggregator = createMockLiquidityPoolAggregator({
-      chainId: chainId,
-    });
-
-    it("should set unstakedFee to the raw fee value on the pool", async () => {
-      const mockDb = MockDb.createMockDb();
-      const fee = 250n;
-
-      const populatedDb = mockDb.entities.LiquidityPoolAggregator.set(
-        mockLiquidityPoolAggregator,
-      );
-
-      const mockEvent = CustomUnstakedFeeModule.SetCustomFee.createMockEvent({
-        pool: mockLiquidityPoolAggregator.poolAddress as `0x${string}`,
-        fee: fee,
-        mockEventData: {
-          block: {
-            timestamp: 1000000,
-            number: 123456,
-            hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
-          },
-          chainId: chainId,
-          logIndex: 1,
-          srcAddress: baseInitialModuleAddress,
-        },
-      });
-
-      const result = await populatedDb.processEvents([mockEvent]);
-
-      const updatedPool = result.entities.LiquidityPoolAggregator.get(
-        mockLiquidityPoolAggregator.id,
-      );
-      expect(updatedPool).toBeDefined();
-      expect(updatedPool?.unstakedFee).toBe(fee);
-      expect(updatedPool?.baseFee).toBe(mockLiquidityPoolAggregator.baseFee);
-      expect(updatedPool?.currentFee).toBe(
-        mockLiquidityPoolAggregator.currentFee,
-      );
-    });
 
     it("should store the raw ZERO_FEE_INDICATOR sentinel (420) without normalization", async () => {
-      const mockDb = MockDb.createMockDb();
-      const sentinelFee = 420n;
+      const pool = common.createMockLiquidityPoolAggregator({ chainId });
+      const populatedDb =
+        MockDb.createMockDb().entities.LiquidityPoolAggregator.set(pool);
 
-      const populatedDb = mockDb.entities.LiquidityPoolAggregator.set(
-        mockLiquidityPoolAggregator,
-      );
-
-      const mockEvent = CustomUnstakedFeeModule.SetCustomFee.createMockEvent({
-        pool: mockLiquidityPoolAggregator.poolAddress as `0x${string}`,
-        fee: sentinelFee,
-        mockEventData: {
-          block: {
-            timestamp: 1000000,
-            number: 123456,
-            hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
-          },
-          chainId: chainId,
-          logIndex: 1,
-          srcAddress: baseInitialModuleAddress,
-        },
+      const event = createSetCustomFeeEvent({
+        poolAddress: pool.poolAddress,
+        fee: 420n,
+        chainId,
+        srcAddress: BASE_INITIAL_MODULE,
       });
 
-      const result = await populatedDb.processEvents([mockEvent]);
+      const result = await populatedDb.processEvents([event]);
 
-      const updatedPool = result.entities.LiquidityPoolAggregator.get(
-        mockLiquidityPoolAggregator.id,
-      );
-      expect(updatedPool?.unstakedFee).toBe(sentinelFee);
+      const updatedPool = result.entities.LiquidityPoolAggregator.get(pool.id);
+      expect(updatedPool?.unstakedFee).toBe(420n);
     });
 
     it("should no-op (not throw) when the pool aggregator does not exist", async () => {
+      const pool = common.createMockLiquidityPoolAggregator({ chainId });
       const mockDb = MockDb.createMockDb();
 
-      const mockEvent = CustomUnstakedFeeModule.SetCustomFee.createMockEvent({
-        pool: mockLiquidityPoolAggregator.poolAddress as `0x${string}`,
+      const event = createSetCustomFeeEvent({
+        poolAddress: pool.poolAddress,
         fee: 250n,
-        mockEventData: {
-          block: {
-            timestamp: 1000000,
-            number: 123456,
-            hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
-          },
-          chainId: chainId,
-          logIndex: 1,
-          srcAddress: baseInitialModuleAddress,
-        },
+        chainId,
+        srcAddress: BASE_INITIAL_MODULE,
       });
 
-      const result = await mockDb.processEvents([mockEvent]);
+      const result = await mockDb.processEvents([event]);
 
-      const updatedPool = result.entities.LiquidityPoolAggregator.get(
-        mockLiquidityPoolAggregator.id,
-      );
+      const updatedPool = result.entities.LiquidityPoolAggregator.get(pool.id);
       expect(updatedPool).toBeUndefined();
-    });
-  });
-
-  describe("SetCustomFee event on Optimism", () => {
-    const chainId = 10;
-    const mockLiquidityPoolAggregator = createMockLiquidityPoolAggregator({
-      chainId: chainId,
-    });
-
-    it("should set unstakedFee when emitted from the Optimism module", async () => {
-      const mockDb = MockDb.createMockDb();
-      const fee = 1000n;
-
-      const populatedDb = mockDb.entities.LiquidityPoolAggregator.set(
-        mockLiquidityPoolAggregator,
-      );
-
-      const mockEvent = CustomUnstakedFeeModule.SetCustomFee.createMockEvent({
-        pool: mockLiquidityPoolAggregator.poolAddress as `0x${string}`,
-        fee: fee,
-        mockEventData: {
-          block: {
-            timestamp: 1000000,
-            number: 123456,
-            hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
-          },
-          chainId: chainId,
-          logIndex: 1,
-          srcAddress: optimismModuleAddress,
-        },
-      });
-
-      const result = await populatedDb.processEvents([mockEvent]);
-
-      const updatedPool = result.entities.LiquidityPoolAggregator.get(
-        mockLiquidityPoolAggregator.id,
-      );
-      expect(updatedPool?.unstakedFee).toBe(fee);
     });
   });
 });

--- a/test/EventHandlers/SwapFeeModule/CustomUnstakedFeeModule.test.ts
+++ b/test/EventHandlers/SwapFeeModule/CustomUnstakedFeeModule.test.ts
@@ -1,0 +1,154 @@
+import {
+  CustomUnstakedFeeModule,
+  MockDb,
+} from "../../../generated/src/TestHelpers.gen";
+import { toChecksumAddress } from "../../../src/Constants";
+import { setupCommon } from "../Pool/common";
+
+describe("CustomUnstakedFeeModule Events", () => {
+  const { createMockLiquidityPoolAggregator } = setupCommon();
+  const baseInitialModuleAddress = toChecksumAddress(
+    "0x0AD08370c76Ff426F534bb2AFFD9b5555338ee68",
+  );
+  const optimismModuleAddress = toChecksumAddress(
+    "0xC565F7ba9c56b157Da983c4Db30e13F5f06C59D9",
+  );
+
+  describe("SetCustomFee event on Base (Initial deployment)", () => {
+    const chainId = 8453;
+    const mockLiquidityPoolAggregator = createMockLiquidityPoolAggregator({
+      chainId: chainId,
+    });
+
+    it("should set unstakedFee to the raw fee value on the pool", async () => {
+      const mockDb = MockDb.createMockDb();
+      const fee = 250n;
+
+      const populatedDb = mockDb.entities.LiquidityPoolAggregator.set(
+        mockLiquidityPoolAggregator,
+      );
+
+      const mockEvent = CustomUnstakedFeeModule.SetCustomFee.createMockEvent({
+        pool: mockLiquidityPoolAggregator.poolAddress as `0x${string}`,
+        fee: fee,
+        mockEventData: {
+          block: {
+            timestamp: 1000000,
+            number: 123456,
+            hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
+          },
+          chainId: chainId,
+          logIndex: 1,
+          srcAddress: baseInitialModuleAddress,
+        },
+      });
+
+      const result = await populatedDb.processEvents([mockEvent]);
+
+      const updatedPool = result.entities.LiquidityPoolAggregator.get(
+        mockLiquidityPoolAggregator.id,
+      );
+      expect(updatedPool).toBeDefined();
+      expect(updatedPool?.unstakedFee).toBe(fee);
+      expect(updatedPool?.baseFee).toBe(mockLiquidityPoolAggregator.baseFee);
+      expect(updatedPool?.currentFee).toBe(
+        mockLiquidityPoolAggregator.currentFee,
+      );
+    });
+
+    it("should store the raw ZERO_FEE_INDICATOR sentinel (420) without normalization", async () => {
+      const mockDb = MockDb.createMockDb();
+      const sentinelFee = 420n;
+
+      const populatedDb = mockDb.entities.LiquidityPoolAggregator.set(
+        mockLiquidityPoolAggregator,
+      );
+
+      const mockEvent = CustomUnstakedFeeModule.SetCustomFee.createMockEvent({
+        pool: mockLiquidityPoolAggregator.poolAddress as `0x${string}`,
+        fee: sentinelFee,
+        mockEventData: {
+          block: {
+            timestamp: 1000000,
+            number: 123456,
+            hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
+          },
+          chainId: chainId,
+          logIndex: 1,
+          srcAddress: baseInitialModuleAddress,
+        },
+      });
+
+      const result = await populatedDb.processEvents([mockEvent]);
+
+      const updatedPool = result.entities.LiquidityPoolAggregator.get(
+        mockLiquidityPoolAggregator.id,
+      );
+      expect(updatedPool?.unstakedFee).toBe(sentinelFee);
+    });
+
+    it("should no-op (not throw) when the pool aggregator does not exist", async () => {
+      const mockDb = MockDb.createMockDb();
+
+      const mockEvent = CustomUnstakedFeeModule.SetCustomFee.createMockEvent({
+        pool: mockLiquidityPoolAggregator.poolAddress as `0x${string}`,
+        fee: 250n,
+        mockEventData: {
+          block: {
+            timestamp: 1000000,
+            number: 123456,
+            hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
+          },
+          chainId: chainId,
+          logIndex: 1,
+          srcAddress: baseInitialModuleAddress,
+        },
+      });
+
+      const result = await mockDb.processEvents([mockEvent]);
+
+      const updatedPool = result.entities.LiquidityPoolAggregator.get(
+        mockLiquidityPoolAggregator.id,
+      );
+      expect(updatedPool).toBeUndefined();
+    });
+  });
+
+  describe("SetCustomFee event on Optimism", () => {
+    const chainId = 10;
+    const mockLiquidityPoolAggregator = createMockLiquidityPoolAggregator({
+      chainId: chainId,
+    });
+
+    it("should set unstakedFee when emitted from the Optimism module", async () => {
+      const mockDb = MockDb.createMockDb();
+      const fee = 1000n;
+
+      const populatedDb = mockDb.entities.LiquidityPoolAggregator.set(
+        mockLiquidityPoolAggregator,
+      );
+
+      const mockEvent = CustomUnstakedFeeModule.SetCustomFee.createMockEvent({
+        pool: mockLiquidityPoolAggregator.poolAddress as `0x${string}`,
+        fee: fee,
+        mockEventData: {
+          block: {
+            timestamp: 1000000,
+            number: 123456,
+            hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
+          },
+          chainId: chainId,
+          logIndex: 1,
+          srcAddress: optimismModuleAddress,
+        },
+      });
+
+      const result = await populatedDb.processEvents([mockEvent]);
+
+      const updatedPool = result.entities.LiquidityPoolAggregator.get(
+        mockLiquidityPoolAggregator.id,
+      );
+      expect(updatedPool?.unstakedFee).toBe(fee);
+    });
+  });
+});

--- a/test/EventHandlers/SwapFeeModule/UnstakedFeeModule.test.ts
+++ b/test/EventHandlers/SwapFeeModule/UnstakedFeeModule.test.ts
@@ -4,161 +4,129 @@ import {
   UnstakedFeeModule,
 } from "../../../generated/src/TestHelpers.gen";
 import { toChecksumAddress } from "../../../src/Constants";
+import "../../eventHandlersRegistration";
 import { setupCommon } from "../Pool/common";
 
-describe("UnstakedFeeModule Events", () => {
-  const { createMockLiquidityPoolAggregator } = setupCommon();
-  const gaugeCapsModuleAddress = toChecksumAddress(
-    "0xCCC21f4750E8B3E9C095BCB5d2fF59247A2CCD35",
-  );
-  const gaugesV3ModuleAddress = toChecksumAddress(
-    "0xc2cc3256434AfbC36Bb5e815e1Bb2151310a1a0b",
-  );
-  const initialCustomModuleAddress = toChecksumAddress(
-    "0x0AD08370c76Ff426F534bb2AFFD9b5555338ee68",
-  );
-  const chainId = 8453; // Base
+const GAUGE_CAPS_MODULE = toChecksumAddress(
+  "0xCCC21f4750E8B3E9C095BCB5d2fF59247A2CCD35",
+);
+const GAUGES_V3_MODULE = toChecksumAddress(
+  "0xc2cc3256434AfbC36Bb5e815e1Bb2151310a1a0b",
+);
+const INITIAL_CUSTOM_MODULE = toChecksumAddress(
+  "0x0AD08370c76Ff426F534bb2AFFD9b5555338ee68",
+);
+const CHAIN_ID_BASE = 8453;
 
-  const mockLiquidityPoolAggregator = createMockLiquidityPoolAggregator({
-    chainId: chainId,
+const DEFAULT_BLOCK = {
+  timestamp: 1000000,
+  number: 123456,
+  hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
+} as const;
+
+function createCustomFeeSetEvent(params: {
+  poolAddress: string;
+  fee: bigint;
+  srcAddress: string;
+  block?: { timestamp: number; number: number; hash: string };
+}) {
+  return UnstakedFeeModule.CustomFeeSet.createMockEvent({
+    pool: params.poolAddress as `0x${string}`,
+    fee: params.fee,
+    mockEventData: {
+      block: params.block ?? DEFAULT_BLOCK,
+      chainId: CHAIN_ID_BASE,
+      logIndex: 1,
+      srcAddress: params.srcAddress as `0x${string}`,
+    },
+  });
+}
+
+describe("UnstakedFeeModule Events", () => {
+  let common: ReturnType<typeof setupCommon>;
+
+  beforeEach(() => {
+    common = setupCommon();
   });
 
   describe("CustomFeeSet event", () => {
-    it("should set unstakedFee to the raw fee value on the pool", async () => {
-      const mockDb = MockDb.createMockDb();
-      const fee = 500n;
-
-      const populatedDb = mockDb.entities.LiquidityPoolAggregator.set(
-        mockLiquidityPoolAggregator,
-      );
-
-      const mockEvent = UnstakedFeeModule.CustomFeeSet.createMockEvent({
-        pool: mockLiquidityPoolAggregator.poolAddress as `0x${string}`,
-        fee: fee,
-        mockEventData: {
-          block: {
-            timestamp: 1000000,
-            number: 123456,
-            hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
-          },
-          chainId: chainId,
-          logIndex: 1,
-          srcAddress: gaugeCapsModuleAddress,
-        },
-      });
-
-      const result = await populatedDb.processEvents([mockEvent]);
-
-      const updatedPool = result.entities.LiquidityPoolAggregator.get(
-        mockLiquidityPoolAggregator.id,
-      );
-      expect(updatedPool).toBeDefined();
-      expect(updatedPool?.unstakedFee).toBe(fee);
-      // baseFee and currentFee must be orthogonal and untouched.
-      expect(updatedPool?.baseFee).toBe(mockLiquidityPoolAggregator.baseFee);
-      expect(updatedPool?.currentFee).toBe(
-        mockLiquidityPoolAggregator.currentFee,
-      );
-    });
-
-    it("should store the raw ZERO_FEE_INDICATOR sentinel (420) without normalization", async () => {
-      const mockDb = MockDb.createMockDb();
-      const sentinelFee = 420n;
-
-      const populatedDb = mockDb.entities.LiquidityPoolAggregator.set(
-        mockLiquidityPoolAggregator,
-      );
-
-      const mockEvent = UnstakedFeeModule.CustomFeeSet.createMockEvent({
-        pool: mockLiquidityPoolAggregator.poolAddress as `0x${string}`,
-        fee: sentinelFee,
-        mockEventData: {
-          block: {
-            timestamp: 1000000,
-            number: 123456,
-            hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
-          },
-          chainId: chainId,
-          logIndex: 1,
-          srcAddress: gaugesV3ModuleAddress,
-        },
-      });
-
-      const result = await populatedDb.processEvents([mockEvent]);
-
-      const updatedPool = result.entities.LiquidityPoolAggregator.get(
-        mockLiquidityPoolAggregator.id,
-      );
-      expect(updatedPool?.unstakedFee).toBe(sentinelFee);
-    });
-
-    it("should store fee=0 raw (distinct from null / never-set)", async () => {
-      const mockDb = MockDb.createMockDb();
-      const populatedDb = mockDb.entities.LiquidityPoolAggregator.set(
-        mockLiquidityPoolAggregator,
-      );
-
-      const mockEvent = UnstakedFeeModule.CustomFeeSet.createMockEvent({
-        pool: mockLiquidityPoolAggregator.poolAddress as `0x${string}`,
+    const feeCases = [
+      {
+        label: "raw fee value",
+        fee: 500n,
+        srcAddress: GAUGE_CAPS_MODULE,
+      },
+      {
+        label: "ZERO_FEE_INDICATOR sentinel (420) without normalization",
+        fee: 420n,
+        srcAddress: GAUGES_V3_MODULE,
+      },
+      {
+        label: "fee=0 raw (distinct from null / never-set)",
         fee: 0n,
-        mockEventData: {
-          block: {
-            timestamp: 1000000,
-            number: 123456,
-            hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
-          },
-          chainId: chainId,
-          logIndex: 1,
-          srcAddress: gaugeCapsModuleAddress,
-        },
-      });
+        srcAddress: GAUGE_CAPS_MODULE,
+      },
+    ] as const;
 
-      const result = await populatedDb.processEvents([mockEvent]);
+    it.each(feeCases)(
+      "should store $label on the pool",
+      async ({ fee, srcAddress }) => {
+        const pool = common.createMockLiquidityPoolAggregator({
+          chainId: CHAIN_ID_BASE,
+        });
+        const populatedDb =
+          MockDb.createMockDb().entities.LiquidityPoolAggregator.set(pool);
 
-      const updatedPool = result.entities.LiquidityPoolAggregator.get(
-        mockLiquidityPoolAggregator.id,
-      );
-      expect(updatedPool?.unstakedFee).toBe(0n);
-    });
+        const event = createCustomFeeSetEvent({
+          poolAddress: pool.poolAddress,
+          fee,
+          srcAddress,
+        });
+
+        const result = await populatedDb.processEvents([event]);
+
+        const updatedPool = result.entities.LiquidityPoolAggregator.get(
+          pool.id,
+        );
+        expect(updatedPool).toBeDefined();
+        expect(updatedPool?.unstakedFee).toBe(fee);
+        // baseFee and currentFee must be orthogonal and untouched.
+        expect(updatedPool?.baseFee).toBe(pool.baseFee);
+        expect(updatedPool?.currentFee).toBe(pool.currentFee);
+      },
+    );
 
     it("should no-op (not throw) when the pool aggregator does not exist", async () => {
+      const pool = common.createMockLiquidityPoolAggregator({
+        chainId: CHAIN_ID_BASE,
+      });
       const mockDb = MockDb.createMockDb();
 
-      const mockEvent = UnstakedFeeModule.CustomFeeSet.createMockEvent({
-        pool: mockLiquidityPoolAggregator.poolAddress as `0x${string}`,
+      const event = createCustomFeeSetEvent({
+        poolAddress: pool.poolAddress,
         fee: 500n,
-        mockEventData: {
-          block: {
-            timestamp: 1000000,
-            number: 123456,
-            hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
-          },
-          chainId: chainId,
-          logIndex: 1,
-          srcAddress: gaugeCapsModuleAddress,
-        },
+        srcAddress: GAUGE_CAPS_MODULE,
       });
 
-      const result = await mockDb.processEvents([mockEvent]);
+      const result = await mockDb.processEvents([event]);
 
-      const updatedPool = result.entities.LiquidityPoolAggregator.get(
-        mockLiquidityPoolAggregator.id,
-      );
+      const updatedPool = result.entities.LiquidityPoolAggregator.get(pool.id);
       expect(updatedPool).toBeUndefined();
     });
   });
 
   describe("Last-writer-wins across module deployments", () => {
     it("applies the most-recent event regardless of which module (Custom vs plain) fired it", async () => {
+      const pool = common.createMockLiquidityPoolAggregator({
+        chainId: CHAIN_ID_BASE,
+      });
       let mockDb = MockDb.createMockDb();
-      mockDb = mockDb.entities.LiquidityPoolAggregator.set(
-        mockLiquidityPoolAggregator,
-      );
+      mockDb = mockDb.entities.LiquidityPoolAggregator.set(pool);
 
       // First: Initial CustomUnstakedFeeModule fires SetCustomFee with 300.
       const initialEvent = CustomUnstakedFeeModule.SetCustomFee.createMockEvent(
         {
-          pool: mockLiquidityPoolAggregator.poolAddress as `0x${string}`,
+          pool: pool.poolAddress as `0x${string}`,
           fee: 300n,
           mockEventData: {
             block: {
@@ -166,34 +134,28 @@ describe("UnstakedFeeModule Events", () => {
               number: 123456,
               hash: "0x1111111111111111111111111111111111111111111111111111111111111111",
             },
-            chainId: chainId,
+            chainId: CHAIN_ID_BASE,
             logIndex: 1,
-            srcAddress: initialCustomModuleAddress,
+            srcAddress: INITIAL_CUSTOM_MODULE,
           },
         },
       );
       mockDb = await mockDb.processEvents([initialEvent]);
 
       // Then: Gauges V3 UnstakedFeeModule fires CustomFeeSet with 700 on a later block.
-      const laterEvent = UnstakedFeeModule.CustomFeeSet.createMockEvent({
-        pool: mockLiquidityPoolAggregator.poolAddress as `0x${string}`,
+      const laterEvent = createCustomFeeSetEvent({
+        poolAddress: pool.poolAddress,
         fee: 700n,
-        mockEventData: {
-          block: {
-            timestamp: 1000100,
-            number: 123500,
-            hash: "0x2222222222222222222222222222222222222222222222222222222222222222",
-          },
-          chainId: chainId,
-          logIndex: 1,
-          srcAddress: gaugesV3ModuleAddress,
+        srcAddress: GAUGES_V3_MODULE,
+        block: {
+          timestamp: 1000100,
+          number: 123500,
+          hash: "0x2222222222222222222222222222222222222222222222222222222222222222",
         },
       });
       const result = await mockDb.processEvents([laterEvent]);
 
-      const updatedPool = result.entities.LiquidityPoolAggregator.get(
-        mockLiquidityPoolAggregator.id,
-      );
+      const updatedPool = result.entities.LiquidityPoolAggregator.get(pool.id);
       expect(updatedPool?.unstakedFee).toBe(700n);
     });
   });

--- a/test/EventHandlers/SwapFeeModule/UnstakedFeeModule.test.ts
+++ b/test/EventHandlers/SwapFeeModule/UnstakedFeeModule.test.ts
@@ -1,0 +1,200 @@
+import {
+  CustomUnstakedFeeModule,
+  MockDb,
+  UnstakedFeeModule,
+} from "../../../generated/src/TestHelpers.gen";
+import { toChecksumAddress } from "../../../src/Constants";
+import { setupCommon } from "../Pool/common";
+
+describe("UnstakedFeeModule Events", () => {
+  const { createMockLiquidityPoolAggregator } = setupCommon();
+  const gaugeCapsModuleAddress = toChecksumAddress(
+    "0xCCC21f4750E8B3E9C095BCB5d2fF59247A2CCD35",
+  );
+  const gaugesV3ModuleAddress = toChecksumAddress(
+    "0xc2cc3256434AfbC36Bb5e815e1Bb2151310a1a0b",
+  );
+  const initialCustomModuleAddress = toChecksumAddress(
+    "0x0AD08370c76Ff426F534bb2AFFD9b5555338ee68",
+  );
+  const chainId = 8453; // Base
+
+  const mockLiquidityPoolAggregator = createMockLiquidityPoolAggregator({
+    chainId: chainId,
+  });
+
+  describe("CustomFeeSet event", () => {
+    it("should set unstakedFee to the raw fee value on the pool", async () => {
+      const mockDb = MockDb.createMockDb();
+      const fee = 500n;
+
+      const populatedDb = mockDb.entities.LiquidityPoolAggregator.set(
+        mockLiquidityPoolAggregator,
+      );
+
+      const mockEvent = UnstakedFeeModule.CustomFeeSet.createMockEvent({
+        pool: mockLiquidityPoolAggregator.poolAddress as `0x${string}`,
+        fee: fee,
+        mockEventData: {
+          block: {
+            timestamp: 1000000,
+            number: 123456,
+            hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
+          },
+          chainId: chainId,
+          logIndex: 1,
+          srcAddress: gaugeCapsModuleAddress,
+        },
+      });
+
+      const result = await populatedDb.processEvents([mockEvent]);
+
+      const updatedPool = result.entities.LiquidityPoolAggregator.get(
+        mockLiquidityPoolAggregator.id,
+      );
+      expect(updatedPool).toBeDefined();
+      expect(updatedPool?.unstakedFee).toBe(fee);
+      // baseFee and currentFee must be orthogonal and untouched.
+      expect(updatedPool?.baseFee).toBe(mockLiquidityPoolAggregator.baseFee);
+      expect(updatedPool?.currentFee).toBe(
+        mockLiquidityPoolAggregator.currentFee,
+      );
+    });
+
+    it("should store the raw ZERO_FEE_INDICATOR sentinel (420) without normalization", async () => {
+      const mockDb = MockDb.createMockDb();
+      const sentinelFee = 420n;
+
+      const populatedDb = mockDb.entities.LiquidityPoolAggregator.set(
+        mockLiquidityPoolAggregator,
+      );
+
+      const mockEvent = UnstakedFeeModule.CustomFeeSet.createMockEvent({
+        pool: mockLiquidityPoolAggregator.poolAddress as `0x${string}`,
+        fee: sentinelFee,
+        mockEventData: {
+          block: {
+            timestamp: 1000000,
+            number: 123456,
+            hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
+          },
+          chainId: chainId,
+          logIndex: 1,
+          srcAddress: gaugesV3ModuleAddress,
+        },
+      });
+
+      const result = await populatedDb.processEvents([mockEvent]);
+
+      const updatedPool = result.entities.LiquidityPoolAggregator.get(
+        mockLiquidityPoolAggregator.id,
+      );
+      expect(updatedPool?.unstakedFee).toBe(sentinelFee);
+    });
+
+    it("should store fee=0 raw (distinct from null / never-set)", async () => {
+      const mockDb = MockDb.createMockDb();
+      const populatedDb = mockDb.entities.LiquidityPoolAggregator.set(
+        mockLiquidityPoolAggregator,
+      );
+
+      const mockEvent = UnstakedFeeModule.CustomFeeSet.createMockEvent({
+        pool: mockLiquidityPoolAggregator.poolAddress as `0x${string}`,
+        fee: 0n,
+        mockEventData: {
+          block: {
+            timestamp: 1000000,
+            number: 123456,
+            hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
+          },
+          chainId: chainId,
+          logIndex: 1,
+          srcAddress: gaugeCapsModuleAddress,
+        },
+      });
+
+      const result = await populatedDb.processEvents([mockEvent]);
+
+      const updatedPool = result.entities.LiquidityPoolAggregator.get(
+        mockLiquidityPoolAggregator.id,
+      );
+      expect(updatedPool?.unstakedFee).toBe(0n);
+    });
+
+    it("should no-op (not throw) when the pool aggregator does not exist", async () => {
+      const mockDb = MockDb.createMockDb();
+
+      const mockEvent = UnstakedFeeModule.CustomFeeSet.createMockEvent({
+        pool: mockLiquidityPoolAggregator.poolAddress as `0x${string}`,
+        fee: 500n,
+        mockEventData: {
+          block: {
+            timestamp: 1000000,
+            number: 123456,
+            hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
+          },
+          chainId: chainId,
+          logIndex: 1,
+          srcAddress: gaugeCapsModuleAddress,
+        },
+      });
+
+      const result = await mockDb.processEvents([mockEvent]);
+
+      const updatedPool = result.entities.LiquidityPoolAggregator.get(
+        mockLiquidityPoolAggregator.id,
+      );
+      expect(updatedPool).toBeUndefined();
+    });
+  });
+
+  describe("Last-writer-wins across module deployments", () => {
+    it("applies the most-recent event regardless of which module (Custom vs plain) fired it", async () => {
+      let mockDb = MockDb.createMockDb();
+      mockDb = mockDb.entities.LiquidityPoolAggregator.set(
+        mockLiquidityPoolAggregator,
+      );
+
+      // First: Initial CustomUnstakedFeeModule fires SetCustomFee with 300.
+      const initialEvent = CustomUnstakedFeeModule.SetCustomFee.createMockEvent(
+        {
+          pool: mockLiquidityPoolAggregator.poolAddress as `0x${string}`,
+          fee: 300n,
+          mockEventData: {
+            block: {
+              timestamp: 1000000,
+              number: 123456,
+              hash: "0x1111111111111111111111111111111111111111111111111111111111111111",
+            },
+            chainId: chainId,
+            logIndex: 1,
+            srcAddress: initialCustomModuleAddress,
+          },
+        },
+      );
+      mockDb = await mockDb.processEvents([initialEvent]);
+
+      // Then: Gauges V3 UnstakedFeeModule fires CustomFeeSet with 700 on a later block.
+      const laterEvent = UnstakedFeeModule.CustomFeeSet.createMockEvent({
+        pool: mockLiquidityPoolAggregator.poolAddress as `0x${string}`,
+        fee: 700n,
+        mockEventData: {
+          block: {
+            timestamp: 1000100,
+            number: 123500,
+            hash: "0x2222222222222222222222222222222222222222222222222222222222222222",
+          },
+          chainId: chainId,
+          logIndex: 1,
+          srcAddress: gaugesV3ModuleAddress,
+        },
+      });
+      const result = await mockDb.processEvents([laterEvent]);
+
+      const updatedPool = result.entities.LiquidityPoolAggregator.get(
+        mockLiquidityPoolAggregator.id,
+      );
+      expect(updatedPool?.unstakedFee).toBe(700n);
+    });
+  });
+});


### PR DESCRIPTION
Closes #636.

## Summary

- Indexes the three Base `UnstakedFeeModule` / `CustomUnstakedFeeModule` deployments plus the Optimism `CustomUnstakedFeeModule` — the contract family listed in the Slipstream README but previously unhandled.
- Stores the raw `customFee` value on `LiquidityPoolAggregator.unstakedFee` (and its hourly snapshot), so downstream consumers can see per-pool unstaked-fee overrides without an extra `eth_call`.

## What changed

### ABIs (two — the event name differs between deployments)

| ABI | Event | Rationale |
|---|---|---|
| `abis/UnstakedFeeModule.json` | `CustomFeeSet(address indexed pool, uint24 indexed fee)` | Matches Gauge Caps (`0xCCC2…`) and Gauges V3 (`0xc2cc…`) on Base. |
| `abis/CustomUnstakedFeeModule.json` | `SetCustomFee(address indexed pool, uint24 indexed fee)` | Matches the Initial Base deployment (`0x0AD0…`) and the Optimism deployment (`0xC565…`). |

Verified against Basescan/Optimistic Etherscan sources — same contract bytecode, event was renamed between the Initial and Gauge Caps releases.

### Chain wiring

- **Base `8453`** — `UnstakedFeeModule`: `0xCCC21f4750E8B3E9C095BCB5d2fF59247A2CCD35`, `0xc2cc3256434AfbC36Bb5e815e1Bb2151310a1a0b`. `CustomUnstakedFeeModule`: `0x0AD08370c76Ff426F534bb2AFFD9b5555338ee68`.
- **Optimism `10`** — `CustomUnstakedFeeModule`: `0xC565F7ba9c56b157Da983c4Db30e13F5f06C59D9` (from velodrome-finance/slipstream README; included opportunistically since it matches the same event shape). Other superchains tracked in a follow-up audit issue.

### Schema

New nullable field on the pool entity + its snapshot:

```graphql
# LiquidityPoolAggregator + LiquidityPoolAggregatorSnapshot
unstakedFee: BigInt @config(precision: 24)
```

Value is the raw `customFee[pool]` emitted by the module. Null until the first event fires for a pool. Per-pool, last-writer-wins across all module instances. Sentinels documented in the schema comment:
- `0` → no override, factory default applies (`100_000` = 10% on Slipstream's current deployments)
- `420` → `ZERO_FEE_INDICATOR`, explicit 0% fee
- else → 6-decimal rate (`500_000` = 50% cap)

### Handler layout

Follows the existing `*SharedLogic.ts` convention (cf. `GaugeSharedLogic.ts`, `VoterCommonLogic.ts`):

- `src/EventHandlers/SwapFeeModule/UnstakedFeeModuleSharedLogic.ts` — single `applyUnstakedFee(...)` helper that both handlers delegate to.
- `src/EventHandlers/SwapFeeModule/UnstakedFeeModule.ts` — hooks `CustomFeeSet`.
- `src/EventHandlers/SwapFeeModule/CustomUnstakedFeeModule.ts` — hooks `SetCustomFee`.

`baseFee`, `currentFee`, and the dynamic-fee plumbing are **not** touched — the unstaked fee is orthogonal to the swap fee, and mixing them would misrepresent the semantics.

### Intentional non-changes

- **No RPC call.** Every state transition on `customFee[pool]` is covered by the event stream (verified against the on-chain source). Matches the existing `CustomSwapFeeModule` handler's event-only approach.
- **No `DynamicFeeGlobalConfig` write.** The existing `CustomSwapFeeModule` handler writes that entity with `secondsAgo: undefined`, but the entity is semantically a per-module TWAP-window store and doesn't apply to unstaked-fee modules. Skipped rather than widening that pattern further.
- **No skim/penalty tracking.** The realized unstaked-fee skim is applied silently inside `applyUnstakedFees` on CL pools — no dedicated event, currently mixed into the gauge-side `totalStakedFeesCollected*` aggregates. That's a materially different surface (CL swap handler) and is queued as a follow-up issue — the field this PR adds is the missing input that makes it tractable.

## Tests

8 new tests across two files, covering:

- Raw value storage (non-sentinel)
- `ZERO_FEE_INDICATOR = 420` stored raw (not normalized)
- `fee = 0` stored raw, distinct from null / never-set
- Pool-missing no-op (warn + skip, no throw)
- Last-writer-wins across module deployments (Initial → Gauges V3)
- Optimism path through the same `CustomUnstakedFeeModule` handler

Full suite: 1072 passed / 32 skipped / 0 failed. `tsc --noEmit` clean. `pnpm qa --write` clean.

## Test plan

- [x] `pnpm envio codegen` — generated types include both new contracts
- [x] `tsc --noEmit` — passes
- [x] `pnpm test` — 1072/1072 passing
- [x] `pnpm qa --write` — biome clean
- [x] Smoke verification on a local Base run: pick up at least one `CustomFeeSet` / `SetCustomFee` event and confirm `unstakedFee` populates on the pool aggregator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unstaked fee module support on Optimism and Base; liquidity pools can have custom unstaked fee overrides.
  * Aggregators and snapshots now expose an unstakedFee field for raw override values.
  * Fee updates are tracked in real time and follow last-writer-wins across modules.

* **Tests**
  * Added thorough tests covering event processing, sentinel values, cross-module ordering, and no-op behavior when pools are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->