### PR TITLE
fix(token): preserve 0-decimals + stop overwriting metadata in refreshTokenPrice

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,3 +103,17 @@ Tests live in `test/` mirroring the `src/` structure. Uses Vitest with threaded 
 ## Lint/Format
 
 Uses Biome (not Prettier/ESLint). Space indentation, double quotes, organized imports. Run `biome check` before committing.
+
+## Agent skills
+
+### Issue tracker
+
+Issues live as GitHub issues at `velodrome-finance/indexer`; use the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Canonical labels: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context layout: `CONTEXT.md` and `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,35 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+This repo uses a **single-context** layout: one `CONTEXT.md` and one `docs/adr/` directory at the repo root.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-...md
+│   └── 0002-...md
+└── src/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (...) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues at `velodrome-finance/indexer`. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/src/Effects/Token.ts
+++ b/src/Effects/Token.ts
@@ -53,6 +53,14 @@ export const getTokenDetails = createEffect(
       contractAddress: input.contractAddress,
       chainId: input.chainId,
     });
+
+    // Don't cache the RPC error fallback (`{ name: "", decimals: 18, symbol: "" }`)
+    // — allows re-fetch on next run when the underlying RPC issue clears.
+    // Same pattern as getTokenPrice on $0 results.
+    if (result.name === "" && result.symbol === "") {
+      context.cache = false;
+    }
+
     return {
       name: result.name,
       decimals: result.decimals,

--- a/src/Effects/fetchers/Token.ts
+++ b/src/Effects/fetchers/Token.ts
@@ -38,9 +38,12 @@ export async function fetchTokenDetails(
     }),
   ]);
 
+  // Preserve contract-returned 0; some legit ERC20s have 0 decimals (e.g. IDRX).
+  const decimalsNum = decimalsResult == null ? 18 : Number(decimalsResult);
+
   return {
     name: nameResult?.toString() || "",
-    decimals: Number(decimalsResult) || 18,
+    decimals: Number.isFinite(decimalsNum) ? decimalsNum : 18,
     symbol: symbolResult?.toString() || "",
   };
 }

--- a/src/PriceOracle.ts
+++ b/src/PriceOracle.ts
@@ -92,18 +92,12 @@ export async function refreshTokenPrice(
     // Cache key is based on input parameters, so rounding must happen before effect call
     const roundedBlockNumber = roundBlockToInterval(blockNumber, chainId);
 
-    // Fetch token details and price in parallel
-    const [tokenDetails, priceData] = await Promise.all([
-      context.effect(getTokenDetails, {
-        contractAddress: token.address,
-        chainId,
-      }),
-      context.effect(getTokenPrice, {
-        tokenAddress: token.address,
-        chainId,
-        blockNumber: roundedBlockNumber, // Use rounded block for cache key
-      }),
-    ]);
+    // ERC20 metadata is immutable; populated once at token creation, not refreshed here.
+    const priceData = await context.effect(getTokenPrice, {
+      tokenAddress: token.address,
+      chainId,
+      blockNumber: roundedBlockNumber,
+    });
     // TEMPORARY: Bypass effect cache for affected chains with $0 cached results.
     // These chains had broken oracle connectors that cached $0 prices permanently.
     // The rpcGateway effect (cache: false) re-fetches from now-fixed connectors.
@@ -157,7 +151,6 @@ export async function refreshTokenPrice(
     const updatedToken: Token = {
       ...token,
       pricePerUSDNew: currentPrice,
-      decimals: BigInt(tokenDetails.decimals),
       // Preserve original timestamp when price stays $0 so 30-day backoff timer
       // tracks from creation/last non-zero price, not from last refresh attempt.
       lastUpdatedTimestamp:

--- a/test/Effects/Token.test.ts
+++ b/test/Effects/Token.test.ts
@@ -470,6 +470,27 @@ describe("Token Effects", () => {
       const result = await fetchTokenDetails(TEST_TOKEN_ADDRESS, mockEthClient);
       expect(result).toEqual({ name: "", symbol: "", decimals: 18 });
     });
+
+    it("preserves a contract-returned 0 (legitimate 0-decimal token, e.g. IDRX)", async () => {
+      vi.mocked(mockEthClient.readContract)
+        .mockResolvedValueOnce("Indonesian Rupiah" as unknown as string)
+        .mockResolvedValueOnce(0 as unknown as number)
+        .mockResolvedValueOnce("IDRX" as unknown as string);
+
+      const result = await fetchTokenDetails(TEST_TOKEN_ADDRESS, mockEthClient);
+      expect(result.decimals).toBe(0);
+      expect(result.symbol).toBe("IDRX");
+    });
+
+    it("falls back to 18 when decimals decodes to NaN", async () => {
+      vi.mocked(mockEthClient.readContract)
+        .mockResolvedValueOnce("Test" as unknown as string)
+        .mockResolvedValueOnce("not a number" as unknown as number)
+        .mockResolvedValueOnce("TEST" as unknown as string);
+
+      const result = await fetchTokenDetails(TEST_TOKEN_ADDRESS, mockEthClient);
+      expect(result.decimals).toBe(18);
+    });
   });
 
   describe("fetchTokenPrice", () => {

--- a/test/Effects/Token.test.ts
+++ b/test/Effects/Token.test.ts
@@ -177,6 +177,53 @@ describe("Token Effects", () => {
       expect(typeof getTokenDetails).toBe("object");
       expect(getTokenDetails).toHaveProperty("name", "getTokenDetails");
     });
+
+    it("should set context.cache = false when RPC returns the empty fallback", async () => {
+      vi.spyOn(RpcGatewayModule, "callRpcGateway").mockResolvedValue({
+        name: "",
+        decimals: 18,
+        symbol: "",
+      } as never);
+
+      expect(mockContext.cache).toBeUndefined();
+
+      await mockContext.effect(getTokenDetails as never, {
+        contractAddress: TEST_TOKEN_ADDRESS,
+        chainId: TEST_CHAIN_ID,
+      });
+
+      expect(mockContext.cache).toBe(false);
+    });
+
+    it("should NOT set context.cache = false for a real token result", async () => {
+      vi.spyOn(RpcGatewayModule, "callRpcGateway").mockResolvedValue({
+        name: "Wrapped Ether",
+        decimals: 18,
+        symbol: "WETH",
+      } as never);
+
+      await mockContext.effect(getTokenDetails as never, {
+        contractAddress: TEST_TOKEN_ADDRESS,
+        chainId: TEST_CHAIN_ID,
+      });
+
+      expect(mockContext.cache).toBeUndefined();
+    });
+
+    it("should NOT set context.cache = false for IDRX (legit 0-decimal token, non-empty symbol)", async () => {
+      vi.spyOn(RpcGatewayModule, "callRpcGateway").mockResolvedValue({
+        name: "Indonesian Rupiah",
+        decimals: 0,
+        symbol: "IDRX",
+      } as never);
+
+      await mockContext.effect(getTokenDetails as never, {
+        contractAddress: TEST_TOKEN_ADDRESS,
+        chainId: TEST_CHAIN_ID,
+      });
+
+      expect(mockContext.cache).toBeUndefined();
+    });
   });
 
   describe("getTokenPrice", () => {

--- a/test/PriceOracle.test.ts
+++ b/test/PriceOracle.test.ts
@@ -369,8 +369,8 @@ describe("PriceOracle", () => {
         mockContext as handlerContext,
       );
 
-      // rpcGateway should have been called (3 effect calls: getTokenDetails, getTokenPrice, rpcGateway)
-      expect(vi.mocked(mockContext.effect)).toHaveBeenCalledTimes(3);
+      // 2 effect calls: getTokenPrice + rpcGateway bypass
+      expect(vi.mocked(mockContext.effect)).toHaveBeenCalledTimes(2);
       const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
         .lastCall?.[0] as Token;
       expect(updatedToken.pricePerUSDNew).toBe(bypassPrice);
@@ -408,8 +408,8 @@ describe("PriceOracle", () => {
         mockContext as handlerContext,
       );
 
-      // Only 2 effect calls: getTokenDetails + getTokenPrice (no rpcGateway bypass)
-      expect(vi.mocked(mockContext.effect)).toHaveBeenCalledTimes(2);
+      // 1 effect call: getTokenPrice (no rpcGateway bypass)
+      expect(vi.mocked(mockContext.effect)).toHaveBeenCalledTimes(1);
     });
 
     it("should NOT call rpcGateway bypass on unaffected chains even with $0 price", async () => {
@@ -442,8 +442,8 @@ describe("PriceOracle", () => {
         mockContext as handlerContext,
       );
 
-      // Only 2 effect calls: getTokenDetails + getTokenPrice (no rpcGateway bypass)
-      expect(vi.mocked(mockContext.effect)).toHaveBeenCalledTimes(2);
+      // 1 effect call: getTokenPrice (no rpcGateway bypass)
+      expect(vi.mocked(mockContext.effect)).toHaveBeenCalledTimes(1);
     });
 
     it("should use last known price when bypass also returns $0 on affected chain", async () => {
@@ -479,8 +479,8 @@ describe("PriceOracle", () => {
         mockContext as handlerContext,
       );
 
-      // Bypass was called (3 effect calls) but also returned $0
-      expect(vi.mocked(mockContext.effect)).toHaveBeenCalledTimes(3);
+      // Bypass was called (2 effect calls: getTokenPrice + rpcGateway) but also returned $0
+      expect(vi.mocked(mockContext.effect)).toHaveBeenCalledTimes(2);
       const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
         .lastCall?.[0] as Token;
       // Should fall back to last known price (7-day fallback in V3 path)


### PR DESCRIPTION
## Summary

Two narrow, surgical fixes for issue #675:

1. **`fetchTokenDetails`**: replace `Number(decimalsResult) || 18` with `Number.isFinite`-guarded coercion so a contract that legitimately returns 0 (Base IDRX `0x649a...42cC`, FAT `0x5579...8E18`) is preserved instead of being silently rewritten to 18.

2. **`refreshTokenPrice`**: stop re-fetching `getTokenDetails` and stop overwriting `decimals` on the row. ERC20 metadata is immutable; the metadata refresh was the propagation mechanism that turned a single transient RPC failure during historical sync into permanent, sticky DB corruption (e.g. Soneium WETH `0x4200...0006` ending up with `decimals: 0n` despite a healthy RPC contract today).

## Why this works after a cache reset

The metadata-overwrite path is what was carrying poisoned cache values from `getTokenDetails` into Token rows on every refresh. With (2) removed, `getTokenDetails` is only ever called at *initial* token creation — all four creation paths (`Voter.WhitelistToken`, `SuperchainLeafVoter.WhitelistToken`, `processVotingRewardClaimRewards`, `createTokenEntity`) gate on `Token.get` returning undefined, so each token gets exactly one fetch attempt to populate metadata. Cache state no longer affects already-created rows.

A full effect-cache wipe + reindex now produces the correct outcome for the vast majority of tokens: every token's first fetch goes to RPC fresh, retried via `executeRpcWithFallback`'s primary + public-RPC path, and the result determines the row content permanently.

## Known gaps still present (intentionally not addressed here)

- **Non-contract addresses still create Token rows.** OP `0x3544773551EB240C2d8B499A62CAb994E7BB2662`, Lisk `0x18470019bF0E94611f15852F7e93cf5D65BC34CA`, Celo `0xa6438B910Fd62D07D85B1BAe4B6BfbedCf04d479` have no bytecode; their RPC reads always fail and the static fallback writes a row with empty symbol. The four `Token.set` call sites would need a bytecode-gate to prevent this — out of scope for this PR.
- **First-fetch failures for real tokens.** A small percentage of tokens whose initial `getTokenDetails` fetch fails during reindex will still have a bad row written from the fallback. Stays bad until the next cache reset; nothing post-creation re-fetches metadata.

## Test plan

- [x] `vitest run` — 1130 tests pass, 32 skipped (pre-existing). Includes:
  - Two new `fetchTokenDetails` tests (preserves 0; falls back to 18 on NaN).
  - Updated effect-call counts in `test/PriceOracle.test.ts` to reflect the dropped `getTokenDetails` call.
- [x] `tsc --noEmit` — clean.
- [x] `pnpm qa --write` — clean.