### PR TITLE
perf(cl-staked): sparse stakedTickEdges list on aggregator (#649)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,14 +39,26 @@ build
 # Coverage
 .nyc_output/
 
-# Script results (local-only test outputs)
+# Script results and local-only output directories
 scripts/results/
+scripts/out/
+scripts/profiles/
 
-# Local-only investigation/benchmark/replay scripts. Pre-existing tracked scripts
-# (generate_whitelist.ts, smoke-effects.ts, test-price-oracles.ts, etc.) remain
-# tracked — gitignore affects only future untracked files. Remove this line when
-# we want to start shipping new scripts in the repo again.
-scripts/
+# Local-only investigation/benchmark/replay scripts.
+# Listed explicitly so that any NEW shared script added to scripts/ is visible
+# by default rather than silently ignored by a blanket scripts/ pattern.
+scripts/analyze-cpuprofile.ts
+scripts/bench-tick-crossings.ts
+scripts/bench-tick-edges.ts
+scripts/check-604-timing.ts
+scripts/measure-cl-pool-staked-vs-swaps.ts
+scripts/measure-cltickstaked-max.ts
+scripts/measure-lisk-tick-sweeps.ts
+scripts/measure-negative-pool-fields.ts
+scripts/measure-staked-nfp-per-pool.ts
+scripts/replay-604-superseed.ts
+scripts/verify-cpuprofile.ts
+scripts/verify-oom-fix.ts
 
 # Claude Code worktrees (ephemeral, local-only)
 .claude/worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -42,5 +42,11 @@ build
 # Script results (local-only test outputs)
 scripts/results/
 
+# Local-only investigation/benchmark/replay scripts. Pre-existing tracked scripts
+# (generate_whitelist.ts, smoke-effects.ts, test-price-oracles.ts, etc.) remain
+# tracked — gitignore affects only future untracked files. Remove this line when
+# we want to start shipping new scripts in the repo again.
+scripts/
+
 # Claude Code worktrees (ephemeral, local-only)
 .claude/worktrees/

--- a/schema.graphql
+++ b/schema.graphql
@@ -60,6 +60,18 @@ type LiquidityPoolAggregator {
   # negligible is tracked in #649 (sparse stakedTickEdges list); until it lands,
   # the latch is "accept a degenerate case to avoid the bookkeeping of clearing".
   hasStakes: Boolean!
+  # Parallel arrays encoding Uniswap v3's per-tick liquidityNet for the staked
+  # subset. Sorted ascending by tick, dedup'd, no zero-net entries. Same length,
+  # same index: (stakedTickEdges[i], stakedTickEdgeNets[i]) is one (tick, net)
+  # pair. Two arrays instead of one list-of-structs because GraphQL lists only
+  # allow scalars or named types — tuples don't exist at this layer.
+  #
+  # Maintained on gauge deposit / withdraw / NFPM staked-position liquidity
+  # changes. Consumed by processTickCrossingsForStaked via in-memory binary
+  # search — no CLTickStaked.get / getWhere calls on the swap path, which
+  # breaks the OOM chain-of-amplification from #648.
+  stakedTickEdges: [BigInt!]!
+  stakedTickEdgeNets: [BigInt!]!
   totalFlashLoanFees0: BigInt @config(precision: 76) # total flash loan fees collected in token0
   totalFlashLoanFees1: BigInt @config(precision: 76) # total flash loan fees collected in token1
   totalFlashLoanFeesUSD: BigInt @config(precision: 76) # total flash loan fees collected in USD

--- a/src/Aggregators/CLStakedLiquidity.ts
+++ b/src/Aggregators/CLStakedLiquidity.ts
@@ -29,6 +29,183 @@ export function isPositionInRange(
 }
 
 /**
+ * Binary-search an ascending-sorted bigint[] for `target` — O(log n) comparisons.
+ *
+ * Returns the lowest index `i` such that `arr[i] >= target`, or `arr.length`
+ * if every element is strictly less than `target`. Matches `std::lower_bound`.
+ *
+ * Why binary search, not linear: per-pool edge counts can reach ~22k (#648's
+ * worst-case envelope). Linear would scan all of them even when a typical swap
+ * crosses 0–few; O(log n) jumps straight to the crossing window.
+ *
+ * @param arr - Sorted ascending array (monotone; no duplicates in stakedTickEdges)
+ * @param target - Tick value to locate
+ * @returns Lower-bound index in [0, arr.length]
+ */
+function lowerBound(arr: readonly bigint[], target: bigint): number {
+  let lo = 0;
+  let hi = arr.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (arr[mid] < target) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+  return lo;
+}
+
+/**
+ * Applies a +/-delta to the running net at `tick` on the parallel (edges, nets)
+ * arrays. Inserts a new (edge, net) entry if `tick` is not present; when the
+ * resulting net becomes 0n the edge is dropped. Returns a NEW pair of arrays —
+ * Envio entities are immutable and must be replaced, not patched.
+ *
+ * Cost: O(log E) for the binary-search locate, O(E) for the immutable array
+ * copy (where E = edges.length). The copy dominates. #648's worst-case
+ * envelope: ~50µs at E=22k on V8 (pointer memcpy at ~10 GB/s). At 2500
+ * stake/unstake writes/batch that's ~125ms extra CPU per batch — the cost
+ * we're paying to break the OOM fan-out.
+ *
+ * The parallel-arrays shape mirrors Uniswap v3's per-tick `liquidityNet`: one
+ * running counter per initialized tick, adjusted on every stake/unstake event
+ * that crosses that boundary. Multiple staked positions at the same edge sum
+ * into the same slot, which is how refcount is expressed implicitly (no
+ * separate counter is needed).
+ *
+ * @param edges - Current sorted-ascending edge list (must be monotone, no dupes)
+ * @param nets - Parallel nets array (same length, same index as `edges`)
+ * @param tick - Tick value to adjust
+ * @param delta - Signed delta to add to the net at `tick`
+ * @returns { edges, nets } new parallel arrays with the delta applied
+ */
+function applyDeltaAtTick(
+  edges: readonly bigint[],
+  nets: readonly bigint[],
+  tick: bigint,
+  delta: bigint,
+): { edges: bigint[]; nets: bigint[] } {
+  const idx = lowerBound(edges, tick);
+  const present = idx < edges.length && edges[idx] === tick;
+
+  if (present) {
+    const newNet = nets[idx] + delta;
+    if (newNet === 0n) {
+      const outEdges = new Array<bigint>(edges.length - 1);
+      const outNets = new Array<bigint>(nets.length - 1);
+      for (let i = 0; i < idx; i++) {
+        outEdges[i] = edges[i];
+        outNets[i] = nets[i];
+      }
+      for (let i = idx + 1; i < edges.length; i++) {
+        outEdges[i - 1] = edges[i];
+        outNets[i - 1] = nets[i];
+      }
+      return { edges: outEdges, nets: outNets };
+    }
+    const outEdges = edges.slice();
+    const outNets = nets.slice();
+    outNets[idx] = newNet;
+    return { edges: outEdges, nets: outNets };
+  }
+
+  // Not present — insert. The caller (applyStakedPositionToEdges) already
+  // rejects delta === 0n at its top guard, so reaching this branch with a
+  // zero delta is unreachable by construction.
+  const outEdges = new Array<bigint>(edges.length + 1);
+  const outNets = new Array<bigint>(nets.length + 1);
+  for (let i = 0; i < idx; i++) {
+    outEdges[i] = edges[i];
+    outNets[i] = nets[i];
+  }
+  outEdges[idx] = tick;
+  outNets[idx] = delta;
+  for (let i = idx; i < edges.length; i++) {
+    outEdges[i + 1] = edges[i];
+    outNets[i + 1] = nets[i];
+  }
+  return { edges: outEdges, nets: outNets };
+}
+
+/**
+ * Reason tag emitted by `applyStakedPositionToEdges` when it refuses to apply a
+ * position. Callers use this to log the anomaly while still receiving valid
+ * (unchanged) arrays to assign into the aggregator diff.
+ *   - "ticks_out_of_range": at least one tick is outside [TICK_MIN, TICK_MAX].
+ *     Indicates upstream state corruption (bad NFPM event, ordering bug, etc.).
+ *   - "degenerate_range": tickLower >= tickUpper. Should never happen for a
+ *     valid Uniswap v3 position; indicates bad upstream data.
+ * `liquidityDelta === 0n` is a legitimate no-op (e.g., the Mint-0 case from
+ * NFPM) and does NOT produce a rejection tag.
+ */
+export type StakedEdgesRejection = "ticks_out_of_range" | "degenerate_range";
+
+/**
+ * Applies a staked-position liquidity change ([tickLower, tickUpper] × liquidityDelta)
+ * to the parallel (edges, nets) arrays. Mirrors the updateTicksForStakedPosition
+ * CLTickStaked write, but in-aggregator so the swap path never needs to load it.
+ *
+ * Convention (same as CLTickStaked):
+ *   - At tickLower: net += liquidityDelta  (positions ENTER range on upward cross)
+ *   - At tickUpper: net -= liquidityDelta  (positions EXIT range on upward cross)
+ *
+ * On stake:   liquidityDelta = +position.liquidity
+ * On unstake: liquidityDelta = -position.liquidity
+ *
+ * When the inputs would violate an invariant (ticks outside Uniswap v3 range,
+ * or tickLower >= tickUpper), the arrays are returned unchanged and `rejected`
+ * carries a tag so the caller can log the anomaly. Zero-delta is a silent
+ * no-op (no tag) because it is a legitimate NFPM Mint-0 / liq-unchanged flow.
+ *
+ * @param edges - Current sorted edge list
+ * @param nets - Parallel nets
+ * @param tickLower - Position's lower tick boundary
+ * @param tickUpper - Position's upper tick boundary
+ * @param liquidityDelta - Signed liquidity change
+ * @returns New parallel (edges, nets) arrays; `rejected` set when an invariant
+ *          violation prevented the update
+ */
+export function applyStakedPositionToEdges(
+  edges: readonly bigint[],
+  nets: readonly bigint[],
+  tickLower: bigint,
+  tickUpper: bigint,
+  liquidityDelta: bigint,
+): { edges: bigint[]; nets: bigint[]; rejected?: StakedEdgesRejection } {
+  if (liquidityDelta === 0n) {
+    return { edges: edges.slice(), nets: nets.slice() };
+  }
+  if (
+    tickLower < TICK_MIN ||
+    tickLower > TICK_MAX ||
+    tickUpper < TICK_MIN ||
+    tickUpper > TICK_MAX
+  ) {
+    return {
+      edges: edges.slice(),
+      nets: nets.slice(),
+      rejected: "ticks_out_of_range",
+    };
+  }
+  if (tickLower >= tickUpper) {
+    return {
+      edges: edges.slice(),
+      nets: nets.slice(),
+      rejected: "degenerate_range",
+    };
+  }
+
+  const afterLower = applyDeltaAtTick(edges, nets, tickLower, liquidityDelta);
+  return applyDeltaAtTick(
+    afterLower.edges,
+    afterLower.nets,
+    tickUpper,
+    -liquidityDelta,
+  );
+}
+
+/**
  * Updates the two CLTickStaked entities that bookend a position's tick range.
  * Mirrors Uniswap v3's ticks[i].liquidityNet but for the staked subset only.
  *
@@ -41,6 +218,13 @@ export function isPositionInRange(
  *
  * On stake:   liquidityDelta = +position.liquidity
  * On unstake: liquidityDelta = -position.liquidity
+ *
+ * DEPRECATED in-place alongside #649: the swap path no longer reads
+ * CLTickStaked, and no other internal consumer remains. The writes are kept
+ * on purpose for one release so the GraphQL entity (which is auto-exposed
+ * to external consumers) doesn't disappear without notice. Scheduled for
+ * removal in velodrome-finance/indexer#652. New callers MUST use
+ * applyStakedPositionToEdges on the aggregator.
  *
  * @param chainId - Chain ID
  * @param poolAddress - CL pool address
@@ -83,77 +267,56 @@ export async function updateTicksForStakedPosition(
 }
 
 /**
- * Aligns a tick value UP to the next tick-spacing boundary STRICTLY ABOVE tick.
- * Used to find the first initialized tick boundary to cross when price moves up.
+ * Processes tick crossings between oldTick and newTick, adjusting
+ * stakedLiquidityInRange by walking the in-aggregator (stakedTickEdges,
+ * stakedTickEdgeNets) parallel arrays.
  *
- * Examples with spacing=200:
- *   alignTickUp(100, 200)  → 200   (next multiple of 200 above 100)
- *   alignTickUp(200, 200)  → 400   (strictly above, so skip 200 itself)
- *   alignTickUp(0, 200)    → 200
- *   alignTickUp(-50, 200)  → 0
- *   alignTickUp(-200, 200) → 0     (strictly above -200)
+ * Replicates the Uniswap v3 pool contract's tick-crossing logic for the staked
+ * subset: when a swap crosses tick T going up, stakedLiq += net[T]; when going
+ * down, stakedLiq -= net[T].
  *
- * @param tick - Current tick value
- * @param spacing - Tick spacing
- * @returns Next tick-spacing-aligned tick strictly above tick
- */
-function alignTickUp(tick: bigint, spacing: bigint): bigint {
-  if (spacing === 0n) return tick;
-  const t = tick + 1n;
-  if (t >= 0n) {
-    return ((t + spacing - 1n) / spacing) * spacing;
-  }
-  return -(-t / spacing) * spacing;
-}
-
-/**
- * Aligns a tick value DOWN to the tick-spacing boundary AT OR BELOW tick.
- * Used to find the first initialized tick boundary to cross when price moves down.
+ * Structural fix for the 20GB OOM (see #648, #649):
+ *   - Zero `.get()` or `.getWhere()` calls on the swap path. The per-edge net is
+ *     read from the in-memory `stakedTickEdgeNets` array carried on the
+ *     aggregator, not from a CLTickStaked entity load.
+ *   - Total cost per swap: O(log E + K) where E = per-pool edge count (worst
+ *     case ~22k per #648) and K = edges actually crossed (typically 0–few).
+ *     Linear scanning all E edges is what this replaces, and what drove the
+ *     OOM in the old implementation — every candidate tick-spacing step
+ *     issued a CLTickStaked.get.
+ *   - Breaks the chain-of-amplification from #648: no LoadManager grouping, no
+ *     postgres-js text[] serialization, no InMemTable CLTickStaked accumulation,
+ *     no 5000-handler preload fan-out.
  *
- * Examples with spacing=200:
- *   alignTickDown(100, 200)  → 0    (floor to multiple of 200)
- *   alignTickDown(200, 200)  → 200  (already aligned, keep it)
- *   alignTickDown(399, 200)  → 200
- *   alignTickDown(-50, 200)  → -200
- *
- * @param tick - Current tick value
- * @param spacing - Tick spacing
- * @returns Tick-spacing-aligned tick at or below tick
- */
-function alignTickDown(tick: bigint, spacing: bigint): bigint {
-  if (spacing === 0n) return tick;
-  if (tick >= 0n) {
-    return (tick / spacing) * spacing;
-  }
-  return -((-tick + spacing - 1n) / spacing) * spacing;
-}
-
-/**
- * Processes tick crossings between oldTick and newTick, adjusting stakedLiquidityInRange
- * by reading CLTickStaked entities at each crossed tick boundary.
- *
- * Replicates the Uniswap v3 pool contract's tick-crossing logic for the staked subset:
- * when a swap crosses tick T going up, stakedLiq += tick[T].stakedLiquidityNet
- * when a swap crosses tick T going down, stakedLiq -= tick[T].stakedLiquidityNet
- *
- * Safety guards (added for the Lisk OOM hotfix):
- *   - `hasStakes=false` short-circuits the sweep for pools that have never been
- *     staked — the per-tick CLTickStaked reads are provably zero, so the loop
- *     cannot change `currentStakedLiqInRange`.
+ * Safety guards retained from PR 1 (#650):
+ *   - `hasStakes=false` short-circuits the walk entirely. Redundant with an
+ *     empty edge list, but kept explicit for parity with other call sites.
  *   - Out-of-range ticks (outside [TICK_MIN, TICK_MAX]) are rejected and logged
- *     instead of driving the loop with millions of iterations.
+ *     with a `STAKED_TICK_DRIFT` tag so ops can alert on it. After a bail the
+ *     aggregator still writes the new tick, so downstream reads of
+ *     `stakedLiquidityInRange` on this pool will be stale by the un-applied
+ *     nets until the next rebuild — worth alerting on.
  *
- * @param chainId - Chain ID
- * @param poolAddress - CL pool address
+ * Pure in-memory computation. Uses the Envio `context` ONLY for
+ * `context.log.error` — any entity access here (e.g. `context.CLTickStaked.get`)
+ * would reintroduce the #648 OOM fan-out this function was written to replace.
+ * Enforced by the throwing spy in test/Aggregators/CLStakedLiquidityEdgeSanity.test.ts
+ * and CLStakedLiquidity.test.ts.
+ *
+ * @param chainId - Chain ID (used only for error logging)
+ * @param poolAddress - CL pool address (used only for error logging)
  * @param oldTick - Tick before the swap
  * @param newTick - Tick after the swap
- * @param tickSpacing - Pool's tick spacing
- * @param context - Handler context for entity access
+ * @param tickSpacing - Pool's tick spacing (used only to short-circuit when 0)
+ * @param context - Envio handler context — used ONLY for context.log.error;
+ *                  must not touch entity APIs (see note above)
  * @param currentStakedLiqInRange - Staked in-range liquidity before the swap
- * @param hasStakes - Whether this pool has ever had a staked position (from the aggregator latch)
+ * @param hasStakes - Whether this pool has ever had a staked position
+ * @param stakedTickEdges - Sorted, dedup'd tick edges from the aggregator
+ * @param stakedTickEdgeNets - Parallel nets (same index as stakedTickEdges)
  * @returns Updated stakedLiquidityInRange after processing tick crossings
  */
-export async function processTickCrossingsForStaked(
+export function processTickCrossingsForStaked(
   chainId: number,
   poolAddress: string,
   oldTick: bigint,
@@ -162,7 +325,9 @@ export async function processTickCrossingsForStaked(
   context: handlerContext,
   currentStakedLiqInRange: bigint,
   hasStakes: boolean,
-): Promise<bigint> {
+  stakedTickEdges: readonly bigint[],
+  stakedTickEdgeNets: readonly bigint[],
+): bigint {
   if (oldTick === newTick || tickSpacing === 0n) {
     return currentStakedLiqInRange;
   }
@@ -179,49 +344,36 @@ export async function processTickCrossingsForStaked(
     newTick > TICK_MAX
   ) {
     context.log.error(
-      `[processTickCrossingsForStaked] Tick out of Uniswap v3 range for pool ${poolAddress} on chain ${chainId}: oldTick=${oldTick}, newTick=${newTick}. Skipping crossing sweep to avoid runaway loop.`,
+      `[STAKED_TICK_DRIFT][processTickCrossingsForStaked] Tick out of Uniswap v3 range for pool ${poolAddress} on chain ${chainId}: oldTick=${oldTick}, newTick=${newTick}. Skipping crossing sweep to avoid runaway loop; stakedLiquidityInRange will be stale on this pool until a subsequent stake/unstake rebuilds it.`,
     );
     return currentStakedLiqInRange;
   }
 
-  // Pools without any CLTickStaked entries cannot contribute to stakedLiq — skip
-  // the sweep entirely. This is the hot path: it eliminates the O((Δtick)/spacing)
-  // per-swap scan for every unstaked pool.
-  if (!hasStakes) {
+  // Pools without any staked positions cannot contribute to stakedLiq — skip
+  // the binary search entirely. This is the hot path: it eliminates the
+  // O(log E + k) per-swap cost for every unstaked pool.
+  if (!hasStakes || stakedTickEdges.length === 0) {
     return currentStakedLiqInRange;
   }
 
   let stakedLiq = currentStakedLiqInRange;
 
   if (newTick > oldTick) {
-    // Price moving up — cross ticks from oldTick toward newTick
-    const startTick = alignTickUp(oldTick, tickSpacing);
-    const tickIds: string[] = [];
-    for (let t = startTick; t <= newTick; t += tickSpacing) {
-      tickIds.push(CLTickStakedId(chainId, poolAddress, t));
-    }
-    const tickEntities = await Promise.all(
-      tickIds.map((id) => context.CLTickStaked.get(id)),
-    );
-    for (const tick of tickEntities) {
-      if (tick) {
-        stakedLiq += tick.stakedLiquidityNet;
-      }
+    // Price moving up — cross ticks STRICTLY above oldTick, up to and including newTick.
+    // Mirror the pre-PR alignTickUp semantics (strictly above oldTick) by starting the
+    // binary search at `oldTick + 1`.
+    const startIdx = lowerBound(stakedTickEdges, oldTick + 1n);
+    for (let i = startIdx; i < stakedTickEdges.length; i++) {
+      if (stakedTickEdges[i] > newTick) break;
+      stakedLiq += stakedTickEdgeNets[i];
     }
   } else {
-    // Price moving down — cross ticks from oldTick toward newTick
-    const startTick = alignTickDown(oldTick, tickSpacing);
-    const tickIds: string[] = [];
-    for (let t = startTick; t > newTick; t -= tickSpacing) {
-      tickIds.push(CLTickStakedId(chainId, poolAddress, t));
-    }
-    const tickEntities = await Promise.all(
-      tickIds.map((id) => context.CLTickStaked.get(id)),
-    );
-    for (const tick of tickEntities) {
-      if (tick) {
-        stakedLiq -= tick.stakedLiquidityNet;
-      }
+    // Price moving down — cross ticks AT OR BELOW oldTick, strictly above newTick.
+    // Walk backwards from the last edge <= oldTick.
+    const endIdx = lowerBound(stakedTickEdges, oldTick + 1n) - 1;
+    for (let i = endIdx; i >= 0; i--) {
+      if (stakedTickEdges[i] <= newTick) break;
+      stakedLiq -= stakedTickEdgeNets[i];
     }
   }
 

--- a/src/Aggregators/CLStakedLiquidity.ts
+++ b/src/Aggregators/CLStakedLiquidity.ts
@@ -92,15 +92,18 @@ function applyDeltaAtTick(
   if (present) {
     const newNet = nets[idx] + delta;
     if (newNet === 0n) {
-      const outEdges = new Array<bigint>(edges.length - 1);
-      const outNets = new Array<bigint>(nets.length - 1);
+      // Build via push to keep V8 packed-elements kind (pre-sized `new Array`
+      // stays HOLEY_SMI_ELEMENTS even after every slot is filled, which
+      // prevents the packed fast path in downstream iterators).
+      const outEdges: bigint[] = [];
+      const outNets: bigint[] = [];
       for (let i = 0; i < idx; i++) {
-        outEdges[i] = edges[i];
-        outNets[i] = nets[i];
+        outEdges.push(edges[i]);
+        outNets.push(nets[i]);
       }
       for (let i = idx + 1; i < edges.length; i++) {
-        outEdges[i - 1] = edges[i];
-        outNets[i - 1] = nets[i];
+        outEdges.push(edges[i]);
+        outNets.push(nets[i]);
       }
       return { edges: outEdges, nets: outNets };
     }
@@ -113,17 +116,18 @@ function applyDeltaAtTick(
   // Not present — insert. The caller (applyStakedPositionToEdges) already
   // rejects delta === 0n at its top guard, so reaching this branch with a
   // zero delta is unreachable by construction.
-  const outEdges = new Array<bigint>(edges.length + 1);
-  const outNets = new Array<bigint>(nets.length + 1);
+  // Build via push to keep V8 packed-elements kind (see note above).
+  const outEdges: bigint[] = [];
+  const outNets: bigint[] = [];
   for (let i = 0; i < idx; i++) {
-    outEdges[i] = edges[i];
-    outNets[i] = nets[i];
+    outEdges.push(edges[i]);
+    outNets.push(nets[i]);
   }
-  outEdges[idx] = tick;
-  outNets[idx] = delta;
+  outEdges.push(tick);
+  outNets.push(delta);
   for (let i = idx; i < edges.length; i++) {
-    outEdges[i + 1] = edges[i];
-    outNets[i + 1] = nets[i];
+    outEdges.push(edges[i]);
+    outNets.push(nets[i]);
   }
   return { edges: outEdges, nets: outNets };
 }

--- a/src/Aggregators/LiquidityPoolAggregator.ts
+++ b/src/Aggregators/LiquidityPoolAggregator.ts
@@ -81,6 +81,24 @@ export interface LiquidityPoolAggregatorDiff {
   incrementalStakedReserve0: bigint;
   incrementalStakedReserve1: bigint;
   hasStakes: boolean;
+  // Replace semantics (NOT incremental): producers — gauge deposit/withdraw,
+  // NFPM liquidity change — compute the full post-edit arrays from `current.
+  // stakedTickEdges` / `current.stakedTickEdgeNets` and pass them whole. The
+  // aggregator writes them verbatim; there is no merge/sum path for these
+  // fields the way `incrementalCurrentLiquidityStaked` & co. have. This is
+  // the same "last-writer-wins" style used for `tick`, `sqrtPriceX96`, etc.
+  //
+  // Why replace (not incremental): the array is a sorted, dedup'd, no-zero
+  // encoding of Uniswap v3's liquidityNet per tick. Splicing in a delta
+  // requires a binary-search locate that only makes sense against the current
+  // state — producers already do it in applyStakedPositionToEdges, so the
+  // aggregator just takes the result.
+  //
+  // Typed `readonly bigint[]` so callers can pass the value straight from the
+  // `LiquidityPoolAggregator` entity (whose array fields are readonly in
+  // envio.d.ts) without a copy.
+  stakedTickEdges: readonly bigint[];
+  stakedTickEdgeNets: readonly bigint[];
   totalVotesDeposited: bigint;
   totalVotesDepositedUSD: bigint;
   incrementalTotalBribeClaimed: bigint;
@@ -218,6 +236,31 @@ export async function updateLiquidityPoolAggregator(
   eventChainId: number,
   blockNumber: number,
 ) {
+  // Invariant check for the parallel-array pair (stakedTickEdges,
+  // stakedTickEdgeNets). Writers are supposed to compute both together via
+  // applyStakedPositionToEdges (see src/Aggregators/CLStakedLiquidity.ts),
+  // but there's nothing in the type system that prevents a future caller
+  // from setting one and forgetting the other. Diverging lengths would
+  // silently desync the sparse map the swap path binary-searches, so fail
+  // loudly at the merge point.
+  if (
+    diff.stakedTickEdges !== undefined &&
+    diff.stakedTickEdgeNets !== undefined &&
+    diff.stakedTickEdges.length !== diff.stakedTickEdgeNets.length
+  ) {
+    throw new Error(
+      `[updateLiquidityPoolAggregator] stakedTickEdges/stakedTickEdgeNets length mismatch for pool ${current.poolAddress} on chain ${current.chainId}: edges.length=${diff.stakedTickEdges.length}, nets.length=${diff.stakedTickEdgeNets.length}. Both arrays MUST be produced together by applyStakedPositionToEdges.`,
+    );
+  }
+  if (
+    (diff.stakedTickEdges !== undefined) !==
+    (diff.stakedTickEdgeNets !== undefined)
+  ) {
+    throw new Error(
+      `[updateLiquidityPoolAggregator] stakedTickEdges and stakedTickEdgeNets must be updated together (parallel arrays) for pool ${current.poolAddress} on chain ${current.chainId}. Got edges=${diff.stakedTickEdges !== undefined ? "set" : "unset"}, nets=${diff.stakedTickEdgeNets !== undefined ? "set" : "unset"}.`,
+    );
+  }
+
   let updated: LiquidityPoolAggregator = {
     ...current,
     // Handle cumulative fields by adding diff values to current values
@@ -339,6 +382,11 @@ export async function updateLiquidityPoolAggregator(
     // Monotonic latch: once a pool has ever been staked, hasStakes stays true
     // even if the diff doesn't explicitly re-assert it.
     hasStakes: current.hasStakes || (diff.hasStakes ?? false),
+    // Replace semantics: if the diff provides a new edge list, use it directly.
+    // Producers compute the post-edit arrays from `current.stakedTickEdges`/
+    // `current.stakedTickEdgeNets` and must replace both together (parallel arrays).
+    stakedTickEdges: diff.stakedTickEdges ?? current.stakedTickEdges,
+    stakedTickEdgeNets: diff.stakedTickEdgeNets ?? current.stakedTickEdgeNets,
     totalVotesDeposited:
       diff.totalVotesDeposited ?? current.totalVotesDeposited,
     totalVotesDepositedUSD:
@@ -743,6 +791,8 @@ export function createLiquidityPoolAggregatorEntity(params: {
     stakedReserve0: 0n,
     stakedReserve1: 0n,
     hasStakes: false,
+    stakedTickEdges: [],
+    stakedTickEdgeNets: [],
     totalFlashLoanFees0: 0n,
     totalFlashLoanFees1: 0n,
     totalFlashLoanFeesUSD: 0n,

--- a/src/Aggregators/LiquidityPoolAggregator.ts
+++ b/src/Aggregators/LiquidityPoolAggregator.ts
@@ -241,24 +241,30 @@ export async function updateLiquidityPoolAggregator(
   // applyStakedPositionToEdges (see src/Aggregators/CLStakedLiquidity.ts),
   // but there's nothing in the type system that prevents a future caller
   // from setting one and forgetting the other. Diverging lengths would
-  // silently desync the sparse map the swap path binary-searches, so fail
-  // loudly at the merge point.
-  if (
-    diff.stakedTickEdges !== undefined &&
-    diff.stakedTickEdgeNets !== undefined &&
-    diff.stakedTickEdges.length !== diff.stakedTickEdgeNets.length
-  ) {
-    throw new Error(
-      `[updateLiquidityPoolAggregator] stakedTickEdges/stakedTickEdgeNets length mismatch for pool ${current.poolAddress} on chain ${current.chainId}: edges.length=${diff.stakedTickEdges.length}, nets.length=${diff.stakedTickEdgeNets.length}. Both arrays MUST be produced together by applyStakedPositionToEdges.`,
+  // silently desync the sparse map the swap path binary-searches, so log
+  // loudly under the [STAKED_TICK_DRIFT] tag and DROP both fields from the
+  // diff — preserving the prior consistent pair is safer than writing a
+  // mismatched one. Does not crash the indexer.
+  const edgesSet = diff.stakedTickEdges !== undefined;
+  const netsSet = diff.stakedTickEdgeNets !== undefined;
+  if (edgesSet !== netsSet) {
+    context.log.error(
+      `[STAKED_TICK_DRIFT][updateLiquidityPoolAggregator] stakedTickEdges and stakedTickEdgeNets must be updated together (parallel arrays) for pool ${current.poolAddress} on chain ${current.chainId}. Got edges=${edgesSet ? "set" : "unset"}, nets=${netsSet ? "set" : "unset"}. Dropping both from this update; aggregator retains the prior consistent pair.`,
     );
-  }
-  if (
-    (diff.stakedTickEdges !== undefined) !==
-    (diff.stakedTickEdgeNets !== undefined)
+    diff.stakedTickEdges = undefined;
+    diff.stakedTickEdgeNets = undefined;
+  } else if (
+    edgesSet &&
+    netsSet &&
+    // biome-ignore lint/style/noNonNullAssertion: edgesSet/netsSet narrow above
+    diff.stakedTickEdges!.length !== diff.stakedTickEdgeNets!.length
   ) {
-    throw new Error(
-      `[updateLiquidityPoolAggregator] stakedTickEdges and stakedTickEdgeNets must be updated together (parallel arrays) for pool ${current.poolAddress} on chain ${current.chainId}. Got edges=${diff.stakedTickEdges !== undefined ? "set" : "unset"}, nets=${diff.stakedTickEdgeNets !== undefined ? "set" : "unset"}.`,
+    context.log.error(
+      // biome-ignore lint/style/noNonNullAssertion: edgesSet/netsSet narrow above
+      `[STAKED_TICK_DRIFT][updateLiquidityPoolAggregator] stakedTickEdges/stakedTickEdgeNets length mismatch for pool ${current.poolAddress} on chain ${current.chainId}: edges.length=${diff.stakedTickEdges!.length}, nets.length=${diff.stakedTickEdgeNets!.length}. Dropping both from this update; aggregator retains the prior consistent pair.`,
     );
+    diff.stakedTickEdges = undefined;
+    diff.stakedTickEdgeNets = undefined;
   }
 
   let updated: LiquidityPoolAggregator = {

--- a/src/EventHandlers/CLPool/CLPoolSwapLogic.ts
+++ b/src/EventHandlers/CLPool/CLPoolSwapLogic.ts
@@ -302,7 +302,7 @@ export async function processCLPoolSwap(
 
   const stakedLiquidityInRange =
     oldTick !== newTick && tickSpacing > 0n
-      ? await processTickCrossingsForStaked(
+      ? processTickCrossingsForStaked(
           event.chainId,
           event.srcAddress,
           oldTick,
@@ -311,6 +311,8 @@ export async function processCLPoolSwap(
           context,
           currentStakedLiqInRange,
           liquidityPoolAggregator.hasStakes,
+          liquidityPoolAggregator.stakedTickEdges,
+          liquidityPoolAggregator.stakedTickEdgeNets,
         )
       : currentStakedLiqInRange;
 

--- a/src/EventHandlers/Gauges/GaugeSharedLogic.ts
+++ b/src/EventHandlers/Gauges/GaugeSharedLogic.ts
@@ -111,7 +111,11 @@ async function computeCLStakedReservesOnGaugeEvent(
   // Gate on sqrtPriceX96 !== 0n: before the pool's first Swap initializes price,
   // `tick` falls back to 0n, which would falsely classify any position spanning
   // tick 0 as "in range" and permanently poison stakedLiquidityInRange.
+  // Also gate on !edgesRejected: if applyStakedPositionToEdges rejected the merge,
+  // the sparse edge map is unchanged, so updating the running in-range total would
+  // make it disagree with the edge set the swap path crosses and drift permanently.
   const stakedLiquidityInRange =
+    !edgesRejected &&
     sqrtPriceX96 !== 0n &&
     isPositionInRange(position.tickLower, position.tickUpper, currentTick)
       ? (liquidityPoolAggregator.stakedLiquidityInRange ?? 0n) +
@@ -338,9 +342,16 @@ export async function processGaugeDeposit(
     stakedTickEdgeNets,
     // Flip the CL pool's hasStakes latch on the first deposit. The latch gates the
     // per-swap CLTickStaked sweep in processTickCrossingsForStaked. Non-CL pools
-    // and already-latched CL pools leave this field alone.
+    // and already-latched CL pools leave this field alone. Also gate on an actual
+    // edge list being produced: if computeCLStakedReservesOnGaugeEvent bailed
+    // early or the edge merge was rejected, latching hasStakes would mark the
+    // pool as staked while the sparse map stays empty, leaving swap-path
+    // attribution incomplete until a later writer repairs it.
     hasStakes:
-      liquidityPoolAggregator.isCL && !liquidityPoolAggregator.hasStakes
+      liquidityPoolAggregator.isCL &&
+      !liquidityPoolAggregator.hasStakes &&
+      stakedTickEdges !== undefined &&
+      stakedTickEdges.length > 0
         ? true
         : undefined,
     lastUpdatedTimestamp: timestamp,

--- a/src/EventHandlers/Gauges/GaugeSharedLogic.ts
+++ b/src/EventHandlers/Gauges/GaugeSharedLogic.ts
@@ -1,5 +1,6 @@
 import type { LiquidityPoolAggregator, handlerContext } from "generated";
 import {
+  applyStakedPositionToEdges,
   isPositionInRange,
   updateTicksForStakedPosition,
 } from "../../Aggregators/CLStakedLiquidity";
@@ -57,6 +58,8 @@ async function computeCLStakedReservesOnGaugeEvent(
   stakedLiquidityInRange?: bigint;
   incrementalStakedReserve0?: bigint;
   incrementalStakedReserve1?: bigint;
+  stakedTickEdges?: bigint[];
+  stakedTickEdgeNets?: bigint[];
 }> {
   if (data.tokenId === undefined) return {};
 
@@ -73,25 +76,47 @@ async function computeCLStakedReservesOnGaugeEvent(
   const currentTick = liquidityPoolAggregator.tick ?? 0n;
   const sqrtPriceX96 = liquidityPoolAggregator.sqrtPriceX96 ?? 0n;
 
-  // Update tick entities: +liquidity on deposit, -liquidity on withdraw
+  // Maintain the deprecated CLTickStaked entity writes (scheduled for removal
+  // in velodrome-finance/indexer#652) alongside the in-aggregator parallel
+  // edge/nets arrays. The swap path reads ONLY the aggregator arrays — the
+  // legacy writes are kept for one release so the auto-exposed GraphQL entity
+  // doesn't vanish without notice.
+  const liquidityDelta = direction * position.liquidity;
   await updateTicksForStakedPosition(
     data.chainId,
     liquidityPoolAggregator.poolAddress,
     position.tickLower,
     position.tickUpper,
-    direction * position.liquidity,
+    liquidityDelta,
     context,
   );
-
-  // stakedLiquidityInRange only changes when the position is in range (drives swap proportional attribution)
-  const stakedLiquidityInRange = isPositionInRange(
+  const {
+    edges: stakedTickEdges,
+    nets: stakedTickEdgeNets,
+    rejected: edgesRejected,
+  } = applyStakedPositionToEdges(
+    liquidityPoolAggregator.stakedTickEdges,
+    liquidityPoolAggregator.stakedTickEdgeNets,
     position.tickLower,
     position.tickUpper,
-    currentTick,
-  )
-    ? (liquidityPoolAggregator.stakedLiquidityInRange ?? 0n) +
-      direction * position.liquidity
-    : undefined;
+    liquidityDelta,
+  );
+  if (edgesRejected) {
+    context.log.error(
+      `[computeCLStakedReservesOnGaugeEvent] applyStakedPositionToEdges rejected position ${data.tokenId} on pool ${liquidityPoolAggregator.poolAddress} chain ${data.chainId}: reason=${edgesRejected} tickLower=${position.tickLower} tickUpper=${position.tickUpper}. Edge list left unchanged.`,
+    );
+  }
+
+  // stakedLiquidityInRange only changes when the position is in range (drives swap proportional attribution).
+  // Gate on sqrtPriceX96 !== 0n: before the pool's first Swap initializes price,
+  // `tick` falls back to 0n, which would falsely classify any position spanning
+  // tick 0 as "in range" and permanently poison stakedLiquidityInRange.
+  const stakedLiquidityInRange =
+    sqrtPriceX96 !== 0n &&
+    isPositionInRange(position.tickLower, position.tickUpper, currentTick)
+      ? (liquidityPoolAggregator.stakedLiquidityInRange ?? 0n) +
+        direction * position.liquidity
+      : undefined;
 
   // stakedReserve0/1 track ALL staked token holdings (in-range + out-of-range) for USD valuation.
   // Out-of-range positions still hold tokens (100% token0 if below, 100% token1 if above),
@@ -128,6 +153,8 @@ async function computeCLStakedReservesOnGaugeEvent(
     stakedLiquidityInRange,
     incrementalStakedReserve0,
     incrementalStakedReserve1,
+    stakedTickEdges,
+    stakedTickEdgeNets,
   };
 }
 
@@ -274,6 +301,8 @@ export async function processGaugeDeposit(
   let stakedLiquidityInRange: bigint | undefined;
   let incrementalStakedReserve0: bigint | undefined;
   let incrementalStakedReserve1: bigint | undefined;
+  let stakedTickEdges: bigint[] | undefined;
+  let stakedTickEdgeNets: bigint[] | undefined;
 
   if (liquidityPoolAggregator.isCL) {
     const clResult = await computeCLStakedReservesOnGaugeEvent(
@@ -287,6 +316,8 @@ export async function processGaugeDeposit(
     stakedLiquidityInRange = clResult.stakedLiquidityInRange;
     incrementalStakedReserve0 = clResult.incrementalStakedReserve0;
     incrementalStakedReserve1 = clResult.incrementalStakedReserve1;
+    stakedTickEdges = clResult.stakedTickEdges;
+    stakedTickEdgeNets = clResult.stakedTickEdgeNets;
   } else {
     poolStakedUSD = computeNonCLPoolStakedUSD(
       newPoolStake,
@@ -303,6 +334,8 @@ export async function processGaugeDeposit(
     stakedLiquidityInRange,
     incrementalStakedReserve0,
     incrementalStakedReserve1,
+    stakedTickEdges,
+    stakedTickEdgeNets,
     // Flip the CL pool's hasStakes latch on the first deposit. The latch gates the
     // per-swap CLTickStaked sweep in processTickCrossingsForStaked. Non-CL pools
     // and already-latched CL pools leave this field alone.
@@ -395,6 +428,8 @@ export async function processGaugeWithdraw(
   let stakedLiquidityInRange: bigint | undefined;
   let incrementalStakedReserve0: bigint | undefined;
   let incrementalStakedReserve1: bigint | undefined;
+  let stakedTickEdges: bigint[] | undefined;
+  let stakedTickEdgeNets: bigint[] | undefined;
 
   if (liquidityPoolAggregator.isCL) {
     const clResult = await computeCLStakedReservesOnGaugeEvent(
@@ -408,6 +443,8 @@ export async function processGaugeWithdraw(
     stakedLiquidityInRange = clResult.stakedLiquidityInRange;
     incrementalStakedReserve0 = clResult.incrementalStakedReserve0;
     incrementalStakedReserve1 = clResult.incrementalStakedReserve1;
+    stakedTickEdges = clResult.stakedTickEdges;
+    stakedTickEdgeNets = clResult.stakedTickEdgeNets;
   } else {
     poolStakedUSD = computeNonCLPoolStakedUSD(
       newPoolStake,
@@ -424,6 +461,8 @@ export async function processGaugeWithdraw(
     stakedLiquidityInRange,
     incrementalStakedReserve0,
     incrementalStakedReserve1,
+    stakedTickEdges,
+    stakedTickEdgeNets,
     lastUpdatedTimestamp: timestamp,
   };
 

--- a/src/EventHandlers/NFPM/NFPMCommonLogic.ts
+++ b/src/EventHandlers/NFPM/NFPMCommonLogic.ts
@@ -1,5 +1,6 @@
 import type { NonFungiblePosition, handlerContext } from "generated";
 import {
+  applyStakedPositionToEdges,
   isPositionInRange,
   updateTicksForStakedPosition,
 } from "../../Aggregators/CLStakedLiquidity";
@@ -109,6 +110,11 @@ export async function updateStakedPositionLiquidity(
 ): Promise<void> {
   const { liquidityPoolAggregator } = poolData;
 
+  // Maintain the deprecated CLTickStaked entity writes (scheduled for removal
+  // in velodrome-finance/indexer#652) alongside the in-aggregator parallel
+  // edge/nets arrays. The swap path reads ONLY the aggregator arrays — the
+  // legacy writes are kept for one release so the auto-exposed GraphQL entity
+  // doesn't vanish without notice.
   await updateTicksForStakedPosition(
     chainId,
     position.pool,
@@ -117,11 +123,45 @@ export async function updateStakedPositionLiquidity(
     liquidityDelta,
     context,
   );
+  const {
+    edges: stakedTickEdges,
+    nets: stakedTickEdgeNets,
+    rejected: edgesRejected,
+  } = applyStakedPositionToEdges(
+    liquidityPoolAggregator.stakedTickEdges,
+    liquidityPoolAggregator.stakedTickEdgeNets,
+    position.tickLower,
+    position.tickUpper,
+    liquidityDelta,
+  );
+  if (edgesRejected) {
+    context.log.error(
+      `[updateStakedPositionLiquidity] applyStakedPositionToEdges rejected position ${position.tokenId} on pool ${position.pool} chain ${chainId}: reason=${edgesRejected} tickLower=${position.tickLower} tickUpper=${position.tickUpper}. Edge list left unchanged.`,
+    );
+  }
+
+  // Belt-and-suspenders: flip the hasStakes latch whenever the edge list is
+  // non-empty. The primary flip happens on gauge Deposit, but pinning it here
+  // too guarantees the swap-path walker sees a consistent (hasStakes=true,
+  // edges.length>0) pairing regardless of event ordering.
+  const hasStakes = stakedTickEdges.length > 0 ? true : undefined;
 
   const currentTick = liquidityPoolAggregator.tick ?? 0n;
   const sqrtPriceX96 = liquidityPoolAggregator.sqrtPriceX96 ?? 0n;
 
-  if (sqrtPriceX96 === 0n) return;
+  if (sqrtPriceX96 === 0n) {
+    // Even without a price, we still persist the edge-list update so the swap
+    // path has correct state once a price is established.
+    await updateLiquidityPoolAggregator(
+      { stakedTickEdges, stakedTickEdgeNets, hasStakes },
+      liquidityPoolAggregator,
+      timestamp,
+      context,
+      chainId,
+      blockNumber,
+    );
+    return;
+  }
 
   // stakedReserve0/1 track ALL staked token holdings (in-range + out-of-range) for USD valuation.
   // Out-of-range positions still hold tokens, and calculatePositionAmountsFromLiquidity handles
@@ -148,6 +188,9 @@ export async function updateStakedPositionLiquidity(
     stakedLiquidityInRange,
     incrementalStakedReserve0: direction * amount0,
     incrementalStakedReserve1: direction * amount1,
+    stakedTickEdges,
+    stakedTickEdgeNets,
+    hasStakes,
   };
 
   await updateLiquidityPoolAggregator(

--- a/test/Aggregators/CLStakedLiquidity.test.ts
+++ b/test/Aggregators/CLStakedLiquidity.test.ts
@@ -1,5 +1,6 @@
 import type { CLTickStaked, handlerContext } from "generated";
 import {
+  applyStakedPositionToEdges,
   computeStakedSwapReserveDelta,
   isPositionInRange,
   processTickCrossingsForStaked,
@@ -91,7 +92,6 @@ describe("CLStakedLiquidity", () => {
     });
 
     it("should accumulate liquidity from multiple positions at same ticks", async () => {
-      // First position: +500 at lower, -500 at upper
       await updateTicksForStakedPosition(
         CHAIN_ID,
         POOL_ADDRESS,
@@ -100,7 +100,6 @@ describe("CLStakedLiquidity", () => {
         500n,
         mockContext,
       );
-      // Second position: +300 at same ticks
       await updateTicksForStakedPosition(
         CHAIN_ID,
         POOL_ADDRESS,
@@ -118,7 +117,6 @@ describe("CLStakedLiquidity", () => {
     });
 
     it("should handle unstake (negative liquidityDelta)", async () => {
-      // Stake 1000
       await updateTicksForStakedPosition(
         CHAIN_ID,
         POOL_ADDRESS,
@@ -127,7 +125,6 @@ describe("CLStakedLiquidity", () => {
         1000n,
         mockContext,
       );
-      // Unstake 1000
       await updateTicksForStakedPosition(
         CHAIN_ID,
         POOL_ADDRESS,
@@ -162,27 +159,215 @@ describe("CLStakedLiquidity", () => {
     });
   });
 
+  describe("applyStakedPositionToEdges", () => {
+    it("should insert both edges with correct signs on stake", () => {
+      const { edges, nets } = applyStakedPositionToEdges(
+        [],
+        [],
+        100n,
+        200n,
+        500n,
+      );
+      expect(edges).toEqual([100n, 200n]);
+      expect(nets).toEqual([500n, -500n]);
+    });
+
+    it("should keep the list sorted when inserting into the middle", () => {
+      // Start with an existing position at [0, 400]
+      const start = applyStakedPositionToEdges([], [], 0n, 400n, 100n);
+      // Insert a nested position at [100, 300]
+      const { edges, nets } = applyStakedPositionToEdges(
+        start.edges,
+        start.nets,
+        100n,
+        300n,
+        50n,
+      );
+      expect(edges).toEqual([0n, 100n, 300n, 400n]);
+      expect(nets).toEqual([100n, 50n, -50n, -100n]);
+    });
+
+    it("should sum nets when two positions share an edge", () => {
+      const a = applyStakedPositionToEdges([], [], 100n, 200n, 500n);
+      const b = applyStakedPositionToEdges(a.edges, a.nets, 100n, 300n, 200n);
+      // tickLower=100 contributes +500 (A) + +200 (B) = +700
+      // tickUpper=200 is only A: -500
+      // tickUpper=300 is only B: -200
+      expect(b.edges).toEqual([100n, 200n, 300n]);
+      expect(b.nets).toEqual([700n, -500n, -200n]);
+    });
+
+    it("should drop an edge when its net becomes zero", () => {
+      // Stake then unstake the same position
+      const a = applyStakedPositionToEdges([], [], 100n, 200n, 500n);
+      const b = applyStakedPositionToEdges(a.edges, a.nets, 100n, 200n, -500n);
+      expect(b.edges).toEqual([]);
+      expect(b.nets).toEqual([]);
+    });
+
+    it("should keep non-zero edges when a partial unstake leaves residual net", () => {
+      // Two positions sharing tickLower=100
+      const a = applyStakedPositionToEdges([], [], 100n, 200n, 500n);
+      const b = applyStakedPositionToEdges(a.edges, a.nets, 100n, 300n, 200n);
+      // Unstake only one of them
+      const c = applyStakedPositionToEdges(b.edges, b.nets, 100n, 200n, -500n);
+      // tickLower=100: +700 - 500 = +200
+      // tickUpper=200: -500 + 500 = 0 → dropped
+      // tickUpper=300: -200 (unchanged)
+      expect(c.edges).toEqual([100n, 300n]);
+      expect(c.nets).toEqual([200n, -200n]);
+    });
+
+    it("should ignore out-of-range ticks and tag them 'ticks_out_of_range'", () => {
+      const result = applyStakedPositionToEdges(
+        [],
+        [],
+        -900000n, // below TICK_MIN
+        100n,
+        500n,
+      );
+      expect(result.edges).toEqual([]);
+      expect(result.nets).toEqual([]);
+      expect(result.rejected).toBe("ticks_out_of_range");
+    });
+
+    it("should ignore degenerate ranges and tag them 'degenerate_range'", () => {
+      const result = applyStakedPositionToEdges([], [], 200n, 100n, 500n);
+      expect(result.edges).toEqual([]);
+      expect(result.nets).toEqual([]);
+      expect(result.rejected).toBe("degenerate_range");
+    });
+
+    it("should silently no-op on liquidityDelta=0 without a rejection tag", () => {
+      // Zero-delta is a legitimate NFPM Mint-0 flow, not an invariant violation.
+      // It must NOT log/alert — the caller treats `rejected: undefined` as success.
+      const seed = applyStakedPositionToEdges([], [], 100n, 200n, 500n);
+      const result = applyStakedPositionToEdges(
+        seed.edges,
+        seed.nets,
+        100n,
+        200n,
+        0n,
+      );
+      expect(result.edges).toEqual([100n, 200n]);
+      expect(result.nets).toEqual([500n, -500n]);
+      expect(result.rejected).toBeUndefined();
+    });
+
+    it("should preserve negative residual nets (upper-tick side + partial overlap)", () => {
+      // Uniswap v3 semantics: at a tickUpper the net is -liquidity (negative).
+      // When two positions share a tick where one uses it as tickUpper and the
+      // other as tickLower, the residual can remain negative but non-zero.
+      // Invariant under test: the edge MUST be preserved (not dropped just because
+      // the net is negative) and the sort order MUST hold.
+      const a = applyStakedPositionToEdges([], [], 100n, 200n, 500n);
+      expect(a.edges).toEqual([100n, 200n]);
+      expect(a.nets).toEqual([500n, -500n]);
+
+      // Second position uses 200 as tickLower, stacking onto the existing -500 net.
+      const b = applyStakedPositionToEdges(a.edges, a.nets, 200n, 300n, 300n);
+      // tickLower=100: +500 (A)
+      // tickLower=200 from B adds +300 onto -500 (A's upper) = -200 (residual NEGATIVE, not dropped)
+      // tickUpper=300 from B: -300
+      expect(b.edges).toEqual([100n, 200n, 300n]);
+      expect(b.nets).toEqual([500n, -200n, -300n]);
+      expect(b.rejected).toBeUndefined();
+
+      // Sanity: sum of nets must still be zero (invariant for a balanced stake set).
+      const totalNet = b.nets.reduce((acc, n) => acc + n, 0n);
+      expect(totalNet).toBe(0n);
+
+      // Swap cross-check: the in-aggregator walker applied across the full
+      // range must see the same answer as summing the negative residuals.
+      // Going up from -inf to +inf, stakedLiq delta = 500 + -200 + -300 = 0.
+      // This is the "closed system" property — all stakes cancel end-to-end.
+    });
+
+    it("should round-trip a stake then unstake back to an empty edge list", () => {
+      // Even with negative residuals in flight, a full unstake must return to
+      // an empty edge list (no orphaned nets, no zombie edges).
+      let edges: readonly bigint[] = [];
+      let nets: readonly bigint[] = [];
+      const positions = [
+        { tl: 100n, tu: 200n, liq: 500n },
+        { tl: 200n, tu: 300n, liq: 300n },
+        { tl: 150n, tu: 250n, liq: 700n },
+      ];
+      for (const p of positions) {
+        const out = applyStakedPositionToEdges(edges, nets, p.tl, p.tu, p.liq);
+        edges = out.edges;
+        nets = out.nets;
+      }
+      expect(edges.length).toBeGreaterThan(0);
+      // Unstake each in reverse order
+      for (const p of positions.slice().reverse()) {
+        const out = applyStakedPositionToEdges(edges, nets, p.tl, p.tu, -p.liq);
+        edges = out.edges;
+        nets = out.nets;
+      }
+      expect(edges).toEqual([]);
+      expect(nets).toEqual([]);
+    });
+
+    it("should not mutate the input arrays", () => {
+      const input = applyStakedPositionToEdges([], [], 100n, 200n, 500n);
+      const frozenEdges = Object.freeze([...input.edges]);
+      const frozenNets = Object.freeze([...input.nets]);
+      applyStakedPositionToEdges(frozenEdges, frozenNets, 300n, 400n, 100n);
+      // Freeze throws on mutation; absence of throw proves no mutation happened.
+      expect(frozenEdges).toEqual([100n, 200n]);
+      expect(frozenNets).toEqual([500n, -500n]);
+    });
+
+    it("should stay monotone after many interleaved stake/unstake events", () => {
+      let edges: readonly bigint[] = [];
+      let nets: readonly bigint[] = [];
+      const positions: { tl: bigint; tu: bigint; liq: bigint }[] = [];
+      for (let i = 0; i < 50; i++) {
+        const tl = BigInt(i * 10);
+        const tu = BigInt(i * 10 + 50);
+        const liq = BigInt(100 + i);
+        positions.push({ tl, tu, liq });
+        const out = applyStakedPositionToEdges(edges, nets, tl, tu, liq);
+        edges = out.edges;
+        nets = out.nets;
+        // Monotone check after every event
+        for (let k = 1; k < edges.length; k++) {
+          expect(edges[k]).toBeGreaterThan(edges[k - 1]);
+        }
+      }
+      // Unstake half of them
+      for (let i = 0; i < 25; i++) {
+        const p = positions[i * 2];
+        const out = applyStakedPositionToEdges(edges, nets, p.tl, p.tu, -p.liq);
+        edges = out.edges;
+        nets = out.nets;
+        for (let k = 1; k < edges.length; k++) {
+          expect(edges[k]).toBeGreaterThan(edges[k - 1]);
+        }
+      }
+      expect(edges.length).toBeGreaterThan(0);
+    });
+  });
+
   describe("processTickCrossingsForStaked", () => {
-    let tickStore: Map<string, CLTickStaked>;
     let mockContext: handlerContext;
     let logErrorSpy: ReturnType<typeof vi.fn>;
+    let getSpy: ReturnType<typeof vi.fn>;
 
     beforeEach(() => {
-      tickStore = new Map();
       logErrorSpy = vi.fn();
+      // The swap path must NEVER call CLTickStaked.get — if it does, the OOM
+      // regression from #648 is back. Make the spy THROW so any accidental
+      // call surfaces loudly in the test output (a silent vi.fn() would let a
+      // regression return `undefined` and skate past weaker assertions).
+      getSpy = vi.fn(() => {
+        throw new Error(
+          "processTickCrossingsForStaked must not call CLTickStaked.get on the swap path (#649 regression)",
+        );
+      });
       mockContext = {
-        CLTickStaked: {
-          get: vi
-            .fn()
-            .mockImplementation((id: string) =>
-              Promise.resolve(tickStore.get(id) ?? null),
-            ),
-          set: vi
-            .fn()
-            .mockImplementation((entity: CLTickStaked) =>
-              tickStore.set(entity.id, entity),
-            ),
-        },
+        CLTickStaked: { get: getSpy, set: vi.fn() },
         log: {
           error: logErrorSpy,
           warn: vi.fn(),
@@ -191,20 +376,6 @@ describe("CLStakedLiquidity", () => {
         },
       } as unknown as handlerContext;
     });
-
-    /**
-     * Helper to seed a CLTickStaked entity at a given tick index.
-     */
-    function seedTick(tickIndex: bigint, stakedLiquidityNet: bigint): void {
-      const id = CLTickStakedId(CHAIN_ID, POOL_ADDRESS, tickIndex);
-      tickStore.set(id, {
-        id,
-        chainId: CHAIN_ID,
-        poolAddress: POOL_ADDRESS,
-        tickIndex,
-        stakedLiquidityNet,
-      });
-    }
 
     it("should return unchanged when oldTick === newTick", async () => {
       const result = await processTickCrossingsForStaked(
@@ -216,8 +387,11 @@ describe("CLStakedLiquidity", () => {
         mockContext,
         500n,
         true,
+        [100n, 200n],
+        [300n, -300n],
       );
       expect(result).toBe(500n);
+      expect(getSpy).not.toHaveBeenCalled();
     });
 
     it("should return unchanged when tickSpacing is zero", async () => {
@@ -230,15 +404,14 @@ describe("CLStakedLiquidity", () => {
         mockContext,
         500n,
         true,
+        [200n],
+        [300n],
       );
       expect(result).toBe(500n);
+      expect(getSpy).not.toHaveBeenCalled();
     });
 
     it("should add stakedLiquidityNet when crossing up", async () => {
-      // Position staked at [200, 400]: lower tick has +300
-      seedTick(200n, 300n);
-
-      // Swap from tick 100 to tick 250 (crosses tick 200 going up)
       const result = await processTickCrossingsForStaked(
         CHAIN_ID,
         POOL_ADDRESS,
@@ -248,18 +421,14 @@ describe("CLStakedLiquidity", () => {
         mockContext,
         0n,
         true,
+        [200n],
+        [300n],
       );
-
-      // alignTickUp(100, 200) = 200, crosses 200 (200 <= 250)
       expect(result).toBe(300n);
+      expect(getSpy).not.toHaveBeenCalled();
     });
 
     it("should subtract stakedLiquidityNet when crossing down", async () => {
-      // Position staked at [200, 400]: lower tick has +300
-      seedTick(200n, 300n);
-
-      // Swap from tick 250 to tick 100 (crosses tick 200 going down)
-      // alignTickDown(250, 200) = 200, crosses 200 (200 > 100)
       const result = await processTickCrossingsForStaked(
         CHAIN_ID,
         POOL_ADDRESS,
@@ -269,19 +438,14 @@ describe("CLStakedLiquidity", () => {
         mockContext,
         300n,
         true,
+        [200n],
+        [300n],
       );
-
       expect(result).toBe(0n);
+      expect(getSpy).not.toHaveBeenCalled();
     });
 
     it("should handle multiple tick crossings going up", async () => {
-      seedTick(200n, 100n);
-      seedTick(400n, 200n);
-      seedTick(600n, -50n);
-
-      // Swap from tick 100 to tick 650
-      // alignTickUp(100, 200) = 200
-      // Crosses: 200 (+100), 400 (+200), 600 (-50) — all <= 650
       const result = await processTickCrossingsForStaked(
         CHAIN_ID,
         POOL_ADDRESS,
@@ -291,20 +455,14 @@ describe("CLStakedLiquidity", () => {
         mockContext,
         0n,
         true,
+        [200n, 400n, 600n],
+        [100n, 200n, -50n],
       );
-
       expect(result).toBe(250n); // 0 + 100 + 200 - 50
+      expect(getSpy).not.toHaveBeenCalled();
     });
 
     it("should handle multiple tick crossings going down", async () => {
-      seedTick(600n, -50n);
-      seedTick(400n, 200n);
-      seedTick(200n, 100n);
-
-      // Swap from tick 650 to tick 100
-      // alignTickDown(650, 200) = 600
-      // Crosses: 600 (sub -50 → +50), 400 (sub 200 → -150), 200 (sub 100 → -250)
-      // All > 100
       const result = await processTickCrossingsForStaked(
         CHAIN_ID,
         POOL_ADDRESS,
@@ -314,38 +472,32 @@ describe("CLStakedLiquidity", () => {
         mockContext,
         250n,
         true,
+        [200n, 400n, 600n],
+        [100n, 200n, -50n],
       );
-
       // 250 - (-50) - 200 - 100 = 250 + 50 - 200 - 100 = 0
       expect(result).toBe(0n);
+      expect(getSpy).not.toHaveBeenCalled();
     });
 
-    it("should skip ticks with no entity (treat as zero)", async () => {
-      // Only seed tick 400, tick 200 has no entity
-      seedTick(400n, 150n);
-
-      // Swap from tick 100 to tick 450
-      // alignTickUp(100, 200) = 200
-      // Crosses: 200 (no entity → skip), 400 (+150) — both <= 450
+    it("should skip edges that fall outside the [oldTick, newTick] window", async () => {
+      // Edges exist at 200 and 400, but swap only crosses 200
       const result = await processTickCrossingsForStaked(
         CHAIN_ID,
         POOL_ADDRESS,
         100n,
-        450n,
+        300n,
         200n,
         mockContext,
         50n,
         true,
+        [200n, 400n],
+        [150n, -150n],
       );
-
-      expect(result).toBe(200n); // 50 + 150
+      expect(result).toBe(200n); // 50 + 150 (only 200 crossed, 400 is beyond newTick=300)
     });
 
     it("should handle negative tick ranges", async () => {
-      seedTick(-200n, 500n);
-
-      // Swap from tick -300 to tick -100 (crosses -200 going up)
-      // alignTickUp(-300, 200) = -200 (strictly above -300)
       const result = await processTickCrossingsForStaked(
         CHAIN_ID,
         POOL_ADDRESS,
@@ -355,17 +507,14 @@ describe("CLStakedLiquidity", () => {
         mockContext,
         0n,
         true,
+        [-200n],
+        [500n],
       );
-
       expect(result).toBe(500n);
     });
 
-    it("should not cross the oldTick itself when going up (alignTickUp is strictly above)", async () => {
-      seedTick(200n, 100n);
-
-      // oldTick = 200, newTick = 350
-      // alignTickUp(200, 200) = 400 (strictly above 200)
-      // 400 > 350, so NO ticks are crossed
+    it("should not cross the oldTick itself when going up (strict-above semantics)", async () => {
+      // oldTick=200, edge at 200 — since we search lowerBound(201), edge is skipped
       const result = await processTickCrossingsForStaked(
         CHAIN_ID,
         POOL_ADDRESS,
@@ -375,17 +524,14 @@ describe("CLStakedLiquidity", () => {
         mockContext,
         0n,
         true,
+        [200n],
+        [100n],
       );
-
       expect(result).toBe(0n);
     });
 
-    it("should include the oldTick boundary when going down (alignTickDown is at-or-below)", async () => {
-      seedTick(200n, 100n);
-
-      // oldTick = 200, newTick = 50
-      // alignTickDown(200, 200) = 200
-      // 200 > 50, so tick 200 IS crossed
+    it("should include the oldTick boundary when going down (at-or-below semantics)", async () => {
+      // oldTick=200, edge at 200 — going down includes it
       const result = await processTickCrossingsForStaked(
         CHAIN_ID,
         POOL_ADDRESS,
@@ -395,20 +541,15 @@ describe("CLStakedLiquidity", () => {
         mockContext,
         100n,
         true,
+        [200n],
+        [100n],
       );
-
-      // 100 - 100 = 0
-      expect(result).toBe(0n);
+      expect(result).toBe(0n); // 100 - 100
     });
 
-    it("should handle tickSpacing of 1", async () => {
-      seedTick(101n, 10n);
-      seedTick(102n, 20n);
-      seedTick(103n, -5n);
-
-      // Swap from tick 100 to tick 103, spacing=1
-      // alignTickUp(100, 1) = 101
-      // Crosses: 101 (+10), 102 (+20), 103 (-5) — all <= 103
+    it("should handle tickSpacing of 1 without scanning per-tick (only edges drive the walk)", async () => {
+      // Edges 101/102/103; spacing=1 means the old impl would sweep per-tick,
+      // but the new impl only visits the edges that exist.
       const result = await processTickCrossingsForStaked(
         CHAIN_ID,
         POOL_ADDRESS,
@@ -418,17 +559,15 @@ describe("CLStakedLiquidity", () => {
         mockContext,
         0n,
         true,
+        [101n, 102n, 103n],
+        [10n, 20n, -5n],
       );
-
       expect(result).toBe(25n); // 0 + 10 + 20 - 5
+      expect(getSpy).not.toHaveBeenCalled();
     });
 
     describe("safety guards", () => {
-      it("should short-circuit when hasStakes is false (skip CLTickStaked reads)", async () => {
-        // Seed a tick entity that would otherwise contribute — the guard must
-        // skip the read so this value is never applied.
-        seedTick(200n, 999n);
-
+      it("should short-circuit when hasStakes is false", async () => {
         const result = await processTickCrossingsForStaked(
           CHAIN_ID,
           POOL_ADDRESS,
@@ -438,30 +577,48 @@ describe("CLStakedLiquidity", () => {
           mockContext,
           500n,
           false,
+          [200n],
+          [999n],
         );
-
         expect(result).toBe(500n);
-        expect(mockContext.CLTickStaked.get).not.toHaveBeenCalled();
+        expect(getSpy).not.toHaveBeenCalled();
+      });
+
+      it("should short-circuit when the edge list is empty (no staked positions)", async () => {
+        const result = await processTickCrossingsForStaked(
+          CHAIN_ID,
+          POOL_ADDRESS,
+          100n,
+          250n,
+          200n,
+          mockContext,
+          500n,
+          true, // latch true but no edges
+          [],
+          [],
+        );
+        expect(result).toBe(500n);
+        expect(getSpy).not.toHaveBeenCalled();
       });
 
       it("should bail and log when oldTick is below TICK_MIN", async () => {
         const result = await processTickCrossingsForStaked(
           CHAIN_ID,
           POOL_ADDRESS,
-          -900000n, // below TICK_MIN = -887272n
+          -900000n,
           100n,
           200n,
           mockContext,
           500n,
           true,
+          [200n],
+          [300n],
         );
-
         expect(result).toBe(500n);
         expect(logErrorSpy).toHaveBeenCalledTimes(1);
         expect(logErrorSpy.mock.calls[0][0]).toContain(
           "out of Uniswap v3 range",
         );
-        expect(mockContext.CLTickStaked.get).not.toHaveBeenCalled();
       });
 
       it("should bail and log when newTick is above TICK_MAX", async () => {
@@ -469,20 +626,19 @@ describe("CLStakedLiquidity", () => {
           CHAIN_ID,
           POOL_ADDRESS,
           100n,
-          900000n, // above TICK_MAX = 887272n
+          900000n,
           200n,
           mockContext,
           500n,
           true,
+          [200n],
+          [300n],
         );
-
         expect(result).toBe(500n);
         expect(logErrorSpy).toHaveBeenCalledTimes(1);
-        expect(mockContext.CLTickStaked.get).not.toHaveBeenCalled();
       });
 
       it("should accept boundary ticks at exactly TICK_MIN and TICK_MAX", async () => {
-        // No tick entities seeded → result should equal the input
         const result = await processTickCrossingsForStaked(
           CHAIN_ID,
           POOL_ADDRESS,
@@ -492,8 +648,9 @@ describe("CLStakedLiquidity", () => {
           mockContext,
           0n,
           true,
+          [],
+          [],
         );
-
         expect(result).toBe(0n);
         expect(logErrorSpy).not.toHaveBeenCalled();
       });

--- a/test/Aggregators/CLStakedLiquidity.test.ts
+++ b/test/Aggregators/CLStakedLiquidity.test.ts
@@ -378,7 +378,7 @@ describe("CLStakedLiquidity", () => {
     });
 
     it("should return unchanged when oldTick === newTick", async () => {
-      const result = await processTickCrossingsForStaked(
+      const result = processTickCrossingsForStaked(
         CHAIN_ID,
         POOL_ADDRESS,
         100n,
@@ -395,7 +395,7 @@ describe("CLStakedLiquidity", () => {
     });
 
     it("should return unchanged when tickSpacing is zero", async () => {
-      const result = await processTickCrossingsForStaked(
+      const result = processTickCrossingsForStaked(
         CHAIN_ID,
         POOL_ADDRESS,
         100n,
@@ -412,7 +412,7 @@ describe("CLStakedLiquidity", () => {
     });
 
     it("should add stakedLiquidityNet when crossing up", async () => {
-      const result = await processTickCrossingsForStaked(
+      const result = processTickCrossingsForStaked(
         CHAIN_ID,
         POOL_ADDRESS,
         100n,
@@ -429,7 +429,7 @@ describe("CLStakedLiquidity", () => {
     });
 
     it("should subtract stakedLiquidityNet when crossing down", async () => {
-      const result = await processTickCrossingsForStaked(
+      const result = processTickCrossingsForStaked(
         CHAIN_ID,
         POOL_ADDRESS,
         250n,
@@ -446,7 +446,7 @@ describe("CLStakedLiquidity", () => {
     });
 
     it("should handle multiple tick crossings going up", async () => {
-      const result = await processTickCrossingsForStaked(
+      const result = processTickCrossingsForStaked(
         CHAIN_ID,
         POOL_ADDRESS,
         100n,
@@ -463,7 +463,7 @@ describe("CLStakedLiquidity", () => {
     });
 
     it("should handle multiple tick crossings going down", async () => {
-      const result = await processTickCrossingsForStaked(
+      const result = processTickCrossingsForStaked(
         CHAIN_ID,
         POOL_ADDRESS,
         650n,
@@ -482,7 +482,7 @@ describe("CLStakedLiquidity", () => {
 
     it("should skip edges that fall outside the [oldTick, newTick] window", async () => {
       // Edges exist at 200 and 400, but swap only crosses 200
-      const result = await processTickCrossingsForStaked(
+      const result = processTickCrossingsForStaked(
         CHAIN_ID,
         POOL_ADDRESS,
         100n,
@@ -498,7 +498,7 @@ describe("CLStakedLiquidity", () => {
     });
 
     it("should handle negative tick ranges", async () => {
-      const result = await processTickCrossingsForStaked(
+      const result = processTickCrossingsForStaked(
         CHAIN_ID,
         POOL_ADDRESS,
         -300n,
@@ -515,7 +515,7 @@ describe("CLStakedLiquidity", () => {
 
     it("should not cross the oldTick itself when going up (strict-above semantics)", async () => {
       // oldTick=200, edge at 200 — since we search lowerBound(201), edge is skipped
-      const result = await processTickCrossingsForStaked(
+      const result = processTickCrossingsForStaked(
         CHAIN_ID,
         POOL_ADDRESS,
         200n,
@@ -532,7 +532,7 @@ describe("CLStakedLiquidity", () => {
 
     it("should include the oldTick boundary when going down (at-or-below semantics)", async () => {
       // oldTick=200, edge at 200 — going down includes it
-      const result = await processTickCrossingsForStaked(
+      const result = processTickCrossingsForStaked(
         CHAIN_ID,
         POOL_ADDRESS,
         200n,
@@ -550,7 +550,7 @@ describe("CLStakedLiquidity", () => {
     it("should handle tickSpacing of 1 without scanning per-tick (only edges drive the walk)", async () => {
       // Edges 101/102/103; spacing=1 means the old impl would sweep per-tick,
       // but the new impl only visits the edges that exist.
-      const result = await processTickCrossingsForStaked(
+      const result = processTickCrossingsForStaked(
         CHAIN_ID,
         POOL_ADDRESS,
         100n,
@@ -568,7 +568,7 @@ describe("CLStakedLiquidity", () => {
 
     describe("safety guards", () => {
       it("should short-circuit when hasStakes is false", async () => {
-        const result = await processTickCrossingsForStaked(
+        const result = processTickCrossingsForStaked(
           CHAIN_ID,
           POOL_ADDRESS,
           100n,
@@ -585,7 +585,7 @@ describe("CLStakedLiquidity", () => {
       });
 
       it("should short-circuit when the edge list is empty (no staked positions)", async () => {
-        const result = await processTickCrossingsForStaked(
+        const result = processTickCrossingsForStaked(
           CHAIN_ID,
           POOL_ADDRESS,
           100n,
@@ -602,7 +602,7 @@ describe("CLStakedLiquidity", () => {
       });
 
       it("should bail and log when oldTick is below TICK_MIN", async () => {
-        const result = await processTickCrossingsForStaked(
+        const result = processTickCrossingsForStaked(
           CHAIN_ID,
           POOL_ADDRESS,
           -900000n,
@@ -622,7 +622,7 @@ describe("CLStakedLiquidity", () => {
       });
 
       it("should bail and log when newTick is above TICK_MAX", async () => {
-        const result = await processTickCrossingsForStaked(
+        const result = processTickCrossingsForStaked(
           CHAIN_ID,
           POOL_ADDRESS,
           100n,
@@ -639,7 +639,7 @@ describe("CLStakedLiquidity", () => {
       });
 
       it("should accept boundary ticks at exactly TICK_MIN and TICK_MAX", async () => {
-        const result = await processTickCrossingsForStaked(
+        const result = processTickCrossingsForStaked(
           CHAIN_ID,
           POOL_ADDRESS,
           -887272n,

--- a/test/Aggregators/CLStakedLiquidityEdgeSanity.test.ts
+++ b/test/Aggregators/CLStakedLiquidityEdgeSanity.test.ts
@@ -1,0 +1,283 @@
+import type { Token } from "generated";
+import { CLGauge, MockDb } from "../../generated/src/TestHelpers.gen";
+import {
+  applyStakedPositionToEdges,
+  processTickCrossingsForStaked,
+} from "../../src/Aggregators/CLStakedLiquidity";
+import {
+  CLTickStakedId,
+  NonFungiblePositionId,
+  PoolId,
+  toChecksumAddress,
+} from "../../src/Constants";
+import { setupCommon } from "../EventHandlers/Pool/common";
+
+/**
+ * Co-located sanity test for #649: replacing `processTickCrossingsForStaked`
+ * fan-out with the sparse stakedTickEdges / stakedTickEdgeNets list on
+ * LiquidityPoolAggregator.
+ *
+ * Two assertions:
+ *   (a) The edge list stays sorted + monotone under arbitrary gauge
+ *       deposit/withdraw ordering across ≥200 synthetic events.
+ *   (b) `processTickCrossingsForStaked` returns the same staked-liq-in-range
+ *       delta as the pre-PR baseline (which reads CLTickStaked entities) for
+ *       a swap window that crosses multiple edges.
+ */
+describe("CLStakedLiquidity edge-list sanity (#649)", () => {
+  const {
+    mockToken0Data,
+    mockToken1Data,
+    createMockLiquidityPoolAggregator,
+    createMockNonFungiblePosition,
+    defaultNfpmAddress,
+  } = setupCommon();
+  const chainId = 10;
+  const gaugeAddress = toChecksumAddress(
+    "0x5555555555555555555555555555555555555555",
+  );
+  const userAddress = toChecksumAddress(
+    "0x2222222222222222222222222222222222222222",
+  );
+
+  it("(a) stakedTickEdges stays sorted + monotone across ≥200 interleaved gauge Deposit/Withdraw events", async () => {
+    let mockDb = MockDb.createMockDb();
+
+    const liquidityPool = createMockLiquidityPoolAggregator({
+      isCL: true,
+      gaugeAddress,
+      hasStakes: false,
+    });
+
+    mockDb = mockDb.entities.LiquidityPoolAggregator.set(liquidityPool);
+    mockDb = mockDb.entities.Token.set(mockToken0Data as Token);
+    mockDb = mockDb.entities.Token.set(mockToken1Data as Token);
+
+    // 100 synthetic positions with varied tick ranges — enough for sorted-insert
+    // collisions and removals to exercise the invariants.
+    const POSITIONS = 100;
+    for (let i = 0; i < POSITIONS; i++) {
+      const tokenId = BigInt(i + 1);
+      const tickLower = BigInt(-500 + (i % 20) * 50);
+      const tickUpper = tickLower + BigInt(100 + (i % 7) * 50);
+      const liquidity = BigInt(1000 + i);
+      const position = createMockNonFungiblePosition({
+        tokenId,
+        nfpmAddress: defaultNfpmAddress,
+        pool: liquidityPool.poolAddress,
+        owner: userAddress,
+        tickLower,
+        tickUpper,
+        liquidity,
+      });
+      mockDb = mockDb.entities.NonFungiblePosition.set(position);
+    }
+
+    // Interleave Deposit and Withdraw events: deposit all, then withdraw half
+    // in a non-sorted order. ≥200 total events (100 deposits + 100 withdraws).
+    const depositEvents = [];
+    for (let i = 0; i < POSITIONS; i++) {
+      const tokenId = BigInt(i + 1);
+      depositEvents.push(
+        CLGauge.Deposit.createMockEvent({
+          user: userAddress,
+          tokenId,
+          liquidityToStake: BigInt(1000 + i),
+          mockEventData: {
+            srcAddress: gaugeAddress,
+            chainId,
+            block: {
+              number: 1_000_000 + i,
+              timestamp: 1_700_000_000 + i,
+              hash: `0x${"a".repeat(64)}`,
+            },
+          },
+        }),
+      );
+    }
+
+    // Withdraw a pseudo-random half of them (deterministic order via i*7 mod).
+    const withdrawEvents = [];
+    for (let i = 0; i < POSITIONS; i++) {
+      if (i % 2 !== 0) continue;
+      const pick = ((i * 7) % POSITIONS) + 1;
+      const tokenId = BigInt(pick);
+      withdrawEvents.push(
+        CLGauge.Withdraw.createMockEvent({
+          user: userAddress,
+          tokenId,
+          liquidityToStake: BigInt(1000 + pick - 1),
+          mockEventData: {
+            srcAddress: gaugeAddress,
+            chainId,
+            block: {
+              number: 2_000_000 + i,
+              timestamp: 1_700_100_000 + i,
+              hash: `0x${"b".repeat(64)}`,
+            },
+          },
+        }),
+      );
+    }
+
+    const events = [...depositEvents, ...withdrawEvents];
+    expect(events.length).toBeGreaterThanOrEqual(150);
+
+    const resultDb = await mockDb.processEvents(events);
+    const updated = resultDb.entities.LiquidityPoolAggregator.get(
+      PoolId(chainId, liquidityPool.poolAddress),
+    );
+
+    expect(updated).toBeDefined();
+    if (!updated) return;
+
+    const edges = updated.stakedTickEdges;
+    const nets = updated.stakedTickEdgeNets;
+
+    // Invariant 1: parallel arrays have the same length
+    expect(edges.length).toBe(nets.length);
+
+    // Invariant 2: sorted strictly ascending (monotone, dedup'd)
+    for (let i = 1; i < edges.length; i++) {
+      expect(edges[i]).toBeGreaterThan(edges[i - 1]);
+    }
+
+    // Invariant 3: no zero-net entries (zero-net means the edge should have been dropped)
+    for (let i = 0; i < nets.length; i++) {
+      expect(nets[i]).not.toBe(0n);
+    }
+
+    // Invariant 4: edge list consistent with CLTickStaked — each edge's net
+    // equals the corresponding CLTickStaked.stakedLiquidityNet.
+    for (let i = 0; i < edges.length; i++) {
+      const tickEntity = resultDb.entities.CLTickStaked.get(
+        CLTickStakedId(chainId, liquidityPool.poolAddress, edges[i]),
+      );
+      expect(tickEntity).toBeDefined();
+      expect(tickEntity?.stakedLiquidityNet).toBe(nets[i]);
+    }
+  });
+
+  it("(b) processTickCrossingsForStaked returns the same in-range delta as a CLTickStaked-reading baseline across a swap window crossing multiple edges", async () => {
+    // Build a realistic edge set by simulating 50 stake events and walking
+    // the exact same events through the pure baseline (a CLTickStaked map).
+    const baselineNet = new Map<bigint, bigint>();
+    let edges: readonly bigint[] = [];
+    let nets: readonly bigint[] = [];
+
+    for (let i = 0; i < 50; i++) {
+      const tickLower = BigInt(-500 + i * 20);
+      const tickUpper = tickLower + 100n;
+      const liquidity = BigInt(500 + i * 10);
+
+      // Baseline: maintain a map keyed by tick, mirroring CLTickStaked.stakedLiquidityNet.
+      baselineNet.set(
+        tickLower,
+        (baselineNet.get(tickLower) ?? 0n) + liquidity,
+      );
+      baselineNet.set(
+        tickUpper,
+        (baselineNet.get(tickUpper) ?? 0n) - liquidity,
+      );
+
+      // Under test: apply to the sparse edge list.
+      const out = applyStakedPositionToEdges(
+        edges,
+        nets,
+        tickLower,
+        tickUpper,
+        liquidity,
+      );
+      edges = out.edges;
+      nets = out.nets;
+    }
+
+    // Pick a swap window that crosses ~20 edges.
+    const oldTick = -400n;
+    const newTick = 400n;
+
+    // Baseline: walk the map directly and sum liquidityNet for ticks strictly
+    // above oldTick through newTick.
+    let baselineResult = 0n;
+    for (const [tick, net] of baselineNet.entries()) {
+      if (tick > oldTick && tick <= newTick) {
+        baselineResult += net;
+      }
+    }
+
+    // Under test: use the new function with in-aggregator arrays. Must NOT
+    // touch CLTickStaked (we assert by installing a spy that throws).
+    const noDbContext = {
+      log: {
+        error: vi.fn(),
+        warn: vi.fn(),
+        info: vi.fn(),
+        debug: vi.fn(),
+      },
+      CLTickStaked: {
+        get: vi.fn(() => {
+          throw new Error(
+            "processTickCrossingsForStaked must not call CLTickStaked.get on the swap path (#649)",
+          );
+        }),
+      },
+      // biome-ignore lint/suspicious/noExplicitAny: test-only shape
+    } as any;
+
+    const newResult = await processTickCrossingsForStaked(
+      chainId,
+      `0x${"1".repeat(40)}`,
+      oldTick,
+      newTick,
+      10n,
+      noDbContext,
+      0n,
+      true,
+      edges,
+      nets,
+    );
+
+    expect(newResult).toBe(baselineResult);
+    expect(noDbContext.CLTickStaked.get).not.toHaveBeenCalled();
+
+    // Sanity: the window actually crosses multiple edges.
+    const crossingCount = edges.filter(
+      (e) => e > oldTick && e <= newTick,
+    ).length;
+    expect(crossingCount).toBeGreaterThan(5);
+
+    // Also verify the OPPOSITE direction (price moving DOWN). Uniswap v3 sign
+    // convention: on a downward cross the pool does `liquidity -= net[T]`, which
+    // means the sparse walker must subtract (not add) across the same edges,
+    // and the window is `newTick < T <= oldTick` (at-or-below oldTick, strictly
+    // above newTick). Seeding stakedLiq with the result of the up-swap gives us
+    // round-trip parity: up then down should land back on the starting liquidity.
+    const oldTickDown = newTick;
+    const newTickDown = oldTick;
+    let baselineDownResult = baselineResult;
+    for (const [tick, net] of baselineNet.entries()) {
+      if (tick > newTickDown && tick <= oldTickDown) {
+        baselineDownResult -= net;
+      }
+    }
+
+    const downResult = await processTickCrossingsForStaked(
+      chainId,
+      `0x${"1".repeat(40)}`,
+      oldTickDown,
+      newTickDown,
+      10n,
+      noDbContext,
+      baselineResult,
+      true,
+      edges,
+      nets,
+    );
+
+    expect(downResult).toBe(baselineDownResult);
+    // Round-trip parity: up-swap then down-swap over the same window must
+    // return stakedLiq to its starting value (0n in this test).
+    expect(downResult).toBe(0n);
+    expect(noDbContext.CLTickStaked.get).not.toHaveBeenCalled();
+  });
+});

--- a/test/Aggregators/CLStakedLiquidityEdgeSanity.test.ts
+++ b/test/Aggregators/CLStakedLiquidityEdgeSanity.test.ts
@@ -40,7 +40,7 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
     "0x2222222222222222222222222222222222222222",
   );
 
-  it("(a) stakedTickEdges stays sorted + monotone across ≥200 interleaved gauge Deposit/Withdraw events", async () => {
+  it("(a) stakedTickEdges stays sorted + monotone across 150 interleaved gauge Deposit/Withdraw events", async () => {
     let mockDb = MockDb.createMockDb();
 
     const liquidityPool = createMockLiquidityPoolAggregator({
@@ -74,7 +74,7 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
     }
 
     // Interleave Deposit and Withdraw events: deposit all, then withdraw half
-    // in a non-sorted order. ≥200 total events (100 deposits + 100 withdraws).
+    // in a non-sorted order. 150 total events (100 deposits + 50 withdraws).
     const depositEvents = [];
     for (let i = 0; i < POSITIONS; i++) {
       const tokenId = BigInt(i + 1);
@@ -159,6 +159,7 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
   });
 
   it("(b) processTickCrossingsForStaked returns the same in-range delta as a CLTickStaked-reading baseline across a swap window crossing multiple edges", async () => {
+    const mockPoolAddress = toChecksumAddress(`0x${"1".repeat(40)}`);
     // Build a realistic edge set by simulating 50 stake events and walking
     // the exact same events through the pure baseline (a CLTickStaked map).
     const baselineNet = new Map<bigint, bigint>();
@@ -226,7 +227,7 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
 
     const newResult = await processTickCrossingsForStaked(
       chainId,
-      `0x${"1".repeat(40)}`,
+      mockPoolAddress,
       oldTick,
       newTick,
       10n,
@@ -263,7 +264,7 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
 
     const downResult = await processTickCrossingsForStaked(
       chainId,
-      `0x${"1".repeat(40)}`,
+      mockPoolAddress,
       oldTickDown,
       newTickDown,
       10n,

--- a/test/Aggregators/CLStakedLiquidityEdgeSanity.test.ts
+++ b/test/Aggregators/CLStakedLiquidityEdgeSanity.test.ts
@@ -149,6 +149,8 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
 
     // Invariant 4: edge list consistent with CLTickStaked — each edge's net
     // equals the corresponding CLTickStaked.stakedLiquidityNet.
+    // TODO(#652): Remove this invariant when the legacy CLTickStaked writes
+    // are deleted; the in-aggregator edge list becomes the sole source of truth.
     for (let i = 0; i < edges.length; i++) {
       const tickEntity = resultDb.entities.CLTickStaked.get(
         CLTickStakedId(chainId, liquidityPool.poolAddress, edges[i]),
@@ -225,7 +227,7 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
       // biome-ignore lint/suspicious/noExplicitAny: test-only shape
     } as any;
 
-    const newResult = await processTickCrossingsForStaked(
+    const newResult = processTickCrossingsForStaked(
       chainId,
       mockPoolAddress,
       oldTick,
@@ -262,7 +264,7 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
       }
     }
 
-    const downResult = await processTickCrossingsForStaked(
+    const downResult = processTickCrossingsForStaked(
       chainId,
       mockPoolAddress,
       oldTickDown,

--- a/test/Aggregators/LiquidityPoolAggregator.test.ts
+++ b/test/Aggregators/LiquidityPoolAggregator.test.ts
@@ -307,6 +307,43 @@ describe("LiquidityPoolAggregator Functions", () => {
       const setCalls = vi.mocked(poolStore.set).mock.calls;
       expect(setCalls.at(-1)?.[0]?.totalLiquidityUSD).toBe(100n);
     });
+
+    it("should preserve hasStakes=true when a full-unstake diff leaves hasStakes undefined (one-way latch)", async () => {
+      // Simulates the NFPMCommonLogic path where the edge list becomes empty
+      // after a full unstake: the producer passes `hasStakes: undefined` (see
+      // src/EventHandlers/NFPM/NFPMCommonLogic.ts:147, `stakedTickEdges.length > 0 ? true : undefined`).
+      // The monotonic-latch merge at LiquidityPoolAggregator.ts:390
+      // (`current.hasStakes || (diff.hasStakes ?? false)`) must keep the
+      // prior `true` value regardless of the empty edge list.
+      await updateLiquidityPoolAggregator(
+        {
+          hasStakes: undefined,
+          stakedTickEdges: [],
+          stakedTickEdgeNets: [],
+        },
+        {
+          ...(liquidityPoolAggregator as LiquidityPoolAggregator),
+          hasStakes: true,
+          stakedTickEdges: [100n, 200n],
+          stakedTickEdgeNets: [500n, -500n],
+        },
+        timestamp,
+        mockContext as handlerContext,
+        10,
+        blockNumber,
+      );
+
+      const poolStore = mockContext.LiquidityPoolAggregator;
+      if (!poolStore) {
+        throw new Error("test setup: LiquidityPoolAggregator store must exist");
+      }
+      const setCalls = vi.mocked(poolStore.set).mock.calls;
+      const updated = setCalls.at(-1)?.[0] as LiquidityPoolAggregator;
+      expect(updated.hasStakes).toBe(true);
+      // Edge arrays should still be replaced (empty) since the diff provides them.
+      expect(updated.stakedTickEdges).toEqual([]);
+      expect(updated.stakedTickEdgeNets).toEqual([]);
+    });
   });
 
   describe("Updating the Liquidity Pool Aggregator", () => {

--- a/test/EventHandlers/CLGaugeFactory/CLGaugeFactoryV2.test.ts
+++ b/test/EventHandlers/CLGaugeFactory/CLGaugeFactoryV2.test.ts
@@ -1,13 +1,13 @@
-import type { LiquidityPoolAggregator } from "generated";
 import {
   CLGaugeFactoryV2,
   MockDb,
 } from "../../../generated/src/TestHelpers.gen";
 import { toChecksumAddress } from "../../../src/Constants";
-import { setupCommon } from "../Pool/common";
+import { type MockLiquidityPoolAggregator, setupCommon } from "../Pool/common";
 
 describe("CLGaugeFactoryV2 Event Handlers", () => {
-  const { mockLiquidityPoolData } = setupCommon();
+  const { mockLiquidityPoolData, createMockLiquidityPoolAggregator } =
+    setupCommon();
   const chainId = 10;
   const mockGaugeFactoryAddress = toChecksumAddress(
     "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -170,16 +170,15 @@ describe("CLGaugeFactoryV2 Event Handlers", () => {
   });
 
   describe("SetEmissionCap Event Handler", () => {
-    let mockPoolWithGauge: LiquidityPoolAggregator;
+    let mockPoolWithGauge: MockLiquidityPoolAggregator;
     let mockDbWithGetWhere: typeof mockDb;
 
     beforeEach(() => {
       // Create a pool entity with a gauge address
-      mockPoolWithGauge = {
-        ...mockLiquidityPoolData,
+      mockPoolWithGauge = createMockLiquidityPoolAggregator({
         gaugeAddress: mockGaugeAddress,
         gaugeEmissionsCap: 0n, // Initial value
-      };
+      });
 
       mockDb = mockDb.entities.LiquidityPoolAggregator.set(mockPoolWithGauge);
 

--- a/test/EventHandlers/CLGaugeFactory/CLGaugeFactoryV3.test.ts
+++ b/test/EventHandlers/CLGaugeFactory/CLGaugeFactoryV3.test.ts
@@ -1,14 +1,15 @@
-import type { CLGaugeConfig, LiquidityPoolAggregator } from "generated";
+import type { CLGaugeConfig } from "generated";
 import {
   CLGaugeFactoryV2,
   CLGaugeFactoryV3,
   MockDb,
 } from "../../../generated/src/TestHelpers.gen";
 import { PoolId, toChecksumAddress } from "../../../src/Constants";
-import { setupCommon } from "../Pool/common";
+import { type MockLiquidityPoolAggregator, setupCommon } from "../Pool/common";
 
 describe("CLGaugeFactoryV3 Event Handlers", () => {
-  const { mockLiquidityPoolData } = setupCommon();
+  const { mockLiquidityPoolData, createMockLiquidityPoolAggregator } =
+    setupCommon();
   const chainId = 8453; // Base — where V3 is deployed
   const v2FactoryAddress = toChecksumAddress(
     "0xB630227a79707D517320b6c0f885806389dFcbB3",
@@ -107,15 +108,14 @@ describe("CLGaugeFactoryV3 Event Handlers", () => {
   });
 
   describe("SetEmissionCap", () => {
-    let mockPoolWithGauge: LiquidityPoolAggregator;
+    let mockPoolWithGauge: MockLiquidityPoolAggregator;
     let mockDbWithGetWhere: typeof mockDb;
 
     beforeEach(() => {
-      mockPoolWithGauge = {
-        ...mockLiquidityPoolData,
+      mockPoolWithGauge = createMockLiquidityPoolAggregator({
         gaugeAddress: mockGaugeAddress,
         gaugeEmissionsCap: 0n,
-      };
+      });
 
       mockDb = mockDb.entities.LiquidityPoolAggregator.set(mockPoolWithGauge);
 
@@ -284,13 +284,12 @@ describe("CLGaugeFactoryV3 Event Handlers", () => {
     const poolOnBaseId = PoolId(chainId, poolAddress);
 
     it("sets minStakeTime on the matching LiquidityPoolAggregator", async () => {
-      const existingPool: LiquidityPoolAggregator = {
-        ...mockLiquidityPoolData,
+      const existingPool = createMockLiquidityPoolAggregator({
         id: poolOnBaseId,
         chainId,
         poolAddress: poolAddress as `0x${string}`,
         minStakeTime: 0n,
-      };
+      });
       const seeded = mockDb.entities.LiquidityPoolAggregator.set(existingPool);
 
       const event = CLGaugeFactoryV3.SetPoolMinStakeTime.createMockEvent({

--- a/test/EventHandlers/CLPool.test.ts
+++ b/test/EventHandlers/CLPool.test.ts
@@ -1,4 +1,4 @@
-import type { LiquidityPoolAggregator, Token } from "generated";
+import type { Token } from "generated";
 import type { MockInstance } from "vitest";
 import { CLPool, MockDb } from "../../generated/src/TestHelpers.gen";
 import {
@@ -13,7 +13,7 @@ import * as CLPoolCollectLogic from "../../src/EventHandlers/CLPool/CLPoolCollec
 import * as CLPoolFlashLogic from "../../src/EventHandlers/CLPool/CLPoolFlashLogic";
 import * as CLPoolMintLogic from "../../src/EventHandlers/CLPool/CLPoolMintLogic";
 import * as CLPoolSwapLogic from "../../src/EventHandlers/CLPool/CLPoolSwapLogic";
-import { setupCommon } from "./Pool/common";
+import { type MockLiquidityPoolAggregator, setupCommon } from "./Pool/common";
 
 describe("CLPool Events", () => {
   const {
@@ -31,7 +31,7 @@ describe("CLPool Events", () => {
   );
 
   let mockDb: ReturnType<typeof MockDb.createMockDb>;
-  let liquidityPool: LiquidityPoolAggregator;
+  let liquidityPool: MockLiquidityPoolAggregator;
   let userStats: ReturnType<typeof createMockUserStatsPerPool>;
 
   beforeEach(() => {
@@ -156,7 +156,7 @@ describe("CLPool Events", () => {
         id: TokenId(chainId, OUSDT_ADDRESS),
       };
 
-      const ousdtPool: LiquidityPoolAggregator = {
+      const ousdtPool = {
         ...liquidityPool,
         token0_address: OUSDT_ADDRESS,
         token0_id: ousdtToken.id,
@@ -183,7 +183,7 @@ describe("CLPool Events", () => {
       expect(swapEntity1.amountOut).toBe(500n); // amount1 = -500n, so amount1Out = 500n
 
       // Test with OUSDT as token1 as well
-      const ousdtToken1Pool: LiquidityPoolAggregator = {
+      const ousdtToken1Pool = {
         ...liquidityPool,
         token1_address: OUSDT_ADDRESS,
         token1_id: ousdtToken.id,
@@ -241,7 +241,7 @@ describe("CLPool Events", () => {
         id: TokenId(chainId, OUSDT_ADDRESS),
       };
 
-      const ousdtPool: LiquidityPoolAggregator = {
+      const ousdtPool = {
         ...liquidityPool,
         token0_address: OUSDT_ADDRESS,
         token0_id: ousdtToken.id,

--- a/test/EventHandlers/Gauges/GaugeSharedLogic.test.ts
+++ b/test/EventHandlers/Gauges/GaugeSharedLogic.test.ts
@@ -1,5 +1,5 @@
 import { TickMath } from "@uniswap/v3-sdk";
-import type { LiquidityPoolAggregator, Token, handlerContext } from "generated";
+import type { Token, handlerContext } from "generated";
 import type { PublicClient } from "viem";
 import { MockDb } from "../../../generated/src/TestHelpers.gen";
 import {
@@ -17,7 +17,7 @@ import {
   processGaugeDeposit,
   processGaugeWithdraw,
 } from "../../../src/EventHandlers/Gauges/GaugeSharedLogic";
-import { setupCommon } from "../Pool/common";
+import { type MockLiquidityPoolAggregator, setupCommon } from "../Pool/common";
 
 describe("GaugeSharedLogic", () => {
   const { mockToken0Data, mockToken1Data, createMockLiquidityPoolAggregator } =
@@ -60,7 +60,7 @@ describe("GaugeSharedLogic", () => {
     isWhitelisted: true,
   };
 
-  let mockLiquidityPoolAggregator: LiquidityPoolAggregator;
+  let mockLiquidityPoolAggregator: MockLiquidityPoolAggregator;
   let mockUserStatsPerPool: ReturnType<
     ReturnType<typeof setupCommon>["createMockUserStatsPerPool"]
   >;
@@ -936,7 +936,7 @@ describe("GaugeSharedLogic", () => {
       TickMath.getSqrtRatioAtTick(0).toString(),
     );
 
-    let clPool: LiquidityPoolAggregator;
+    let clPool: MockLiquidityPoolAggregator;
     let clMockContext: typeof mockContext;
 
     const mockTokenId1 = 42n;

--- a/test/EventHandlers/NFPM/NFPMCommonLogic.test.ts
+++ b/test/EventHandlers/NFPM/NFPMCommonLogic.test.ts
@@ -2,6 +2,7 @@ import { TickMath } from "@uniswap/v3-sdk";
 import type { NonFungiblePosition, handlerContext } from "generated";
 import { MockDb } from "../../../generated/src/TestHelpers.gen";
 import {
+  applyStakedPositionToEdges,
   isPositionInRange,
   updateTicksForStakedPosition,
 } from "../../../src/Aggregators/CLStakedLiquidity";
@@ -296,6 +297,13 @@ describe("NFPMCommonLogic", () => {
         amount0: 100n,
         amount1: 200n,
       });
+      // applyStakedPositionToEdges is auto-mocked by vi.mock above; return a
+      // valid shape so NFPMCommonLogic's destructure doesn't trip.
+      vi.mocked(applyStakedPositionToEdges).mockReset();
+      vi.mocked(applyStakedPositionToEdges).mockReturnValue({
+        edges: [-200n, 200n],
+        nets: [5000n, -5000n],
+      });
     });
 
     it("should always update tick entities regardless of in-range status", async () => {
@@ -346,6 +354,9 @@ describe("NFPMCommonLogic", () => {
           stakedLiquidityInRange: 6000n, // 1000 + 5000
           incrementalStakedReserve0: 100n, // direction=+1 * 100
           incrementalStakedReserve1: 200n, // direction=+1 * 200
+          stakedTickEdges: [-200n, 200n],
+          stakedTickEdgeNets: [5000n, -5000n],
+          hasStakes: true, // belt-and-suspenders: NFPM path also flips the latch when edges are non-empty
         },
         poolData.liquidityPoolAggregator,
         timestamp,
@@ -380,6 +391,9 @@ describe("NFPMCommonLogic", () => {
           stakedLiquidityInRange: -2000n, // 1000 + (-3000)
           incrementalStakedReserve0: -100n, // direction=-1 * 100
           incrementalStakedReserve1: -200n, // direction=-1 * 200
+          stakedTickEdges: [-200n, 200n],
+          stakedTickEdgeNets: [5000n, -5000n],
+          hasStakes: true,
         },
         poolData.liquidityPoolAggregator,
         timestamp,
@@ -414,6 +428,9 @@ describe("NFPMCommonLogic", () => {
           stakedLiquidityInRange: undefined, // not in range, so unchanged
           incrementalStakedReserve0: 100n,
           incrementalStakedReserve1: 200n,
+          stakedTickEdges: [-200n, 200n],
+          stakedTickEdgeNets: [5000n, -5000n],
+          hasStakes: true,
         },
         poolData.liquidityPoolAggregator,
         timestamp,
@@ -423,7 +440,7 @@ describe("NFPMCommonLogic", () => {
       );
     });
 
-    it("should not update total staked reserves when sqrtPriceX96 is zero", async () => {
+    it("should persist edge-list updates even when sqrtPriceX96 is zero", async () => {
       vi.mocked(isPositionInRange).mockReturnValue(true);
 
       const poolDataZeroPrice: PoolData = {
@@ -445,7 +462,21 @@ describe("NFPMCommonLogic", () => {
       );
 
       expect(updateTicksForStakedPosition).toHaveBeenCalled();
-      expect(updateLiquidityPoolAggregator).not.toHaveBeenCalled();
+      // Reserve math is skipped (no sqrtPriceX96 to split into token0/token1),
+      // but we still persist the edge-list update so the swap path has correct
+      // state once the pool is initialized.
+      expect(updateLiquidityPoolAggregator).toHaveBeenCalledWith(
+        {
+          stakedTickEdges: [-200n, 200n],
+          stakedTickEdgeNets: [5000n, -5000n],
+          hasStakes: true,
+        },
+        poolDataZeroPrice.liquidityPoolAggregator,
+        timestamp,
+        mockContext,
+        chainId,
+        blockNumber,
+      );
     });
   });
 });

--- a/test/EventHandlers/Pool/Claim.test.ts
+++ b/test/EventHandlers/Pool/Claim.test.ts
@@ -9,6 +9,9 @@ describe("Pool Claim Event", () => {
   let mockToken0Data: Token;
   let mockToken1Data: Token;
   let mockLiquidityPoolData: MockLiquidityPoolAggregator;
+  let createMockLiquidityPoolAggregator: ReturnType<
+    typeof setupCommon
+  >["createMockLiquidityPoolAggregator"];
   let mockDb: ReturnType<typeof MockDb.createMockDb>;
   let mockPriceOracle: MockInstance;
 
@@ -20,10 +23,11 @@ describe("Pool Claim Event", () => {
     const {
       mockToken0Data: token0,
       mockToken1Data: token1,
-      createMockLiquidityPoolAggregator,
+      createMockLiquidityPoolAggregator: builder,
     } = setupCommon();
     mockToken0Data = token0;
     mockToken1Data = token1;
+    createMockLiquidityPoolAggregator = builder;
     mockLiquidityPoolData = createMockLiquidityPoolAggregator({
       gaugeAddress: gaugeAddress,
     });
@@ -281,10 +285,9 @@ describe("Pool Claim Event", () => {
       });
 
       it("should handle case when gauge address is undefined", async () => {
-        const poolWithoutGauge = {
-          ...mockLiquidityPoolData,
+        const poolWithoutGauge = createMockLiquidityPoolAggregator({
           gaugeAddress: undefined,
-        };
+        });
 
         const eventData = {
           sender: gaugeAddress,

--- a/test/EventHandlers/Pool/Claim.test.ts
+++ b/test/EventHandlers/Pool/Claim.test.ts
@@ -3,12 +3,12 @@ import type { MockInstance } from "vitest";
 import { MockDb, Pool } from "../../../generated/src/TestHelpers.gen";
 import { toChecksumAddress } from "../../../src/Constants";
 import * as PriceOracle from "../../../src/PriceOracle";
-import { setupCommon } from "./common";
+import { type MockLiquidityPoolAggregator, setupCommon } from "./common";
 
 describe("Pool Claim Event", () => {
   let mockToken0Data: Token;
   let mockToken1Data: Token;
-  let mockLiquidityPoolData: LiquidityPoolAggregator;
+  let mockLiquidityPoolData: MockLiquidityPoolAggregator;
   let mockDb: ReturnType<typeof MockDb.createMockDb>;
   let mockPriceOracle: MockInstance;
 
@@ -20,14 +20,13 @@ describe("Pool Claim Event", () => {
     const {
       mockToken0Data: token0,
       mockToken1Data: token1,
-      mockLiquidityPoolData: pool,
+      createMockLiquidityPoolAggregator,
     } = setupCommon();
     mockToken0Data = token0;
     mockToken1Data = token1;
-    mockLiquidityPoolData = {
-      ...pool,
+    mockLiquidityPoolData = createMockLiquidityPoolAggregator({
       gaugeAddress: gaugeAddress,
-    } as LiquidityPoolAggregator;
+    });
 
     mockDb = MockDb.createMockDb();
     mockPriceOracle = vi
@@ -69,7 +68,7 @@ describe("Pool Claim Event", () => {
 
       beforeEach(async () => {
         const updatedDB1 = mockDb.entities.LiquidityPoolAggregator.set(
-          mockLiquidityPoolData as LiquidityPoolAggregator,
+          mockLiquidityPoolData,
         );
         const updatedDB2 = updatedDB1.entities.Token.set(
           mockToken0Data as Token,
@@ -169,7 +168,7 @@ describe("Pool Claim Event", () => {
 
       beforeEach(async () => {
         const updatedDB1 = mockDb.entities.LiquidityPoolAggregator.set(
-          mockLiquidityPoolData as LiquidityPoolAggregator,
+          mockLiquidityPoolData,
         );
         const updatedDB2 = updatedDB1.entities.Token.set(
           mockToken0Data as Token,
@@ -248,7 +247,7 @@ describe("Pool Claim Event", () => {
         };
 
         const updatedDB1 = mockDb.entities.LiquidityPoolAggregator.set(
-          mockLiquidityPoolData as LiquidityPoolAggregator,
+          mockLiquidityPoolData,
         );
         const updatedDB2 = updatedDB1.entities.Token.set(
           mockToken0Data as Token,
@@ -285,7 +284,7 @@ describe("Pool Claim Event", () => {
         const poolWithoutGauge = {
           ...mockLiquidityPoolData,
           gaugeAddress: undefined,
-        } as LiquidityPoolAggregator;
+        };
 
         const eventData = {
           sender: gaugeAddress,
@@ -308,9 +307,8 @@ describe("Pool Claim Event", () => {
           },
         };
 
-        const updatedDB1 = mockDb.entities.LiquidityPoolAggregator.set(
-          poolWithoutGauge as LiquidityPoolAggregator,
-        );
+        const updatedDB1 =
+          mockDb.entities.LiquidityPoolAggregator.set(poolWithoutGauge);
         const updatedDB2 = updatedDB1.entities.Token.set(
           mockToken0Data as Token,
         );

--- a/test/EventHandlers/Pool/Swap.test.ts
+++ b/test/EventHandlers/Pool/Swap.test.ts
@@ -15,7 +15,9 @@ import { setupCommon } from "./common";
 describe("Pool Swap Event", () => {
   let mockToken0Data: Token;
   let mockToken1Data: Token;
-  let mockLiquidityPoolData: LiquidityPoolAggregator;
+  let mockLiquidityPoolData: ReturnType<
+    typeof setupCommon
+  >["mockLiquidityPoolData"];
   let createMockToken: ReturnType<typeof setupCommon>["createMockToken"];
 
   const expectations = {
@@ -108,9 +110,11 @@ describe("Pool Swap Event", () => {
     let updatedPool: LiquidityPoolAggregator | undefined;
 
     beforeEach(async () => {
-      const updatedDB1 = mockDb.entities.LiquidityPoolAggregator.set(
-        mockLiquidityPoolData as LiquidityPoolAggregator,
-      );
+      const updatedDB1 = mockDb.entities.LiquidityPoolAggregator.set({
+        ...mockLiquidityPoolData,
+        stakedTickEdges: [...mockLiquidityPoolData.stakedTickEdges],
+        stakedTickEdgeNets: [...mockLiquidityPoolData.stakedTickEdgeNets],
+      });
       const updatedDB2 = updatedDB1.entities.Token.set(mockToken0Data as Token);
       const updatedDB3 = updatedDB2.entities.Token.set(mockToken1Data as Token);
 
@@ -218,15 +222,16 @@ describe("Pool Swap Event", () => {
       });
 
       // Update pool to reference OUSDT token
-      const poolWithOusdt: LiquidityPoolAggregator = {
+      const poolWithOusdt = {
         ...mockLiquidityPoolData,
         token0_id: ousdtToken.id,
         token0_address: ousdtAddress,
+        stakedTickEdges: [...mockLiquidityPoolData.stakedTickEdges],
+        stakedTickEdgeNets: [...mockLiquidityPoolData.stakedTickEdgeNets],
       };
 
-      const updatedDB1 = mockDb.entities.LiquidityPoolAggregator.set(
-        poolWithOusdt as LiquidityPoolAggregator,
-      );
+      const updatedDB1 =
+        mockDb.entities.LiquidityPoolAggregator.set(poolWithOusdt);
       const updatedDB2 = updatedDB1.entities.Token.set(ousdtToken as Token);
       const updatedDB3 = updatedDB2.entities.Token.set(mockToken1Data as Token);
 
@@ -253,15 +258,16 @@ describe("Pool Swap Event", () => {
       });
 
       // Update pool to reference OUSDT token
-      const poolWithOusdt: LiquidityPoolAggregator = {
+      const poolWithOusdt = {
         ...mockLiquidityPoolData,
         token1_id: ousdtToken.id,
         token1_address: ousdtAddress,
+        stakedTickEdges: [...mockLiquidityPoolData.stakedTickEdges],
+        stakedTickEdgeNets: [...mockLiquidityPoolData.stakedTickEdgeNets],
       };
 
-      const updatedDB1 = mockDb.entities.LiquidityPoolAggregator.set(
-        poolWithOusdt as LiquidityPoolAggregator,
-      );
+      const updatedDB1 =
+        mockDb.entities.LiquidityPoolAggregator.set(poolWithOusdt);
       const updatedDB2 = updatedDB1.entities.Token.set(mockToken0Data as Token);
       const updatedDB3 = updatedDB2.entities.Token.set(ousdtToken as Token);
 
@@ -285,9 +291,11 @@ describe("Pool Swap Event", () => {
     });
 
     it("should not create OUSDTSwap entity when neither token is OUSDT", async () => {
-      const updatedDB1 = mockDb.entities.LiquidityPoolAggregator.set(
-        mockLiquidityPoolData as LiquidityPoolAggregator,
-      );
+      const updatedDB1 = mockDb.entities.LiquidityPoolAggregator.set({
+        ...mockLiquidityPoolData,
+        stakedTickEdges: [...mockLiquidityPoolData.stakedTickEdges],
+        stakedTickEdgeNets: [...mockLiquidityPoolData.stakedTickEdgeNets],
+      });
       const updatedDB2 = updatedDB1.entities.Token.set(mockToken0Data as Token);
       const updatedDB3 = updatedDB2.entities.Token.set(mockToken1Data as Token);
 

--- a/test/EventHandlers/Pool/Sync.test.ts
+++ b/test/EventHandlers/Pool/Sync.test.ts
@@ -1,4 +1,4 @@
-import type { LiquidityPoolAggregator, Token } from "generated";
+import type { Token } from "generated";
 import { MockDb, Pool } from "../../../generated/src/TestHelpers.gen";
 import {
   PoolId,
@@ -10,7 +10,9 @@ import { setupCommon } from "./common";
 describe("Pool Sync Event", () => {
   let mockToken0Data: Token;
   let mockToken1Data: Token;
-  let mockLiquidityPoolData: LiquidityPoolAggregator;
+  let mockLiquidityPoolData: ReturnType<
+    typeof setupCommon
+  >["mockLiquidityPoolData"];
 
   const expectations = {
     reserveAmount0In: 0n,
@@ -80,9 +82,11 @@ describe("Pool Sync Event", () => {
     let postEventDB: ReturnType<typeof MockDb.createMockDb>;
 
     beforeEach(async () => {
-      const updatedDB1 = mockDb.entities.LiquidityPoolAggregator.set(
-        mockLiquidityPoolData as LiquidityPoolAggregator,
-      );
+      const updatedDB1 = mockDb.entities.LiquidityPoolAggregator.set({
+        ...mockLiquidityPoolData,
+        stakedTickEdges: [...mockLiquidityPoolData.stakedTickEdges],
+        stakedTickEdgeNets: [...mockLiquidityPoolData.stakedTickEdgeNets],
+      });
       const updatedDB2 = updatedDB1.entities.Token.set(mockToken0Data);
       const updatedDB3 = updatedDB2.entities.Token.set(mockToken1Data);
 

--- a/test/EventHandlers/Pool/Sync.test.ts
+++ b/test/EventHandlers/Pool/Sync.test.ts
@@ -5,6 +5,7 @@ import {
   TEN_TO_THE_18_BI,
   toChecksumAddress,
 } from "../../../src/Constants";
+import { setupLiquidityPoolAggregator } from "../../testHelpers";
 import { setupCommon } from "./common";
 
 describe("Pool Sync Event", () => {
@@ -82,11 +83,11 @@ describe("Pool Sync Event", () => {
     let postEventDB: ReturnType<typeof MockDb.createMockDb>;
 
     beforeEach(async () => {
-      const updatedDB1 = mockDb.entities.LiquidityPoolAggregator.set({
-        ...mockLiquidityPoolData,
-        stakedTickEdges: [...mockLiquidityPoolData.stakedTickEdges],
-        stakedTickEdgeNets: [...mockLiquidityPoolData.stakedTickEdgeNets],
-      });
+      const updatedDB1 = setupLiquidityPoolAggregator(
+        mockDb,
+        mockLiquidityPoolData,
+        eventData.mockEventData.srcAddress,
+      );
       const updatedDB2 = updatedDB1.entities.Token.set(mockToken0Data);
       const updatedDB3 = updatedDB2.entities.Token.set(mockToken1Data);
 

--- a/test/EventHandlers/Pool/common.ts
+++ b/test/EventHandlers/Pool/common.ts
@@ -31,6 +31,22 @@ export const defaultNfpmAddress = toChecksumAddress(
   "0xbB5DFE1380333CEE4c2EeBd7202c80dE2256AdF4",
 );
 
+/**
+ * Shared alias for the mock `LiquidityPoolAggregator` shape returned by
+ * `setupCommon().createMockLiquidityPoolAggregator(...)`.
+ *
+ * Why the alias exists: envio codegen emits TWO slightly different array-field
+ * types for the same entity — `readonly bigint[]` in `envio.d.ts` vs mutable
+ * `bigint[]` in `Indexer.gen.ts`. `createMockLiquidityPoolAggregator` deliberately
+ * returns an inferred (untyped) shape with mutable arrays so it satisfies both.
+ * Annotating a test variable as `LiquidityPoolAggregator` directly conflicts
+ * with `MockDb.set()`'s expected mutable shape. Tests should use this alias
+ * instead of duplicating the `ReturnType<...>` incantation per file.
+ */
+export type MockLiquidityPoolAggregator = ReturnType<
+  ReturnType<typeof setupCommon>["createMockLiquidityPoolAggregator"]
+>;
+
 export function setupCommon() {
   const CHAIN_ID = 10;
   const POOL_ADDRESS = toChecksumAddress(
@@ -68,7 +84,10 @@ export function setupCommon() {
     lastUpdatedTimestamp: new Date(),
   };
 
-  const mockLiquidityPoolData: LiquidityPoolAggregator = {
+  // Not annotated as LiquidityPoolAggregator to avoid readonly bigint[] vs bigint[] mismatch
+  // between envio.d.ts (readonly bigint[]) and Indexer.gen.ts (bigint[]) for stakedTickEdges /
+  // stakedTickEdgeNets array fields. Same workaround as mockUserStatsPerPoolData.
+  const mockLiquidityPoolData = {
     id: POOL_ID,
     poolAddress: POOL_ADDRESS,
     chainId: CHAIN_ID,
@@ -135,6 +154,8 @@ export function setupCommon() {
     stakedReserve0: 0n,
     stakedReserve1: 0n,
     hasStakes: false,
+    stakedTickEdges: [],
+    stakedTickEdgeNets: [],
     totalFlashLoanFees0: 0n,
     totalFlashLoanFees1: 0n,
     totalFlashLoanFeesUSD: 0n,
@@ -392,11 +413,13 @@ export function setupCommon() {
    * All fields default to values from mockLiquidityPoolData, allowing tests to override only what they need.
    *
    * @param overrides - Partial LiquidityPoolAggregator to override default values
-   * @returns A complete LiquidityPoolAggregator entity
+   * @returns A complete LiquidityPoolAggregator entity (untyped return to let TS
+   *   infer mutable bigint[] for stakedTickEdges / stakedTickEdgeNets — same
+   *   readonly-vs-mutable workaround as createMockUserStatsPerPool).
    */
   function createMockLiquidityPoolAggregator(
     overrides: Partial<LiquidityPoolAggregator> = {},
-  ): LiquidityPoolAggregator {
+  ) {
     // Calculate id if poolAddress or chainId are provided
     const chainId = overrides.chainId ?? CHAIN_ID;
     const poolAddress = toChecksumAddress(
@@ -415,6 +438,15 @@ export function setupCommon() {
     return {
       ...mockLiquidityPoolData,
       ...overrides,
+      // Array fields: ensure mutable bigint[] to satisfy both envio.d.ts
+      // (readonly bigint[]) and Indexer.gen.ts (bigint[]) types used by MockDb.set()
+      stakedTickEdges: [
+        ...(overrides.stakedTickEdges ?? mockLiquidityPoolData.stakedTickEdges),
+      ],
+      stakedTickEdgeNets: [
+        ...(overrides.stakedTickEdgeNets ??
+          mockLiquidityPoolData.stakedTickEdgeNets),
+      ],
       poolAddress,
       chainId,
       id,

--- a/test/EventHandlers/PoolLauncher/CLPoolLauncher.test.ts
+++ b/test/EventHandlers/PoolLauncher/CLPoolLauncher.test.ts
@@ -1,7 +1,7 @@
 import type { PoolLauncherPool, Token } from "generated";
 import { CLPoolLauncher, MockDb } from "generated/src/TestHelpers.gen";
 import { PoolId, TokenId, toChecksumAddress } from "../../../src/Constants";
-import { setupCommon } from "../Pool/common";
+import { type MockLiquidityPoolAggregator, setupCommon } from "../Pool/common";
 
 describe("CLPoolLauncher Events", () => {
   const { createMockLiquidityPoolAggregator, mockToken0Data, mockToken1Data } =
@@ -57,9 +57,7 @@ describe("CLPoolLauncher Events", () => {
     isWhitelisted: true,
   };
 
-  let mockLiquidityPoolAggregator: ReturnType<
-    typeof createMockLiquidityPoolAggregator
-  >;
+  let mockLiquidityPoolAggregator: MockLiquidityPoolAggregator;
   let mockDb: ReturnType<typeof MockDb.createMockDb>;
 
   beforeEach(() => {

--- a/test/EventHandlers/PoolLauncher/CLPoolLauncher.test.ts
+++ b/test/EventHandlers/PoolLauncher/CLPoolLauncher.test.ts
@@ -1,8 +1,4 @@
-import type {
-  LiquidityPoolAggregator,
-  PoolLauncherPool,
-  Token,
-} from "generated";
+import type { PoolLauncherPool, Token } from "generated";
 import { CLPoolLauncher, MockDb } from "generated/src/TestHelpers.gen";
 import { PoolId, TokenId, toChecksumAddress } from "../../../src/Constants";
 import { setupCommon } from "../Pool/common";
@@ -61,7 +57,9 @@ describe("CLPoolLauncher Events", () => {
     isWhitelisted: true,
   };
 
-  let mockLiquidityPoolAggregator: LiquidityPoolAggregator;
+  let mockLiquidityPoolAggregator: ReturnType<
+    typeof createMockLiquidityPoolAggregator
+  >;
   let mockDb: ReturnType<typeof MockDb.createMockDb>;
 
   beforeEach(() => {

--- a/test/EventHandlers/PoolLauncher/PoolLauncherLogic.test.ts
+++ b/test/EventHandlers/PoolLauncher/PoolLauncherLogic.test.ts
@@ -29,7 +29,14 @@ describe("PoolLauncherLogic", () => {
       LiquidityPoolAggregator: {
         get: (id: string) => mockDb.entities.LiquidityPoolAggregator.get(id),
         set: (entity: LiquidityPoolAggregator) => {
-          mockDb = mockDb.entities.LiquidityPoolAggregator.set(entity);
+          // Copy readonly bigint[] fields into mutable bigint[] to satisfy
+          // MockDb.set() — envio.d.ts types these as readonly but Indexer.gen.ts
+          // expects mutable. Same workaround as createMockLiquidityPoolAggregator.
+          mockDb = mockDb.entities.LiquidityPoolAggregator.set({
+            ...entity,
+            stakedTickEdges: [...entity.stakedTickEdges],
+            stakedTickEdgeNets: [...entity.stakedTickEdgeNets],
+          });
         },
       },
       isPreload: false,

--- a/test/EventHandlers/PoolLauncher/V2PoolLauncher.test.ts
+++ b/test/EventHandlers/PoolLauncher/V2PoolLauncher.test.ts
@@ -1,8 +1,4 @@
-import type {
-  LiquidityPoolAggregator,
-  PoolLauncherPool,
-  Token,
-} from "generated";
+import type { PoolLauncherPool, Token } from "generated";
 import { MockDb, V2PoolLauncher } from "generated/src/TestHelpers.gen";
 import { PoolId, TokenId, toChecksumAddress } from "../../../src/Constants";
 import { setupCommon } from "../Pool/common";
@@ -60,7 +56,9 @@ describe("V2PoolLauncher Events", () => {
     isWhitelisted: true,
   };
 
-  let mockLiquidityPoolAggregator: LiquidityPoolAggregator;
+  let mockLiquidityPoolAggregator: ReturnType<
+    typeof createMockLiquidityPoolAggregator
+  >;
   let mockDb: ReturnType<typeof MockDb.createMockDb>;
 
   beforeEach(() => {

--- a/test/EventHandlers/PoolLauncher/V2PoolLauncher.test.ts
+++ b/test/EventHandlers/PoolLauncher/V2PoolLauncher.test.ts
@@ -1,7 +1,7 @@
 import type { PoolLauncherPool, Token } from "generated";
 import { MockDb, V2PoolLauncher } from "generated/src/TestHelpers.gen";
 import { PoolId, TokenId, toChecksumAddress } from "../../../src/Constants";
-import { setupCommon } from "../Pool/common";
+import { type MockLiquidityPoolAggregator, setupCommon } from "../Pool/common";
 
 describe("V2PoolLauncher Events", () => {
   const { createMockLiquidityPoolAggregator, mockToken0Data, mockToken1Data } =
@@ -56,9 +56,7 @@ describe("V2PoolLauncher Events", () => {
     isWhitelisted: true,
   };
 
-  let mockLiquidityPoolAggregator: ReturnType<
-    typeof createMockLiquidityPoolAggregator
-  >;
+  let mockLiquidityPoolAggregator: MockLiquidityPoolAggregator;
   let mockDb: ReturnType<typeof MockDb.createMockDb>;
 
   beforeEach(() => {

--- a/test/EventHandlers/Redistributor/Redistributor.test.ts
+++ b/test/EventHandlers/Redistributor/Redistributor.test.ts
@@ -1,6 +1,6 @@
 import { MockDb, Redistributor } from "../../../generated/src/TestHelpers.gen";
 import { toChecksumAddress } from "../../../src/Constants";
-import { setupCommon } from "../Pool/common";
+import { type MockLiquidityPoolAggregator, setupCommon } from "../Pool/common";
 import { makeRedistributorMockEventData } from "./common";
 
 describe("Redistributor Event Handlers", () => {
@@ -43,7 +43,7 @@ describe("Redistributor Event Handlers", () => {
   const seedPool = (
     existingForfeited = 0n,
     existingRedistributed = 0n,
-  ): ReturnType<typeof createMockLiquidityPoolAggregator> =>
+  ): MockLiquidityPoolAggregator =>
     createMockLiquidityPoolAggregator({
       chainId,
       gaugeAddress,

--- a/test/EventHandlers/RootCLPoolFactory.test.ts
+++ b/test/EventHandlers/RootCLPoolFactory.test.ts
@@ -1,4 +1,3 @@
-import type { LiquidityPoolAggregator } from "generated";
 import { MockDb, RootCLPoolFactory } from "generated/src/TestHelpers.gen";
 import {
   PendingRootPoolMappingId,
@@ -13,7 +12,7 @@ import {
   toChecksumAddress,
 } from "../../src/Constants";
 import { flushPendingVotesAndDistributionsForRootPool } from "../../src/EventHandlers/Voter/CrossChainPendingResolution";
-import { setupCommon } from "./Pool/common";
+import { type MockLiquidityPoolAggregator, setupCommon } from "./Pool/common";
 
 vi.mock(
   "../../src/EventHandlers/Voter/CrossChainPendingResolution",
@@ -74,7 +73,7 @@ describe("RootCLPoolFactory Events", () => {
 
     describe("when matching pool exists on leaf chain", () => {
       let resultDB: ReturnType<typeof MockDb.createMockDb>;
-      let mockLiquidityPool: LiquidityPoolAggregator;
+      let mockLiquidityPool: MockLiquidityPoolAggregator;
 
       beforeEach(async () => {
         const { createMockLiquidityPoolAggregator } = setupCommon();
@@ -278,8 +277,8 @@ describe("RootCLPoolFactory Events", () => {
 
     describe("when multiple matching pools exist", () => {
       let resultDB: ReturnType<typeof MockDb.createMockDb>;
-      let mockLiquidityPool1: LiquidityPoolAggregator;
-      let mockLiquidityPool2: LiquidityPoolAggregator;
+      let mockLiquidityPool1: MockLiquidityPoolAggregator;
+      let mockLiquidityPool2: MockLiquidityPoolAggregator;
 
       beforeEach(async () => {
         const { createMockLiquidityPoolAggregator } = setupCommon();

--- a/test/EventHandlers/Voter/SuperchainLeafVoter.test.ts
+++ b/test/EventHandlers/Voter/SuperchainLeafVoter.test.ts
@@ -1,4 +1,4 @@
-import type { LiquidityPoolAggregator, Token } from "generated";
+import type { Token } from "generated";
 import { MockDb, SuperchainLeafVoter } from "generated/src/TestHelpers.gen";
 import * as LiquidityPoolAggregatorModule from "../../../src/Aggregators/LiquidityPoolAggregator";
 import {
@@ -7,7 +7,7 @@ import {
   TokenId,
   toChecksumAddress,
 } from "../../../src/Constants";
-import { setupCommon } from "../Pool/common";
+import { type MockLiquidityPoolAggregator, setupCommon } from "../Pool/common";
 
 describe("SuperchainLeafVoter Events", () => {
   beforeEach(() => {
@@ -67,7 +67,7 @@ describe("SuperchainLeafVoter Events", () => {
 
     describe("when pool entity exists", () => {
       let resultDB: ReturnType<typeof MockDb.createMockDb>;
-      let mockLiquidityPool: LiquidityPoolAggregator;
+      let mockLiquidityPool: MockLiquidityPoolAggregator;
 
       beforeEach(async () => {
         mockLiquidityPool = createMockLiquidityPoolAggregator({
@@ -378,7 +378,7 @@ describe("SuperchainLeafVoter Events", () => {
 
     describe("when pool entity exists", () => {
       let resultDB: ReturnType<typeof MockDb.createMockDb>;
-      let mockLiquidityPool: LiquidityPoolAggregator;
+      let mockLiquidityPool: MockLiquidityPoolAggregator;
       const feeVotingRewardAddress = toChecksumAddress(
         "0x6572b2b30f63B960608f3aA5205711C558998398",
       );
@@ -476,7 +476,7 @@ describe("SuperchainLeafVoter Events", () => {
 
     describe("when pool entity exists", () => {
       let resultDB: ReturnType<typeof MockDb.createMockDb>;
-      let mockLiquidityPool: LiquidityPoolAggregator;
+      let mockLiquidityPool: MockLiquidityPoolAggregator;
       const feeVotingRewardAddress = toChecksumAddress(
         "0x6572b2b30f63B960608f3aA5205711C558998398",
       );

--- a/test/EventHandlers/Voter/Voter.test.ts
+++ b/test/EventHandlers/Voter/Voter.test.ts
@@ -1,9 +1,4 @@
-import type {
-  LiquidityPoolAggregator,
-  Token,
-  VeNFTPoolVote,
-  VeNFTState,
-} from "generated";
+import type { Token, VeNFTPoolVote, VeNFTState } from "generated";
 import {
   MockDb,
   RootCLPoolFactory,
@@ -27,7 +22,7 @@ import {
   toChecksumAddress,
 } from "../../../src/Constants";
 import { getTokensDeposited } from "../../../src/Effects/Voter";
-import { setupCommon } from "../Pool/common";
+import { type MockLiquidityPoolAggregator, setupCommon } from "../Pool/common";
 
 type MockUserStatsPerPool = ReturnType<
   ReturnType<typeof setupCommon>["createMockUserStatsPerPool"]
@@ -152,26 +147,25 @@ describe("Voter Events", () => {
 
     describe("when pool data exists", () => {
       let resultDB: ReturnType<typeof MockDb.createMockDb>;
-      let mockLiquidityPool: LiquidityPoolAggregator;
+      let mockLiquidityPool: MockLiquidityPoolAggregator;
       let mockUserStats: MockUserStatsPerPool;
       let mockVeNFTState: VeNFTState;
 
       beforeEach(async () => {
         const {
-          mockLiquidityPoolData,
+          createMockLiquidityPoolAggregator,
           mockToken0Data,
           mockToken1Data,
           createMockUserStatsPerPool,
           createMockVeNFTState,
         } = setupCommon();
 
-        mockLiquidityPool = {
-          ...mockLiquidityPoolData,
+        mockLiquidityPool = createMockLiquidityPoolAggregator({
           id: PoolId(chainId, poolAddress),
           chainId: chainId,
           poolAddress: poolAddress,
           veNFTamountStaked: 0n,
-        } as LiquidityPoolAggregator;
+        });
 
         mockUserStats = createMockUserStatsPerPool({
           userAddress: ownerAddress,
@@ -250,14 +244,17 @@ describe("Voter Events", () => {
 
     describe("when pool data exists but VeNFTState is missing", () => {
       it("should return early without updating pool or creating vote entities", async () => {
-        const { mockLiquidityPoolData, mockToken0Data, mockToken1Data } =
-          setupCommon();
-        const poolWithZeroStaked = {
-          ...mockLiquidityPoolData,
+        const {
+          createMockLiquidityPoolAggregator,
+          mockToken0Data,
+          mockToken1Data,
+        } = setupCommon();
+        const poolWithZeroStaked = createMockLiquidityPoolAggregator({
           id: PoolId(chainId, poolAddress),
           chainId,
+          poolAddress,
           veNFTamountStaked: 0n,
-        } as LiquidityPoolAggregator;
+        });
         let db = MockDb.createMockDb();
         db = db.entities.LiquidityPoolAggregator.set(poolWithZeroStaked);
         db = db.entities.Token.set(mockToken0Data);
@@ -920,7 +917,7 @@ describe("Voter Events", () => {
       const realTimestamp = 1734595305;
       const rootChainId = 10; // Optimism
       const leafChainId = 252; // Fraxtal
-      let mockLeafPool: LiquidityPoolAggregator;
+      let mockLeafPool: MockLiquidityPoolAggregator;
       let mockUserStats: MockUserStatsPerPool;
       let mockVeNFTState: VeNFTState;
 
@@ -1178,28 +1175,27 @@ describe("Voter Events", () => {
 
     describe("when pool data exists", () => {
       let resultDB: ReturnType<typeof MockDb.createMockDb>;
-      let mockLiquidityPool: LiquidityPoolAggregator;
+      let mockLiquidityPool: MockLiquidityPoolAggregator;
       let mockUserStats: MockUserStatsPerPool;
       let mockVeNFTState: VeNFTState;
       let mockVeNFTPoolVote: VeNFTPoolVote;
 
       beforeEach(async () => {
         const {
-          mockLiquidityPoolData,
           mockToken0Data,
           mockToken1Data,
+          createMockLiquidityPoolAggregator,
           createMockUserStatsPerPool,
           createMockVeNFTState,
           createMockVeNFTPoolVote,
         } = setupCommon();
 
-        mockLiquidityPool = {
-          ...mockLiquidityPoolData,
+        mockLiquidityPool = createMockLiquidityPoolAggregator({
           id: PoolId(chainId, poolAddress),
           chainId: chainId,
           poolAddress: poolAddress,
           veNFTamountStaked: 2000n, // Initial staked amount
-        } as LiquidityPoolAggregator;
+        });
 
         mockUserStats = createMockUserStatsPerPool({
           userAddress: ownerAddress,
@@ -1275,14 +1271,16 @@ describe("Voter Events", () => {
 
     describe("when pool data exists but VeNFTState is missing", () => {
       it("should return early without updating pool or creating vote entities", async () => {
-        const { mockLiquidityPoolData, mockToken0Data, mockToken1Data } =
-          setupCommon();
-        const poolWithStaked = {
-          ...mockLiquidityPoolData,
+        const {
+          createMockLiquidityPoolAggregator,
+          mockToken0Data,
+          mockToken1Data,
+        } = setupCommon();
+        const poolWithStaked = createMockLiquidityPoolAggregator({
           id: PoolId(chainId, poolAddress),
           chainId,
           veNFTamountStaked: 1000n,
-        } as LiquidityPoolAggregator;
+        });
         let db = MockDb.createMockDb();
         db = db.entities.LiquidityPoolAggregator.set(poolWithStaked);
         db = db.entities.Token.set(mockToken0Data);
@@ -1340,7 +1338,7 @@ describe("Voter Events", () => {
       const rootChainId = 10; // Optimism
       const leafChainId = 252; // Fraxtal
       const initialUserStaked = 50000000000000000000000n; // 50k tokens (18 decimals) - initial amount before withdrawal
-      let mockLeafPool: LiquidityPoolAggregator;
+      let mockLeafPool: MockLiquidityPoolAggregator;
       let mockUserStats: MockUserStatsPerPool;
       let mockVeNFTState: VeNFTState;
       let mockVeNFTPoolVote: VeNFTPoolVote;
@@ -1744,17 +1742,16 @@ describe("Voter Events", () => {
 
     describe("when pool entity exists", () => {
       let resultDB: ReturnType<typeof MockDb.createMockDb>;
-      let mockLiquidityPool: LiquidityPoolAggregator;
+      let mockLiquidityPool: MockLiquidityPoolAggregator;
 
       beforeEach(async () => {
-        const { mockLiquidityPoolData } = setupCommon();
+        const { createMockLiquidityPoolAggregator } = setupCommon();
 
-        mockLiquidityPool = {
-          ...mockLiquidityPoolData,
+        mockLiquidityPool = createMockLiquidityPoolAggregator({
           id: PoolId(chainId, poolAddress),
           chainId: chainId,
           gaugeAddress: "", // Initially empty
-        } as LiquidityPoolAggregator;
+        });
 
         mockDb = mockDb.entities.LiquidityPoolAggregator.set(mockLiquidityPool);
 
@@ -1799,18 +1796,17 @@ describe("Voter Events", () => {
 
     describe("when pool factory is CL factory", () => {
       let resultDB: ReturnType<typeof MockDb.createMockDb>;
-      let mockLiquidityPool: LiquidityPoolAggregator;
+      let mockLiquidityPool: MockLiquidityPoolAggregator;
       let clFactoryEvent: ReturnType<typeof Voter.GaugeCreated.createMockEvent>;
 
       beforeEach(async () => {
-        const { mockLiquidityPoolData } = setupCommon();
+        const { createMockLiquidityPoolAggregator } = setupCommon();
 
-        mockLiquidityPool = {
-          ...mockLiquidityPoolData,
+        mockLiquidityPool = createMockLiquidityPoolAggregator({
           id: PoolId(chainId, poolAddress),
           chainId: chainId,
           gaugeAddress: "", // Initially empty
-        } as LiquidityPoolAggregator;
+        });
 
         // Create event with CL factory address (from CLPOOLS_FACTORY_LIST)
         clFactoryEvent = Voter.GaugeCreated.createMockEvent({
@@ -1895,7 +1891,7 @@ describe("Voter Events", () => {
 
     describe("when pool entity exists", () => {
       let resultDB: ReturnType<typeof MockDb.createMockDb>;
-      let mockLiquidityPool: LiquidityPoolAggregator;
+      let mockLiquidityPool: MockLiquidityPoolAggregator;
       const feeVotingRewardAddress = toChecksumAddress(
         "0x6572b2b30f63B960608f3aA5205711C558998398",
       );
@@ -1904,17 +1900,16 @@ describe("Voter Events", () => {
       );
 
       beforeEach(async () => {
-        const { mockLiquidityPoolData } = setupCommon();
+        const { createMockLiquidityPoolAggregator } = setupCommon();
 
-        mockLiquidityPool = {
-          ...mockLiquidityPoolData,
+        mockLiquidityPool = createMockLiquidityPoolAggregator({
           id: PoolId(chainId, poolAddress),
           chainId: chainId,
           gaugeAddress: gaugeAddress, // Initially has gauge address
           gaugeIsAlive: true, // Initially alive
           feeVotingRewardAddress: feeVotingRewardAddress, // Has voting reward addresses
           bribeVotingRewardAddress: bribeVotingRewardAddress,
-        } as LiquidityPoolAggregator;
+        });
 
         // Mock findPoolByGaugeAddress to return the pool
         vi.spyOn(
@@ -1994,7 +1989,7 @@ describe("Voter Events", () => {
 
     describe("when pool entity exists", () => {
       let resultDB: ReturnType<typeof MockDb.createMockDb>;
-      let mockLiquidityPool: LiquidityPoolAggregator;
+      let mockLiquidityPool: MockLiquidityPoolAggregator;
       const feeVotingRewardAddress = toChecksumAddress(
         "0x6572b2b30f63B960608f3aA5205711C558998398",
       );
@@ -2003,17 +1998,16 @@ describe("Voter Events", () => {
       );
 
       beforeEach(async () => {
-        const { mockLiquidityPoolData } = setupCommon();
+        const { createMockLiquidityPoolAggregator } = setupCommon();
 
-        mockLiquidityPool = {
-          ...mockLiquidityPoolData,
+        mockLiquidityPool = createMockLiquidityPoolAggregator({
           id: PoolId(chainId, poolAddress),
           chainId: chainId,
           gaugeAddress: gaugeAddress, // Has gauge address
           gaugeIsAlive: false, // Initially killed
           feeVotingRewardAddress: feeVotingRewardAddress, // Has voting reward addresses
           bribeVotingRewardAddress: bribeVotingRewardAddress,
-        } as LiquidityPoolAggregator;
+        });
 
         // Mock findPoolByGaugeAddress to return the pool
         vi.spyOn(
@@ -2235,7 +2229,7 @@ describe("Voter Events", () => {
       let updatedDB: ReturnType<typeof MockDb.createMockDb>;
       let cleanup: () => void;
 
-      const { mockLiquidityPoolData } = setupCommon();
+      const { createMockLiquidityPoolAggregator } = setupCommon();
 
       let expectations: {
         totalEmissions: bigint;
@@ -2245,8 +2239,7 @@ describe("Voter Events", () => {
       };
 
       beforeEach(async () => {
-        const liquidityPool: LiquidityPoolAggregator = {
-          ...mockLiquidityPoolData,
+        const liquidityPool = createMockLiquidityPoolAggregator({
           id: PoolId(chainId, poolAddress),
           chainId: chainId,
           totalEmissions: 0n,
@@ -2254,7 +2247,7 @@ describe("Voter Events", () => {
           totalVotesDeposited: 0n,
           totalVotesDepositedUSD: 0n,
           gaugeIsAlive: false, // DistributeReward does not set this; we assert it remains unchanged
-        } as LiquidityPoolAggregator;
+        });
 
         expectations = {
           totalEmissions: 1000n * 10n ** 18n, // normalizedEmissionsAmount
@@ -2333,8 +2326,7 @@ describe("Voter Events", () => {
         let originalChainConstantsAlive: (typeof CHAIN_CONSTANTS)[typeof chainId];
 
         beforeEach(async () => {
-          const liquidityPool: LiquidityPoolAggregator = {
-            ...mockLiquidityPoolData,
+          const liquidityPool = createMockLiquidityPoolAggregator({
             id: PoolId(chainId, poolAddress),
             chainId: chainId,
             totalEmissions: 0n,
@@ -2342,7 +2334,7 @@ describe("Voter Events", () => {
             totalVotesDeposited: 0n,
             totalVotesDepositedUSD: 0n,
             gaugeIsAlive: true,
-          } as LiquidityPoolAggregator;
+          });
 
           const rewardToken: Token = {
             id: TokenId(chainId, rewardTokenAddress),
@@ -2780,13 +2772,15 @@ describe("Voter Events", () => {
 
       // TODO: Skip until envio migrates to createTestIndexer — vi.spyOn can't intercept tsx-loaded modules (alpha.18)
       it.skip("should apply distribution to leaf pool without overwriting gaugeAddress", async () => {
-        const { mockLiquidityPoolData, mockToken0Data, mockToken1Data } =
-          setupCommon();
+        const {
+          createMockLiquidityPoolAggregator,
+          mockToken0Data,
+          mockToken1Data,
+        } = setupCommon();
 
         const leafToken0Id = TokenId(leafChainId, mockToken0Data.address);
         const leafToken1Id = TokenId(leafChainId, mockToken1Data.address);
-        const leafPool: LiquidityPoolAggregator = {
-          ...mockLiquidityPoolData,
+        const leafPool = createMockLiquidityPoolAggregator({
           id: leafPoolId,
           poolAddress: leafPoolAddress as `0x${string}`,
           chainId: leafChainId,
@@ -2800,7 +2794,7 @@ describe("Voter Events", () => {
           totalVotesDepositedUSD: 0n,
           gaugeAddress: leafGaugeAddress,
           gaugeIsAlive: true,
-        } as LiquidityPoolAggregator;
+        });
 
         const rewardToken: Token = {
           id: TokenId(chainId, rewardTokenAddress),
@@ -2898,13 +2892,12 @@ describe("Voter Events", () => {
       let originalChainConstantsForRewardTest: (typeof CHAIN_CONSTANTS)[typeof chainId];
 
       it("should log warning and return early when reward token is missing", async () => {
-        const { mockLiquidityPoolData } = setupCommon();
-        const liquidityPool: LiquidityPoolAggregator = {
-          ...mockLiquidityPoolData,
+        const { createMockLiquidityPoolAggregator } = setupCommon();
+        const liquidityPool = createMockLiquidityPoolAggregator({
           id: PoolId(chainId, poolAddress),
           chainId: chainId,
           totalEmissions: 0n, // Start with 0 to test that it remains unchanged
-        } as LiquidityPoolAggregator;
+        });
 
         // Mock CHAIN_CONSTANTS rewardToken function
         originalChainConstantsForRewardTest = CHAIN_CONSTANTS[chainId];

--- a/test/EventHandlers/VotingReward/BribesVotingReward.test.ts
+++ b/test/EventHandlers/VotingReward/BribesVotingReward.test.ts
@@ -13,6 +13,7 @@ describe("BribesVotingReward Events", () => {
     mockToken1Data,
     mockLiquidityPoolData,
     createMockLiquidityPoolAggregator,
+    createMockUserStatsPerPool,
   } = setupCommon();
   const poolAddress = mockLiquidityPoolData.poolAddress;
   const chainId = 10;
@@ -44,7 +45,6 @@ describe("BribesVotingReward Events", () => {
     });
 
     // Set up user stats
-    const { createMockUserStatsPerPool } = setupCommon();
     userStats = createMockUserStatsPerPool({
       userAddress: userAddress,
       poolAddress: poolAddress,

--- a/test/EventHandlers/VotingReward/BribesVotingReward.test.ts
+++ b/test/EventHandlers/VotingReward/BribesVotingReward.test.ts
@@ -1,15 +1,19 @@
-import type { LiquidityPoolAggregator, Token } from "generated";
+import type { Token } from "generated";
 import {
   BribesVotingReward,
   MockDb,
 } from "../../../generated/src/TestHelpers.gen";
 import { TokenId, toChecksumAddress } from "../../../src/Constants";
 import * as VotingRewardSharedLogic from "../../../src/EventHandlers/VotingReward/VotingRewardSharedLogic";
-import { setupCommon } from "../Pool/common";
+import { type MockLiquidityPoolAggregator, setupCommon } from "../Pool/common";
 
 describe("BribesVotingReward Events", () => {
-  const { mockToken0Data, mockToken1Data, mockLiquidityPoolData } =
-    setupCommon();
+  const {
+    mockToken0Data,
+    mockToken1Data,
+    mockLiquidityPoolData,
+    createMockLiquidityPoolAggregator,
+  } = setupCommon();
   const poolAddress = mockLiquidityPoolData.poolAddress;
   const chainId = 10;
   const votingRewardAddress = toChecksumAddress(
@@ -23,7 +27,7 @@ describe("BribesVotingReward Events", () => {
   );
 
   let mockDb: ReturnType<typeof MockDb.createMockDb>;
-  let liquidityPool: LiquidityPoolAggregator;
+  let liquidityPool: MockLiquidityPoolAggregator;
   let userStats: ReturnType<
     ReturnType<typeof setupCommon>["createMockUserStatsPerPool"]
   >;
@@ -34,11 +38,10 @@ describe("BribesVotingReward Events", () => {
     mockDb = MockDb.createMockDb();
 
     // Set up liquidity pool with bribe voting reward address
-    liquidityPool = {
-      ...mockLiquidityPoolData,
+    liquidityPool = createMockLiquidityPoolAggregator({
       bribeVotingRewardAddress: toChecksumAddress(votingRewardAddress),
       feeVotingRewardAddress: "",
-    } as LiquidityPoolAggregator;
+    });
 
     // Set up user stats
     const { createMockUserStatsPerPool } = setupCommon();

--- a/test/EventHandlers/VotingReward/FeesVotingReward.test.ts
+++ b/test/EventHandlers/VotingReward/FeesVotingReward.test.ts
@@ -1,15 +1,11 @@
-import type {
-  LiquidityPoolAggregator,
-  Token,
-  UserStatsPerPool,
-} from "generated";
+import type { Token } from "generated";
 import {
   FeesVotingReward,
   MockDb,
 } from "../../../generated/src/TestHelpers.gen";
 import { TokenId, toChecksumAddress } from "../../../src/Constants";
 import * as VotingRewardSharedLogic from "../../../src/EventHandlers/VotingReward/VotingRewardSharedLogic";
-import { setupCommon } from "../Pool/common";
+import { type MockLiquidityPoolAggregator, setupCommon } from "../Pool/common";
 
 describe("FeesVotingReward Events", () => {
   const {
@@ -17,6 +13,7 @@ describe("FeesVotingReward Events", () => {
     mockToken1Data,
     mockLiquidityPoolData,
     createMockUserStatsPerPool,
+    createMockLiquidityPoolAggregator,
   } = setupCommon();
   const poolAddress = mockLiquidityPoolData.poolAddress;
   const chainId = 10;
@@ -31,7 +28,7 @@ describe("FeesVotingReward Events", () => {
   );
 
   let mockDb: ReturnType<typeof MockDb.createMockDb>;
-  let liquidityPool: LiquidityPoolAggregator;
+  let liquidityPool: MockLiquidityPoolAggregator;
   let userStats: ReturnType<typeof createMockUserStatsPerPool>;
   let rewardToken: Token;
 
@@ -40,11 +37,10 @@ describe("FeesVotingReward Events", () => {
     mockDb = MockDb.createMockDb();
 
     // Set up liquidity pool with fee voting reward address
-    liquidityPool = {
-      ...mockLiquidityPoolData,
+    liquidityPool = createMockLiquidityPoolAggregator({
       feeVotingRewardAddress: toChecksumAddress(votingRewardAddress),
       bribeVotingRewardAddress: "",
-    } as LiquidityPoolAggregator;
+    });
 
     // Set up user stats
     userStats = createMockUserStatsPerPool({

--- a/test/EventHandlers/VotingReward/SuperchainIncentiveVotingReward.test.ts
+++ b/test/EventHandlers/VotingReward/SuperchainIncentiveVotingReward.test.ts
@@ -1,11 +1,11 @@
-import type { LiquidityPoolAggregator, Token, VeNFTState } from "generated";
+import type { Token, VeNFTState } from "generated";
 import {
   MockDb,
   SuperchainIncentiveVotingReward,
 } from "../../../generated/src/TestHelpers.gen";
 import { TokenId, VeNFTId, toChecksumAddress } from "../../../src/Constants";
 import * as VotingRewardSharedLogic from "../../../src/EventHandlers/VotingReward/VotingRewardSharedLogic";
-import { setupCommon } from "../Pool/common";
+import { type MockLiquidityPoolAggregator, setupCommon } from "../Pool/common";
 
 describe("SuperchainIncentiveVotingReward Events", () => {
   const { mockToken0Data, mockToken1Data } = setupCommon();
@@ -22,7 +22,7 @@ describe("SuperchainIncentiveVotingReward Events", () => {
   const tokenId = 1n;
 
   let mockDb: ReturnType<typeof MockDb.createMockDb>;
-  let liquidityPool: LiquidityPoolAggregator;
+  let liquidityPool: MockLiquidityPoolAggregator;
   let userStats: ReturnType<
     ReturnType<typeof setupCommon>["createMockUserStatsPerPool"]
   >;

--- a/test/Snapshots/SchemaParity.test.ts
+++ b/test/Snapshots/SchemaParity.test.ts
@@ -45,6 +45,16 @@ describe("Snapshot schema parity", () => {
         // Control-flow latch for processTickCrossingsForStaked — once true, stays
         // true. No analytical value in trending it over time.
         "hasStakes",
+        // Implementation detail of the #649 swap-path optimization: a sparse
+        // in-memory liquidityNet list keyed by tick, consumed only by
+        // processTickCrossingsForStaked. Not snapshotted hourly — the arrays
+        // are derived state (sum-of-stakes per tick) and the per-stake history
+        // is already captured by Gauge Deposit/Withdraw and NFPM
+        // IncreaseLiquidity/DecreaseLiquidity events. Legacy CLTickStaked
+        // entity is the current GraphQL mirror; scheduled for removal in
+        // velodrome-finance/indexer#652.
+        "stakedTickEdges",
+        "stakedTickEdgeNets",
       ],
     ],
     ["UserStatsPerPool", ["firstActivityTimestamp", "lastSnapshotTimestamp"]],

--- a/test/testHelpers.ts
+++ b/test/testHelpers.ts
@@ -113,6 +113,9 @@ export function setupLiquidityPoolAggregator(
     id: poolId,
     poolAddress: poolAddress,
     isCL: mockLiquidityPoolData.isCL ?? true,
+    // Array fields: force mutable bigint[] (envio.d.ts uses readonly; set() wants mutable).
+    stakedTickEdges: [...mockLiquidityPoolData.stakedTickEdges],
+    stakedTickEdgeNets: [...mockLiquidityPoolData.stakedTickEdgeNets],
   };
   return mockDb.entities.LiquidityPoolAggregator.set(
     mockLiquidityPoolAggregator,


### PR DESCRIPTION
## Summary

Structural fix for the 20GB OOM described in #648. Replaces the per-tick `CLTickStaked.get` fan-out on the swap path with a sparse, sorted, monotone parallel-array list (`stakedTickEdges` + `stakedTickEdgeNets`) carried on `LiquidityPoolAggregator`. Zero `.get()` / `.getWhere()` on the swap path — binary-searched in memory.

- Dependency: #651 (hasStakes latch + `TICK_MIN`/`TICK_MAX` bounds clamp). This PR targets that branch. After #651 merges, rebase onto `main`.
- Follow-up: #652 removes the legacy `CLTickStaked` entity (kept one release for the auto-exposed GraphQL surface).

## Root cause recap (#648)

`processTickCrossingsForStaked` walked every candidate tick from `oldTick` to `newTick` by `tickSpacing`, issuing a `CLTickStaked.get` per step — up to ~1.77M iterations per swap at `tickSpacing=1`. Under Envio's 5000-concurrent-handler preload, LoadManager grouped those into `postgres-js text[]` arrays, InMemTable accumulated every loaded row, and the aggregator version grew to ~1.4 MB. 100 pools × many batches → 20 GB OOM.

## Design

**Two new fields on `LiquidityPoolAggregator`** (`schema.graphql`):

- `stakedTickEdges: [BigInt!]!` — sorted ascending, deduplicated, no zero-net.
- `stakedTickEdgeNets: [BigInt!]!` — parallel, same index = per-edge `liquidityNet`.

**Writers** (`Gauge` Deposit/Withdraw, `NFPM` IncreaseLiquidity/DecreaseLiquidity) maintain the pair via `applyStakedPositionToEdges` — immutable array copies, binary-search locate + splice, drop edges on zero-net. Replace semantics at the diff level (whole-array substitution, not incremental).

**Reader** (`processTickCrossingsForStaked` on the swap path) `lowerBound`s into the arrays, walks the crossing window, applies Uniswap v3 sign convention (`+net` on up-cross, `-net` on down-cross). Pure in-memory — no entity access, enforced by throwing `CLTickStaked.get` spy in tests.

## Acceptance criteria (#649)

- [x] Zero `CLTickStaked.get` / `getWhere` calls on the swap path — throwing spy enforces.
- [x] `stakedTickEdges` / `stakedTickEdgeNets` on aggregator.
- [x] Maintained on gauge Deposit/Withdraw + NFPM liq-change.
- [x] `hasStakes` latch + `[TICK_MIN, TICK_MAX]` bounds preserved from #651.
- [x] Co-located MockDb.processEvents sanity test with ≥200 events asserting sortedness/monotonicity/parity (`test/Aggregators/CLStakedLiquidityEdgeSanity.test.ts`).
- [x] Baseline parity assertion — new path matches an in-test CLTickStaked map for up-swap AND down-swap with round-trip.
- [x] `pnpm envio codegen` + `tsc --noEmit` + `pnpm test` + `pnpm qa` clean.

## Review fixes applied (ce-review pass)

| # | Fix |
|---|---|
| #2 | Gauge path gates `stakedLiquidityInRange` on `sqrtPriceX96 !== 0n` (mirror of NFPM fix) — prevents pre-Initialize stakes from poisoning it with stale `tick=0n`. |
| #3 | `applyStakedPositionToEdges` returns a `rejected` tag on invariant violations; callsites log via `context.log.error`. |
| #4 | NFPM liq-change sets `hasStakes: true` whenever edges non-empty (belt-and-suspenders against event reordering). |
| #5 | `processTickCrossingsForStaked` dropped `async` (zero awaits, pure sync now). |
| #6 (lite) | `updateLiquidityPoolAggregator` asserts `stakedTickEdges`/`stakedTickEdgeNets` length parity + pair-together invariants at the diff-merge point. |
| #9 | `STAKED_TICK_DRIFT` greppable tag on the OOB-tick bail log. |
| #10 | Exported `MockLiquidityPoolAggregator` type alias; migrated 12 test files off inline `ReturnType<...>` gymnastics. |
| #11 | Throwing `CLTickStaked.get` spy in the shared `beforeEach` — enforces the no-entity-reads-on-swap-path contract across all 16 swap-path tests. |
| #13 | Down-swap parity + round-trip-to-zero assertion in EdgeSanity (b). |
| #14 | Negative-residual-net + rejection-tag + full round-trip unit tests. |
| #16 | Dead zero-delta branch in `applyDeltaAtTick` removed (caller now rejects zero at top). |
| #18 | Stale "source of truth" / "retained for downstream consumers" CLTickStaked comments updated across 4 files to reference #652. |

Deferred to #652:
- #1 (legacy `updateTicksForStakedPosition` + `CLTickStaked` entity removal) — breaking GraphQL change, scoped separately.

Deferred as operational verification pre-rollout:
- #7 (Envio postgres-js `text[]` serialization cost of the new `[BigInt!]!` arrays on a pool with E≈22k) — measurement, not a code change.

## Performance envelope

Measured via `scripts/bench-tick-edges.ts` (local-only; `scripts/` is gitignored):

| E | Read (µs) | Write (µs) | Memory/pool |
|---|-----------|-----------|-------------|
| 1k | sub-µs | ~15 | ~50 KB |
| 22k (#648 envelope) | sub-µs | ~170 | 1.01 MB |
| 100k (stress) | sub-µs | ~650 | 4.58 MB |

Macrobench: 2500 writes/batch @ E=22k = ~301 ms. Above #648's 125 ms rough figure but still bounded, and writes are the cold path — reads (binary-search) dominate at swap frequency.

## Test plan

- [x] `pnpm envio codegen`
- [x] `tsc --noEmit` — clean
- [x] `pnpm test` — 96 files, 1126 tests pass
- [x] `pnpm qa --write --unsafe` — clean
- [ ] Staging env: deploy and confirm `array_length(staked_tick_edges, 1)` distribution on hot pools matches the bench's E envelope
- [ ] Staging env: verify Envio `[BigInt!]!` entity-write serialization doesn't recreate a memory-pressure channel (#7, pre-rollout gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LiquidityPoolAggregator now exposes stakedTickEdges and stakedTickEdgeNets for per-tick staked liquidity visibility.

* **Bug Fixes**
  * Prevented misclassification of positions spanning tick 0 before price initialization.
  * Ensured staked edge-list updates are persisted even when pool price is not yet available.

* **Tests**
  * Added extensive tests validating edge-list behavior, crossings, and rejection cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->