### PR TITLE
perf(cl-staked): remove legacy CLTickStaked entity (#652)

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -52,7 +52,7 @@ type LiquidityPoolAggregator {
   stakedReserve0: BigInt @config(precision: 76) # staked reserves in token0 raw units (running counter)
   stakedReserve1: BigInt @config(precision: 76) # staked reserves in token1 raw units (running counter)
   # True once any staked position has been recorded for this pool. Gates the
-  # per-swap CLTickStaked sweep in processTickCrossingsForStaked: pools that have
+  # per-swap staked-tick sweep in processTickCrossingsForStaked: pools that have
   # never been staked skip the sweep entirely. Set on the first gauge Deposit.
   # One-way latch: does NOT clear if every staked position is later withdrawn.
   # A transiently-staked-then-fully-unstaked pool will keep running the sweep
@@ -68,8 +68,8 @@ type LiquidityPoolAggregator {
   #
   # Maintained on gauge deposit / withdraw / NFPM staked-position liquidity
   # changes. Consumed by processTickCrossingsForStaked via in-memory binary
-  # search — no CLTickStaked.get / getWhere calls on the swap path, which
-  # breaks the OOM chain-of-amplification from #648.
+  # search — no per-tick entity loads on the swap path, which breaks the OOM
+  # chain-of-amplification from #648.
   stakedTickEdges: [BigInt!]!
   stakedTickEdgeNets: [BigInt!]!
   totalFlashLoanFees0: BigInt @config(precision: 76) # total flash loan fees collected in token0
@@ -405,17 +405,6 @@ type NonFungiblePositionSnapshot {
   lastUpdatedTimestamp: Timestamp!
   isStakedInGauge: Boolean!
   timestamp: Timestamp! @index
-}
-
-# Tracks staked liquidity net delta per initialized tick for CL pools.
-# Mirrors Uniswap v3's ticks[i].liquidityNet but only for the staked subset.
-# Used to maintain stakedLiquidityInRange on the pool aggregator during tick crossings.
-type CLTickStaked {
-  id: ID! # Format: {chainId}-{poolAddress}-{tickIndex} (CLTickStakedId)
-  chainId: Int!
-  poolAddress: String! @index
-  tickIndex: BigInt! @config(precision: 24)
-  stakedLiquidityNet: BigInt! @config(precision: 76) # net staked liquidity change when crossing this tick
 }
 
 type VeNFTState {

--- a/src/Aggregators/CLStakedLiquidity.ts
+++ b/src/Aggregators/CLStakedLiquidity.ts
@@ -1,12 +1,11 @@
 import type { handlerContext } from "generated";
-import { CLTickStakedId } from "../Constants";
 
 /**
  * Uniswap v3 absolute tick range. Any tick outside [TICK_MIN, TICK_MAX] is
  * unreachable by a valid swap; seeing one indicates corrupt upstream state
  * (missed Initialize, event ordering bug, RPC inconsistency) and MUST NOT be
- * used to drive the CLTickStaked sweep — at tickSpacing=1 that is ~1.77M
- * iterations, each triggering an entity fetch.
+ * used to drive the staked-tick sweep — at tickSpacing=1 that is ~1.77M
+ * iterations.
  */
 export const TICK_MIN = -887272n;
 export const TICK_MAX = 887272n;
@@ -147,10 +146,10 @@ export type StakedEdgesRejection = "ticks_out_of_range" | "degenerate_range";
 
 /**
  * Applies a staked-position liquidity change ([tickLower, tickUpper] × liquidityDelta)
- * to the parallel (edges, nets) arrays. Mirrors the updateTicksForStakedPosition
- * CLTickStaked write, but in-aggregator so the swap path never needs to load it.
+ * to the parallel (edges, nets) arrays. In-aggregator only — the swap path never
+ * needs to load a per-tick entity.
  *
- * Convention (same as CLTickStaked):
+ * Convention (mirrors Uniswap v3 per-tick liquidityNet):
  *   - At tickLower: net += liquidityDelta  (positions ENTER range on upward cross)
  *   - At tickUpper: net -= liquidityDelta  (positions EXIT range on upward cross)
  *
@@ -210,67 +209,6 @@ export function applyStakedPositionToEdges(
 }
 
 /**
- * Updates the two CLTickStaked entities that bookend a position's tick range.
- * Mirrors Uniswap v3's ticks[i].liquidityNet but for the staked subset only.
- *
- * The +/- convention follows Uniswap v3: when a swap crosses a tick going UP
- * (price increasing), the pool applies `liquidity += ticks[t].liquidityNet`.
- *   - At tickLower: position ENTERS range on upward cross → +liquidityDelta
- *   - At tickUpper: position EXITS range on upward cross  → -liquidityDelta
- * When crossing DOWN, the pool subtracts liquidityNet, which naturally reverses
- * both signs, correctly handling the opposite direction.
- *
- * On stake:   liquidityDelta = +position.liquidity
- * On unstake: liquidityDelta = -position.liquidity
- *
- * DEPRECATED in-place alongside #649: the swap path no longer reads
- * CLTickStaked, and no other internal consumer remains. The writes are kept
- * on purpose for one release so the GraphQL entity (which is auto-exposed
- * to external consumers) doesn't disappear without notice. Scheduled for
- * removal in velodrome-finance/indexer#652. New callers MUST use
- * applyStakedPositionToEdges on the aggregator.
- *
- * @param chainId - Chain ID
- * @param poolAddress - CL pool address
- * @param tickLower - Position's lower tick boundary
- * @param tickUpper - Position's upper tick boundary
- * @param liquidityDelta - Liquidity to add (positive) or remove (negative)
- * @param context - Handler context for entity access
- */
-export async function updateTicksForStakedPosition(
-  chainId: number,
-  poolAddress: string,
-  tickLower: bigint,
-  tickUpper: bigint,
-  liquidityDelta: bigint,
-  context: handlerContext,
-): Promise<void> {
-  const lowerTickId = CLTickStakedId(chainId, poolAddress, tickLower);
-  const upperTickId = CLTickStakedId(chainId, poolAddress, tickUpper);
-
-  const [lowerTick, upperTick] = await Promise.all([
-    context.CLTickStaked.get(lowerTickId),
-    context.CLTickStaked.get(upperTickId),
-  ]);
-
-  context.CLTickStaked.set({
-    id: lowerTickId,
-    chainId,
-    poolAddress,
-    tickIndex: tickLower,
-    stakedLiquidityNet: (lowerTick?.stakedLiquidityNet ?? 0n) + liquidityDelta,
-  });
-
-  context.CLTickStaked.set({
-    id: upperTickId,
-    chainId,
-    poolAddress,
-    tickIndex: tickUpper,
-    stakedLiquidityNet: (upperTick?.stakedLiquidityNet ?? 0n) - liquidityDelta,
-  });
-}
-
-/**
  * Processes tick crossings between oldTick and newTick, adjusting
  * stakedLiquidityInRange by walking the in-aggregator (stakedTickEdges,
  * stakedTickEdgeNets) parallel arrays.
@@ -282,15 +220,14 @@ export async function updateTicksForStakedPosition(
  * Structural fix for the 20GB OOM (see #648, #649):
  *   - Zero `.get()` or `.getWhere()` calls on the swap path. The per-edge net is
  *     read from the in-memory `stakedTickEdgeNets` array carried on the
- *     aggregator, not from a CLTickStaked entity load.
+ *     aggregator.
  *   - Total cost per swap: O(log E + K) where E = per-pool edge count (worst
  *     case ~22k per #648) and K = edges actually crossed (typically 0–few).
  *     Linear scanning all E edges is what this replaces, and what drove the
- *     OOM in the old implementation — every candidate tick-spacing step
- *     issued a CLTickStaked.get.
+ *     OOM in the old implementation.
  *   - Breaks the chain-of-amplification from #648: no LoadManager grouping, no
- *     postgres-js text[] serialization, no InMemTable CLTickStaked accumulation,
- *     no 5000-handler preload fan-out.
+ *     postgres-js text[] serialization, no InMemTable accumulation, no
+ *     5000-handler preload fan-out.
  *
  * Safety guards retained from PR 1 (#650):
  *   - `hasStakes=false` short-circuits the walk entirely. Redundant with an
@@ -302,10 +239,8 @@ export async function updateTicksForStakedPosition(
  *     nets until the next rebuild — worth alerting on.
  *
  * Pure in-memory computation. Uses the Envio `context` ONLY for
- * `context.log.error` — any entity access here (e.g. `context.CLTickStaked.get`)
- * would reintroduce the #648 OOM fan-out this function was written to replace.
- * Enforced by the throwing spy in test/Aggregators/CLStakedLiquidityEdgeSanity.test.ts
- * and CLStakedLiquidity.test.ts.
+ * `context.log.error` — any entity access here would reintroduce the #648 OOM
+ * fan-out this function was written to replace.
  *
  * @param chainId - Chain ID (used only for error logging)
  * @param poolAddress - CL pool address (used only for error logging)

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -1029,19 +1029,6 @@ export const NonFungiblePositionId = (
 ) => `${chainId}-${nfpmAddress}-${tokenId}`;
 
 /**
- * Create a unique ID for a CLTickStaked entity.
- * @param chainId - Chain ID
- * @param poolAddress - Address of the CL pool (must be EIP-55 checksum-cased; do not pre-lowercase)
- * @param tickIndex - Tick index (aligned to tick spacing)
- * @returns string Combined tick staked ID.
- */
-export const CLTickStakedId = (
-  chainId: number,
-  poolAddress: string,
-  tickIndex: bigint,
-) => `${chainId}-${poolAddress}-${tickIndex}`;
-
-/**
  * Create a unique ID for a token on a specific chain at a specific block. Really should only be used
  * for TokenPrice Entities.
  * @param chainId

--- a/src/EventHandlers/Gauges/GaugeSharedLogic.ts
+++ b/src/EventHandlers/Gauges/GaugeSharedLogic.ts
@@ -2,7 +2,6 @@ import type { LiquidityPoolAggregator, handlerContext } from "generated";
 import {
   applyStakedPositionToEdges,
   isPositionInRange,
-  updateTicksForStakedPosition,
 } from "../../Aggregators/CLStakedLiquidity";
 import type { PoolData } from "../../Aggregators/LiquidityPoolAggregator";
 import {
@@ -76,20 +75,7 @@ async function computeCLStakedReservesOnGaugeEvent(
   const currentTick = liquidityPoolAggregator.tick ?? 0n;
   const sqrtPriceX96 = liquidityPoolAggregator.sqrtPriceX96 ?? 0n;
 
-  // Maintain the deprecated CLTickStaked entity writes (scheduled for removal
-  // in velodrome-finance/indexer#652) alongside the in-aggregator parallel
-  // edge/nets arrays. The swap path reads ONLY the aggregator arrays — the
-  // legacy writes are kept for one release so the auto-exposed GraphQL entity
-  // doesn't vanish without notice.
   const liquidityDelta = direction * position.liquidity;
-  await updateTicksForStakedPosition(
-    data.chainId,
-    liquidityPoolAggregator.poolAddress,
-    position.tickLower,
-    position.tickUpper,
-    liquidityDelta,
-    context,
-  );
   const {
     edges: stakedTickEdges,
     nets: stakedTickEdgeNets,
@@ -341,7 +327,7 @@ export async function processGaugeDeposit(
     stakedTickEdges,
     stakedTickEdgeNets,
     // Flip the CL pool's hasStakes latch on the first deposit. The latch gates the
-    // per-swap CLTickStaked sweep in processTickCrossingsForStaked. Non-CL pools
+    // per-swap staked-tick sweep in processTickCrossingsForStaked. Non-CL pools
     // and already-latched CL pools leave this field alone. Also gate on an actual
     // edge list being produced: if computeCLStakedReservesOnGaugeEvent bailed
     // early or the edge merge was rejected, latching hasStakes would mark the

--- a/src/EventHandlers/Gauges/GaugeSharedLogic.ts
+++ b/src/EventHandlers/Gauges/GaugeSharedLogic.ts
@@ -36,8 +36,9 @@ export interface GaugeEventData {
 
 /**
  * Computes the CL staked reserve deltas and updated pool staked USD when a position
- * is deposited to or withdrawn from a gauge. Handles tick entity updates and determines
- * whether the position is in range.
+ * is deposited to or withdrawn from a gauge. Applies the position's liquidity to the
+ * aggregator's in-memory (stakedTickEdges, stakedTickEdgeNets) arrays via
+ * applyStakedPositionToEdges and determines whether the position is in range.
  *
  * @param data - Gauge event data (must have tokenId for CL)
  * @param liquidityPoolAggregator - Current pool entity

--- a/src/EventHandlers/NFPM/NFPMCommonLogic.ts
+++ b/src/EventHandlers/NFPM/NFPMCommonLogic.ts
@@ -2,7 +2,6 @@ import type { NonFungiblePosition, handlerContext } from "generated";
 import {
   applyStakedPositionToEdges,
   isPositionInRange,
-  updateTicksForStakedPosition,
 } from "../../Aggregators/CLStakedLiquidity";
 import type { PoolData } from "../../Aggregators/LiquidityPoolAggregator";
 import { updateLiquidityPoolAggregator } from "../../Aggregators/LiquidityPoolAggregator";
@@ -88,8 +87,8 @@ export async function attributeLiquidityChangeToUserStatsPerPool(
 }
 
 /**
- * Updates CLTickStaked entities and pool staked reserves when a staked position's
- * liquidity changes (IncreaseLiquidity or DecreaseLiquidity).
+ * Updates the aggregator's staked-tick edge list and pool staked reserves when
+ * a staked position's liquidity changes (IncreaseLiquidity or DecreaseLiquidity).
  *
  * @param position - The NonFungiblePosition being modified
  * @param poolData - Pool data with liquidityPoolAggregator and token instances
@@ -110,19 +109,6 @@ export async function updateStakedPositionLiquidity(
 ): Promise<void> {
   const { liquidityPoolAggregator } = poolData;
 
-  // Maintain the deprecated CLTickStaked entity writes (scheduled for removal
-  // in velodrome-finance/indexer#652) alongside the in-aggregator parallel
-  // edge/nets arrays. The swap path reads ONLY the aggregator arrays — the
-  // legacy writes are kept for one release so the auto-exposed GraphQL entity
-  // doesn't vanish without notice.
-  await updateTicksForStakedPosition(
-    chainId,
-    position.pool,
-    position.tickLower,
-    position.tickUpper,
-    liquidityDelta,
-    context,
-  );
   const {
     edges: stakedTickEdges,
     nets: stakedTickEdgeNets,

--- a/test/Aggregators/CLStakedLiquidity.test.ts
+++ b/test/Aggregators/CLStakedLiquidity.test.ts
@@ -1,12 +1,10 @@
-import type { CLTickStaked, handlerContext } from "generated";
+import type { handlerContext } from "generated";
 import {
   applyStakedPositionToEdges,
   computeStakedSwapReserveDelta,
   isPositionInRange,
   processTickCrossingsForStaked,
-  updateTicksForStakedPosition,
 } from "../../src/Aggregators/CLStakedLiquidity";
-import { CLTickStakedId } from "../../src/Constants";
 
 describe("CLStakedLiquidity", () => {
   const CHAIN_ID = 8453;
@@ -49,113 +47,6 @@ describe("CLStakedLiquidity", () => {
     it("should handle single-tick range (tickLower = tickUpper - 1)", () => {
       expect(isPositionInRange(99n, 100n, 99n)).toBe(true);
       expect(isPositionInRange(99n, 100n, 100n)).toBe(false);
-    });
-  });
-
-  describe("updateTicksForStakedPosition", () => {
-    let tickStore: Map<string, CLTickStaked>;
-    let mockContext: handlerContext;
-
-    beforeEach(() => {
-      tickStore = new Map();
-      mockContext = {
-        CLTickStaked: {
-          get: vi
-            .fn()
-            .mockImplementation((id: string) =>
-              Promise.resolve(tickStore.get(id) ?? null),
-            ),
-          set: vi
-            .fn()
-            .mockImplementation((entity: CLTickStaked) =>
-              tickStore.set(entity.id, entity),
-            ),
-        },
-      } as unknown as handlerContext;
-    });
-
-    it("should create new tick entities on first stake", async () => {
-      await updateTicksForStakedPosition(
-        CHAIN_ID,
-        POOL_ADDRESS,
-        -200n,
-        200n,
-        1000n,
-        mockContext,
-      );
-
-      const lowerId = CLTickStakedId(CHAIN_ID, POOL_ADDRESS, -200n);
-      const upperId = CLTickStakedId(CHAIN_ID, POOL_ADDRESS, 200n);
-
-      expect(tickStore.get(lowerId)?.stakedLiquidityNet).toBe(1000n);
-      expect(tickStore.get(upperId)?.stakedLiquidityNet).toBe(-1000n);
-    });
-
-    it("should accumulate liquidity from multiple positions at same ticks", async () => {
-      await updateTicksForStakedPosition(
-        CHAIN_ID,
-        POOL_ADDRESS,
-        0n,
-        400n,
-        500n,
-        mockContext,
-      );
-      await updateTicksForStakedPosition(
-        CHAIN_ID,
-        POOL_ADDRESS,
-        0n,
-        400n,
-        300n,
-        mockContext,
-      );
-
-      const lowerId = CLTickStakedId(CHAIN_ID, POOL_ADDRESS, 0n);
-      const upperId = CLTickStakedId(CHAIN_ID, POOL_ADDRESS, 400n);
-
-      expect(tickStore.get(lowerId)?.stakedLiquidityNet).toBe(800n);
-      expect(tickStore.get(upperId)?.stakedLiquidityNet).toBe(-800n);
-    });
-
-    it("should handle unstake (negative liquidityDelta)", async () => {
-      await updateTicksForStakedPosition(
-        CHAIN_ID,
-        POOL_ADDRESS,
-        -100n,
-        100n,
-        1000n,
-        mockContext,
-      );
-      await updateTicksForStakedPosition(
-        CHAIN_ID,
-        POOL_ADDRESS,
-        -100n,
-        100n,
-        -1000n,
-        mockContext,
-      );
-
-      const lowerId = CLTickStakedId(CHAIN_ID, POOL_ADDRESS, -100n);
-      const upperId = CLTickStakedId(CHAIN_ID, POOL_ADDRESS, 100n);
-
-      expect(tickStore.get(lowerId)?.stakedLiquidityNet).toBe(0n);
-      expect(tickStore.get(upperId)?.stakedLiquidityNet).toBe(0n);
-    });
-
-    it("should store correct chainId, poolAddress, and tickIndex", async () => {
-      await updateTicksForStakedPosition(
-        CHAIN_ID,
-        POOL_ADDRESS,
-        -600n,
-        600n,
-        100n,
-        mockContext,
-      );
-
-      const lowerId = CLTickStakedId(CHAIN_ID, POOL_ADDRESS, -600n);
-      const lower = tickStore.get(lowerId);
-      expect(lower?.chainId).toBe(CHAIN_ID);
-      expect(lower?.poolAddress).toBe(POOL_ADDRESS);
-      expect(lower?.tickIndex).toBe(-600n);
     });
   });
 
@@ -353,21 +244,10 @@ describe("CLStakedLiquidity", () => {
   describe("processTickCrossingsForStaked", () => {
     let mockContext: handlerContext;
     let logErrorSpy: ReturnType<typeof vi.fn>;
-    let getSpy: ReturnType<typeof vi.fn>;
 
     beforeEach(() => {
       logErrorSpy = vi.fn();
-      // The swap path must NEVER call CLTickStaked.get — if it does, the OOM
-      // regression from #648 is back. Make the spy THROW so any accidental
-      // call surfaces loudly in the test output (a silent vi.fn() would let a
-      // regression return `undefined` and skate past weaker assertions).
-      getSpy = vi.fn(() => {
-        throw new Error(
-          "processTickCrossingsForStaked must not call CLTickStaked.get on the swap path (#649 regression)",
-        );
-      });
       mockContext = {
-        CLTickStaked: { get: getSpy, set: vi.fn() },
         log: {
           error: logErrorSpy,
           warn: vi.fn(),
@@ -391,7 +271,6 @@ describe("CLStakedLiquidity", () => {
         [300n, -300n],
       );
       expect(result).toBe(500n);
-      expect(getSpy).not.toHaveBeenCalled();
     });
 
     it("should return unchanged when tickSpacing is zero", async () => {
@@ -408,7 +287,6 @@ describe("CLStakedLiquidity", () => {
         [300n],
       );
       expect(result).toBe(500n);
-      expect(getSpy).not.toHaveBeenCalled();
     });
 
     it("should add stakedLiquidityNet when crossing up", async () => {
@@ -425,7 +303,6 @@ describe("CLStakedLiquidity", () => {
         [300n],
       );
       expect(result).toBe(300n);
-      expect(getSpy).not.toHaveBeenCalled();
     });
 
     it("should subtract stakedLiquidityNet when crossing down", async () => {
@@ -442,7 +319,6 @@ describe("CLStakedLiquidity", () => {
         [300n],
       );
       expect(result).toBe(0n);
-      expect(getSpy).not.toHaveBeenCalled();
     });
 
     it("should handle multiple tick crossings going up", async () => {
@@ -459,7 +335,6 @@ describe("CLStakedLiquidity", () => {
         [100n, 200n, -50n],
       );
       expect(result).toBe(250n); // 0 + 100 + 200 - 50
-      expect(getSpy).not.toHaveBeenCalled();
     });
 
     it("should handle multiple tick crossings going down", async () => {
@@ -477,7 +352,6 @@ describe("CLStakedLiquidity", () => {
       );
       // 250 - (-50) - 200 - 100 = 250 + 50 - 200 - 100 = 0
       expect(result).toBe(0n);
-      expect(getSpy).not.toHaveBeenCalled();
     });
 
     it("should skip edges that fall outside the [oldTick, newTick] window", async () => {
@@ -563,7 +437,6 @@ describe("CLStakedLiquidity", () => {
         [10n, 20n, -5n],
       );
       expect(result).toBe(25n); // 0 + 10 + 20 - 5
-      expect(getSpy).not.toHaveBeenCalled();
     });
 
     describe("safety guards", () => {
@@ -581,7 +454,6 @@ describe("CLStakedLiquidity", () => {
           [999n],
         );
         expect(result).toBe(500n);
-        expect(getSpy).not.toHaveBeenCalled();
       });
 
       it("should short-circuit when the edge list is empty (no staked positions)", async () => {
@@ -598,7 +470,6 @@ describe("CLStakedLiquidity", () => {
           [],
         );
         expect(result).toBe(500n);
-        expect(getSpy).not.toHaveBeenCalled();
       });
 
       it("should bail and log when oldTick is below TICK_MIN", async () => {

--- a/test/Aggregators/CLStakedLiquidityEdgeSanity.test.ts
+++ b/test/Aggregators/CLStakedLiquidityEdgeSanity.test.ts
@@ -5,7 +5,6 @@ import {
   processTickCrossingsForStaked,
 } from "../../src/Aggregators/CLStakedLiquidity";
 import {
-  CLTickStakedId,
   NonFungiblePositionId,
   PoolId,
   toChecksumAddress,
@@ -21,8 +20,8 @@ import { setupCommon } from "../EventHandlers/Pool/common";
  *   (a) The edge list stays sorted + monotone under arbitrary gauge
  *       deposit/withdraw ordering across ≥200 synthetic events.
  *   (b) `processTickCrossingsForStaked` returns the same staked-liq-in-range
- *       delta as the pre-PR baseline (which reads CLTickStaked entities) for
- *       a swap window that crosses multiple edges.
+ *       delta as a pure in-test baseline map for a swap window that crosses
+ *       multiple edges.
  */
 describe("CLStakedLiquidity edge-list sanity (#649)", () => {
   const {
@@ -147,23 +146,43 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
       expect(nets[i]).not.toBe(0n);
     }
 
-    // Invariant 4: edge list consistent with CLTickStaked — each edge's net
-    // equals the corresponding CLTickStaked.stakedLiquidityNet.
-    // TODO(#652): Remove this invariant when the legacy CLTickStaked writes
-    // are deleted; the in-aggregator edge list becomes the sole source of truth.
+    // Invariant 4: edge list matches a pure-function in-test baseline that
+    // replays the same deposit/withdraw stream onto a Map<tick, net>. This
+    // pins the aggregator's sparse encoding to the underlying Uniswap v3
+    // per-tick liquidityNet semantics without depending on any entity.
+    const withdrawnTokenIds = new Set<bigint>();
+    for (let i = 0; i < POSITIONS; i++) {
+      if (i % 2 !== 0) continue;
+      const pick = ((i * 7) % POSITIONS) + 1;
+      withdrawnTokenIds.add(BigInt(pick));
+    }
+
+    const baseline = new Map<bigint, bigint>();
+    for (let i = 0; i < POSITIONS; i++) {
+      const tokenId = BigInt(i + 1);
+      if (withdrawnTokenIds.has(tokenId)) continue;
+      const tickLower = BigInt(-500 + (i % 20) * 50);
+      const tickUpper = tickLower + BigInt(100 + (i % 7) * 50);
+      const liquidity = BigInt(1000 + i);
+      baseline.set(tickLower, (baseline.get(tickLower) ?? 0n) + liquidity);
+      baseline.set(tickUpper, (baseline.get(tickUpper) ?? 0n) - liquidity);
+    }
+
+    const baselineSorted = [...baseline.entries()]
+      .filter(([, net]) => net !== 0n)
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+
+    expect(edges.length).toBe(baselineSorted.length);
     for (let i = 0; i < edges.length; i++) {
-      const tickEntity = resultDb.entities.CLTickStaked.get(
-        CLTickStakedId(chainId, liquidityPool.poolAddress, edges[i]),
-      );
-      expect(tickEntity).toBeDefined();
-      expect(tickEntity?.stakedLiquidityNet).toBe(nets[i]);
+      expect(edges[i]).toBe(baselineSorted[i][0]);
+      expect(nets[i]).toBe(baselineSorted[i][1]);
     }
   });
 
-  it("(b) processTickCrossingsForStaked returns the same in-range delta as a CLTickStaked-reading baseline across a swap window crossing multiple edges", async () => {
+  it("(b) processTickCrossingsForStaked returns the same in-range delta as a pure-map baseline across a swap window crossing multiple edges", async () => {
     const mockPoolAddress = toChecksumAddress(`0x${"1".repeat(40)}`);
     // Build a realistic edge set by simulating 50 stake events and walking
-    // the exact same events through the pure baseline (a CLTickStaked map).
+    // the exact same events through a pure-map baseline.
     const baselineNet = new Map<bigint, bigint>();
     let edges: readonly bigint[] = [];
     let nets: readonly bigint[] = [];
@@ -173,7 +192,7 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
       const tickUpper = tickLower + 100n;
       const liquidity = BigInt(500 + i * 10);
 
-      // Baseline: maintain a map keyed by tick, mirroring CLTickStaked.stakedLiquidityNet.
+      // Baseline: maintain a map keyed by tick (Uniswap v3 per-tick liquidityNet).
       baselineNet.set(
         tickLower,
         (baselineNet.get(tickLower) ?? 0n) + liquidity,
@@ -208,21 +227,13 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
       }
     }
 
-    // Under test: use the new function with in-aggregator arrays. Must NOT
-    // touch CLTickStaked (we assert by installing a spy that throws).
+    // Under test: use the new function with in-aggregator arrays.
     const noDbContext = {
       log: {
         error: vi.fn(),
         warn: vi.fn(),
         info: vi.fn(),
         debug: vi.fn(),
-      },
-      CLTickStaked: {
-        get: vi.fn(() => {
-          throw new Error(
-            "processTickCrossingsForStaked must not call CLTickStaked.get on the swap path (#649)",
-          );
-        }),
       },
       // biome-ignore lint/suspicious/noExplicitAny: test-only shape
     } as any;
@@ -241,7 +252,6 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
     );
 
     expect(newResult).toBe(baselineResult);
-    expect(noDbContext.CLTickStaked.get).not.toHaveBeenCalled();
 
     // Sanity: the window actually crosses multiple edges.
     const crossingCount = edges.filter(
@@ -281,6 +291,5 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
     // Round-trip parity: up-swap then down-swap over the same window must
     // return stakedLiq to its starting value (0n in this test).
     expect(downResult).toBe(0n);
-    expect(noDbContext.CLTickStaked.get).not.toHaveBeenCalled();
   });
 });

--- a/test/EventHandlers/CLPool/CLPoolSwapLogic.test.ts
+++ b/test/EventHandlers/CLPool/CLPoolSwapLogic.test.ts
@@ -104,10 +104,6 @@ describe("CLPoolSwapLogic", () => {
       warn: vi.fn(),
       info: vi.fn(),
     },
-    CLTickStaked: {
-      get: vi.fn().mockResolvedValue(null),
-      set: vi.fn(),
-    },
   } as unknown as handlerContext;
 
   describe("calculateSwapVolume", () => {

--- a/test/EventHandlers/Gauges/GaugeSharedLogic.test.ts
+++ b/test/EventHandlers/Gauges/GaugeSharedLogic.test.ts
@@ -1015,10 +1015,6 @@ describe("GaugeSharedLogic", () => {
           get: async (id: string) => positionMap.get(id),
           getWhere: async () => [],
         },
-        CLTickStaked: {
-          get: async () => undefined,
-          set: () => {},
-        },
         LiquidityPoolAggregatorSnapshot: {
           set: () => {},
         },

--- a/test/EventHandlers/NFPM/NFPMCommonLogic.test.ts
+++ b/test/EventHandlers/NFPM/NFPMCommonLogic.test.ts
@@ -4,7 +4,6 @@ import { MockDb } from "../../../generated/src/TestHelpers.gen";
 import {
   applyStakedPositionToEdges,
   isPositionInRange,
-  updateTicksForStakedPosition,
 } from "../../../src/Aggregators/CLStakedLiquidity";
 import {
   type PoolData,
@@ -287,8 +286,6 @@ describe("NFPMCommonLogic", () => {
     const blockNumber = 123456;
 
     beforeEach(() => {
-      vi.mocked(updateTicksForStakedPosition).mockReset();
-      vi.mocked(updateTicksForStakedPosition).mockResolvedValue(undefined);
       vi.mocked(isPositionInRange).mockReset();
       vi.mocked(updateLiquidityPoolAggregator).mockReset();
       vi.mocked(updateLiquidityPoolAggregator).mockResolvedValue(undefined);
@@ -306,7 +303,7 @@ describe("NFPMCommonLogic", () => {
       });
     });
 
-    it("should always update tick entities regardless of in-range status", async () => {
+    it("should apply the liquidity delta to the aggregator edge list regardless of in-range status", async () => {
       vi.mocked(isPositionInRange).mockReturnValue(false);
 
       await updateStakedPositionLiquidity(
@@ -319,13 +316,12 @@ describe("NFPMCommonLogic", () => {
         blockNumber,
       );
 
-      expect(updateTicksForStakedPosition).toHaveBeenCalledWith(
-        chainId,
-        stakedPosition.pool,
+      expect(applyStakedPositionToEdges).toHaveBeenCalledWith(
+        poolData.liquidityPoolAggregator.stakedTickEdges,
+        poolData.liquidityPoolAggregator.stakedTickEdgeNets,
         stakedPosition.tickLower,
         stakedPosition.tickUpper,
         5000n,
-        mockContext,
       );
     });
 
@@ -416,7 +412,6 @@ describe("NFPMCommonLogic", () => {
         blockNumber,
       );
 
-      expect(updateTicksForStakedPosition).toHaveBeenCalled();
       expect(calculatePositionAmountsFromLiquidity).toHaveBeenCalledWith(
         5000n,
         sqrtPriceX96AtTick0,
@@ -461,7 +456,6 @@ describe("NFPMCommonLogic", () => {
         blockNumber,
       );
 
-      expect(updateTicksForStakedPosition).toHaveBeenCalled();
       // Reserve math is skipped (no sqrtPriceX96 to split into token0/token1),
       // but we still persist the edge-list update so the swap path has correct
       // state once the pool is initialized.

--- a/test/IdNormalization.test.ts
+++ b/test/IdNormalization.test.ts
@@ -5,7 +5,6 @@ import {
   ALMLPWrapperTransferInTxId,
   CLPoolMintEventId,
   CLPositionPendingPrincipalId,
-  CLTickStakedId,
   LiquidityPoolAggregatorSnapshotId,
   MailboxMessageId,
   NonFungiblePositionId,
@@ -45,7 +44,6 @@ const TX_HASH =
 const MSG_ID =
   "0xdead0123456789abcdef0123456789abcdef0123456789abcdef0123456789be";
 const TOKEN_ID = 42n;
-const TICK_INDEX = 0n;
 const TICK_LOWER = -100n;
 const TICK_UPPER = 100n;
 const EPOCH_MS = 1700000000000;
@@ -129,11 +127,6 @@ describe("ID helpers preserve EIP-55 checksum input (issue #633)", () => {
       name: "NonFungiblePositionId",
       actual: () => NonFungiblePositionId(CHAIN_ID, POOL, TOKEN_ID),
       expected: `${CHAIN_ID}-${POOL}-${TOKEN_ID}`,
-    },
-    {
-      name: "CLTickStakedId",
-      actual: () => CLTickStakedId(CHAIN_ID, POOL, TICK_INDEX),
-      expected: `${CHAIN_ID}-${POOL}-${TICK_INDEX}`,
     },
     {
       name: "PoolTransferInTxId",

--- a/test/Snapshots/SchemaParity.test.ts
+++ b/test/Snapshots/SchemaParity.test.ts
@@ -50,9 +50,7 @@ describe("Snapshot schema parity", () => {
         // processTickCrossingsForStaked. Not snapshotted hourly — the arrays
         // are derived state (sum-of-stakes per tick) and the per-stake history
         // is already captured by Gauge Deposit/Withdraw and NFPM
-        // IncreaseLiquidity/DecreaseLiquidity events. Legacy CLTickStaked
-        // entity is the current GraphQL mirror; scheduled for removal in
-        // velodrome-finance/indexer#652.
+        // IncreaseLiquidity/DecreaseLiquidity events.
         "stakedTickEdges",
         "stakedTickEdgeNets",
       ],


### PR DESCRIPTION
Resolves #652. Depends on #653 (`feature/cl-staked-tick-edges-sparse-list`); rebase onto `main` once that merges.

## Summary

- Drops the `CLTickStaked` writes that #649 retained for one release. With no internal consumer, the legacy `2× get + 2× set` per stake / unstake / liq-change was pure 4× preload amplification on a write-only channel.
- Deletes `updateTicksForStakedPosition` in `src/Aggregators/CLStakedLiquidity.ts` and its call sites in `GaugeSharedLogic.ts` and `NFPMCommonLogic.ts`. The aggregator `stakedTickEdges` / `stakedTickEdgeNets` arrays are now the only writer.
- Removes the `CLTickStaked` type from `schema.graphql` and the `CLTickStakedId` helper from `Constants.ts`.
- Replaces the `CLTickStaked`-parity assertion (invariant 4) in `CLStakedLiquidityEdgeSanity.test.ts` with a pure in-test baseline map — pins the sparse encoding to Uniswap v3 per-tick `liquidityNet` semantics without any entity dependency.
- Cleans up the stale `source of truth` / `GraphQL mirror` comments flagged in the #649 review.

## Breaking change

`CLTickStaked` is no longer exposed via the auto-generated GraphQL API. Removal requires:
- [ ] Audit downstream consumers (analytics dashboards, data pipelines).
- [ ] One-release deprecation window if any consumer is identified.
- [ ] Full re-index on deploy — entity removal forces a backfill.

## Test plan

- [x] `pnpm envio codegen` — clean.
- [x] `tsc --noEmit` — clean.
- [x] `pnpm test` — 1121 passed, 32 skipped, 0 failed.
- [x] `biome check` — clean.
- [ ] Verify no `CLTickStaked`-reading external consumers before merge.
- [ ] Confirm benchmark from #649 shows no regression on the write path (should get faster — 4 fewer entity touches per stake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed deprecated staked-tick entity type and consolidated staked-tick sweep processing into aggregator logic for improved efficiency.

* **Tests**
  * Updated test suites to align with streamlined staked-tick handling approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->