### PR TITLE
fix(cl): per-segment Uniswap v3 attribution for staked reserve deltas (#666)

### DIFF
--- a/src/Aggregators/CLStakedLiquidity.ts
+++ b/src/Aggregators/CLStakedLiquidity.ts
@@ -1,3 +1,4 @@
+import { TickMath } from "@uniswap/v3-sdk";
 import type { handlerContext } from "generated";
 
 /**
@@ -9,6 +10,23 @@ import type { handlerContext } from "generated";
  */
 export const TICK_MIN = -887272n;
 export const TICK_MAX = 887272n;
+
+/** Q96 fixed-point scale used by Uniswap v3 sqrtPriceX96. */
+const Q96 = 1n << 96n;
+
+/**
+ * Wraps `TickMath.getSqrtRatioAtTick` to return a bigint instead of JSBI.
+ * Tick is clamped to the Uniswap v3 valid range upstream by every caller
+ * (`processTickCrossingsForStaked` runs the bound check before the loop;
+ * edges in `stakedTickEdges` are enforced in-range by `applyStakedPositionToEdges`),
+ * so this helper trusts the input and does no validation.
+ *
+ * @param tick - Tick index (must be within [TICK_MIN, TICK_MAX])
+ * @returns sqrt(1.0001^tick) in Q64.96 fixed-point as bigint
+ */
+function sqrtRatioAtTick(tick: bigint): bigint {
+  return BigInt(TickMath.getSqrtRatioAtTick(Number(tick)).toString());
+}
 
 /**
  * Returns true if a position's tick range includes the current tick.
@@ -209,34 +227,86 @@ export function applyStakedPositionToEdges(
 }
 
 /**
- * Processes tick crossings between oldTick and newTick, adjusting
- * stakedLiquidityInRange by walking the in-aggregator (stakedTickEdges,
- * stakedTickEdgeNets) parallel arrays.
+ * Per-segment Uniswap v3 swap math at constant L. The pool's sqrt price moves
+ * from `segStart` to `segEnd` while staked liquidity in range is `stakedLiq`.
  *
- * Replicates the Uniswap v3 pool contract's tick-crossing logic for the staked
- * subset: when a swap crosses tick T going up, stakedLiq += net[T]; when going
- * down, stakedLiq -= net[T].
+ *   stakedDelta0 = stakedLiq * (segStart - segEnd) * Q96 / (segStart * segEnd)
+ *   stakedDelta1 = stakedLiq * (segEnd - segStart) / Q96
  *
- * Structural fix for the 20GB OOM (see #648, #649):
- *   - Zero `.get()` or `.getWhere()` calls on the swap path. The per-edge net is
- *     read from the in-memory `stakedTickEdgeNets` array carried on the
- *     aggregator.
- *   - Total cost per swap: O(log E + K) where E = per-pool edge count (worst
- *     case ~22k per #648) and K = edges actually crossed (typically 0–few).
- *     Linear scanning all E edges is what this replaces, and what drove the
- *     OOM in the old implementation.
- *   - Breaks the chain-of-amplification from #648: no LoadManager grouping, no
- *     postgres-js text[] serialization, no InMemTable accumulation, no
- *     5000-handler preload fan-out.
+ * Both expressions are signed and direction-agnostic: when sqrt moves UP
+ * (segEnd > segStart), token0 leaves the pool (delta0 negative) and token1
+ * enters (delta1 positive); the signs flip on a DOWN move. These match the
+ * sign convention of `event.params.amount0/amount1` on `CLPool.Swap` (positive
+ * = into pool).
  *
- * Safety guards retained from PR 1 (#650):
- *   - `hasStakes=false` short-circuits the walk entirely. Redundant with an
- *     empty edge list, but kept explicit for parity with other call sites.
- *   - Out-of-range ticks (outside [TICK_MIN, TICK_MAX]) are rejected and logged
- *     with a `STAKED_TICK_DRIFT` tag so ops can alert on it. After a bail the
- *     aggregator still writes the new tick, so downstream reads of
- *     `stakedLiquidityInRange` on this pool will be stale by the un-applied
- *     nets until the next rebuild — worth alerting on.
+ * The L_total of the pool cancels out of the staked-share formula, so callers
+ * only need staked-edge state — not a parallel total-liquidity edge map.
+ *
+ * No-op short-circuits (segStart === segEnd, stakedLiq === 0n) are handled by
+ * the caller before invocation to avoid wasted bigint multiplies on the hot
+ * path.
+ *
+ * @param stakedLiq - Staked liquidity active across this segment
+ * @param segStart - sqrtPriceX96 at the start of the segment
+ * @param segEnd - sqrtPriceX96 at the end of the segment
+ * @returns Signed reserve deltas attributable to the staked share over this segment
+ */
+function segmentStakedReserveDelta(
+  stakedLiq: bigint,
+  segStart: bigint,
+  segEnd: bigint,
+): { stakedDelta0: bigint; stakedDelta1: bigint } {
+  return {
+    stakedDelta0: (stakedLiq * (segStart - segEnd) * Q96) / (segStart * segEnd),
+    stakedDelta1: (stakedLiq * (segEnd - segStart)) / Q96,
+  };
+}
+
+/**
+ * Processes tick crossings between oldTick and newTick, returning both the
+ * updated `stakedLiquidityInRange` AND the per-segment staked-reserve deltas
+ * (`stakedDelta0`, `stakedDelta1`) attributable to the staked share of the
+ * swap.
+ *
+ * Per-segment correctness (the fix for #666):
+ *   The pool's sqrt price moves through a sequence of segments separated by
+ *   crossed staked-tick edges. Within each segment, staked liquidity is constant
+ *   and the staked share's reserve change follows exact Uniswap v3 swap math:
+ *     Δ0 = L_staked * (S_start - S_end) * Q96 / (S_start * S_end)
+ *     Δ1 = L_staked * (S_end - S_start) / Q96
+ *   (signed; UP swap → Δ0 negative, Δ1 positive). The L_total of the pool
+ *   cancels in the staked-share formula, which is why no per-pool total-edge
+ *   map is needed.
+ *
+ *   The previous implementation applied the *post-crossing* staked/total ratio
+ *   to the entire swap's net deltas. That over- or under-credits positions
+ *   that exit (or enter) range mid-swap; over many swaps, those errors
+ *   accumulated into the negative `stakedReserve0/1` drift observed on 166 CL
+ *   pools (issue #666).
+ *
+ * Tick-crossing semantics:
+ *   - UP   (newTick > oldTick): cross ticks STRICTLY above oldTick, up to and
+ *     including newTick. stakedLiq += stakedTickEdgeNets[T] at each crossing.
+ *   - DOWN (newTick < oldTick): cross ticks AT OR BELOW oldTick, strictly above
+ *     newTick. stakedLiq -= stakedTickEdgeNets[T] at each crossing.
+ *   - Single segment (no edges crossed, including oldTick === newTick within a
+ *     single tick): one segment from oldSqrt to newSqrt with current stakedLiq.
+ *
+ * Structural fix for the 20GB OOM (preserved from #650/#653):
+ *   - Zero `.get()` or `.getWhere()` calls. Per-edge nets are read from the
+ *     in-memory `stakedTickEdgeNets` array carried on the aggregator.
+ *   - Total cost per swap: O(log E + K) where E = per-pool edge count and
+ *     K = edges actually crossed (typically 0–few).
+ *
+ * Safety guards:
+ *   - `tickSpacing === 0n` (uninitialized pool) → return current stakedLiq,
+ *     zero deltas. No sqrt prices to compute against.
+ *   - `oldSqrtPriceX96 === 0n` || `newSqrtPriceX96 === 0n` → same. The first
+ *     swap that hits a pool whose `sqrtPriceX96` was never set cannot be
+ *     attributed; we accept zero deltas rather than divide by zero.
+ *   - Out-of-range ticks ([TICK_MIN, TICK_MAX]) are rejected and logged with
+ *     a `STAKED_TICK_DRIFT` tag. The bound check runs BEFORE the hasStakes
+ *     short-circuit so unstaked-pool corruption is still surfaced.
  *
  * Pure in-memory computation. Uses the Envio `context` ONLY for
  * `context.log.error` — any entity access here would reintroduce the #648 OOM
@@ -246,6 +316,8 @@ export function applyStakedPositionToEdges(
  * @param poolAddress - CL pool address (used only for error logging)
  * @param oldTick - Tick before the swap
  * @param newTick - Tick after the swap
+ * @param oldSqrtPriceX96 - Pool sqrt price (Q64.96) before the swap
+ * @param newSqrtPriceX96 - Pool sqrt price (Q64.96) after the swap (from event.params.sqrtPriceX96)
  * @param tickSpacing - Pool's tick spacing (used only to short-circuit when 0)
  * @param context - Envio handler context — used ONLY for context.log.error;
  *                  must not touch entity APIs (see note above)
@@ -253,22 +325,34 @@ export function applyStakedPositionToEdges(
  * @param hasStakes - Whether this pool has ever had a staked position
  * @param stakedTickEdges - Sorted, dedup'd tick edges from the aggregator
  * @param stakedTickEdgeNets - Parallel nets (same index as stakedTickEdges)
- * @returns Updated stakedLiquidityInRange after processing tick crossings
+ * @returns Updated `stakedLiquidityInRange` and signed per-segment
+ *          `stakedDelta0`/`stakedDelta1` (in pool-reserve sign convention:
+ *          positive = added to pool, negative = removed)
  */
 export function processTickCrossingsForStaked(
   chainId: number,
   poolAddress: string,
   oldTick: bigint,
   newTick: bigint,
+  oldSqrtPriceX96: bigint,
+  newSqrtPriceX96: bigint,
   tickSpacing: bigint,
   context: handlerContext,
   currentStakedLiqInRange: bigint,
   hasStakes: boolean,
   stakedTickEdges: readonly bigint[],
   stakedTickEdgeNets: readonly bigint[],
-): bigint {
-  if (oldTick === newTick || tickSpacing === 0n) {
-    return currentStakedLiqInRange;
+): {
+  stakedLiquidityInRange: bigint;
+  stakedDelta0: bigint;
+  stakedDelta1: bigint;
+} {
+  if (tickSpacing === 0n || oldSqrtPriceX96 === 0n || newSqrtPriceX96 === 0n) {
+    return {
+      stakedLiquidityInRange: currentStakedLiqInRange,
+      stakedDelta0: 0n,
+      stakedDelta1: 0n,
+    };
   }
 
   // Bounds check runs BEFORE the hasStakes short-circuit so that out-of-range
@@ -285,62 +369,67 @@ export function processTickCrossingsForStaked(
     context.log.error(
       `[STAKED_TICK_DRIFT][processTickCrossingsForStaked] Tick out of Uniswap v3 range for pool ${poolAddress} on chain ${chainId}: oldTick=${oldTick}, newTick=${newTick}. Skipping crossing sweep to avoid runaway loop; stakedLiquidityInRange will be stale on this pool until a subsequent stake/unstake rebuilds it.`,
     );
-    return currentStakedLiqInRange;
-  }
-
-  // Pools without any staked positions cannot contribute to stakedLiq — skip
-  // the binary search entirely. This is the hot path: it eliminates the
-  // O(log E + k) per-swap cost for every unstaked pool.
-  if (!hasStakes || stakedTickEdges.length === 0) {
-    return currentStakedLiqInRange;
+    return {
+      stakedLiquidityInRange: currentStakedLiqInRange,
+      stakedDelta0: 0n,
+      stakedDelta1: 0n,
+    };
   }
 
   let stakedLiq = currentStakedLiqInRange;
+  let segStart = oldSqrtPriceX96;
+  let stakedDelta0 = 0n;
+  let stakedDelta1 = 0n;
 
-  if (newTick > oldTick) {
-    // Price moving up — cross ticks STRICTLY above oldTick, up to and including newTick.
-    // Mirror the pre-PR alignTickUp semantics (strictly above oldTick) by starting the
-    // binary search at `oldTick + 1`.
-    const startIdx = lowerBound(stakedTickEdges, oldTick + 1n);
-    for (let i = startIdx; i < stakedTickEdges.length; i++) {
-      if (stakedTickEdges[i] > newTick) break;
-      stakedLiq += stakedTickEdgeNets[i];
-    }
-  } else {
-    // Price moving down — cross ticks AT OR BELOW oldTick, strictly above newTick.
-    // Walk backwards from the last edge <= oldTick.
-    const endIdx = lowerBound(stakedTickEdges, oldTick + 1n) - 1;
-    for (let i = endIdx; i >= 0; i--) {
-      if (stakedTickEdges[i] <= newTick) break;
-      stakedLiq -= stakedTickEdgeNets[i];
+  // Walk staked-tick edges only when the pool actually has stakes. Unstaked
+  // pools (and pools whose stakes have all cancelled) skip the binary search
+  // and the per-edge loop entirely — the hot path remains O(1).
+  if (hasStakes && stakedTickEdges.length > 0) {
+    if (newTick > oldTick) {
+      // UP: cross strictly above oldTick, up to and including newTick.
+      const startIdx = lowerBound(stakedTickEdges, oldTick + 1n);
+      for (let i = startIdx; i < stakedTickEdges.length; i++) {
+        const edgeTick = stakedTickEdges[i];
+        if (edgeTick > newTick) break;
+        const segEnd = sqrtRatioAtTick(edgeTick);
+        if (stakedLiq > 0n && segStart !== segEnd) {
+          const seg = segmentStakedReserveDelta(stakedLiq, segStart, segEnd);
+          stakedDelta0 += seg.stakedDelta0;
+          stakedDelta1 += seg.stakedDelta1;
+        }
+        stakedLiq += stakedTickEdgeNets[i];
+        segStart = segEnd;
+      }
+    } else if (newTick < oldTick) {
+      // DOWN: cross at or below oldTick, strictly above newTick.
+      const endIdx = lowerBound(stakedTickEdges, oldTick + 1n) - 1;
+      for (let i = endIdx; i >= 0; i--) {
+        const edgeTick = stakedTickEdges[i];
+        if (edgeTick <= newTick) break;
+        const segEnd = sqrtRatioAtTick(edgeTick);
+        if (stakedLiq > 0n && segStart !== segEnd) {
+          const seg = segmentStakedReserveDelta(stakedLiq, segStart, segEnd);
+          stakedDelta0 += seg.stakedDelta0;
+          stakedDelta1 += seg.stakedDelta1;
+        }
+        stakedLiq -= stakedTickEdgeNets[i];
+        segStart = segEnd;
+      }
     }
   }
 
-  return stakedLiq;
-}
-
-/**
- * Computes the staked portion of a swap's reserve deltas using the proportional split.
- * All in-range liquidity participates equally in swaps, so staked share =
- * stakedLiqInRange / totalLiqInRange.
- *
- * @param reserveDelta0 - Total pool reserve change for token0
- * @param reserveDelta1 - Total pool reserve change for token1
- * @param stakedLiqInRange - Staked in-range liquidity
- * @param totalLiqInRange - Total in-range liquidity (from Swap event)
- * @returns Object with stakedDelta0 and stakedDelta1
- */
-export function computeStakedSwapReserveDelta(
-  reserveDelta0: bigint,
-  reserveDelta1: bigint,
-  stakedLiqInRange: bigint,
-  totalLiqInRange: bigint,
-): { stakedDelta0: bigint; stakedDelta1: bigint } {
-  if (totalLiqInRange === 0n || stakedLiqInRange === 0n) {
-    return { stakedDelta0: 0n, stakedDelta1: 0n };
+  // Final segment: from the last crossed edge (or oldSqrt if none) to newSqrt.
+  // Also covers the within-a-tick case (oldTick === newTick) where no edges
+  // are walked and the entire swap is a single segment.
+  if (stakedLiq > 0n && segStart !== newSqrtPriceX96) {
+    const seg = segmentStakedReserveDelta(stakedLiq, segStart, newSqrtPriceX96);
+    stakedDelta0 += seg.stakedDelta0;
+    stakedDelta1 += seg.stakedDelta1;
   }
+
   return {
-    stakedDelta0: (reserveDelta0 * stakedLiqInRange) / totalLiqInRange,
-    stakedDelta1: (reserveDelta1 * stakedLiqInRange) / totalLiqInRange,
+    stakedLiquidityInRange: stakedLiq,
+    stakedDelta0,
+    stakedDelta1,
   };
 }

--- a/src/Aggregators/CLStakedLiquidity.ts
+++ b/src/Aggregators/CLStakedLiquidity.ts
@@ -347,19 +347,12 @@ export function processTickCrossingsForStaked(
   stakedDelta0: bigint;
   stakedDelta1: bigint;
 } {
-  if (tickSpacing === 0n || oldSqrtPriceX96 === 0n || newSqrtPriceX96 === 0n) {
-    return {
-      stakedLiquidityInRange: currentStakedLiqInRange,
-      stakedDelta0: 0n,
-      stakedDelta1: 0n,
-    };
-  }
-
-  // Bounds check runs BEFORE the hasStakes short-circuit so that out-of-range
-  // ticks — which indicate upstream correctness bugs (missed Initialize, event
-  // ordering, RPC inconsistency) — get surfaced regardless of whether the pool
-  // has ever been staked. Unstaked CL pools are the majority, and silencing the
-  // diagnostic on them would mask the signal.
+  // Bounds check runs BEFORE the zero-sqrt/tickSpacing bailout so that
+  // out-of-range ticks — which indicate upstream correctness bugs (missed
+  // Initialize, event ordering, RPC inconsistency) — get surfaced even on
+  // uninitialized pools where sqrtPriceX96/tickSpacing are still 0n. Unstaked
+  // CL pools are the majority, and silencing the diagnostic on them would
+  // mask the signal.
   if (
     oldTick < TICK_MIN ||
     oldTick > TICK_MAX ||
@@ -369,6 +362,14 @@ export function processTickCrossingsForStaked(
     context.log.error(
       `[STAKED_TICK_DRIFT][processTickCrossingsForStaked] Tick out of Uniswap v3 range for pool ${poolAddress} on chain ${chainId}: oldTick=${oldTick}, newTick=${newTick}. Skipping crossing sweep to avoid runaway loop; stakedLiquidityInRange will be stale on this pool until a subsequent stake/unstake rebuilds it.`,
     );
+    return {
+      stakedLiquidityInRange: currentStakedLiqInRange,
+      stakedDelta0: 0n,
+      stakedDelta1: 0n,
+    };
+  }
+
+  if (tickSpacing === 0n || oldSqrtPriceX96 === 0n || newSqrtPriceX96 === 0n) {
     return {
       stakedLiquidityInRange: currentStakedLiqInRange,
       stakedDelta0: 0n,

--- a/src/EventHandlers/CLPool/CLPoolSwapLogic.ts
+++ b/src/EventHandlers/CLPool/CLPoolSwapLogic.ts
@@ -4,10 +4,7 @@ import type {
   Token,
   handlerContext,
 } from "generated";
-import {
-  computeStakedSwapReserveDelta,
-  processTickCrossingsForStaked,
-} from "../../Aggregators/CLStakedLiquidity";
+import { processTickCrossingsForStaked } from "../../Aggregators/CLStakedLiquidity";
 import type { LiquidityPoolAggregatorDiff } from "../../Aggregators/LiquidityPoolAggregator";
 import type { UserStatsPerPoolDiff } from "../../Aggregators/UserStatsPerPool";
 import { CL_FEE_SCALE } from "../../Constants";
@@ -293,47 +290,27 @@ export async function processCLPoolSwap(
       clFeeRate,
     );
 
-  // Process tick crossings for staked liquidity tracking
-  const oldTick = liquidityPoolAggregator.tick ?? 0n;
-  const newTick = event.params.tick;
-  const tickSpacing = liquidityPoolAggregator.tickSpacing;
-  const currentStakedLiqInRange =
-    liquidityPoolAggregator.stakedLiquidityInRange ?? 0n;
-
-  const stakedLiquidityInRange =
-    oldTick !== newTick && tickSpacing > 0n
-      ? processTickCrossingsForStaked(
-          event.chainId,
-          event.srcAddress,
-          oldTick,
-          newTick,
-          tickSpacing,
-          context,
-          currentStakedLiqInRange,
-          liquidityPoolAggregator.hasStakes,
-          liquidityPoolAggregator.stakedTickEdges,
-          liquidityPoolAggregator.stakedTickEdgeNets,
-        )
-      : currentStakedLiqInRange;
-
-  // Attribute staked share of swap reserve deltas proportionally.
-  //
-  // KNOWN APPROXIMATION: When a swap crosses multiple ticks, the staked/total liquidity
-  // ratio changes at each tick boundary (positions enter/exit range). We apply the
-  // post-crossing ratio to the entire swap's net reserve deltas, rather than computing
-  // per-segment contributions. This is because the Swap event only emits net amount0/amount1
-  // totals — per-segment token flows are not available. The error per swap is proportional
-  // to how much the staked ratio varies across crossed segments. This drift accumulates
-  // over time and is NOT corrected at snapshot time (snapshots re-price existing reserves
-  // at current token prices but do not recompute reserve quantities).
+  // Process tick crossings for staked liquidity tracking AND compute the
+  // per-segment staked share of the swap's reserve deltas. The walk and the
+  // attribution share the same edge sweep — see CLStakedLiquidity.ts for the
+  // per-segment Uniswap v3 math (fix for #666).
   const reserveDelta0 = newReserve0 - liquidityPoolAggregator.reserve0;
   const reserveDelta1 = newReserve1 - liquidityPoolAggregator.reserve1;
-  const { stakedDelta0, stakedDelta1 } = computeStakedSwapReserveDelta(
-    reserveDelta0,
-    reserveDelta1,
-    stakedLiquidityInRange,
-    event.params.liquidity,
-  );
+  const { stakedLiquidityInRange, stakedDelta0, stakedDelta1 } =
+    processTickCrossingsForStaked(
+      event.chainId,
+      event.srcAddress,
+      liquidityPoolAggregator.tick ?? 0n,
+      event.params.tick,
+      liquidityPoolAggregator.sqrtPriceX96 ?? 0n,
+      event.params.sqrtPriceX96,
+      liquidityPoolAggregator.tickSpacing,
+      context,
+      liquidityPoolAggregator.stakedLiquidityInRange ?? 0n,
+      liquidityPoolAggregator.hasStakes,
+      liquidityPoolAggregator.stakedTickEdges,
+      liquidityPoolAggregator.stakedTickEdgeNets,
+    );
 
   // Build complete liquidity pool aggregator diff
   const liquidityPoolDiff = {

--- a/test/Aggregators/CLStakedLiquidity.test.ts
+++ b/test/Aggregators/CLStakedLiquidity.test.ts
@@ -1,4 +1,3 @@
-import { TickMath } from "@uniswap/v3-sdk";
 import type { handlerContext } from "generated";
 import {
   applyStakedPositionToEdges,
@@ -6,14 +5,7 @@ import {
   processTickCrossingsForStaked,
 } from "../../src/Aggregators/CLStakedLiquidity";
 import { calculatePositionAmountsFromLiquidity } from "../../src/Helpers";
-
-/**
- * Returns sqrt(1.0001^tick) in Q64.96 fixed-point as bigint — the same
- * conversion the source-of-truth helper uses internally. Centralizes the
- * JSBI→bigint plumbing so test math reads cleanly.
- */
-const sqrtAt = (tick: bigint): bigint =>
-  BigInt(TickMath.getSqrtRatioAtTick(Number(tick)).toString());
+import { sqrtAt } from "./common";
 
 describe("CLStakedLiquidity", () => {
   const CHAIN_ID = 8453;
@@ -503,6 +495,10 @@ describe("CLStakedLiquidity", () => {
 
     describe("safety guards", () => {
       it("should short-circuit when hasStakes is false", async () => {
+        // Precondition: hasStakes=false ⇒ pool has never had a staked position,
+        // so currentStakedLiqInRange MUST be 0n. Seed 0n to reflect that and
+        // assert zero deltas — non-zero L would let the final-segment fallback
+        // emit attribution despite the edge loop being skipped.
         const result = processTickCrossingsForStaked(
           CHAIN_ID,
           POOL_ADDRESS,
@@ -512,15 +508,19 @@ describe("CLStakedLiquidity", () => {
           sqrtAt(250n),
           200n,
           mockContext,
-          500n,
+          0n,
           false,
           [200n],
           [999n],
         );
-        expect(result.stakedLiquidityInRange).toBe(500n);
+        expect(result.stakedLiquidityInRange).toBe(0n);
+        expect(result.stakedDelta0).toBe(0n);
+        expect(result.stakedDelta1).toBe(0n);
       });
 
       it("should short-circuit when the edge list is empty (no staked positions)", async () => {
+        // Precondition: empty edge list ⇒ no active staked positions ⇒
+        // currentStakedLiqInRange MUST be 0n. Same reasoning as above.
         const result = processTickCrossingsForStaked(
           CHAIN_ID,
           POOL_ADDRESS,
@@ -530,12 +530,14 @@ describe("CLStakedLiquidity", () => {
           sqrtAt(250n),
           200n,
           mockContext,
-          500n,
+          0n,
           true, // latch true but no edges
           [],
           [],
         );
-        expect(result.stakedLiquidityInRange).toBe(500n);
+        expect(result.stakedLiquidityInRange).toBe(0n);
+        expect(result.stakedDelta0).toBe(0n);
+        expect(result.stakedDelta1).toBe(0n);
       });
 
       it("should bail and log when oldTick is below TICK_MIN", async () => {

--- a/test/Aggregators/CLStakedLiquidity.test.ts
+++ b/test/Aggregators/CLStakedLiquidity.test.ts
@@ -1,14 +1,27 @@
+import { TickMath } from "@uniswap/v3-sdk";
 import type { handlerContext } from "generated";
 import {
   applyStakedPositionToEdges,
-  computeStakedSwapReserveDelta,
   isPositionInRange,
   processTickCrossingsForStaked,
 } from "../../src/Aggregators/CLStakedLiquidity";
+import { calculatePositionAmountsFromLiquidity } from "../../src/Helpers";
+
+/**
+ * Returns sqrt(1.0001^tick) in Q64.96 fixed-point as bigint — the same
+ * conversion the source-of-truth helper uses internally. Centralizes the
+ * JSBI→bigint plumbing so test math reads cleanly.
+ */
+const sqrtAt = (tick: bigint): bigint =>
+  BigInt(TickMath.getSqrtRatioAtTick(Number(tick)).toString());
 
 describe("CLStakedLiquidity", () => {
   const CHAIN_ID = 8453;
   const POOL_ADDRESS = "0x1234567890123456789012345678901234567890";
+  // Non-zero sqrt placeholders for tests that don't exercise delta math —
+  // the function early-returns zero deltas if either sqrt is 0n, so use
+  // sqrtAt(0) (= 1*Q96) when the test only cares about stakedLiquidityInRange.
+  const SQRT_AT_ZERO = sqrtAt(0n);
 
   describe("isPositionInRange", () => {
     it("should return true when currentTick is within range", () => {
@@ -263,6 +276,8 @@ describe("CLStakedLiquidity", () => {
         POOL_ADDRESS,
         100n,
         100n,
+        sqrtAt(100n),
+        sqrtAt(100n),
         200n,
         mockContext,
         500n,
@@ -270,7 +285,10 @@ describe("CLStakedLiquidity", () => {
         [100n, 200n],
         [300n, -300n],
       );
-      expect(result).toBe(500n);
+      expect(result.stakedLiquidityInRange).toBe(500n);
+      // Same sqrt → final segment is a no-op → zero deltas
+      expect(result.stakedDelta0).toBe(0n);
+      expect(result.stakedDelta1).toBe(0n);
     });
 
     it("should return unchanged when tickSpacing is zero", async () => {
@@ -279,6 +297,8 @@ describe("CLStakedLiquidity", () => {
         POOL_ADDRESS,
         100n,
         300n,
+        sqrtAt(100n),
+        sqrtAt(300n),
         0n,
         mockContext,
         500n,
@@ -286,7 +306,31 @@ describe("CLStakedLiquidity", () => {
         [200n],
         [300n],
       );
-      expect(result).toBe(500n);
+      expect(result.stakedLiquidityInRange).toBe(500n);
+      expect(result.stakedDelta0).toBe(0n);
+      expect(result.stakedDelta1).toBe(0n);
+    });
+
+    it("should return unchanged when oldSqrtPriceX96 is zero (pre-Initialize)", async () => {
+      // First swap on a pool whose sqrtPriceX96 was never set: cannot attribute,
+      // accept zero deltas rather than divide by zero.
+      const result = processTickCrossingsForStaked(
+        CHAIN_ID,
+        POOL_ADDRESS,
+        100n,
+        300n,
+        0n,
+        sqrtAt(300n),
+        200n,
+        mockContext,
+        500n,
+        true,
+        [200n],
+        [300n],
+      );
+      expect(result.stakedLiquidityInRange).toBe(500n);
+      expect(result.stakedDelta0).toBe(0n);
+      expect(result.stakedDelta1).toBe(0n);
     });
 
     it("should add stakedLiquidityNet when crossing up", async () => {
@@ -295,6 +339,8 @@ describe("CLStakedLiquidity", () => {
         POOL_ADDRESS,
         100n,
         250n,
+        sqrtAt(100n),
+        sqrtAt(250n),
         200n,
         mockContext,
         0n,
@@ -302,7 +348,7 @@ describe("CLStakedLiquidity", () => {
         [200n],
         [300n],
       );
-      expect(result).toBe(300n);
+      expect(result.stakedLiquidityInRange).toBe(300n);
     });
 
     it("should subtract stakedLiquidityNet when crossing down", async () => {
@@ -311,6 +357,8 @@ describe("CLStakedLiquidity", () => {
         POOL_ADDRESS,
         250n,
         100n,
+        sqrtAt(250n),
+        sqrtAt(100n),
         200n,
         mockContext,
         300n,
@@ -318,7 +366,7 @@ describe("CLStakedLiquidity", () => {
         [200n],
         [300n],
       );
-      expect(result).toBe(0n);
+      expect(result.stakedLiquidityInRange).toBe(0n);
     });
 
     it("should handle multiple tick crossings going up", async () => {
@@ -327,6 +375,8 @@ describe("CLStakedLiquidity", () => {
         POOL_ADDRESS,
         100n,
         650n,
+        sqrtAt(100n),
+        sqrtAt(650n),
         200n,
         mockContext,
         0n,
@@ -334,7 +384,7 @@ describe("CLStakedLiquidity", () => {
         [200n, 400n, 600n],
         [100n, 200n, -50n],
       );
-      expect(result).toBe(250n); // 0 + 100 + 200 - 50
+      expect(result.stakedLiquidityInRange).toBe(250n); // 0 + 100 + 200 - 50
     });
 
     it("should handle multiple tick crossings going down", async () => {
@@ -343,6 +393,8 @@ describe("CLStakedLiquidity", () => {
         POOL_ADDRESS,
         650n,
         100n,
+        sqrtAt(650n),
+        sqrtAt(100n),
         200n,
         mockContext,
         250n,
@@ -351,7 +403,7 @@ describe("CLStakedLiquidity", () => {
         [100n, 200n, -50n],
       );
       // 250 - (-50) - 200 - 100 = 250 + 50 - 200 - 100 = 0
-      expect(result).toBe(0n);
+      expect(result.stakedLiquidityInRange).toBe(0n);
     });
 
     it("should skip edges that fall outside the [oldTick, newTick] window", async () => {
@@ -361,6 +413,8 @@ describe("CLStakedLiquidity", () => {
         POOL_ADDRESS,
         100n,
         300n,
+        sqrtAt(100n),
+        sqrtAt(300n),
         200n,
         mockContext,
         50n,
@@ -368,7 +422,7 @@ describe("CLStakedLiquidity", () => {
         [200n, 400n],
         [150n, -150n],
       );
-      expect(result).toBe(200n); // 50 + 150 (only 200 crossed, 400 is beyond newTick=300)
+      expect(result.stakedLiquidityInRange).toBe(200n); // 50 + 150 (only 200 crossed, 400 is beyond newTick=300)
     });
 
     it("should handle negative tick ranges", async () => {
@@ -377,6 +431,8 @@ describe("CLStakedLiquidity", () => {
         POOL_ADDRESS,
         -300n,
         -100n,
+        sqrtAt(-300n),
+        sqrtAt(-100n),
         200n,
         mockContext,
         0n,
@@ -384,7 +440,7 @@ describe("CLStakedLiquidity", () => {
         [-200n],
         [500n],
       );
-      expect(result).toBe(500n);
+      expect(result.stakedLiquidityInRange).toBe(500n);
     });
 
     it("should not cross the oldTick itself when going up (strict-above semantics)", async () => {
@@ -394,6 +450,8 @@ describe("CLStakedLiquidity", () => {
         POOL_ADDRESS,
         200n,
         350n,
+        sqrtAt(200n),
+        sqrtAt(350n),
         200n,
         mockContext,
         0n,
@@ -401,7 +459,7 @@ describe("CLStakedLiquidity", () => {
         [200n],
         [100n],
       );
-      expect(result).toBe(0n);
+      expect(result.stakedLiquidityInRange).toBe(0n);
     });
 
     it("should include the oldTick boundary when going down (at-or-below semantics)", async () => {
@@ -411,6 +469,8 @@ describe("CLStakedLiquidity", () => {
         POOL_ADDRESS,
         200n,
         50n,
+        sqrtAt(200n),
+        sqrtAt(50n),
         200n,
         mockContext,
         100n,
@@ -418,7 +478,7 @@ describe("CLStakedLiquidity", () => {
         [200n],
         [100n],
       );
-      expect(result).toBe(0n); // 100 - 100
+      expect(result.stakedLiquidityInRange).toBe(0n); // 100 - 100
     });
 
     it("should handle tickSpacing of 1 without scanning per-tick (only edges drive the walk)", async () => {
@@ -429,6 +489,8 @@ describe("CLStakedLiquidity", () => {
         POOL_ADDRESS,
         100n,
         103n,
+        sqrtAt(100n),
+        sqrtAt(103n),
         1n,
         mockContext,
         0n,
@@ -436,7 +498,7 @@ describe("CLStakedLiquidity", () => {
         [101n, 102n, 103n],
         [10n, 20n, -5n],
       );
-      expect(result).toBe(25n); // 0 + 10 + 20 - 5
+      expect(result.stakedLiquidityInRange).toBe(25n); // 0 + 10 + 20 - 5
     });
 
     describe("safety guards", () => {
@@ -446,6 +508,8 @@ describe("CLStakedLiquidity", () => {
           POOL_ADDRESS,
           100n,
           250n,
+          sqrtAt(100n),
+          sqrtAt(250n),
           200n,
           mockContext,
           500n,
@@ -453,7 +517,7 @@ describe("CLStakedLiquidity", () => {
           [200n],
           [999n],
         );
-        expect(result).toBe(500n);
+        expect(result.stakedLiquidityInRange).toBe(500n);
       });
 
       it("should short-circuit when the edge list is empty (no staked positions)", async () => {
@@ -462,6 +526,8 @@ describe("CLStakedLiquidity", () => {
           POOL_ADDRESS,
           100n,
           250n,
+          sqrtAt(100n),
+          sqrtAt(250n),
           200n,
           mockContext,
           500n,
@@ -469,15 +535,19 @@ describe("CLStakedLiquidity", () => {
           [],
           [],
         );
-        expect(result).toBe(500n);
+        expect(result.stakedLiquidityInRange).toBe(500n);
       });
 
       it("should bail and log when oldTick is below TICK_MIN", async () => {
+        // oldTick out of range — pass dummy non-zero sqrt placeholders since
+        // sqrtAt(out-of-range) would throw before we even reach the function.
         const result = processTickCrossingsForStaked(
           CHAIN_ID,
           POOL_ADDRESS,
           -900000n,
           100n,
+          SQRT_AT_ZERO,
+          sqrtAt(100n),
           200n,
           mockContext,
           500n,
@@ -485,7 +555,9 @@ describe("CLStakedLiquidity", () => {
           [200n],
           [300n],
         );
-        expect(result).toBe(500n);
+        expect(result.stakedLiquidityInRange).toBe(500n);
+        expect(result.stakedDelta0).toBe(0n);
+        expect(result.stakedDelta1).toBe(0n);
         expect(logErrorSpy).toHaveBeenCalledTimes(1);
         expect(logErrorSpy.mock.calls[0][0]).toContain(
           "out of Uniswap v3 range",
@@ -498,6 +570,8 @@ describe("CLStakedLiquidity", () => {
           POOL_ADDRESS,
           100n,
           900000n,
+          sqrtAt(100n),
+          SQRT_AT_ZERO,
           200n,
           mockContext,
           500n,
@@ -505,7 +579,7 @@ describe("CLStakedLiquidity", () => {
           [200n],
           [300n],
         );
-        expect(result).toBe(500n);
+        expect(result.stakedLiquidityInRange).toBe(500n);
         expect(logErrorSpy).toHaveBeenCalledTimes(1);
       });
 
@@ -515,6 +589,8 @@ describe("CLStakedLiquidity", () => {
           POOL_ADDRESS,
           -887272n,
           887272n,
+          sqrtAt(-887272n),
+          sqrtAt(887272n),
           200n,
           mockContext,
           0n,
@@ -522,66 +598,330 @@ describe("CLStakedLiquidity", () => {
           [],
           [],
         );
-        expect(result).toBe(0n);
+        expect(result.stakedLiquidityInRange).toBe(0n);
         expect(logErrorSpy).not.toHaveBeenCalled();
       });
     });
-  });
 
-  describe("computeStakedSwapReserveDelta", () => {
-    it("should compute proportional split correctly", () => {
-      const result = computeStakedSwapReserveDelta(
-        -100n,
-        500n,
-        200n, // staked
-        1000n, // total
-      );
+    describe("per-segment reserve delta attribution (#666 fix)", () => {
+      it("returns zero deltas when stakedLiq is zero throughout the swap", () => {
+        const result = processTickCrossingsForStaked(
+          CHAIN_ID,
+          POOL_ADDRESS,
+          100n,
+          300n,
+          sqrtAt(100n),
+          sqrtAt(300n),
+          200n,
+          mockContext,
+          0n, // no staked liq
+          false,
+          [],
+          [],
+        );
+        expect(result.stakedDelta0).toBe(0n);
+        expect(result.stakedDelta1).toBe(0n);
+      });
 
-      // -100 * 200/1000 = -20, 500 * 200/1000 = 100
-      expect(result.stakedDelta0).toBe(-20n);
-      expect(result.stakedDelta1).toBe(100n);
-    });
+      it("matches calculatePositionAmountsFromLiquidity diff for an in-range single-segment swap", () => {
+        // Single staked position [-100, 100] with liquidity L; swap from tick=0
+        // to tick=50 (both in range, no edge crossings since neither bound is
+        // crossed). The function's delta MUST equal the position-amount diff
+        // produced by the canonical helper at the two prices — that is the
+        // ground truth for what the staked share lost or gained.
+        const L = 10n ** 18n;
+        const tickLower = -100n;
+        const tickUpper = 100n;
+        const oldTick = 0n;
+        const newTick = 50n;
+        const oldSqrt = sqrtAt(oldTick);
+        const newSqrt = sqrtAt(newTick);
 
-    it("should return zero when totalLiqInRange is zero", () => {
-      const result = computeStakedSwapReserveDelta(-100n, 500n, 200n, 0n);
+        // Edges from a single staked position: [tL: +L, tU: -L]
+        const edges = [tickLower, tickUpper];
+        const nets = [L, -L];
 
-      expect(result.stakedDelta0).toBe(0n);
-      expect(result.stakedDelta1).toBe(0n);
-    });
+        const result = processTickCrossingsForStaked(
+          CHAIN_ID,
+          POOL_ADDRESS,
+          oldTick,
+          newTick,
+          oldSqrt,
+          newSqrt,
+          1n,
+          mockContext,
+          L,
+          true,
+          edges,
+          nets,
+        );
 
-    it("should return zero when stakedLiqInRange is zero", () => {
-      const result = computeStakedSwapReserveDelta(-100n, 500n, 0n, 1000n);
+        expect(result.stakedLiquidityInRange).toBe(L);
 
-      expect(result.stakedDelta0).toBe(0n);
-      expect(result.stakedDelta1).toBe(0n);
-    });
+        const before = calculatePositionAmountsFromLiquidity(
+          L,
+          oldSqrt,
+          tickLower,
+          tickUpper,
+        );
+        const after = calculatePositionAmountsFromLiquidity(
+          L,
+          newSqrt,
+          tickLower,
+          tickUpper,
+        );
+        // Pool reserve sign convention: positive = into pool. amount0 in pool
+        // decreases as price moves up; amount1 increases. The helper returns
+        // *in-pool* positives, so the signed delta is `after - before`.
+        const expectedDelta0 = after.amount0 - before.amount0;
+        const expectedDelta1 = after.amount1 - before.amount1;
+        // Bigint truncation may differ by ≤1 wei vs the source helper.
+        expect(result.stakedDelta0 - expectedDelta0).toBeGreaterThanOrEqual(
+          -1n,
+        );
+        expect(result.stakedDelta0 - expectedDelta0).toBeLessThanOrEqual(1n);
+        expect(result.stakedDelta1 - expectedDelta1).toBeGreaterThanOrEqual(
+          -1n,
+        );
+        expect(result.stakedDelta1 - expectedDelta1).toBeLessThanOrEqual(1n);
+      });
 
-    it("should return full delta when stakedLiq equals totalLiq (100% staked)", () => {
-      const result = computeStakedSwapReserveDelta(-100n, 500n, 1000n, 1000n);
+      it("attributes nothing past the boundary when the position exits range mid-swap", () => {
+        // Position [-100, 100], L; swap drives the price DOWN from tick=50 to
+        // tick=-200, crossing the lower edge at -100. After the cross, staked
+        // liquidity in range drops to 0 — no further attribution should accrue.
+        // This is the exact failure mode behind #666: the old proportional
+        // split kept attributing post-crossing reserve flow to a position that
+        // had already exited.
+        const L = 10n ** 18n;
+        const tickLower = -100n;
+        const tickUpper = 100n;
+        const oldTick = 50n;
+        const newTick = -200n;
+        const oldSqrt = sqrtAt(oldTick);
+        const newSqrt = sqrtAt(newTick);
+        const sqrtAtLower = sqrtAt(tickLower);
 
-      expect(result.stakedDelta0).toBe(-100n);
-      expect(result.stakedDelta1).toBe(500n);
-    });
+        const result = processTickCrossingsForStaked(
+          CHAIN_ID,
+          POOL_ADDRESS,
+          oldTick,
+          newTick,
+          oldSqrt,
+          newSqrt,
+          1n,
+          mockContext,
+          L,
+          true,
+          [tickLower, tickUpper],
+          [L, -L],
+        );
 
-    it("should handle rounding via bigint truncation", () => {
-      // 100 * 1 / 3 = 33 (truncated from 33.33...)
-      const result = computeStakedSwapReserveDelta(100n, -100n, 1n, 3n);
+        // Position fully exited going down → stakedLiq drops to 0
+        expect(result.stakedLiquidityInRange).toBe(0n);
 
-      expect(result.stakedDelta0).toBe(33n);
-      expect(result.stakedDelta1).toBe(-33n);
-    });
+        // Expected delta = single segment from oldSqrt down to sqrtAtLower
+        // with L active. Nothing attributed past the boundary.
+        const before = calculatePositionAmountsFromLiquidity(
+          L,
+          oldSqrt,
+          tickLower,
+          tickUpper,
+        );
+        const atBoundary = calculatePositionAmountsFromLiquidity(
+          L,
+          sqrtAtLower,
+          tickLower,
+          tickUpper,
+        );
+        const expectedDelta0 = atBoundary.amount0 - before.amount0;
+        const expectedDelta1 = atBoundary.amount1 - before.amount1;
+        expect(result.stakedDelta0 - expectedDelta0).toBeGreaterThanOrEqual(
+          -1n,
+        );
+        expect(result.stakedDelta0 - expectedDelta0).toBeLessThanOrEqual(1n);
+        expect(result.stakedDelta1 - expectedDelta1).toBeGreaterThanOrEqual(
+          -1n,
+        );
+        expect(result.stakedDelta1 - expectedDelta1).toBeLessThanOrEqual(1n);
+      });
 
-    it("should handle large values", () => {
-      const large = 10n ** 30n;
-      const result = computeStakedSwapReserveDelta(
-        large,
-        -large,
-        large / 2n,
-        large,
-      );
+      it("telescopes Deposit + swap + Withdraw to ~0 when the position exits range mid-swap (#666 invariant)", () => {
+        // The canonical drift scenario: Deposit at in-range tick, swap drives
+        // price out of range below, Withdraw at the post-swap (out-of-range)
+        // price. The three signed reserve contributions MUST sum to ~0 — the
+        // staked share's net reserve change equals 0 because the tokens
+        // entered (on Deposit) and left (on Withdraw) the staked envelope.
+        // The old proportional split broke this invariant; per-segment math
+        // restores it.
+        const L = 10n ** 18n;
+        const tickLower = -100n;
+        const tickUpper = 100n;
+        const tickAtDeposit = 50n;
+        const tickAfterSwap = -200n;
+        const sqrtAtDeposit = sqrtAt(tickAtDeposit);
+        const sqrtAfterSwap = sqrtAt(tickAfterSwap);
 
-      expect(result.stakedDelta0).toBe(large / 2n);
-      expect(result.stakedDelta1).toBe(-(large / 2n));
+        // 1) Deposit at sqrtAtDeposit (in range): incrementalStakedReserve =
+        //    +position amounts at deposit price.
+        const depositAmounts = calculatePositionAmountsFromLiquidity(
+          L,
+          sqrtAtDeposit,
+          tickLower,
+          tickUpper,
+        );
+
+        // 2) Swap moves price down through the lower edge. Per-segment
+        //    attribution credits only the in-range segment.
+        const swapResult = processTickCrossingsForStaked(
+          CHAIN_ID,
+          POOL_ADDRESS,
+          tickAtDeposit,
+          tickAfterSwap,
+          sqrtAtDeposit,
+          sqrtAfterSwap,
+          1n,
+          mockContext,
+          L,
+          true,
+          [tickLower, tickUpper],
+          [L, -L],
+        );
+
+        // 3) Withdraw at sqrtAfterSwap (out of range below): incremental
+        //    staked reserve = -position amounts at the post-swap price (all
+        //    token0 capacity, zero token1).
+        const withdrawAmounts = calculatePositionAmountsFromLiquidity(
+          L,
+          sqrtAfterSwap,
+          tickLower,
+          tickUpper,
+        );
+
+        const net0 =
+          depositAmounts.amount0 +
+          swapResult.stakedDelta0 -
+          withdrawAmounts.amount0;
+        const net1 =
+          depositAmounts.amount1 +
+          swapResult.stakedDelta1 -
+          withdrawAmounts.amount1;
+
+        // Tolerance: a few wei from bigint truncation across the three steps.
+        expect(net0).toBeGreaterThanOrEqual(-2n);
+        expect(net0).toBeLessThanOrEqual(2n);
+        expect(net1).toBeGreaterThanOrEqual(-2n);
+        expect(net1).toBeLessThanOrEqual(2n);
+      });
+
+      it("telescopes when the position never enters range during the swap", () => {
+        // Position [-100, 100], swap moves from tick=200 to tick=300 — entirely
+        // above the position's range. stakedLiq is 0 throughout (price never
+        // crossed the upper edge from above), so deltas are 0.
+        const L = 10n ** 18n;
+        const tickLower = -100n;
+        const tickUpper = 100n;
+        const oldTick = 200n;
+        const newTick = 300n;
+
+        const result = processTickCrossingsForStaked(
+          CHAIN_ID,
+          POOL_ADDRESS,
+          oldTick,
+          newTick,
+          sqrtAt(oldTick),
+          sqrtAt(newTick),
+          1n,
+          mockContext,
+          0n, // out of range — not staked-in-range
+          true,
+          [tickLower, tickUpper],
+          [L, -L],
+        );
+
+        expect(result.stakedLiquidityInRange).toBe(0n);
+        expect(result.stakedDelta0).toBe(0n);
+        expect(result.stakedDelta1).toBe(0n);
+      });
+
+      it("attributes only the in-range segment when the position enters range mid-swap", () => {
+        // Position [-100, 100], L; swap drives price UP from tick=-200 to
+        // tick=50. Position enters range when price crosses tickLower=-100
+        // upward. Pre-cross: stakedLiq=0 → no attribution. Post-cross:
+        // stakedLiq=L → attribute the segment from sqrtAt(-100) to sqrtAt(50).
+        const L = 10n ** 18n;
+        const tickLower = -100n;
+        const tickUpper = 100n;
+        const oldTick = -200n;
+        const newTick = 50n;
+        const newSqrt = sqrtAt(newTick);
+        const sqrtAtLower = sqrtAt(tickLower);
+
+        const result = processTickCrossingsForStaked(
+          CHAIN_ID,
+          POOL_ADDRESS,
+          oldTick,
+          newTick,
+          sqrtAt(oldTick),
+          newSqrt,
+          1n,
+          mockContext,
+          0n, // pre-swap: out of range below → not staked-in-range
+          true,
+          [tickLower, tickUpper],
+          [L, -L],
+        );
+
+        expect(result.stakedLiquidityInRange).toBe(L);
+
+        // Expected: single in-range segment from sqrtAt(-100) (boundary cross)
+        // up to newSqrt. Equivalent to position-amounts diff at those prices.
+        const atBoundary = calculatePositionAmountsFromLiquidity(
+          L,
+          sqrtAtLower,
+          tickLower,
+          tickUpper,
+        );
+        const after = calculatePositionAmountsFromLiquidity(
+          L,
+          newSqrt,
+          tickLower,
+          tickUpper,
+        );
+        const expectedDelta0 = after.amount0 - atBoundary.amount0;
+        const expectedDelta1 = after.amount1 - atBoundary.amount1;
+        expect(result.stakedDelta0 - expectedDelta0).toBeGreaterThanOrEqual(
+          -1n,
+        );
+        expect(result.stakedDelta0 - expectedDelta0).toBeLessThanOrEqual(1n);
+        expect(result.stakedDelta1 - expectedDelta1).toBeGreaterThanOrEqual(
+          -1n,
+        );
+        expect(result.stakedDelta1 - expectedDelta1).toBeLessThanOrEqual(1n);
+      });
+
+      it("returns zero deltas when oldSqrt === newSqrt (no movement) regardless of tick", () => {
+        // Edge case: tick changed (e.g. via Initialize replay) but sqrt did not.
+        // No reserve flow → no attribution.
+        const L = 10n ** 18n;
+        const sqrt = sqrtAt(0n);
+        const result = processTickCrossingsForStaked(
+          CHAIN_ID,
+          POOL_ADDRESS,
+          -50n,
+          50n,
+          sqrt,
+          sqrt,
+          1n,
+          mockContext,
+          L,
+          true,
+          [-100n, 100n],
+          [L, -L],
+        );
+        expect(result.stakedDelta0).toBe(0n);
+        expect(result.stakedDelta1).toBe(0n);
+      });
     });
   });
 });

--- a/test/Aggregators/CLStakedLiquidityEdgeSanity.test.ts
+++ b/test/Aggregators/CLStakedLiquidityEdgeSanity.test.ts
@@ -1,4 +1,3 @@
-import { TickMath } from "@uniswap/v3-sdk";
 import type { Token } from "generated";
 import { CLGauge, MockDb } from "../../generated/src/TestHelpers.gen";
 import {
@@ -11,9 +10,7 @@ import {
   toChecksumAddress,
 } from "../../src/Constants";
 import { setupCommon } from "../EventHandlers/Pool/common";
-
-const sqrtAt = (tick: bigint): bigint =>
-  BigInt(TickMath.getSqrtRatioAtTick(Number(tick)).toString());
+import { sqrtAt } from "./common";
 
 /**
  * Co-located sanity test for #649: replacing `processTickCrossingsForStaked`

--- a/test/Aggregators/CLStakedLiquidityEdgeSanity.test.ts
+++ b/test/Aggregators/CLStakedLiquidityEdgeSanity.test.ts
@@ -1,3 +1,4 @@
+import { TickMath } from "@uniswap/v3-sdk";
 import type { Token } from "generated";
 import { CLGauge, MockDb } from "../../generated/src/TestHelpers.gen";
 import {
@@ -10,6 +11,9 @@ import {
   toChecksumAddress,
 } from "../../src/Constants";
 import { setupCommon } from "../EventHandlers/Pool/common";
+
+const sqrtAt = (tick: bigint): bigint =>
+  BigInt(TickMath.getSqrtRatioAtTick(Number(tick)).toString());
 
 /**
  * Co-located sanity test for #649: replacing `processTickCrossingsForStaked`
@@ -243,6 +247,8 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
       mockPoolAddress,
       oldTick,
       newTick,
+      sqrtAt(oldTick),
+      sqrtAt(newTick),
       10n,
       noDbContext,
       0n,
@@ -251,7 +257,7 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
       nets,
     );
 
-    expect(newResult).toBe(baselineResult);
+    expect(newResult.stakedLiquidityInRange).toBe(baselineResult);
 
     // Sanity: the window actually crosses multiple edges.
     const crossingCount = edges.filter(
@@ -279,6 +285,8 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
       mockPoolAddress,
       oldTickDown,
       newTickDown,
+      sqrtAt(oldTickDown),
+      sqrtAt(newTickDown),
       10n,
       noDbContext,
       baselineResult,
@@ -287,9 +295,9 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
       nets,
     );
 
-    expect(downResult).toBe(baselineDownResult);
+    expect(downResult.stakedLiquidityInRange).toBe(baselineDownResult);
     // Round-trip parity: up-swap then down-swap over the same window must
     // return stakedLiq to its starting value (0n in this test).
-    expect(downResult).toBe(0n);
+    expect(downResult.stakedLiquidityInRange).toBe(0n);
   });
 });

--- a/test/Aggregators/common.ts
+++ b/test/Aggregators/common.ts
@@ -1,0 +1,12 @@
+import { TickMath } from "@uniswap/v3-sdk";
+
+/**
+ * Returns sqrt(1.0001^tick) in Q64.96 fixed-point as bigint — the same
+ * conversion the source-of-truth helper uses internally. Centralizes the
+ * JSBI→bigint plumbing so test math reads cleanly.
+ *
+ * @param tick - Tick to convert; must be in `[TickMath.MIN_TICK, TickMath.MAX_TICK]` or the SDK will throw.
+ * @returns Q64.96 sqrt price as bigint.
+ */
+export const sqrtAt = (tick: bigint): bigint =>
+  BigInt(TickMath.getSqrtRatioAtTick(Number(tick)).toString());


### PR DESCRIPTION
## Summary

- Replaces the post-crossing proportional split of swap reserve deltas (the source of the negative `stakedReserve0/1` drift on 166 CL pools) with **exact per-segment Uniswap v3 math** walking the same staked-tick edge sweep already used to keep `stakedLiquidityInRange` in sync.
- `processTickCrossingsForStaked` now returns `{ stakedLiquidityInRange, stakedDelta0, stakedDelta1 }` and accepts `oldSqrtPriceX96 / newSqrtPriceX96` so attribution and the sweep share one pass. `computeStakedSwapReserveDelta` is removed.
- `L_total` cancels in the staked-share formula (`Δ = L_staked * (...)`), so this needs **no new edge state** beyond the existing `stakedTickEdges` / `stakedTickEdgeNets` parallel arrays — purely a math-correctness fix on top of #649.

Per segment between two crossed staked-tick edges, with constant `L_staked`:

```
Δ0 = L_staked * (S_start - S_end) * Q96 / (S_start * S_end)
Δ1 = L_staked * (S_end - S_start) / Q96
```

Both are signed and direction-agnostic (UP swap → Δ0 negative, Δ1 positive; DOWN flips signs), matching the `event.params.amount0/amount1` sign convention of `CLPool.Swap`.

Closes the AFK Slice 1 of #666.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `pnpm qa --write` clean
- [x] `pnpm test` — 97/97 test files pass
- [x] New unit coverage in `test/Aggregators/CLStakedLiquidity.test.ts`:
  - zero-staked short-circuit returns `{ 0n, 0n, 0n }`
  - in-range single-segment swap matches `calculatePositionAmountsFromLiquidity` diff (±1 wei)
  - position exits range mid-swap — only the in-range segment is attributed
  - position enters range mid-swap
  - position never enters range — zero deltas
  - telescoping invariant: deposit + per-segment swap + withdraw ≈ 0n (±2 wei tolerance for bigint truncation)
  - pre-Initialize guard: returns zeros when `oldSqrtPriceX96 === 0n`
- [x] Updated edge-sanity suite (`CLStakedLiquidityEdgeSanity.test.ts`) for the new return shape — including UP/DOWN round-trip parity over the same window.
- [x] **Slice 2 (next PR / follow-up)**: local end-to-end correctness test against the historical repro pool `10-0x1ea36eb...` (the ~80% TVL outlier flagged in #666) using the existing `repro/666-narrow-config` worktree. Two invariants at the three known checkpoint blocks `124360969`, `124362052`, `124362406`:
  1. **No-negative**: `stakedReserve0/1 >= 0` at every checkpoint.
  2. **On-chain truth**: `stakedReserve0/1` agree with the on-chain `Pool.staked0()/staked1()` reads at each block (within rounding tolerance) — i.e., we're not just preventing the negative, we're producing the *correct* value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed reserve calculation accuracy for staked positions during swap operations, ensuring proper tracking of staked liquidity amounts across price movements and tick crossings.

* **Tests**
  * Enhanced test coverage for staked liquidity calculations, including edge cases, boundary conditions, and multi-step deposit-swap-withdraw scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->