### PR TITLE
fix(price-oracle): blacklist + canonical rebind for known-bad oracle reads (#669)

### DIFF
--- a/src/PriceOracle.ts
+++ b/src/PriceOracle.ts
@@ -12,6 +12,7 @@ import {
   roundBlockToInterval,
 } from "./Effects/Index";
 import { EffectType, rpcGateway } from "./Effects/RpcGateway";
+import { getRebindTarget, isBlacklistedToken } from "./PriceOverrides";
 import { setTokenPriceSnapshot } from "./Snapshots/TokenPriceSnapshot";
 export interface TokenPriceData {
   pricePerUSDNew: bigint;
@@ -85,6 +86,44 @@ export async function refreshTokenPrice(
 
   if (!shouldRefresh) {
     return token;
+  }
+
+  // Issue #669: blacklist + canonical rebind override the oracle for known-bad
+  // (chain, token) pairs. See src/PriceOverrides.ts for rationale per token.
+  if (isBlacklistedToken(chainId, token.address)) {
+    const updated: Token = {
+      ...token,
+      pricePerUSDNew: 0n,
+      lastUpdatedTimestamp: new Date(blockTimestampMs),
+    };
+    context.Token.set(updated);
+    return updated;
+  }
+
+  const rebindTarget = getRebindTarget(chainId, token.address);
+  if (rebindTarget) {
+    const sourceToken = await context.Token.get(
+      TokenId(rebindTarget.chainId, rebindTarget.address),
+    );
+    const sourcePrice = sourceToken?.pricePerUSDNew ?? 0n;
+    const updated: Token = {
+      ...token,
+      pricePerUSDNew: sourcePrice,
+      lastUpdatedTimestamp: new Date(blockTimestampMs),
+    };
+    context.Token.set(updated);
+    if (sourcePrice > 0n) {
+      setTokenPriceSnapshot(
+        token.address,
+        chainId,
+        blockNumber,
+        new Date(blockTimestampMs),
+        sourcePrice,
+        token.isWhitelisted,
+        context,
+      );
+    }
+    return updated;
   }
 
   try {

--- a/src/PriceOverrides.ts
+++ b/src/PriceOverrides.ts
@@ -1,0 +1,120 @@
+import { TokenId, toChecksumAddress } from "./Constants";
+
+export interface RebindTarget {
+  readonly chainId: number;
+  readonly address: string;
+}
+
+/**
+ * Tokens whose on-chain price oracle is structurally unusable: every read either
+ * returns a value derived from a broken DEX pool (no real off-chain market exists
+ * to disagree) or is silent except for transient swap-time spikes that contaminate
+ * lifetime totals. For these, the only correct price is 0 — pool-USD calcs already
+ * route through the counterparty when one side is $0.
+ *
+ * Issue #669: $Manatee (no real market; tBTC/$Manatee pool routes price through
+ * tBTC and produces $76K-$92K; alETH/$Manatee disagrees with alUSD/$Manatee by 10x).
+ * Issue #669: SQUID (oracle returns 0 at every stable read; the $13B contaminated
+ * total comes from transient single-block spikes during swaps).
+ */
+const BLACKLIST: ReadonlySet<string> = new Set([
+  TokenId(10, toChecksumAddress("0x7909Bda52eAf7C3cc12745E727Eb527a485241D8")), // $Manatee / Optimism
+  TokenId(
+    57073,
+    toChecksumAddress("0x2e3b82891d1B2b90655597110cCA9b6587607e0c"),
+  ), // SQUID / Ink
+]);
+
+/**
+ * Chains where Velodrome's SuperERC20 deployments live at the same address as
+ * their canonical Optimism counterpart (1:1 mint/burn through Hyperlane).
+ */
+const SUPERCHAINS = [
+  252, // Fraxtal
+  1135, // Lisk
+  34443, // Mode
+  1750, // Metal
+  1923, // Swell
+  1868, // Soneium
+  42220, // Celo
+  130, // Unichain
+  57073, // Ink
+  5330, // Superseed
+] as const;
+
+/**
+ * Tokens whose price should be copied verbatim from another (already-priced)
+ * Token entity, bypassing the on-chain oracle entirely. Each entry declares a
+ * canonical `source` and every `target` (chain + address) that mirrors it.
+ *
+ * Two patterns:
+ *  - Bridged 1:1 superchain tokens (XVELO across all superchains -> canonical
+ *    VELO on Optimism; SuperERC20 mint/burn through Hyperlane preserves parity)
+ *  - LST/LRT cross-chain duals (rsETH on Swell -> wrsETH on Base; both are Kelp
+ *    wrappers of the same underlying restaked-ETH position; Aerodrome's deep
+ *    wrsETH/WETH pool gives a clean Base price)
+ *
+ * If the source token has not yet been priced (price === 0), the rebind still
+ * fires and writes 0 — explicitly NOT falling back to the corrupt on-chain
+ * oracle for the target chain, which is the whole point of the rebind.
+ */
+const REBINDS: ReadonlyArray<{
+  source: RebindTarget;
+  targets: ReadonlyArray<RebindTarget>;
+}> = [
+  {
+    // rsETH on Swell -> wrsETH on Base (Aerodrome wrsETH/WETH pool prices it cleanly)
+    source: {
+      chainId: 8453,
+      address: toChecksumAddress("0xEDfa23602D0EC14714057867A78d01e94176BEA0"),
+    },
+    targets: [
+      {
+        chainId: 1923,
+        address: toChecksumAddress(
+          "0xc3eaCf0612346366Db554c991D7858716db09f58",
+        ),
+      },
+    ],
+  },
+  {
+    // XVELO on every superchain -> canonical VELO on Optimism
+    source: {
+      chainId: 10,
+      address: toChecksumAddress("0x9560e827aF36c94D2Ac33a39bCE1Fe78631088Db"),
+    },
+    targets: SUPERCHAINS.map((chainId) => ({
+      chainId,
+      address: toChecksumAddress("0x7f9AdFbd38b669F03d1d11000Bc76b9AaEA28A81"),
+    })),
+  },
+];
+
+const PRICE_REBIND: ReadonlyMap<string, RebindTarget> = new Map(
+  REBINDS.flatMap(({ source, targets }) =>
+    targets.map((t): [string, RebindTarget] => [
+      TokenId(t.chainId, t.address),
+      source,
+    ]),
+  ),
+);
+
+/**
+ * Whether this token's price should be forced to 0, bypassing the oracle entirely.
+ * @param chainId - Chain the token lives on
+ * @param address - Token address (must be EIP-55 checksum-cased to match config)
+ * @returns true if the token is blacklisted on that chain
+ */
+export const isBlacklistedToken = (chainId: number, address: string): boolean =>
+  BLACKLIST.has(TokenId(chainId, address));
+
+/**
+ * Where this token's price should be copied from, if anywhere.
+ * @param chainId - Chain the target token lives on
+ * @param address - Target token address (EIP-55 checksum-cased)
+ * @returns Source {chainId, address} to read the price from, or undefined if no rebind is configured
+ */
+export const getRebindTarget = (
+  chainId: number,
+  address: string,
+): RebindTarget | undefined => PRICE_REBIND.get(TokenId(chainId, address));

--- a/test/PriceOracle.test.ts
+++ b/test/PriceOracle.test.ts
@@ -276,6 +276,116 @@ describe("PriceOracle", () => {
       });
     });
 
+    describe("Override path: blacklist + rebind (issue #669)", () => {
+      // Issue #669: tokens whose on-chain oracle is structurally unusable get
+      // either forced to 0 (blacklist) or copied from another chain's already-
+      // priced Token entity (rebind). Either path bypasses the on-chain oracle
+      // entirely — no getTokenPrice/rpcGateway/getTokenDetails calls fire.
+      const oneHourAndOneMinuteAgo = () =>
+        new Date(blockDatetime.getTime() - 61 * 60 * 1000);
+
+      beforeEach(() => {
+        vi.mocked(mockContext.Token?.set)?.mockClear();
+        vi.mocked(mockContext.Token?.get)?.mockReset();
+        vi.mocked(mockContext.effect)?.mockClear();
+        vi.mocked(mockContext.TokenPriceSnapshot?.set)?.mockClear();
+      });
+
+      it("blacklisted token: forces price to 0 and skips the oracle entirely", async () => {
+        const MANATEE_OP = toChecksumAddress(
+          "0x7909Bda52eAf7C3cc12745E727Eb527a485241D8",
+        );
+        const fetchedToken = {
+          ...mockToken0Data,
+          address: MANATEE_OP,
+          pricePerUSDNew: 388_328n * 10n ** 18n, // contaminated baseline
+          lastUpdatedTimestamp: oneHourAndOneMinuteAgo(),
+        };
+
+        const result = await PriceOracle.refreshTokenPrice(
+          fetchedToken,
+          blockNumber,
+          blockDatetime.getTime() / 1000,
+          10, // Optimism, where $Manatee is blacklisted
+          mockContext as handlerContext,
+        );
+
+        expect(result.pricePerUSDNew).toBe(0n);
+        expect(vi.mocked(mockContext.effect)).not.toHaveBeenCalled();
+        expect(
+          vi.mocked(mockContext.TokenPriceSnapshot?.set),
+        ).not.toHaveBeenCalled();
+      });
+
+      it("rebind: copies price from the source chain's Token entity", async () => {
+        const RSETH_SWELL = toChecksumAddress(
+          "0xc3eaCf0612346366Db554c991D7858716db09f58",
+        );
+        const WRSETH_BASE = toChecksumAddress(
+          "0xEDfa23602D0EC14714057867A78d01e94176BEA0",
+        );
+        const sourcePrice = 2_443n * 10n ** 18n;
+        vi.mocked(mockContext.Token?.get)?.mockImplementation(async (id) => {
+          if (id === `8453-${WRSETH_BASE}`) {
+            return { pricePerUSDNew: sourcePrice } as Token;
+          }
+          return undefined;
+        });
+
+        const fetchedToken = {
+          ...mockToken0Data,
+          address: RSETH_SWELL,
+          pricePerUSDNew: 3_620_000n * 10n ** 18n, // corrupt baseline ($3.62M)
+          lastUpdatedTimestamp: oneHourAndOneMinuteAgo(),
+        };
+
+        const result = await PriceOracle.refreshTokenPrice(
+          fetchedToken,
+          blockNumber,
+          blockDatetime.getTime() / 1000,
+          1923, // Swell, where rsETH rebinds to wrsETH/Base
+          mockContext as handlerContext,
+        );
+
+        expect(result.pricePerUSDNew).toBe(sourcePrice);
+        expect(vi.mocked(mockContext.effect)).not.toHaveBeenCalled();
+        // Snapshot should fire when source has a non-zero price
+        expect(
+          vi.mocked(mockContext.TokenPriceSnapshot?.set),
+        ).toHaveBeenCalled();
+      });
+
+      it("rebind with unpriced source: writes 0 rather than falling back to oracle", async () => {
+        const XVELO = toChecksumAddress(
+          "0x7f9AdFbd38b669F03d1d11000Bc76b9AaEA28A81",
+        );
+        vi.mocked(mockContext.Token?.get)?.mockResolvedValue(undefined);
+
+        const fetchedToken = {
+          ...mockToken0Data,
+          address: XVELO,
+          pricePerUSDNew: 0n,
+          lastUpdatedTimestamp: oneHourAndOneMinuteAgo(),
+        };
+
+        const result = await PriceOracle.refreshTokenPrice(
+          fetchedToken,
+          blockNumber,
+          blockDatetime.getTime() / 1000,
+          252, // Fraxtal — XVELO rebinds to VELO/OP
+          mockContext as handlerContext,
+        );
+
+        // Critical: must NOT fall through to oracle (which would re-introduce corruption)
+        expect(result.pricePerUSDNew).toBe(0n);
+        expect(vi.mocked(mockContext.effect)).not.toHaveBeenCalled();
+        // No snapshot when source price is 0 (would be a no-op and is noisy)
+        expect(
+          vi.mocked(mockContext.TokenPriceSnapshot?.set),
+        ).not.toHaveBeenCalled();
+      });
+    });
+
     describe("when price fetch fails", () => {
       let originalToken: Token;
       beforeEach(async () => {

--- a/test/PriceOverrides.test.ts
+++ b/test/PriceOverrides.test.ts
@@ -1,0 +1,100 @@
+import { toChecksumAddress } from "../src/Constants";
+import { getRebindTarget, isBlacklistedToken } from "../src/PriceOverrides";
+
+describe("PriceOverrides", () => {
+  describe("isBlacklistedToken", () => {
+    it("returns true for $Manatee on Optimism", () => {
+      expect(
+        isBlacklistedToken(
+          10,
+          toChecksumAddress("0x7909Bda52eAf7C3cc12745E727Eb527a485241D8"),
+        ),
+      ).toBe(true);
+    });
+
+    it("returns true for SQUID on Ink", () => {
+      expect(
+        isBlacklistedToken(
+          57073,
+          toChecksumAddress("0x2e3b82891d1B2b90655597110cCA9b6587607e0c"),
+        ),
+      ).toBe(true);
+    });
+
+    it("returns false for tokens not in the blacklist", () => {
+      expect(
+        isBlacklistedToken(
+          10,
+          toChecksumAddress("0x4200000000000000000000000000000000000006"),
+        ),
+      ).toBe(false);
+    });
+
+    it("returns false when the chain has no blacklist entries", () => {
+      expect(
+        isBlacklistedToken(
+          8453,
+          toChecksumAddress("0x7909Bda52eAf7C3cc12745E727Eb527a485241D8"),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("getRebindTarget", () => {
+    const VELO_OP = toChecksumAddress(
+      "0x9560e827aF36c94D2Ac33a39bCE1Fe78631088Db",
+    );
+    const XVELO = toChecksumAddress(
+      "0x7f9AdFbd38b669F03d1d11000Bc76b9AaEA28A81",
+    );
+    const RSETH_SWELL = toChecksumAddress(
+      "0xc3eaCf0612346366Db554c991D7858716db09f58",
+    );
+    const WRSETH_BASE = toChecksumAddress(
+      "0xEDfa23602D0EC14714057867A78d01e94176BEA0",
+    );
+
+    it("rebinds rsETH/Swell to wrsETH/Base", () => {
+      expect(getRebindTarget(1923, RSETH_SWELL)).toEqual({
+        chainId: 8453,
+        address: WRSETH_BASE,
+      });
+    });
+
+    it.each([
+      [252, "Fraxtal"],
+      [1135, "Lisk"],
+      [34443, "Mode"],
+      [1750, "Metal"],
+      [1923, "Swell"],
+      [1868, "Soneium"],
+      [42220, "Celo"],
+      [130, "Unichain"],
+      [57073, "Ink"],
+      [5330, "Superseed"],
+    ])("rebinds XVELO on chainId=%i (%s) to VELO/Optimism", (chainId) => {
+      expect(getRebindTarget(chainId, XVELO)).toEqual({
+        chainId: 10,
+        address: VELO_OP,
+      });
+    });
+
+    it("returns undefined for tokens without a rebind", () => {
+      expect(
+        getRebindTarget(
+          10,
+          toChecksumAddress("0x4200000000000000000000000000000000000006"),
+        ),
+      ).toBeUndefined();
+    });
+
+    it("returns undefined for chains without any rebinds", () => {
+      expect(
+        getRebindTarget(
+          8453,
+          toChecksumAddress("0x7f9AdFbd38b669F03d1d11000Bc76b9AaEA28A81"),
+        ),
+      ).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes the four #669 cases where Velodrome's on-chain `SpotPriceAggregator` is structurally unusable for a given token. Instead of trying to filter bad reads heuristically, we bypass the oracle for those specific (chain, token) pairs.

Two override mechanisms in `src/PriceOverrides.ts`:

- **Blacklist** — force `pricePerUSDNew = 0n` and skip the oracle entirely. For tokens with no real off-chain market and an oracle that either (a) routes through a contaminated pool or (b) returns 0 except during transient swap-time spikes that contaminate lifetime totals.
- **Canonical rebind** — copy `pricePerUSDNew` verbatim from another already-priced `Token` entity. For tokens that are economically 1:1 with a token we price cleanly on a different chain (bridged superchain tokens, cross-chain LST/LRT duals).

Both fire **before** the oracle is consulted in `refreshTokenPrice`. If a rebind source has not yet been priced, we explicitly write 0 rather than falling back to the corrupt oracle — that fallback is the bug we are fixing.

## Tokens covered

| token | chain | mode | source / target |
|---|---|---|---|
| `$Manatee` `0x7909Bda5…` | Optimism (10) | blacklist | n/a — no real off-chain market |
| `SQUID` `0x2e3b8289…` | Ink (57073) | blacklist | n/a — oracle returns 0 except during transient swap spikes |
| `XVELO` `0x7f9AdFbd…` | Fraxtal, Lisk, Mode, Metal, Swell, Soneium, Celo, Unichain, Ink, Superseed | rebind | VELO/Optimism (`0x9560e827…`) — 1:1 SuperERC20 mint/burn via Hyperlane |
| `rsETH/Swell` `0xc3eaCf06…` | Swell (1923) | rebind | wrsETH/Base (`0xEDfa2360…`) — both Kelp wrappers of the same underlying restaked-ETH position; Aerodrome's wrsETH/WETH pool gives a clean Base price |

## Why not Llama / GeckoTerminal / Dexscreener

Investigated all three as fallbacks. None is sufficient on its own:

- $Manatee has no off-chain coverage at all — every external API reads the same broken DEX pool we already read on-chain.
- SQUID coverage is sparse and lifetime totals can't be reconstructed retroactively.
- XVELO has spotty coverage and the canonical 1:1 relationship to VELO is more authoritative than a third-party feed.
- rsETH/Swell is already covered by our own Base index via the deep Aerodrome wrsETH/WETH pool, so an external API would be a strict downgrade.

## What's NOT in this PR

- Spike / per-unit-cap heuristics. An earlier version of this PR added a Layer-1 spike gate (`isAcceptablePrice`); on review it added complexity without addressing any case the explicit overrides don't, and could false-positive on legitimate new-listing pumps. Reverted in `c5aa4aa`. If a future bad token appears, the right lever is to extend `PriceOverrides.ts`.
- Issue #672 (Soneium-specific symptoms). Distinct root causes — `getTokenDetails` failing silently and possible Soneium connector misconfiguration. Same override mechanism could be reused for any Soneium tokens identified later, but #672 needs its own investigation and is explicitly out of scope here.

## Test plan

- [x] `pnpm test` — 1148 passed, 32 skipped
- [x] `tsc --noEmit` clean
- [x] `pnpm qa --write` clean
- [ ] Reindex one of the affected pools (e.g. rsETH/WETH on Swell) and confirm lifetime totals are sane
- [ ] Confirm rsETH on Swell refreshes to ~\$2.4K (matching Base wrsETH), \$Manatee and SQUID stay at \$0, XVELO refreshes to VELO/OP price

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added token price override mechanisms: blacklist tokens to force zero price and bypass oracle fetching, and configure rebind rules to inherit prices from canonical source tokens across chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->