### PR TITLE
feat(redistributor): index Redistributor events on Base (#637)

### DIFF
--- a/abis/Redistributor.json
+++ b/abis/Redistributor.json
@@ -1,0 +1,148 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "gauge",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Deposited",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "gauge",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Redistributed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "gauge",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "NotifyRewardWithoutClaim",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "keeper",
+        "type": "address"
+      }
+    ],
+    "name": "SetKeeper",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "upkeepManager",
+        "type": "address"
+      }
+    ],
+    "name": "SetUpkeepManager",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "proxy",
+        "type": "address"
+      }
+    ],
+    "name": "SetArtProxy",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bool",
+        "name": "enabled",
+        "type": "bool"
+      }
+    ],
+    "name": "ToggleSplit",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "redistributor",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newRedistributor",
+        "type": "address"
+      }
+    ],
+    "name": "PermissionsTransferred",
+    "type": "event"
+  }
+]

--- a/config.yaml
+++ b/config.yaml
@@ -213,6 +213,14 @@ contracts:
     events:
       - event: DispatchId
       - event: ProcessId
+  - name: Redistributor
+    abi_file_path: abis/Redistributor.json
+    handler: src/EventHandlers/Redistributor/Redistributor.ts
+    events:
+      - event: Deposited
+      - event: Redistributed
+      - event: SetKeeper
+      - event: SetUpkeepManager
 chains:
   - id: 10 # Optimism
     start_block: 0
@@ -370,6 +378,10 @@ chains:
       - name: Mailbox
         address:
           - 0xeA87ae93Fa0019a82A727bfd3eBd1cFCa8f64f1D
+      - name: Redistributor
+        address:
+          - 0x11a53f31Bf406de59fCf9613E1922bd3E283A4B4 # Slipstream README — Gauge Caps Deployment
+          - 0xEe5b3C7b333e2870B746b3B2b168EF0958e55e15 # Slipstream README — Gauges V3 Deployment (current)
   - id: 42220 # Celo
     hypersync_config:
       url: https://celo.hypersync.xyz

--- a/schema.graphql
+++ b/schema.graphql
@@ -35,6 +35,8 @@ type LiquidityPoolAggregator {
   totalVotesDepositedUSD: BigInt! @config(precision: 76) # total votes deposited in USD
   totalEmissions: BigInt! @config(precision: 76) # total emissions for the pool in reward token units (VELO form Optimism and AERO for Base)
   totalEmissionsUSD: BigInt! @config(precision: 76) # total emissions for the pool in USD
+  totalEmissionsRedistributed: BigInt! @config(precision: 76) # cumulative reward tokens this pool's gauge received from the Redistributor (Redistributed events)
+  totalEmissionsForfeited: BigInt! @config(precision: 76) # cumulative reward tokens this pool's gauge forwarded to the Redistributor or minter because it was over its cap (Deposited events)
 
   lastUpdatedTimestamp: Timestamp! # timestamp of last update
   lastSnapshotTimestamp: Timestamp! # timestamp of last snapshot
@@ -137,6 +139,8 @@ type LiquidityPoolAggregatorSnapshot {
   totalVotesDepositedUSD: BigInt! @config(precision: 76) # total votes deposited in USD
   totalEmissions: BigInt! @config(precision: 76) # total emissions for the pool in reward token units (VELO form Optimism and AERO for Base)
   totalEmissionsUSD: BigInt! @config(precision: 76) # total emissions for the pool in USD
+  totalEmissionsRedistributed: BigInt! @config(precision: 76) # cumulative reward tokens this pool's gauge received from the Redistributor at snapshot time
+  totalEmissionsForfeited: BigInt! @config(precision: 76) # cumulative reward tokens this pool's gauge forwarded to the Redistributor or minter at snapshot time
 
   gaugeIsAlive: Boolean! # whether the gauge is alive
   gaugeAddress: String @index # address of the gauge for this pool
@@ -761,4 +765,20 @@ type ALMLPWrapperTransferInTx {
   isBurn: Boolean! # to == 0x0
   consumedByLogIndex: Int # logIndex of the Withdraw event that consumed this transfer (undefined if unused)
   timestamp: Timestamp!
+}
+
+# Singleton config state per Redistributor contract, updated by SetKeeper /
+# SetUpkeepManager events. Last-writer-wins — the row reflects the most recent
+# keeper / upkeep manager addresses.
+#
+# Redistributed and Deposited events are folded into LiquidityPoolAggregator
+# counters (totalEmissionsRedistributed / totalEmissionsForfeited) via a
+# gauge→pool lookup; they have no dedicated entity.
+type RedistributorConfig {
+  id: ID! # Format: {chainId}-{redistributorAddress}
+  chainId: Int! @index
+  redistributorAddress: String! # Redistributor contract address
+  keeper: String! # Current keeper address (empty string until SetKeeper fires)
+  upkeepManager: String! # Current upkeep manager address (empty string until SetUpkeepManager fires)
+  lastUpdatedTimestamp: Timestamp!
 }

--- a/src/Aggregators/LiquidityPoolAggregator.ts
+++ b/src/Aggregators/LiquidityPoolAggregator.ts
@@ -50,6 +50,8 @@ export interface LiquidityPoolAggregatorDiff {
   incrementalNumberOfSwaps: bigint;
   incrementalTotalEmissions: bigint;
   incrementalTotalEmissionsUSD: bigint;
+  incrementalTotalEmissionsRedistributed: bigint;
+  incrementalTotalEmissionsForfeited: bigint;
   incrementalTotalFlashLoanFees0: bigint;
   incrementalTotalFlashLoanFees1: bigint;
   incrementalTotalFlashLoanFeesUSD: bigint;
@@ -263,6 +265,12 @@ export async function updateLiquidityPoolAggregator(
       (diff.incrementalTotalEmissions ?? 0n) + current.totalEmissions,
     totalEmissionsUSD:
       (diff.incrementalTotalEmissionsUSD ?? 0n) + current.totalEmissionsUSD,
+    totalEmissionsRedistributed:
+      (diff.incrementalTotalEmissionsRedistributed ?? 0n) +
+      current.totalEmissionsRedistributed,
+    totalEmissionsForfeited:
+      (diff.incrementalTotalEmissionsForfeited ?? 0n) +
+      current.totalEmissionsForfeited,
     totalFlashLoanFees0:
       (diff.incrementalTotalFlashLoanFees0 ?? 0n) +
       (current.totalFlashLoanFees0 ?? 0n),
@@ -707,6 +715,8 @@ export function createLiquidityPoolAggregatorEntity(params: {
     token1Price: 0n,
     totalEmissions: 0n,
     totalEmissionsUSD: 0n,
+    totalEmissionsRedistributed: 0n,
+    totalEmissionsForfeited: 0n,
     totalVotesDeposited: 0n,
     totalVotesDepositedUSD: 0n,
     gaugeIsAlive: false,

--- a/src/EventHandlers/Redistributor/Redistributor.ts
+++ b/src/EventHandlers/Redistributor/Redistributor.ts
@@ -1,0 +1,111 @@
+import { Redistributor, type handlerContext } from "generated";
+import {
+  type LiquidityPoolAggregatorDiff,
+  updateLiquidityPoolAggregator,
+} from "../../Aggregators/LiquidityPoolAggregator";
+import { applyRedistributorConfigUpdate } from "./RedistributorConfigSharedLogic";
+
+type RedistributorCounterDelta = Partial<
+  Pick<
+    LiquidityPoolAggregatorDiff,
+    | "incrementalTotalEmissionsRedistributed"
+    | "incrementalTotalEmissionsForfeited"
+  >
+>;
+
+/**
+ * Resolve the `LiquidityPoolAggregator` whose `gaugeAddress` matches the event's
+ * gauge and apply a cumulative delta to one of the redistributor counters.
+ *
+ * Log-and-drop when no pool matches: Redistributor and the Voter/Gauge factories
+ * are same-chain, so `Voter.GaugeCreated` must have indexed before any
+ * `Deposited`/`Redistributed` can fire for that gauge on-chain. A missing
+ * mapping therefore signals a config gap (e.g. Voter not wired in `config.yaml`),
+ * not a race.
+ *
+ * @param gauge - Gauge address emitted by the Redistributor event
+ * @param delta - Partial diff to apply (only one of the two redistributor counters)
+ * @param blockTimestampSeconds - Block timestamp (seconds) of the event
+ * @param eventChainId - EVM chain id of the event
+ * @param blockNumber - Block number of the event
+ * @param context - Envio handler context
+ * @returns Promise that resolves once the update is staged, or no-ops if no pool matches
+ */
+async function applyRedistributorCounterDelta(
+  gauge: string,
+  delta: RedistributorCounterDelta,
+  blockTimestampSeconds: number,
+  eventChainId: number,
+  blockNumber: number,
+  context: handlerContext,
+): Promise<void> {
+  const poolEntityList = await context.LiquidityPoolAggregator.getWhere({
+    gaugeAddress: { _eq: gauge },
+  });
+
+  if (!poolEntityList || poolEntityList.length === 0) {
+    context.log.error(
+      `[Redistributor] Pool entity not found for gauge ${gauge}`,
+    );
+    return;
+  }
+
+  if (poolEntityList.length > 1) {
+    context.log.warn(
+      `[Redistributor] Multiple pools found for gauge ${gauge}, using first match`,
+    );
+  }
+
+  const poolEntity = poolEntityList[0];
+
+  await updateLiquidityPoolAggregator(
+    delta,
+    poolEntity,
+    new Date(blockTimestampSeconds * 1000),
+    context,
+    eventChainId,
+    blockNumber,
+  );
+}
+
+Redistributor.Deposited.handler(async ({ event, context }) => {
+  await applyRedistributorCounterDelta(
+    event.params.gauge,
+    { incrementalTotalEmissionsForfeited: event.params.amount },
+    event.block.timestamp,
+    event.chainId,
+    event.block.number,
+    context,
+  );
+});
+
+Redistributor.Redistributed.handler(async ({ event, context }) => {
+  await applyRedistributorCounterDelta(
+    event.params.gauge,
+    { incrementalTotalEmissionsRedistributed: event.params.amount },
+    event.block.timestamp,
+    event.chainId,
+    event.block.number,
+    context,
+  );
+});
+
+Redistributor.SetKeeper.handler(async ({ event, context }) => {
+  await applyRedistributorConfigUpdate(
+    event.chainId,
+    event.srcAddress,
+    { keeper: event.params.keeper },
+    event.block.timestamp,
+    context,
+  );
+});
+
+Redistributor.SetUpkeepManager.handler(async ({ event, context }) => {
+  await applyRedistributorConfigUpdate(
+    event.chainId,
+    event.srcAddress,
+    { upkeepManager: event.params.upkeepManager },
+    event.block.timestamp,
+    context,
+  );
+});

--- a/src/EventHandlers/Redistributor/RedistributorConfigSharedLogic.ts
+++ b/src/EventHandlers/Redistributor/RedistributorConfigSharedLogic.ts
@@ -1,0 +1,52 @@
+import type { handlerContext } from "generated";
+
+/**
+ * Format the composite id for a `RedistributorConfig` row.
+ *
+ * @param chainId - EVM chain id where the Redistributor is deployed
+ * @param redistributorAddress - Redistributor contract address (event.srcAddress)
+ * @returns Deterministic `{chainId}-{address}` id used for all upserts
+ */
+const redistributorConfigId = (
+  chainId: number,
+  redistributorAddress: string,
+): string => `${chainId}-${redistributorAddress}`;
+
+/**
+ * Upsert the `RedistributorConfig` singleton for a given Redistributor contract.
+ *
+ * `SetKeeper` / `SetUpkeepManager` events fire independently, so each call patches
+ * only its own field and preserves whatever was previously recorded for the
+ * other. On first-ever event the row is seeded with empty strings for any
+ * field that has not been observed yet.
+ *
+ * @param chainId - EVM chain id of the Redistributor
+ * @param redistributorAddress - Redistributor contract address (srcAddress)
+ * @param patch - Partial override: at most one of `keeper` / `upkeepManager`
+ * @param blockTimestampSeconds - Block timestamp of the current event in seconds
+ * @param context - Envio handler context used to read and stage the row
+ * @returns Promise that resolves once the upsert is staged
+ */
+export async function applyRedistributorConfigUpdate(
+  chainId: number,
+  redistributorAddress: string,
+  patch: { keeper?: string; upkeepManager?: string },
+  blockTimestampSeconds: number,
+  context: handlerContext,
+): Promise<void> {
+  const id = redistributorConfigId(chainId, redistributorAddress);
+  const timestamp = new Date(blockTimestampSeconds * 1000);
+
+  const existing = await context.RedistributorConfig.get(id);
+  context.RedistributorConfig.set({
+    ...(existing ?? {
+      id,
+      chainId,
+      redistributorAddress,
+      keeper: "",
+      upkeepManager: "",
+    }),
+    ...patch,
+    lastUpdatedTimestamp: timestamp,
+  });
+}

--- a/src/Snapshots/LiquidityPoolAggregatorSnapshot.ts
+++ b/src/Snapshots/LiquidityPoolAggregatorSnapshot.ts
@@ -65,6 +65,8 @@ export function createLiquidityPoolAggregatorSnapshot(
     totalVotesDepositedUSD: entity.totalVotesDepositedUSD,
     totalEmissions: entity.totalEmissions,
     totalEmissionsUSD: entity.totalEmissionsUSD,
+    totalEmissionsRedistributed: entity.totalEmissionsRedistributed,
+    totalEmissionsForfeited: entity.totalEmissionsForfeited,
     gaugeIsAlive: entity.gaugeIsAlive,
     gaugeAddress: entity.gaugeAddress,
     gaugeEmissionsCap: entity.gaugeEmissionsCap,

--- a/test/EventHandlers/Pool/common.ts
+++ b/test/EventHandlers/Pool/common.ts
@@ -116,6 +116,8 @@ export function setupCommon() {
     totalVotesDepositedUSD: 1n * TEN_TO_THE_18_BI,
     totalEmissions: 1n,
     totalEmissionsUSD: 1n * TEN_TO_THE_18_BI,
+    totalEmissionsRedistributed: 0n,
+    totalEmissionsForfeited: 0n,
     gaugeIsAlive: true,
     isCL: false,
     lastUpdatedTimestamp: new Date(),

--- a/test/EventHandlers/Redistributor/Redistributor.test.ts
+++ b/test/EventHandlers/Redistributor/Redistributor.test.ts
@@ -1,0 +1,303 @@
+import { MockDb, Redistributor } from "../../../generated/src/TestHelpers.gen";
+import { toChecksumAddress } from "../../../src/Constants";
+import { setupCommon } from "../Pool/common";
+
+describe("Redistributor Event Handlers", () => {
+  const { createMockLiquidityPoolAggregator } = setupCommon();
+  const chainId = 8453; // Base
+  const redistributorAddress = toChecksumAddress(
+    "0xEe5b3C7b333e2870B746b3B2b168EF0958e55e15",
+  );
+  const gaugeAddress = toChecksumAddress(
+    "0x1111111111111111111111111111111111111111",
+  );
+  const unknownGaugeAddress = toChecksumAddress(
+    "0x9999999999999999999999999999999999999999",
+  );
+  const keeperAddress = toChecksumAddress(
+    "0x3333333333333333333333333333333333333333",
+  );
+  const upkeepManagerAddress = toChecksumAddress(
+    "0x4444444444444444444444444444444444444444",
+  );
+  const senderAddress = toChecksumAddress(
+    "0x5555555555555555555555555555555555555555",
+  );
+  const txHash =
+    "0xabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabca";
+
+  const seedPool = (
+    existingForfeited = 0n,
+    existingRedistributed = 0n,
+  ): ReturnType<typeof createMockLiquidityPoolAggregator> =>
+    createMockLiquidityPoolAggregator({
+      chainId,
+      gaugeAddress,
+      totalEmissionsForfeited: existingForfeited,
+      totalEmissionsRedistributed: existingRedistributed,
+    });
+
+  describe("Deposited event", () => {
+    it("increments totalEmissionsForfeited on the gauge's pool", async () => {
+      const pool = seedPool(10n);
+      const populatedDb =
+        MockDb.createMockDb().entities.LiquidityPoolAggregator.set(pool);
+      const amount = 1_234_567_890_000_000_000n;
+
+      const mockEvent = Redistributor.Deposited.createMockEvent({
+        gauge: gaugeAddress,
+        to: redistributorAddress,
+        amount,
+        mockEventData: {
+          block: {
+            number: 987654,
+            timestamp: 1_700_000_000,
+            hash: "0xblockhashblockhashblockhashblockhashblockhashblockhashblockhash0",
+          },
+          chainId,
+          logIndex: 7,
+          srcAddress: redistributorAddress,
+          transaction: { hash: txHash },
+        },
+      });
+
+      const result = await populatedDb.processEvents([mockEvent]);
+      const updatedPool = result.entities.LiquidityPoolAggregator.get(pool.id);
+
+      expect(updatedPool?.totalEmissionsForfeited).toBe(10n + amount);
+      expect(updatedPool?.totalEmissionsRedistributed).toBe(0n);
+      expect(updatedPool?.totalEmissions).toBe(pool.totalEmissions);
+    });
+
+    it("no-ops when the gauge does not match any pool", async () => {
+      const pool = seedPool();
+      const populatedDb =
+        MockDb.createMockDb().entities.LiquidityPoolAggregator.set(pool);
+
+      const mockEvent = Redistributor.Deposited.createMockEvent({
+        gauge: unknownGaugeAddress,
+        to: redistributorAddress,
+        amount: 123n,
+        mockEventData: {
+          block: {
+            number: 987654,
+            timestamp: 1_700_000_050,
+            hash: "0xblockhashblockhashblockhashblockhashblockhashblockhashblockhash1",
+          },
+          chainId,
+          logIndex: 1,
+          srcAddress: redistributorAddress,
+          transaction: { hash: txHash },
+        },
+      });
+
+      const result = await populatedDb.processEvents([mockEvent]);
+      const unchangedPool = result.entities.LiquidityPoolAggregator.get(
+        pool.id,
+      );
+
+      expect(unchangedPool?.totalEmissionsForfeited).toBe(0n);
+      expect(unchangedPool?.totalEmissionsRedistributed).toBe(0n);
+    });
+  });
+
+  describe("Redistributed event", () => {
+    it("increments totalEmissionsRedistributed on the gauge's pool", async () => {
+      const pool = seedPool(0n, 3n);
+      const populatedDb =
+        MockDb.createMockDb().entities.LiquidityPoolAggregator.set(pool);
+      const amount = 42_000_000_000_000_000_000n;
+
+      const mockEvent = Redistributor.Redistributed.createMockEvent({
+        sender: senderAddress,
+        gauge: gaugeAddress,
+        amount,
+        mockEventData: {
+          block: {
+            number: 987700,
+            timestamp: 1_700_000_100,
+            hash: "0xblockhashblockhashblockhashblockhashblockhashblockhashblockhash2",
+          },
+          chainId,
+          logIndex: 12,
+          srcAddress: redistributorAddress,
+          transaction: { hash: txHash },
+        },
+      });
+
+      const result = await populatedDb.processEvents([mockEvent]);
+      const updatedPool = result.entities.LiquidityPoolAggregator.get(pool.id);
+
+      expect(updatedPool?.totalEmissionsRedistributed).toBe(3n + amount);
+      expect(updatedPool?.totalEmissionsForfeited).toBe(0n);
+      expect(updatedPool?.totalEmissions).toBe(pool.totalEmissions);
+    });
+
+    it("accumulates across multiple Redistributed events in the same tx", async () => {
+      const pool = seedPool();
+      const populatedDb =
+        MockDb.createMockDb().entities.LiquidityPoolAggregator.set(pool);
+
+      const firstEvent = Redistributor.Redistributed.createMockEvent({
+        sender: senderAddress,
+        gauge: gaugeAddress,
+        amount: 1n,
+        mockEventData: {
+          block: {
+            number: 1,
+            timestamp: 1_700_000_200,
+            hash: "0xblockhashblockhashblockhashblockhashblockhashblockhashblockhash3",
+          },
+          chainId,
+          logIndex: 1,
+          srcAddress: redistributorAddress,
+          transaction: { hash: txHash },
+        },
+      });
+      const secondEvent = Redistributor.Redistributed.createMockEvent({
+        sender: senderAddress,
+        gauge: gaugeAddress,
+        amount: 2n,
+        mockEventData: {
+          block: {
+            number: 1,
+            timestamp: 1_700_000_200,
+            hash: "0xblockhashblockhashblockhashblockhashblockhashblockhashblockhash3",
+          },
+          chainId,
+          logIndex: 2,
+          srcAddress: redistributorAddress,
+          transaction: { hash: txHash },
+        },
+      });
+
+      const result = await populatedDb.processEvents([firstEvent, secondEvent]);
+      const updatedPool = result.entities.LiquidityPoolAggregator.get(pool.id);
+
+      expect(updatedPool?.totalEmissionsRedistributed).toBe(3n);
+    });
+  });
+
+  describe("SetKeeper / SetUpkeepManager", () => {
+    it("SetKeeper creates a RedistributorConfig with keeper set and upkeepManager empty", async () => {
+      const mockDb = MockDb.createMockDb();
+      const blockTimestamp = 1_700_000_300;
+
+      const mockEvent = Redistributor.SetKeeper.createMockEvent({
+        keeper: keeperAddress,
+        mockEventData: {
+          block: {
+            number: 10,
+            timestamp: blockTimestamp,
+            hash: "0xblockhashblockhashblockhashblockhashblockhashblockhashblockhash4",
+          },
+          chainId,
+          logIndex: 1,
+          srcAddress: redistributorAddress,
+          transaction: { hash: txHash },
+        },
+      });
+
+      const result = await mockDb.processEvents([mockEvent]);
+
+      const configId = `${chainId}-${redistributorAddress}`;
+      const config = result.entities.RedistributorConfig.get(configId);
+      expect(config).toBeDefined();
+      expect(config?.chainId).toBe(chainId);
+      expect(config?.redistributorAddress).toBe(redistributorAddress);
+      expect(config?.keeper).toBe(keeperAddress);
+      expect(config?.upkeepManager).toBe("");
+      expect(config?.lastUpdatedTimestamp).toEqual(
+        new Date(blockTimestamp * 1000),
+      );
+    });
+
+    it("SetUpkeepManager after SetKeeper preserves the keeper and updates only upkeepManager", async () => {
+      const mockDb = MockDb.createMockDb();
+      const firstTs = 1_700_000_400;
+      const secondTs = 1_700_000_500;
+
+      const setKeeper = Redistributor.SetKeeper.createMockEvent({
+        keeper: keeperAddress,
+        mockEventData: {
+          block: {
+            number: 20,
+            timestamp: firstTs,
+            hash: "0xblockhashblockhashblockhashblockhashblockhashblockhashblockhash5",
+          },
+          chainId,
+          logIndex: 1,
+          srcAddress: redistributorAddress,
+          transaction: { hash: txHash },
+        },
+      });
+      const setUpkeep = Redistributor.SetUpkeepManager.createMockEvent({
+        upkeepManager: upkeepManagerAddress,
+        mockEventData: {
+          block: {
+            number: 21,
+            timestamp: secondTs,
+            hash: "0xblockhashblockhashblockhashblockhashblockhashblockhashblockhash6",
+          },
+          chainId,
+          logIndex: 1,
+          srcAddress: redistributorAddress,
+          transaction: { hash: txHash },
+        },
+      });
+
+      const result = await mockDb.processEvents([setKeeper, setUpkeep]);
+
+      const configId = `${chainId}-${redistributorAddress}`;
+      const config = result.entities.RedistributorConfig.get(configId);
+      expect(config).toBeDefined();
+      expect(config?.keeper).toBe(keeperAddress);
+      expect(config?.upkeepManager).toBe(upkeepManagerAddress);
+      expect(config?.lastUpdatedTimestamp).toEqual(new Date(secondTs * 1000));
+    });
+
+    it("SetUpkeepManager before SetKeeper seeds the config with keeper empty and later SetKeeper preserves upkeepManager", async () => {
+      const mockDb = MockDb.createMockDb();
+      const firstTs = 1_700_000_600;
+      const secondTs = 1_700_000_700;
+
+      const setUpkeep = Redistributor.SetUpkeepManager.createMockEvent({
+        upkeepManager: upkeepManagerAddress,
+        mockEventData: {
+          block: {
+            number: 30,
+            timestamp: firstTs,
+            hash: "0xblockhashblockhashblockhashblockhashblockhashblockhashblockhash7",
+          },
+          chainId,
+          logIndex: 1,
+          srcAddress: redistributorAddress,
+          transaction: { hash: txHash },
+        },
+      });
+      const setKeeper = Redistributor.SetKeeper.createMockEvent({
+        keeper: keeperAddress,
+        mockEventData: {
+          block: {
+            number: 31,
+            timestamp: secondTs,
+            hash: "0xblockhashblockhashblockhashblockhashblockhashblockhashblockhash8",
+          },
+          chainId,
+          logIndex: 1,
+          srcAddress: redistributorAddress,
+          transaction: { hash: txHash },
+        },
+      });
+
+      const result = await mockDb.processEvents([setUpkeep, setKeeper]);
+
+      const configId = `${chainId}-${redistributorAddress}`;
+      const config = result.entities.RedistributorConfig.get(configId);
+      expect(config).toBeDefined();
+      expect(config?.keeper).toBe(keeperAddress);
+      expect(config?.upkeepManager).toBe(upkeepManagerAddress);
+      expect(config?.lastUpdatedTimestamp).toEqual(new Date(secondTs * 1000));
+    });
+  });
+});

--- a/test/EventHandlers/Redistributor/Redistributor.test.ts
+++ b/test/EventHandlers/Redistributor/Redistributor.test.ts
@@ -1,6 +1,7 @@
 import { MockDb, Redistributor } from "../../../generated/src/TestHelpers.gen";
 import { toChecksumAddress } from "../../../src/Constants";
 import { setupCommon } from "../Pool/common";
+import { makeRedistributorMockEventData } from "./common";
 
 describe("Redistributor Event Handlers", () => {
   const { createMockLiquidityPoolAggregator } = setupCommon();
@@ -26,6 +27,19 @@ describe("Redistributor Event Handlers", () => {
   const txHash =
     "0xabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabca";
 
+  const buildMockEventData = (overrides: {
+    blockNumber: number;
+    timestamp: number;
+    blockHash: string;
+    logIndex: number;
+  }) =>
+    makeRedistributorMockEventData({
+      ...overrides,
+      chainId,
+      srcAddress: redistributorAddress,
+      txHash,
+    });
+
   const seedPool = (
     existingForfeited = 0n,
     existingRedistributed = 0n,
@@ -48,17 +62,13 @@ describe("Redistributor Event Handlers", () => {
         gauge: gaugeAddress,
         to: redistributorAddress,
         amount,
-        mockEventData: {
-          block: {
-            number: 987654,
-            timestamp: 1_700_000_000,
-            hash: "0xblockhashblockhashblockhashblockhashblockhashblockhashblockhash0",
-          },
-          chainId,
+        mockEventData: buildMockEventData({
+          blockNumber: 987654,
+          timestamp: 1_700_000_000,
+          blockHash:
+            "0xblockhashblockhashblockhashblockhashblockhashblockhashblockhash0",
           logIndex: 7,
-          srcAddress: redistributorAddress,
-          transaction: { hash: txHash },
-        },
+        }),
       });
 
       const result = await populatedDb.processEvents([mockEvent]);
@@ -78,17 +88,13 @@ describe("Redistributor Event Handlers", () => {
         gauge: unknownGaugeAddress,
         to: redistributorAddress,
         amount: 123n,
-        mockEventData: {
-          block: {
-            number: 987654,
-            timestamp: 1_700_000_050,
-            hash: "0xblockhashblockhashblockhashblockhashblockhashblockhashblockhash1",
-          },
-          chainId,
+        mockEventData: buildMockEventData({
+          blockNumber: 987654,
+          timestamp: 1_700_000_050,
+          blockHash:
+            "0xblockhashblockhashblockhashblockhashblockhashblockhashblockhash1",
           logIndex: 1,
-          srcAddress: redistributorAddress,
-          transaction: { hash: txHash },
-        },
+        }),
       });
 
       const result = await populatedDb.processEvents([mockEvent]);
@@ -98,6 +104,10 @@ describe("Redistributor Event Handlers", () => {
 
       expect(unchangedPool?.totalEmissionsForfeited).toBe(0n);
       expect(unchangedPool?.totalEmissionsRedistributed).toBe(0n);
+      // Guard against the handler synthesising a pool entity on gauge miss.
+      expect(
+        Array.from(result.entities.LiquidityPoolAggregator.getAll()).length,
+      ).toBe(1);
     });
   });
 
@@ -112,17 +122,13 @@ describe("Redistributor Event Handlers", () => {
         sender: senderAddress,
         gauge: gaugeAddress,
         amount,
-        mockEventData: {
-          block: {
-            number: 987700,
-            timestamp: 1_700_000_100,
-            hash: "0xblockhashblockhashblockhashblockhashblockhashblockhashblockhash2",
-          },
-          chainId,
+        mockEventData: buildMockEventData({
+          blockNumber: 987700,
+          timestamp: 1_700_000_100,
+          blockHash:
+            "0xblockhashblockhashblockhashblockhashblockhashblockhashblockhash2",
           logIndex: 12,
-          srcAddress: redistributorAddress,
-          transaction: { hash: txHash },
-        },
+        }),
       });
 
       const result = await populatedDb.processEvents([mockEvent]);
@@ -142,33 +148,25 @@ describe("Redistributor Event Handlers", () => {
         sender: senderAddress,
         gauge: gaugeAddress,
         amount: 1n,
-        mockEventData: {
-          block: {
-            number: 1,
-            timestamp: 1_700_000_200,
-            hash: "0xblockhashblockhashblockhashblockhashblockhashblockhashblockhash3",
-          },
-          chainId,
+        mockEventData: buildMockEventData({
+          blockNumber: 1,
+          timestamp: 1_700_000_200,
+          blockHash:
+            "0xblockhashblockhashblockhashblockhashblockhashblockhashblockhash3",
           logIndex: 1,
-          srcAddress: redistributorAddress,
-          transaction: { hash: txHash },
-        },
+        }),
       });
       const secondEvent = Redistributor.Redistributed.createMockEvent({
         sender: senderAddress,
         gauge: gaugeAddress,
         amount: 2n,
-        mockEventData: {
-          block: {
-            number: 1,
-            timestamp: 1_700_000_200,
-            hash: "0xblockhashblockhashblockhashblockhashblockhashblockhashblockhash3",
-          },
-          chainId,
+        mockEventData: buildMockEventData({
+          blockNumber: 1,
+          timestamp: 1_700_000_200,
+          blockHash:
+            "0xblockhashblockhashblockhashblockhashblockhashblockhashblockhash3",
           logIndex: 2,
-          srcAddress: redistributorAddress,
-          transaction: { hash: txHash },
-        },
+        }),
       });
 
       const result = await populatedDb.processEvents([firstEvent, secondEvent]);
@@ -185,17 +183,13 @@ describe("Redistributor Event Handlers", () => {
 
       const mockEvent = Redistributor.SetKeeper.createMockEvent({
         keeper: keeperAddress,
-        mockEventData: {
-          block: {
-            number: 10,
-            timestamp: blockTimestamp,
-            hash: "0xblockhashblockhashblockhashblockhashblockhashblockhashblockhash4",
-          },
-          chainId,
+        mockEventData: buildMockEventData({
+          blockNumber: 10,
+          timestamp: blockTimestamp,
+          blockHash:
+            "0xblockhashblockhashblockhashblockhashblockhashblockhashblockhash4",
           logIndex: 1,
-          srcAddress: redistributorAddress,
-          transaction: { hash: txHash },
-        },
+        }),
       });
 
       const result = await mockDb.processEvents([mockEvent]);
@@ -219,31 +213,23 @@ describe("Redistributor Event Handlers", () => {
 
       const setKeeper = Redistributor.SetKeeper.createMockEvent({
         keeper: keeperAddress,
-        mockEventData: {
-          block: {
-            number: 20,
-            timestamp: firstTs,
-            hash: "0xblockhashblockhashblockhashblockhashblockhashblockhashblockhash5",
-          },
-          chainId,
+        mockEventData: buildMockEventData({
+          blockNumber: 20,
+          timestamp: firstTs,
+          blockHash:
+            "0xblockhashblockhashblockhashblockhashblockhashblockhashblockhash5",
           logIndex: 1,
-          srcAddress: redistributorAddress,
-          transaction: { hash: txHash },
-        },
+        }),
       });
       const setUpkeep = Redistributor.SetUpkeepManager.createMockEvent({
         upkeepManager: upkeepManagerAddress,
-        mockEventData: {
-          block: {
-            number: 21,
-            timestamp: secondTs,
-            hash: "0xblockhashblockhashblockhashblockhashblockhashblockhashblockhash6",
-          },
-          chainId,
+        mockEventData: buildMockEventData({
+          blockNumber: 21,
+          timestamp: secondTs,
+          blockHash:
+            "0xblockhashblockhashblockhashblockhashblockhashblockhashblockhash6",
           logIndex: 1,
-          srcAddress: redistributorAddress,
-          transaction: { hash: txHash },
-        },
+        }),
       });
 
       const result = await mockDb.processEvents([setKeeper, setUpkeep]);
@@ -263,31 +249,23 @@ describe("Redistributor Event Handlers", () => {
 
       const setUpkeep = Redistributor.SetUpkeepManager.createMockEvent({
         upkeepManager: upkeepManagerAddress,
-        mockEventData: {
-          block: {
-            number: 30,
-            timestamp: firstTs,
-            hash: "0xblockhashblockhashblockhashblockhashblockhashblockhashblockhash7",
-          },
-          chainId,
+        mockEventData: buildMockEventData({
+          blockNumber: 30,
+          timestamp: firstTs,
+          blockHash:
+            "0xblockhashblockhashblockhashblockhashblockhashblockhashblockhash7",
           logIndex: 1,
-          srcAddress: redistributorAddress,
-          transaction: { hash: txHash },
-        },
+        }),
       });
       const setKeeper = Redistributor.SetKeeper.createMockEvent({
         keeper: keeperAddress,
-        mockEventData: {
-          block: {
-            number: 31,
-            timestamp: secondTs,
-            hash: "0xblockhashblockhashblockhashblockhashblockhashblockhashblockhash8",
-          },
-          chainId,
+        mockEventData: buildMockEventData({
+          blockNumber: 31,
+          timestamp: secondTs,
+          blockHash:
+            "0xblockhashblockhashblockhashblockhashblockhashblockhashblockhash8",
           logIndex: 1,
-          srcAddress: redistributorAddress,
-          transaction: { hash: txHash },
-        },
+        }),
       });
 
       const result = await mockDb.processEvents([setUpkeep, setKeeper]);

--- a/test/EventHandlers/Redistributor/common.ts
+++ b/test/EventHandlers/Redistributor/common.ts
@@ -1,0 +1,38 @@
+/**
+ * Build the `mockEventData` shape shared by Redistributor event fixtures.
+ *
+ * Every Redistributor test case passes the same keys (`block`, `chainId`,
+ * `logIndex`, `srcAddress`, `transaction.hash`); only a handful vary across
+ * cases. Centralising construction here keeps individual tests focused on the
+ * field(s) they are actually asserting on.
+ *
+ * @param fields - Per-test overrides for the varying fields
+ * @returns The `mockEventData` object to pass into a Redistributor mock event
+ */
+type HexString = `0x${string}`;
+
+// Callers typically pass `toChecksumAddress(...)` or inline hex literals whose
+// types widen to `string` before reaching the helper; the generated mock APIs
+// demand `0x${string}` template-literal types. Narrow once here so each test
+// case doesn't need its own cast.
+const asHex = (value: string): HexString => value as HexString;
+
+export const makeRedistributorMockEventData = (fields: {
+  blockNumber: number;
+  timestamp: number;
+  blockHash: string;
+  logIndex: number;
+  chainId: number;
+  srcAddress: string;
+  txHash: string;
+}) => ({
+  block: {
+    number: fields.blockNumber,
+    timestamp: fields.timestamp,
+    hash: asHex(fields.blockHash),
+  },
+  chainId: fields.chainId,
+  logIndex: fields.logIndex,
+  srcAddress: asHex(fields.srcAddress),
+  transaction: { hash: asHex(fields.txHash) },
+});


### PR DESCRIPTION
## Summary

Closes #637. Adds support for the Aerodrome `Redistributor` contract on Base:

- Indexes 4 events: `Deposited`, `Redistributed`, `SetKeeper`, `SetUpkeepManager`.
- `Deposited`/`Redistributed` fold into two new cumulative counters on the existing `LiquidityPoolAggregator` (and its snapshot) — `totalEmissionsForfeited` and `totalEmissionsRedistributed` — via a gauge→pool lookup (`getWhere({ gaugeAddress })`). No separate append-only event entities.
- `totalEmissions` is left untouched; the new fields are additive signals.
- `SetKeeper`/`SetUpkeepManager` upsert a singleton `RedistributorConfig` keyed by `{chainId}-{redistributorAddress}`, preserving the sibling field (empty string sentinel until observed).
- Log-and-drop on gauge→pool miss — Redistributor is same-chain with `Voter.GaugeCreated`, so a missing mapping signals a config gap, not a race.

Base addresses wired under chain 8453: `0x11a53f31Bf406de59fCf9613E1922bd3E283A4B4` (Gauge Caps) and `0xEe5b3C7b333e2870B746b3B2b168EF0958e55e15` (Gauges V3).

## Test plan

- [x] `pnpm envio codegen` clean
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test` — 1070 passed / 32 skipped (7 new Redistributor tests)
- [x] `pnpm qa --write` clean
- [ ] Deploy to staging and verify counters increment on real Base Redistributor events

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated Redistributor on Optimism with monitoring of redistribution and deposit events.
  * Added liquidity pool emission metrics: totalEmissionsRedistributed and totalEmissionsForfeited.
  * Added per-Redistributor configuration tracking for keeper and upkeep manager (with last-updated timestamps).

* **Tests**
  * Added test suites and fixtures validating Redistributor event handling, emission accumulation, and config lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->