### PR TITLE
Scaffold agent skills config (issue tracker, triage, domain docs)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,3 +103,17 @@ Tests live in `test/` mirroring the `src/` structure. Uses Vitest with threaded 
 ## Lint/Format
 
 Uses Biome (not Prettier/ESLint). Space indentation, double quotes, organized imports. Run `biome check` before committing.
+
+## Agent skills
+
+### Issue tracker
+
+Issues live as GitHub issues at `velodrome-finance/indexer`; use the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Canonical labels: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context layout: `CONTEXT.md` and `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,35 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+This repo uses a **single-context** layout: one `CONTEXT.md` and one `docs/adr/` directory at the repo root.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-...md
+│   └── 0002-...md
+└── src/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (...) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues at `velodrome-finance/indexer`. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
## Summary
- Add `docs/agents/issue-tracker.md` declaring GitHub + `gh` CLI as the issue tracker
- Add `docs/agents/triage-labels.md` mapping the five canonical triage roles to their label strings (defaults retained)
- Add `docs/agents/domain.md` declaring single-context layout (`CONTEXT.md` + `docs/adr/` at repo root)
- Add an `## Agent skills` section to `CLAUDE.md` pointing at the three docs so skills like `to-issues`, `triage`, `to-prd`, `grill-with-docs`, `improve-codebase-architecture`, `diagnose`, and `tdd` know where to read/write

Docs-only change. No runtime or schema impact.

## Test plan
- [x] `pnpm qa --write` passes (no fixes applied)
- [x] `## Agent skills` block present at the end of `CLAUDE.md`
- [x] All three `docs/agents/*.md` files committed
- [x] Open a fresh Claude Code session and confirm it reads the new section *(needs human — verification step)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added guidance documentation for agent skills, including setup and usage standards
* Documented domain documentation consumption standards and expected file layout
* Documented GitHub issue tracker workflow and conventions using the CLI
* Added canonical triage role to label mapping reference guide

<!-- end of auto-generated comment: release notes by coderabbit.ai -->