### PR TITLE
fix(pool-aggregator): drop redundant block rounding before refreshTokenPrice

### DIFF
--- a/src/Aggregators/LiquidityPoolAggregator.ts
+++ b/src/Aggregators/LiquidityPoolAggregator.ts
@@ -5,7 +5,7 @@ import type {
   handlerContext,
 } from "generated";
 import { PoolId, TokenId, isKnownSinkRootPool } from "../Constants";
-import { getSwapFee, roundBlockToInterval } from "../Effects/Index";
+import { getSwapFee } from "../Effects/Index";
 import { calculateTotalUSD, generatePoolName } from "../Helpers";
 import { refreshTokenPrice } from "../PriceOracle";
 import {
@@ -466,16 +466,14 @@ export async function loadPoolData(
   }
 
   // Refresh token prices if block data is provided
-  // refreshTokenPrice will decide internally if refresh is needed
+  // refreshTokenPrice will decide internally if refresh is needed and handles block rounding
   let updatedToken0 = token0Instance;
   let updatedToken1 = token1Instance;
   if (blockNumber !== undefined && blockTimestamp !== undefined) {
-    const roundedBlockNumber = roundBlockToInterval(blockNumber, chainId);
-
     // Wrap each refresh in a promise that catches errors individually
     const token0Refresh = refreshTokenPrice(
       token0Instance,
-      roundedBlockNumber,
+      blockNumber,
       blockTimestamp,
       chainId,
       context,
@@ -488,7 +486,7 @@ export async function loadPoolData(
 
     const token1Refresh = refreshTokenPrice(
       token1Instance,
-      roundedBlockNumber,
+      blockNumber,
       blockTimestamp,
       chainId,
       context,


### PR DESCRIPTION
## Summary

- `refreshTokenPrice` already rounds the block number internally via `roundBlockToInterval` at `src/PriceOracle.ts:93`.
- `loadPoolData` in `LiquidityPoolAggregator.ts` was calling `roundBlockToInterval` again before handing off to `refreshTokenPrice` — same function, same inputs, idempotent, purely redundant.
- Drops the pre-call rounding and the now-unused import. Behaviour is unchanged.

Closes #476

## Test plan

- [x] `tsc --noEmit` passes
- [x] `biome check` clean
- [x] `vitest run test/EventHandlers/Pool test/EventHandlers/CLPool test/EventHandlers/Voter test/EventHandlers/NFPM` — 424 pass, 0 fail (the suites exercising `loadPoolData`'s price-refresh path)
- [x] CI green on the PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization for block number handling, delegating rounding logic to reduce redundant calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->