### PR TITLE
fix(price-oracle): blacklist ION/Lisk for inflated $196M TVL (#671)

### DIFF
--- a/src/PriceOverrides.ts
+++ b/src/PriceOverrides.ts
@@ -16,6 +16,9 @@ export interface RebindTarget {
  * tBTC and produces $76K-$92K; alETH/$Manatee disagrees with alUSD/$Manatee by 10x).
  * Issue #669: SQUID (oracle returns 0 at every stable read; the $13B contaminated
  * total comes from transient single-block spikes during swaps).
+ * Issue #671: ION/Lisk (one-sided pool 11.2M ION + 0.24 WETH; oracle reports $17
+ * but the pool's own reserve ratio implies ~$5e-5, inflating TVL to $196M for a
+ * pool with $22K lifetime volume across 24K swaps — no real swappable market).
  */
 const BLACKLIST: ReadonlySet<string> = new Set([
   TokenId(10, toChecksumAddress("0x7909Bda52eAf7C3cc12745E727Eb527a485241D8")), // $Manatee / Optimism
@@ -23,6 +26,10 @@ const BLACKLIST: ReadonlySet<string> = new Set([
     57073,
     toChecksumAddress("0x2e3b82891d1B2b90655597110cCA9b6587607e0c"),
   ), // SQUID / Ink
+  TokenId(
+    1135,
+    toChecksumAddress("0x3f608A49a3ab475dA7fBb167C1Be6b7a45cD7013"),
+  ), // ION / Lisk
 ]);
 
 /**

--- a/test/PriceOverrides.test.ts
+++ b/test/PriceOverrides.test.ts
@@ -21,6 +21,15 @@ describe("PriceOverrides", () => {
       ).toBe(true);
     });
 
+    it("returns true for ION on Lisk", () => {
+      expect(
+        isBlacklistedToken(
+          1135,
+          toChecksumAddress("0x3f608A49a3ab475dA7fBb167C1Be6b7a45cD7013"),
+        ),
+      ).toBe(true);
+    });
+
     it("returns false for tokens not in the blacklist", () => {
       expect(
         isBlacklistedToken(


### PR DESCRIPTION
## Summary

Closes #671. Adds Lisk ION (`0x3f608A49a3ab475dA7fBb167C1Be6b7a45cD7013`) to the `BLACKLIST` introduced in #678 so `refreshTokenPrice` writes `0` instead of the inflated on-chain oracle read.

## Root cause (verified on-chain)

The reported pool `1135-0x076d0CD6228B042aA28E1E6A0894Cf6C97abc23b` shows `totalLiquidityUSD ≈ $196M` against `$22K` lifetime volume across 24K swaps. The issue listed reserve drift / missed Burns / decimal corruption as the likely culprits — none of those holds up:

| field | on-chain (Lisk RPC) | indexer |
|---|---|---|
| `reserve0` (ION, 18 dec) | 11,213,611 ION | matches |
| `reserve1` (WETH, 18 dec) | 0.241 WETH | matches |
| ION decimals | 18 | 18 |
| WETH decimals | 18 | 18 |

So reserves and decimals are correct. The bug is on the **price side**:

- The pool's own reserve ratio implies `0.241 / 11.2M = ~2.15e-8 WETH per ION ≈ $5e-5 per ION` at WETH=$2,330
- The on-chain oracle reports **$17 per ION** — a 340,000× disagreement with the pool's own implied price
- TVL = `11.2M × $17 + 0.241 × $2,330 = $190M ≈ $196M` ✓ (indexer math is correct given the bad oracle input)

This is a one-sided position whose ION side has no real swappable market on Lisk — exactly the failure mode #669/#678 introduced the blacklist for ($Manatee, SQUID).

## Why blacklist (not rebind)

There is no canonical 1:1 ION elsewhere in the Velodrome footprint to rebind to. The only honest valuation of an unswappable position is `0` for that side; pool-USD calcs already route through the counterparty when one side is `$0`, so `totalLiquidityUSD` collapses to just the WETH side (`~$560`) post-reindex.

## Why not a TVL/volume divergence warning instead

Considered the same shape as #679 (`[FEE_VOLUME_DIVERGENCE]` log when fees > 5% of volume). For this case it would only repeat the symptom we already see in the GraphQL query — the lever the codebase has already chosen for this failure mode is `PriceOverrides.ts`, and the fix slots into it in two lines.

## Dependency

Built on top of #678 (`fix/oracle-sanity-gates-issue-669`) since `PriceOverrides.ts` does not exist on `main` yet. Base is set accordingly; will rebase onto `main` once #678 merges.

## Test plan

- [x] Red: `vitest run test/PriceOverrides.test.ts` — new "returns true for ION on Lisk" case fails (`expected false to be true`)
- [x] Green: same test passes after the BLACKLIST entry is added
- [x] `pnpm test` — 1149 passed, 32 skipped (pre-existing)
- [x] `tsc --noEmit` — clean
- [x] `pnpm qa --write` — clean
- [ ] Reindex Lisk and confirm pool `1135-0x076d0CD6228B042aA28E1E6A0894Cf6C97abc23b` `totalLiquidityUSD` drops to `~$560` (the WETH-only value)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added ION token on Lisk to the token blacklist for proper system handling

* **Tests**
  * Added test coverage to verify blacklist functionality for the ION token

<!-- end of auto-generated comment: release notes by coderabbit.ai -->