### PR TITLE
refactor(voter): use calculateTokenAmountUSD for USD conversions

### DIFF
--- a/src/EventHandlers/Voter/VoterCommonLogic.ts
+++ b/src/EventHandlers/Voter/VoterCommonLogic.ts
@@ -17,8 +17,10 @@ import {
   isKnownSinkRootPool,
 } from "../../Constants";
 import { getTokensDeposited } from "../../Effects/Index";
-import { normalizeTokenAmountTo1e18 } from "../../Helpers";
-import { multiplyBase1e18 } from "../../Maths";
+import {
+  calculateTokenAmountUSD,
+  normalizeTokenAmountTo1e18,
+} from "../../Helpers";
 
 export interface VoterCommonResult {
   isAlive: boolean;
@@ -57,25 +59,22 @@ export async function computeVoterDistributeValues(
     );
   }
 
-  // Normalize amounts to 1e18
+  const rewardTokenDecimals = Number(rewardToken.decimals);
+
   const normalizedEmissionsAmount = normalizeTokenAmountTo1e18(
     amountEmittedRaw,
-    Number(rewardToken.decimals),
+    rewardTokenDecimals,
   );
 
-  const normalizedVotesDepositedAmount = normalizeTokenAmountTo1e18(
-    BigInt(tokensDeposited.toString()),
-    Number(rewardToken.decimals),
-  );
-
-  // USD conversions
-  const normalizedEmissionsAmountUsd = multiplyBase1e18(
-    normalizedEmissionsAmount,
+  const normalizedEmissionsAmountUsd = calculateTokenAmountUSD(
+    amountEmittedRaw,
+    rewardTokenDecimals,
     rewardToken.pricePerUSDNew,
   );
 
-  const normalizedVotesDepositedAmountUsd = multiplyBase1e18(
-    normalizedVotesDepositedAmount,
+  const normalizedVotesDepositedAmountUsd = calculateTokenAmountUSD(
+    BigInt(tokensDeposited.toString()),
+    rewardTokenDecimals,
     rewardToken.pricePerUSDNew,
   );
 


### PR DESCRIPTION
## Summary

- `VoterCommonLogic.computeVoterDistributeValues` was hand-composing USD values with `normalizeTokenAmountTo1e18` + `multiplyBase1e18` instead of going through the centralised `calculateTokenAmountUSD` helper.
- This was the last event handler still calling `multiplyBase1e18` directly. After this change, no event handler reaches for `multiplyBase1e18` — all USD conversions go through `calculateTokenAmountUSD` (`src/Helpers.ts:71`), which internally composes the two primitives.
- `normalizeTokenAmountTo1e18` is still used here for the `normalizedEmissionsAmount` return field (non-USD 1e18 normalisation), consistent with how `CLPoolSwapLogic` uses it for raw fee amounts.
- Numerical behaviour is unchanged — `calculateTokenAmountUSD(amount, decimals, price)` is exactly `multiplyBase1e18(normalizeTokenAmountTo1e18(amount, decimals), price)`.

Closes #475

## Test plan

- [x] `tsc --noEmit` passes
- [x] `biome check` clean
- [x] `vitest run test/EventHandlers/Voter` — 110 pass, 0 fail (includes `VoterCommonLogic.test.ts` with explicit numeric assertions on `normalizedEmissionsAmountUsd` and `normalizedVotesDepositedAmountUsd`)
- [x] CI green on the PR