### PR TITLE
feat(cl): index CLPool.Initialize to populate sqrtPriceX96/tick pre-swap

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -39,6 +39,7 @@ contracts:
       - event: CollectFees
       - event: Flash
       - event: IncreaseObservationCardinalityNext
+      - event: Initialize
       - event: Mint
       - event: SetFeeProtocol
       - event: Swap

--- a/src/EventHandlers/CLPool.ts
+++ b/src/EventHandlers/CLPool.ts
@@ -17,6 +17,7 @@ import { processCLPoolBurn } from "./CLPool/CLPoolBurnLogic";
 import { processCLPoolCollectFees } from "./CLPool/CLPoolCollectFeesLogic";
 import { processCLPoolCollect } from "./CLPool/CLPoolCollectLogic";
 import { processCLPoolFlash } from "./CLPool/CLPoolFlashLogic";
+import { processCLPoolInitialize } from "./CLPool/CLPoolInitializeLogic";
 import { processCLPoolMint } from "./CLPool/CLPoolMintLogic";
 import { processCLPoolSwap } from "./CLPool/CLPoolSwapLogic";
 
@@ -271,6 +272,38 @@ CLPool.IncreaseObservationCardinalityNext.handler(
     );
   },
 );
+
+// Initialize fires once per pool, between PoolCreated and the first Mint/Swap.
+// Writing sqrtPriceX96/tick here closes the pre-first-swap dead-zone so NFPM
+// handlers can compute range math for positions minted before any swap has
+// occurred (see velodrome-finance/indexer#654).
+CLPool.Initialize.handler(async ({ event, context }) => {
+  const poolData = await loadPoolData(
+    event.srcAddress,
+    event.chainId,
+    context,
+    event.block.number,
+    event.block.timestamp,
+  );
+
+  if (!poolData) {
+    return;
+  }
+
+  const { liquidityPoolAggregator } = poolData;
+  const timestamp = new Date(event.block.timestamp * 1000);
+
+  const { liquidityPoolDiff } = processCLPoolInitialize(event);
+
+  await updateLiquidityPoolAggregator(
+    liquidityPoolDiff,
+    liquidityPoolAggregator,
+    timestamp,
+    context,
+    event.chainId,
+    event.block.number,
+  );
+});
 
 CLPool.Mint.handler(async ({ event, context }) => {
   // Pool-only update; user liquidity added is attributed from NFPM.Transfer (mint) and NFPM.IncreaseLiquidity

--- a/src/EventHandlers/CLPool/CLPoolInitializeLogic.ts
+++ b/src/EventHandlers/CLPool/CLPoolInitializeLogic.ts
@@ -1,0 +1,30 @@
+import type { CLPool_Initialize_event } from "generated";
+import type { LiquidityPoolAggregatorDiff } from "../../Aggregators/LiquidityPoolAggregator";
+
+export interface CLPoolInitializeResult {
+  liquidityPoolDiff: Partial<LiquidityPoolAggregatorDiff>;
+}
+
+/**
+ * Builds the aggregator diff for a CLPool.Initialize event. Initialize fires
+ * once, between PoolCreated and the first Mint/Swap, and is the earliest
+ * canonical source of sqrtPriceX96/tick. Indexing it closes the pre-first-swap
+ * dead-zone where downstream NFPM handlers silently drop range math on a pool
+ * whose price has not yet been observed (see velodrome-finance/indexer#654).
+ *
+ * @param event - The CLPool.Initialize event
+ * @returns Partial aggregator diff with sqrtPriceX96, tick, and lastUpdatedTimestamp
+ */
+export function processCLPoolInitialize(
+  event: CLPool_Initialize_event,
+): CLPoolInitializeResult {
+  const liquidityPoolDiff: Partial<LiquidityPoolAggregatorDiff> = {
+    sqrtPriceX96: event.params.sqrtPriceX96,
+    tick: event.params.tick,
+    lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
+  };
+
+  return {
+    liquidityPoolDiff,
+  };
+}

--- a/src/EventHandlers/NFPM/NFPMCommonLogic.ts
+++ b/src/EventHandlers/NFPM/NFPMCommonLogic.ts
@@ -136,8 +136,13 @@ export async function updateStakedPositionLiquidity(
   const sqrtPriceX96 = liquidityPoolAggregator.sqrtPriceX96 ?? 0n;
 
   if (sqrtPriceX96 === 0n) {
-    // Even without a price, we still persist the edge-list update so the swap
-    // path has correct state once a price is established.
+    // Defensive fallback: since velodrome-finance/indexer#654 wired
+    // CLPool.Initialize to populate sqrtPriceX96/tick on the aggregator, a
+    // zero price here implies the pool was never Initialize'd in the indexed
+    // range (e.g. pre-existing data from a previous indexer version). Persist
+    // the edge-list update so the swap path has correct state once a price is
+    // established, but skip the amount math that would otherwise produce
+    // garbage from sqrtPriceX96=0.
     await updateLiquidityPoolAggregator(
       { stakedTickEdges, stakedTickEdgeNets, hasStakes },
       liquidityPoolAggregator,

--- a/src/EventHandlers/NFPM/NFPMTransferLogic.ts
+++ b/src/EventHandlers/NFPM/NFPMTransferLogic.ts
@@ -198,6 +198,13 @@ export function isGaugeTransfer(
  * Attributes the position's token0/token1 amounts to UserStatsPerPool: REMOVE from sender, ADD to recipient (if not zero address).
  * No-op if sqrtPriceX96 is missing/zero.
  *
+ * Defensive fallback: since velodrome-finance/indexer#654 wired CLPool.Initialize
+ * to populate sqrtPriceX96, a zero/undefined price here implies the pool was
+ * never Initialize'd in the indexed range (e.g. pre-existing data from a
+ * previous indexer version). In that case we skip the attribution — amount math
+ * off sqrtPriceX96=0 would produce garbage — and let the caller still update
+ * the owner field.
+ *
  * @param event - The NFPM.Transfer event
  * @param position - The NonFungiblePosition entity
  * @param context - The handler context

--- a/test/EventHandlers/CLPool/CLPoolInitializeLogic.test.ts
+++ b/test/EventHandlers/CLPool/CLPoolInitializeLogic.test.ts
@@ -1,0 +1,137 @@
+import { TickMath } from "@uniswap/v3-sdk";
+import type { CLPool_Initialize_event } from "generated";
+import { CLPool, MockDb } from "../../../generated/src/TestHelpers.gen";
+import { toChecksumAddress } from "../../../src/Constants";
+import { processCLPoolInitialize } from "../../../src/EventHandlers/CLPool/CLPoolInitializeLogic";
+import "../../eventHandlersRegistration";
+import { setupCommon } from "../Pool/common";
+
+describe("CLPoolInitializeLogic", () => {
+  const { mockLiquidityPoolData, mockToken0Data, mockToken1Data } =
+    setupCommon();
+  const poolAddress = mockLiquidityPoolData.poolAddress;
+  const chainId = 10;
+  const sqrtPriceX96AtTick0 = BigInt(TickMath.getSqrtRatioAtTick(0).toString());
+
+  describe("processCLPoolInitialize", () => {
+    it("writes sqrtPriceX96, tick, and lastUpdatedTimestamp to the diff", () => {
+      const mockEvent = {
+        chainId,
+        block: { number: 12345, timestamp: 1_000_000 },
+        logIndex: 1,
+        srcAddress: poolAddress,
+        transaction: { hash: "0x0" },
+        params: {
+          sqrtPriceX96: sqrtPriceX96AtTick0,
+          tick: 42n,
+        },
+      } as unknown as CLPool_Initialize_event;
+
+      const { liquidityPoolDiff } = processCLPoolInitialize(mockEvent);
+
+      expect(liquidityPoolDiff.sqrtPriceX96).toBe(sqrtPriceX96AtTick0);
+      expect(liquidityPoolDiff.tick).toBe(42n);
+      expect(liquidityPoolDiff.lastUpdatedTimestamp).toEqual(
+        new Date(1_000_000 * 1000),
+      );
+    });
+
+    it("preserves negative ticks (int24 below zero)", () => {
+      const mockEvent = {
+        chainId,
+        block: { number: 1, timestamp: 1 },
+        logIndex: 0,
+        srcAddress: poolAddress,
+        transaction: { hash: "0x0" },
+        params: {
+          sqrtPriceX96: 1n,
+          tick: -200_000n,
+        },
+      } as unknown as CLPool_Initialize_event;
+
+      const { liquidityPoolDiff } = processCLPoolInitialize(mockEvent);
+
+      expect(liquidityPoolDiff.tick).toBe(-200_000n);
+    });
+  });
+
+  describe("CLPool.Initialize handler", () => {
+    let mockDb: ReturnType<typeof MockDb.createMockDb>;
+
+    beforeEach(() => {
+      // Pool starts uninitialized — sqrtPriceX96/tick are 0n until Initialize
+      // fires, matching the pre-first-swap dead-zone that #654 closes.
+      mockDb = MockDb.createMockDb();
+      const poolPreInit = {
+        ...mockLiquidityPoolData,
+        isCL: true,
+        sqrtPriceX96: 0n,
+        tick: 0n,
+      };
+      mockDb = mockDb.entities.LiquidityPoolAggregator.set(poolPreInit)
+        .entities.Token.set(mockToken0Data)
+        .entities.Token.set(mockToken1Data);
+    });
+
+    it("populates sqrtPriceX96 and tick on the aggregator before any swap", async () => {
+      const mockEvent = CLPool.Initialize.createMockEvent({
+        sqrtPriceX96: sqrtPriceX96AtTick0,
+        tick: 17n,
+        mockEventData: {
+          block: {
+            timestamp: 1_234_567,
+            number: 42,
+            hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
+          },
+          chainId,
+          logIndex: 0,
+          srcAddress: poolAddress as `0x${string}`,
+          transaction: {
+            hash: "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+          },
+        },
+      });
+
+      const result = await mockDb.processEvents([mockEvent]);
+
+      const updatedPool = result.entities.LiquidityPoolAggregator.get(
+        mockLiquidityPoolData.id,
+      );
+      expect(updatedPool).toBeDefined();
+      if (!updatedPool) return;
+      expect(updatedPool.sqrtPriceX96).toBe(sqrtPriceX96AtTick0);
+      expect(updatedPool.tick).toBe(17n);
+    });
+
+    it("no-ops when the pool aggregator is missing (defensive)", async () => {
+      const unknownPool = toChecksumAddress(
+        "0x9999999999999999999999999999999999999999",
+      );
+      const mockEvent = CLPool.Initialize.createMockEvent({
+        sqrtPriceX96: sqrtPriceX96AtTick0,
+        tick: 1n,
+        mockEventData: {
+          block: {
+            timestamp: 1_234_567,
+            number: 42,
+            hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
+          },
+          chainId,
+          logIndex: 0,
+          srcAddress: unknownPool as `0x${string}`,
+          transaction: {
+            hash: "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+          },
+        },
+      });
+
+      // Should not throw or create a phantom aggregator for the unknown pool.
+      const result = await mockDb.processEvents([mockEvent]);
+      expect(
+        result.entities.LiquidityPoolAggregator.get(
+          `${chainId}-${unknownPool}`,
+        ),
+      ).toBeUndefined();
+    });
+  });
+});

--- a/test/EventHandlers/CLPool/CLPoolInitializeLogic.test.ts
+++ b/test/EventHandlers/CLPool/CLPoolInitializeLogic.test.ts
@@ -1,7 +1,7 @@
 import { TickMath } from "@uniswap/v3-sdk";
 import type { CLPool_Initialize_event } from "generated";
 import { CLPool, MockDb } from "../../../generated/src/TestHelpers.gen";
-import { toChecksumAddress } from "../../../src/Constants";
+import { PoolId, toChecksumAddress } from "../../../src/Constants";
 import { processCLPoolInitialize } from "../../../src/EventHandlers/CLPool/CLPoolInitializeLogic";
 import "../../eventHandlersRegistration";
 import { setupCommon } from "../Pool/common";
@@ -129,7 +129,7 @@ describe("CLPoolInitializeLogic", () => {
       const result = await mockDb.processEvents([mockEvent]);
       expect(
         result.entities.LiquidityPoolAggregator.get(
-          `${chainId}-${unknownPool}`,
+          PoolId(chainId, unknownPool),
         ),
       ).toBeUndefined();
     });


### PR DESCRIPTION
Closes #654. Stacks on #653 (`feature/cl-staked-tick-edges-sparse-list`) — base this PR on #653 and rebase onto `main` once #653 merges.

## Summary

- Subscribe `CLPool` to `Initialize` in `config.yaml`
- New `processCLPoolInitialize` logic module (`src/EventHandlers/CLPool/CLPoolInitializeLogic.ts`) producing a `{sqrtPriceX96, tick, lastUpdatedTimestamp}` aggregator diff
- Register `CLPool.Initialize.handler` in `src/EventHandlers/CLPool.ts`, slotted alphabetically between `IncreaseObservationCardinalityNext` and `Mint`
- Narrow the two `sqrtPriceX96 === 0n` bail-outs (`NFPMCommonLogic.ts:152`, `NFPMTransferLogic.ts:213`) from "primary path" to "defensive fallback for pre-existing data where Initialize was never indexed", with comments pointing at #654

## Why

`CLPool.Initialize(sqrtPriceX96, tick)` was not indexed. `schema.graphql:48-49` already documented the intent (`sqrtPriceX96` / `tick` "updated from Swap/Initialize events") but only `Swap` wrote the fields. Between `pool.initialize()` and the first `pool.swap()`, the aggregator kept `sqrtPriceX96 === 0n`, causing:

- `NFPMCommonLogic.updateStakedPositionLiquidity` to skip `stakedLiquidityInRange` / `stakedReserve0/1` math for pre-swap mints (#653 kept the edge-list write — just not the reserves/in-range number)
- `NFPMTransferLogic.attributeTransferToUserStatsPerPool` to no-op entirely for mint/transfer attribution on pre-swap positions

Deviation from issue's step 1 (measurement): skipped because the measurement needs live DB access the author does not have, the fix is small and self-contained, and the schema already treats Initialize as an authoritative update source. Bail-outs stay (narrowed) so pre-existing data from older indexer runs does not explode when replayed.

## Test plan
- [x] `pnpm qa --write` clean
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm test` — 97/97 test files pass
- [x] New tests (`test/EventHandlers/CLPool/CLPoolInitializeLogic.test.ts`): unit + `processEvents` integration, negative-tick int24 preservation, unknown-pool defensive no-op
- [ ] Reviewer spot-check: on a fresh re-index, confirm the first CLPool.Initialize event updates `LiquidityPoolAggregator.sqrtPriceX96` and `tick` before the first Swap

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added indexing support for CLPool `Initialize` events to properly track when liquidity pools are initialized.

* **Documentation**
  * Enhanced clarifications regarding uninitialized pool handling to prevent incorrect token amount calculations in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->