### PR TITLE
feat(price-oracle): cross-chain RPC prefetch when rebind source is unpriced

### DIFF
--- a/src/ChainBlockTime.ts
+++ b/src/ChainBlockTime.ts
@@ -1,0 +1,59 @@
+/**
+ * Per-chain anchor pairs for converting a wall-clock timestamp into an
+ * approximate block number on that chain.
+ *
+ * Each anchor is a single (block, unix-timestamp) reference pair plus the
+ * chain's nominal block time. Estimation is plain arithmetic:
+ *
+ *     estimatedBlock = anchorBlock + floor((timestamp - anchorTimestamp) / blocktime)
+ *
+ * This is a HEURISTIC — real block times drift slightly, so the estimate can
+ * be off by a handful of blocks over months. Callers should pair this with
+ * `roundBlockToInterval` (1-hour buckets ≈ 1800 blocks on 2s chains), which
+ * absorbs drift and aligns the estimate with the cache key the source chain's
+ * own indexer will eventually use.
+ *
+ * Only chains that act as a `source` in `PriceOverrides.REBINDS` need an
+ * anchor — that is currently Optimism and Base.
+ *
+ * NOTE: `blocktimeSeconds` here must match the implicit blocktime in
+ * `roundBlockToInterval` (Effects/Token.ts), otherwise the prefetched cache
+ * slot won't line up with the source chain's eventual native refresh.
+ */
+interface ChainAnchor {
+  readonly block: number;
+  readonly timestamp: number; // unix seconds
+  readonly blocktimeSeconds: number;
+}
+
+const CHAIN_ANCHORS: ReadonlyMap<number, ChainAnchor> = new Map([
+  // Optimism Bedrock genesis: block 105_235_063 at 2023-06-06 16:28:23 UTC.
+  [10, { block: 105_235_063, timestamp: 1_686_068_903, blocktimeSeconds: 2 }],
+  // Base genesis: block 0 at 2023-06-15 00:35:47 UTC.
+  [8453, { block: 0, timestamp: 1_686_789_347, blocktimeSeconds: 2 }],
+]);
+
+/**
+ * Estimates a chain's block number at a given wall-clock timestamp using a
+ * fixed (block, timestamp) anchor and the chain's nominal block time.
+ *
+ * Returns `undefined` when:
+ *  - the chain has no anchor configured (caller should skip cross-chain
+ *    prefetch — there's no way to guess the right block)
+ *  - the timestamp is before the anchor (chain hadn't started yet)
+ *
+ * @param chainId - Chain whose block number is being estimated.
+ * @param timestampSec - Wall-clock target timestamp in unix seconds.
+ * @returns Estimated block number, or undefined if it can't be estimated.
+ */
+export function estimateBlockAtTimestamp(
+  chainId: number,
+  timestampSec: number,
+): number | undefined {
+  const anchor = CHAIN_ANCHORS.get(chainId);
+  if (!anchor) return undefined;
+  if (timestampSec < anchor.timestamp) return undefined;
+
+  const elapsedSec = timestampSec - anchor.timestamp;
+  return anchor.block + Math.floor(elapsedSec / anchor.blocktimeSeconds);
+}

--- a/src/PriceOracle.ts
+++ b/src/PriceOracle.ts
@@ -1,4 +1,5 @@
 import type { Token, handlerContext } from "generated";
+import { estimateBlockAtTimestamp } from "./ChainBlockTime";
 import {
   AFFECTED_CHAINS,
   CHAIN_CONSTANTS,
@@ -105,7 +106,34 @@ export async function refreshTokenPrice(
     const sourceToken = await context.Token.get(
       TokenId(rebindTarget.chainId, rebindTarget.address),
     );
-    const sourcePrice = sourceToken?.pricePerUSDNew ?? 0n;
+    let sourcePrice = sourceToken?.pricePerUSDNew ?? 0n;
+
+    // Cold-sync gap: the source chain's indexer hasn't priced the source token
+    // yet (e.g. Swell handler at T runs while OP indexer is still behind T).
+    // Reach across to the source chain's oracle directly. The effect cache
+    // key is (tokenAddress, chainId, blockNumber), and we round to the same
+    // hour bucket the source chain's own indexer will use — so when the
+    // source catches up its native refresh hits this cache slot for free.
+    // Worked example walked through in test/PriceOracle.test.ts.
+    if (sourcePrice === 0n) {
+      const estimatedSourceBlock = estimateBlockAtTimestamp(
+        rebindTarget.chainId,
+        blockTimestamp,
+      );
+      if (estimatedSourceBlock !== undefined) {
+        const sourceBlockRounded = roundBlockToInterval(
+          estimatedSourceBlock,
+          rebindTarget.chainId,
+        );
+        const prefetched = await context.effect(getTokenPrice, {
+          tokenAddress: rebindTarget.address,
+          chainId: rebindTarget.chainId,
+          blockNumber: sourceBlockRounded,
+        });
+        sourcePrice = prefetched.pricePerUSDNew;
+      }
+    }
+
     const updated: Token = {
       ...token,
       pricePerUSDNew: sourcePrice,

--- a/test/ChainBlockTime.test.ts
+++ b/test/ChainBlockTime.test.ts
@@ -1,0 +1,47 @@
+import { estimateBlockAtTimestamp } from "../src/ChainBlockTime";
+
+describe("estimateBlockAtTimestamp", () => {
+  // Optimism Bedrock genesis is the OP anchor:
+  //   block 105_235_063 at unix 1_686_068_903 (2023-06-06 16:28:23 UTC), 2s blocks.
+  describe("Optimism (chain 10)", () => {
+    it("returns the anchor block when timestamp == anchor timestamp", () => {
+      expect(estimateBlockAtTimestamp(10, 1_686_068_903)).toBe(105_235_063);
+    });
+
+    it("advances by one block per 2 seconds elapsed", () => {
+      // 10 seconds after anchor → 5 blocks ahead
+      expect(estimateBlockAtTimestamp(10, 1_686_068_903 + 10)).toBe(
+        105_235_063 + 5,
+      );
+    });
+
+    it("estimates block 112_250_611 at unix 1_700_100_000 (~Nov 2023)", () => {
+      // Worked example from the PR description / code comment.
+      // elapsed = 1_700_100_000 - 1_686_068_903 = 14_031_097s
+      // blocks  = floor(14_031_097 / 2)            = 7_015_548
+      // result  = 105_235_063 + 7_015_548          = 112_250_611
+      expect(estimateBlockAtTimestamp(10, 1_700_100_000)).toBe(112_250_611);
+    });
+  });
+
+  describe("Base (chain 8453)", () => {
+    it("returns a positive block for a post-genesis timestamp", () => {
+      const result = estimateBlockAtTimestamp(8453, 1_700_000_000);
+      expect(result).toBeDefined();
+      expect(result).toBeGreaterThan(0);
+    });
+  });
+
+  describe("when the chain has no anchor configured", () => {
+    it("returns undefined for an unknown chainId", () => {
+      expect(estimateBlockAtTimestamp(99999, 1_700_000_000)).toBeUndefined();
+    });
+  });
+
+  describe("when timestamp is before the anchor", () => {
+    it("returns undefined (cannot estimate negative block)", () => {
+      // Anchor is 2023-06-06; ask for 2020-01-01.
+      expect(estimateBlockAtTimestamp(10, 1_577_836_800)).toBeUndefined();
+    });
+  });
+});

--- a/test/PriceOracle.test.ts
+++ b/test/PriceOracle.test.ts
@@ -279,8 +279,10 @@ describe("PriceOracle", () => {
     describe("Override path: blacklist + rebind (issue #669)", () => {
       // Issue #669: tokens whose on-chain oracle is structurally unusable get
       // either forced to 0 (blacklist) or copied from another chain's already-
-      // priced Token entity (rebind). Either path bypasses the on-chain oracle
-      // entirely — no getTokenPrice/rpcGateway/getTokenDetails calls fire.
+      // priced Token entity (rebind). Both paths bypass the *local* on-chain
+      // oracle entirely. The rebind path may dispatch a single cross-chain
+      // `getTokenPrice` against the SOURCE chain when the local Token entity
+      // for the source token hasn't been priced yet (cold-sync gap).
       const oneHourAndOneMinuteAgo = () =>
         new Date(blockDatetime.getTime() - 61 * 60 * 1000);
 
@@ -355,31 +357,111 @@ describe("PriceOracle", () => {
         ).toHaveBeenCalled();
       });
 
-      it("rebind with unpriced source: writes 0 rather than falling back to oracle", async () => {
+      // Worked example for the cross-chain prefetch:
+      //   Fraxtal handler firing at wall-clock T (block 9_999_999 on Fraxtal)
+      //   wants the price of XVELO (which rebinds to VELO/OP).
+      //   Local Token entity for VELO/OP is unpriced (OP indexer is behind).
+      //   → estimateBlockAtTimestamp(10, T)  estimates VELO/OP's block at T
+      //   → roundBlockToInterval(estimate, 10) snaps to a 1-hour bucket
+      //   → context.effect(getTokenPrice, { tokenAddress: VELO_OP, chainId: 10, blockNumber: snapped })
+      //   When the OP indexer eventually refreshes VELO at any block in that
+      //   same hour, it rounds to the same bucket → cache hit, zero extra RPCs.
+      // Both rebind sources (OP, Base) anchor in mid-2023, so prefetch tests
+      // pick a timestamp comfortably after both: 2023-11-16 (~unix 1_700_100_000).
+      const postAnchorTimestamp = 1_700_100_000;
+      const postAnchorDate = new Date(postAnchorTimestamp * 1000);
+      const postAnchorOneHourAgo = () =>
+        new Date(postAnchorDate.getTime() - 61 * 60 * 1000);
+
+      it("rebind with unpriced source: prefetches the source chain's oracle", async () => {
         const XVELO = toChecksumAddress(
           "0x7f9AdFbd38b669F03d1d11000Bc76b9AaEA28A81",
         );
+        const VELO_OP = toChecksumAddress(
+          "0x9560e827aF36c94D2Ac33a39bCE1Fe78631088Db",
+        );
+        const sourcePrice = 5n * 10n ** 17n; // $0.50
+
+        // Local Token entity for VELO/OP not yet priced (cold-sync gap).
         vi.mocked(mockContext.Token?.get)?.mockResolvedValue(undefined);
+
+        // Source-chain prefetch returns the live VELO/OP price.
+        vi.mocked(mockContext.effect)?.mockImplementation(
+          async (effect, input) => {
+            const name = (effect as { name?: string }).name;
+            const args = input as { tokenAddress?: string; chainId?: number };
+            if (
+              name === "getTokenPrice" &&
+              args.chainId === 10 &&
+              args.tokenAddress === VELO_OP
+            ) {
+              return { pricePerUSDNew: sourcePrice, priceOracleType: "V3" };
+            }
+            return { pricePerUSDNew: 0n, priceOracleType: "V1" };
+          },
+        );
 
         const fetchedToken = {
           ...mockToken0Data,
           address: XVELO,
           pricePerUSDNew: 0n,
-          lastUpdatedTimestamp: oneHourAndOneMinuteAgo(),
+          lastUpdatedTimestamp: postAnchorOneHourAgo(),
         };
 
         const result = await PriceOracle.refreshTokenPrice(
           fetchedToken,
           blockNumber,
-          blockDatetime.getTime() / 1000,
+          postAnchorTimestamp,
           252, // Fraxtal — XVELO rebinds to VELO/OP
           mockContext as handlerContext,
         );
 
-        // Critical: must NOT fall through to oracle (which would re-introduce corruption)
+        expect(result.pricePerUSDNew).toBe(sourcePrice);
+        // The effect must dispatch against the SOURCE chain (10), not the
+        // local chain (252). That's what makes the cache key reusable when
+        // the OP indexer eventually catches up.
+        expect(vi.mocked(mockContext.effect)).toHaveBeenCalledWith(
+          expect.objectContaining({ name: "getTokenPrice" }),
+          expect.objectContaining({ tokenAddress: VELO_OP, chainId: 10 }),
+        );
+        expect(
+          vi.mocked(mockContext.TokenPriceSnapshot?.set),
+        ).toHaveBeenCalled();
+      });
+
+      it("rebind with unpriced source AND prefetch returns 0: writes 0 (no fall-through to local oracle)", async () => {
+        const XVELO = toChecksumAddress(
+          "0x7f9AdFbd38b669F03d1d11000Bc76b9AaEA28A81",
+        );
+        vi.mocked(mockContext.Token?.get)?.mockResolvedValue(undefined);
+        // Source-chain prefetch also returns 0 (no price path on source oracle).
+        vi.mocked(mockContext.effect)?.mockResolvedValue({
+          pricePerUSDNew: 0n,
+          priceOracleType: "V3",
+        });
+
+        const fetchedToken = {
+          ...mockToken0Data,
+          address: XVELO,
+          pricePerUSDNew: 0n,
+          lastUpdatedTimestamp: postAnchorOneHourAgo(),
+        };
+
+        const result = await PriceOracle.refreshTokenPrice(
+          fetchedToken,
+          blockNumber,
+          postAnchorTimestamp,
+          252, // Fraxtal
+          mockContext as handlerContext,
+        );
+
+        // Prefetched 0 — write 0. We MUST NOT fall through to the local
+        // (corrupt) oracle: that's the whole point of the rebind.
         expect(result.pricePerUSDNew).toBe(0n);
-        expect(vi.mocked(mockContext.effect)).not.toHaveBeenCalled();
-        // No snapshot when source price is 0 (would be a no-op and is noisy)
+        expect(vi.mocked(mockContext.effect)).toHaveBeenCalledWith(
+          expect.objectContaining({ name: "getTokenPrice" }),
+          expect.objectContaining({ chainId: 10 }),
+        );
         expect(
           vi.mocked(mockContext.TokenPriceSnapshot?.set),
         ).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

- When a token is rebound to another chain's source token (e.g. XVELO on superchains → VELO/Optimism, rsETH/Swell → wrsETH/Base) and the local `Token` entity for that source has not yet been priced, the rebind branch now reaches across to the source chain's oracle directly instead of writing $0.
- New `src/ChainBlockTime.ts` exports `estimateBlockAtTimestamp(chainId, timestampSec)` with per-chain `(block, timestamp, blocktime)` anchors for the only chains that act as rebind sources today: Optimism and Base.
- The estimated source-chain block is rounded to a 1-hour bucket via the existing `roundBlockToInterval`, so the prefetch fills the **same** effect-cache slot the source chain's own indexer will hit on its eventual native refresh — zero extra RPCs once the source catches up.

## Why

Background, in case the rebind path is unfamiliar (see #678): some target tokens have a structurally broken on-chain oracle. Their price is rebound to a canonical source token on another chain (e.g. every superchain's XVELO copies VELO/Optimism's price, since SuperERC20 + Hyperlane preserve 1:1 parity). Until #678, if the source `Token` entity hadn't been priced yet the rebind silently wrote `0` and waited for the source chain's indexer to catch up. That's correct but wasteful — and on cold-sync it produces a window of $0 prices.

This PR closes that gap. Multi-chain handlers run independently, so the target chain's handler may run ahead of the source chain's. Now, when the local source is unpriced, we estimate the source chain's block from the target's wall-clock timestamp and dispatch `getTokenPrice` against the source chain. The cache key is `(tokenAddress, chainId, blockNumber)`, so when the source chain's own indexer eventually reaches the same hour bucket, it hits the cache slot we already filled.

## Worked example (also in `test/PriceOracle.test.ts`)

```
Fraxtal handler at unix T = 1_700_100_000 wants the price of XVELO,
which rebinds to VELO/Optimism. Local Token entity for VELO/OP unpriced.

  estimateBlockAtTimestamp(10, T)              → 112_250_611
  roundBlockToInterval(112_250_611, 10)        → 112_249_800   (1-hour bucket)
  context.effect(getTokenPrice, {
    tokenAddress: VELO_OP,
    chainId:      10,
    blockNumber:  112_249_800,
  })

When the OP indexer eventually refreshes VELO at any block in that
same hour, it rounds to 112_249_800 and hits the cache slot above.
```

## Behavior guarantees

- If the prefetch returns a non-zero price → use it, write a snapshot.
- If the prefetch also returns 0 → still write 0. We **never** fall through to the local (corrupt) oracle — that's the whole point of the rebind.
- If the source chain has no anchor configured (= no entry in `CHAIN_ANCHORS`) → skip the prefetch and write 0 as before.

## Files

- `src/ChainBlockTime.ts` — new
- `test/ChainBlockTime.test.ts` — new
- `src/PriceOracle.ts` — rebind branch updated
- `test/PriceOracle.test.ts` — rebind tests updated for prefetch behavior

## Test plan

- [x] `pnpm test` — full suite passes (1160 passed / 32 skipped)
- [x] `tsc --noEmit` clean
- [x] `pnpm qa` (biome) clean
- [ ] Reindex one cold-sync scenario locally and confirm the target chain's tokens populate non-zero prices ahead of the source chain's natural catch-up
- [ ] Confirm the source chain's native refresh hits the prefetched cache slot (no duplicate RPCs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cross-chain block-time estimation functionality enabling calculation of approximate block numbers from UNIX timestamps
  * Enhanced price oracle with source-chain prefetching capability for rebind/canonical oracle override scenarios, improving pricing accuracy when local source tokens have unavailable pricing data

* **Tests**
  * Test coverage added for cross-chain block-time estimation and source-chain price oracle prefetch scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->