### PR TITLE
fix(price-oracle): unblock totalEmissionsUSD on every chain (#673)

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -370,6 +370,11 @@ type chainConstants = {
     startBlock: number;
     updateDelta: number;
     priceConnectors: PriceConnector[];
+    // Issue #688: V1/V2 oracles' getManyRatesWithConnectors reverts when the
+    // connector array contains tokens with no AMM pool at the queried block.
+    // Lowercased addresses listed here are stripped from connectors only when
+    // querying V1/V2 oracles. V3+ tolerates these silently.
+    v1v2ConnectorBlacklist: Set<string>;
   };
   rewardToken: (blockNumber: number) => string;
   eth_client: PublicClient;
@@ -409,6 +414,10 @@ const OPTIMISM_CONSTANTS: chainConstants = {
     startBlock: 107676013,
     updateDelta: 60 * 60, // 1 hour
     priceConnectors: OPTIMISM_PRICE_CONNECTORS,
+    v1v2ConnectorBlacklist: new Set([
+      "0x01bff41798a0bcf287b996046ca68b395dbc1071",
+      "0x1217bfe6c773eec6cc4a38b5dc45b92292b6e189",
+    ]),
   },
   rewardToken: (blockNumber: number) => {
     if (blockNumber < 105896880) {
@@ -463,6 +472,10 @@ const BASE_CONSTANTS: chainConstants = {
     startBlock: 3219857,
     updateDelta: 60 * 60, // 1 hour
     priceConnectors: BASE_PRICE_CONNECTORS,
+    v1v2ConnectorBlacklist: new Set([
+      "0x1217bfe6c773eec6cc4a38b5dc45b92292b6e189",
+      "0x5d3a1ff2b6bab83b63cd9ad0787074081a52ef34",
+    ]),
   },
   rewardToken: (blockNumber: number) =>
     "0x940181a94A35A4569E4529A3CDfB74e38FD98631",
@@ -509,6 +522,7 @@ const LISK_CONSTANTS: chainConstants = {
     startBlock: 8380726,
     updateDelta: 60 * 60, // 1 hour
     priceConnectors: LISK_PRICE_CONNECTORS,
+    v1v2ConnectorBlacklist: new Set(),
   },
   rewardToken: (blockNumber: number) =>
     "0x7f9AdFbd38b669F03d1d11000Bc76b9AaEA28A81",
@@ -555,6 +569,9 @@ const MODE_CONSTANTS: chainConstants = {
     startBlock: 15591759,
     updateDelta: 60 * 60, // 1 hour
     priceConnectors: MODE_PRICE_CONNECTORS,
+    v1v2ConnectorBlacklist: new Set([
+      "0x1217bfe6c773eec6cc4a38b5dc45b92292b6e189",
+    ]),
   },
   rewardToken: (blockNumber: number) =>
     "0x7f9AdFbd38b669F03d1d11000Bc76b9AaEA28A81",
@@ -587,6 +604,7 @@ const CELO_CONSTANTS: chainConstants = {
     startBlock: 31690441,
     updateDelta: 60 * 60, // 1 hour
     priceConnectors: CELO_PRICE_CONNECTORS,
+    v1v2ConnectorBlacklist: new Set(),
   },
   rewardToken: (blockNumber: number) =>
     "0x7f9AdFbd38b669F03d1d11000Bc76b9AaEA28A81",
@@ -619,6 +637,7 @@ const SONEIUM_CONSTANTS: chainConstants = {
     startBlock: 1863998, // TODO: Get start block
     updateDelta: 60 * 60, // 1 hour
     priceConnectors: SONEIUM_PRICE_CONNECTORS,
+    v1v2ConnectorBlacklist: new Set(),
   },
   rewardToken: (blockNumber: number) =>
     "0x7f9AdFbd38b669F03d1d11000Bc76b9AaEA28A81",
@@ -651,6 +670,7 @@ const UNICHAIN_CONSTANTS: chainConstants = {
     startBlock: 9415475,
     updateDelta: 60 * 60, // 1 hour
     priceConnectors: UNICHAIN_PRICE_CONNECTORS,
+    v1v2ConnectorBlacklist: new Set(),
   },
   rewardToken: (blockNumber: number) =>
     "0x7f9AdFbd38b669F03d1d11000Bc76b9AaEA28A81",
@@ -697,6 +717,9 @@ const FRAXTAL_CONSTANTS: chainConstants = {
     startBlock: 12640176,
     updateDelta: 60 * 60, // 1 hour
     priceConnectors: FRAXTAL_PRICE_CONNECTORS,
+    v1v2ConnectorBlacklist: new Set([
+      "0x1217bfe6c773eec6cc4a38b5dc45b92292b6e189",
+    ]),
   },
   rewardToken: (blockNumber: number) =>
     "0x7f9AdFbd38b669F03d1d11000Bc76b9AaEA28A81",
@@ -729,6 +752,7 @@ const INK_CONSTANTS: chainConstants = {
     startBlock: 3361885,
     updateDelta: 60 * 60, // 1 hour
     priceConnectors: INK_PRICE_CONNECTORS,
+    v1v2ConnectorBlacklist: new Set(),
   },
   rewardToken: (blockNumber: number) =>
     "0x7f9AdFbd38b669F03d1d11000Bc76b9AaEA28A81",
@@ -761,6 +785,7 @@ const METAL_CONSTANTS: chainConstants = {
     startBlock: 11438647,
     updateDelta: 60 * 60, // 1 hour
     priceConnectors: METAL_PRICE_CONNECTORS,
+    v1v2ConnectorBlacklist: new Set(),
   },
   rewardToken: (blockNumber: number) =>
     "0x7f9AdFbd38b669F03d1d11000Bc76b9AaEA28A81",
@@ -793,6 +818,7 @@ const SWELL_CONSTANTS: chainConstants = {
     startBlock: 3733759,
     updateDelta: 60 * 60, // 1 hour
     priceConnectors: SWELL_PRICE_CONNECTORS,
+    v1v2ConnectorBlacklist: new Set(),
   },
   rewardToken: (blockNumber: number) =>
     "0x7f9AdFbd38b669F03d1d11000Bc76b9AaEA28A81",
@@ -825,6 +851,7 @@ const SUPERSEED_CONSTANTS: chainConstants = {
     startBlock: 5642528,
     updateDelta: 60 * 60, // 1 hour
     priceConnectors: SUPERSEED_PRICE_CONNECTORS,
+    v1v2ConnectorBlacklist: new Set(),
   },
   rewardToken: (blockNumber: number) =>
     "0x7f9AdFbd38b669F03d1d11000Bc76b9AaEA28A81",

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -415,8 +415,8 @@ const OPTIMISM_CONSTANTS: chainConstants = {
     updateDelta: 60 * 60, // 1 hour
     priceConnectors: OPTIMISM_PRICE_CONNECTORS,
     v1v2ConnectorBlacklist: new Set([
-      "0x01bff41798a0bcf287b996046ca68b395dbc1071",
-      "0x1217bfe6c773eec6cc4a38b5dc45b92292b6e189",
+      "0x01bFF41798a0BcF287b996046Ca68b395DbC1071",
+      "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189",
     ]),
   },
   rewardToken: (blockNumber: number) => {
@@ -473,8 +473,7 @@ const BASE_CONSTANTS: chainConstants = {
     updateDelta: 60 * 60, // 1 hour
     priceConnectors: BASE_PRICE_CONNECTORS,
     v1v2ConnectorBlacklist: new Set([
-      "0x1217bfe6c773eec6cc4a38b5dc45b92292b6e189",
-      "0x5d3a1ff2b6bab83b63cd9ad0787074081a52ef34",
+      "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189",
     ]),
   },
   rewardToken: (blockNumber: number) =>
@@ -570,7 +569,7 @@ const MODE_CONSTANTS: chainConstants = {
     updateDelta: 60 * 60, // 1 hour
     priceConnectors: MODE_PRICE_CONNECTORS,
     v1v2ConnectorBlacklist: new Set([
-      "0x1217bfe6c773eec6cc4a38b5dc45b92292b6e189",
+      "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189",
     ]),
   },
   rewardToken: (blockNumber: number) =>
@@ -718,7 +717,7 @@ const FRAXTAL_CONSTANTS: chainConstants = {
     updateDelta: 60 * 60, // 1 hour
     priceConnectors: FRAXTAL_PRICE_CONNECTORS,
     v1v2ConnectorBlacklist: new Set([
-      "0x1217bfe6c773eec6cc4a38b5dc45b92292b6e189",
+      "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189",
     ]),
   },
   rewardToken: (blockNumber: number) =>

--- a/src/Effects/RpcGateway.ts
+++ b/src/Effects/RpcGateway.ts
@@ -393,13 +393,25 @@ async function handleGetTokenPrice(
 
   const WETH_ADDRESS = chain.weth;
   const SYSTEM_TOKEN_ADDRESS = chain.rewardToken(blockNumber);
-  const connectors = chain.oracle.priceConnectors
+  let connectors = chain.oracle.priceConnectors
     .filter((c) => c.createdBlock <= blockNumber)
     .map((c) => c.address)
     .filter((a) => a !== tokenAddress)
     .filter((a) => a !== WETH_ADDRESS)
     .filter((a) => a !== DESTINATION_TOKEN_ADDRESS)
     .filter((a) => a !== SYSTEM_TOKEN_ADDRESS);
+
+  // Issue #688: V1/V2 (VeloPriceOracle.getManyRatesWithConnectors) reverts
+  // when the connector array contains tokens with no AMM pool at the queried
+  // block. Strip the per-chain blacklist for V1/V2 calls only — V3+ silently
+  // skips unreachable paths and tolerates the full list.
+  const oracleType = chain.oracle.getType(blockNumber);
+  if (oracleType === PriceOracleType.V1 || oracleType === PriceOracleType.V2) {
+    const blacklist = chain.oracle.v1v2ConnectorBlacklist;
+    if (blacklist.size > 0) {
+      connectors = connectors.filter((a) => !blacklist.has(a.toLowerCase()));
+    }
+  }
 
   const operationName = rpcGatewayOpName(EffectType.GET_TOKEN_PRICE);
   const logDetails = { tokenAddress, chainId, blockNumber };

--- a/src/Effects/RpcGateway.ts
+++ b/src/Effects/RpcGateway.ts
@@ -419,7 +419,7 @@ async function handleGetTokenPrice(
   const logDetails = { tokenAddress, chainId, blockNumber };
   const fallback = {
     pricePerUSDNew: 0n,
-    priceOracleType: chain.oracle.getType(blockNumber).toString(),
+    priceOracleType: oracleType.toString(),
   };
   const buildPriceFetcher = (client: typeof chain.eth_client) => () =>
     fetchTokenPrice(

--- a/src/Effects/RpcGateway.ts
+++ b/src/Effects/RpcGateway.ts
@@ -404,12 +404,14 @@ async function handleGetTokenPrice(
   // Issue #688: V1/V2 (VeloPriceOracle.getManyRatesWithConnectors) reverts
   // when the connector array contains tokens with no AMM pool at the queried
   // block. Strip the per-chain blacklist for V1/V2 calls only — V3+ silently
-  // skips unreachable paths and tolerates the full list.
+  // skips unreachable paths and tolerates the full list. Blacklist entries
+  // mirror the checksum casing used in price_connectors.json so this matches
+  // the same case-sensitive convention as the dedup filter above.
   const oracleType = chain.oracle.getType(blockNumber);
   if (oracleType === PriceOracleType.V1 || oracleType === PriceOracleType.V2) {
     const blacklist = chain.oracle.v1v2ConnectorBlacklist;
     if (blacklist.size > 0) {
-      connectors = connectors.filter((a) => !blacklist.has(a.toLowerCase()));
+      connectors = connectors.filter((a) => !blacklist.has(a));
     }
   }
 

--- a/src/PriceOracle.ts
+++ b/src/PriceOracle.ts
@@ -215,13 +215,18 @@ export async function refreshTokenPrice(
       return updatedToken;
     }
 
+    // Issue #673: only preserve the timestamp once the oracle has actually
+    // been queryable. For tokens whose entity is created before
+    // `oracle.startBlock`, every pre-deploy refresh returns $0 and would
+    // otherwise pin the timestamp at creation — letting the 30-day backoff
+    // trip before the oracle ever runs and stranding reward tokens at $0.
+    const oracleDeployed =
+      blockNumber >= CHAIN_CONSTANTS[chainId].oracle.startBlock;
     const updatedToken: Token = {
       ...token,
       pricePerUSDNew: currentPrice,
-      // Preserve original timestamp when price stays $0 so 30-day backoff timer
-      // tracks from creation/last non-zero price, not from last refresh attempt.
       lastUpdatedTimestamp:
-        currentPrice === 0n && token.pricePerUSDNew === 0n
+        oracleDeployed && currentPrice === 0n && token.pricePerUSDNew === 0n
           ? token.lastUpdatedTimestamp
           : new Date(blockTimestampMs),
     };

--- a/test/Constants.test.ts
+++ b/test/Constants.test.ts
@@ -95,20 +95,23 @@ describe("nfpmForCLPool", () => {
 
 describe("oracle.v1v2ConnectorBlacklist (#688)", () => {
   // Empirically determined connectors that revert V1/V2
-  // `getManyRatesWithConnectors`. Lowercased per filter contract in
-  // src/Effects/RpcGateway.ts.
-  const OUSDT = "0x1217bfe6c773eec6cc4a38b5dc45b92292b6e189";
+  // `getManyRatesWithConnectors`. Casing matches price_connectors.json so the
+  // case-sensitive filter in src/Effects/RpcGateway.ts strikes them.
+  const OUSDT = "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189";
 
   it("populates the OP V1/V2 poison set", () => {
     const set = CHAIN_CONSTANTS[10].oracle.v1v2ConnectorBlacklist;
-    expect(set.has("0x01bff41798a0bcf287b996046ca68b395dbc1071")).toBe(true);
+    expect(set.has("0x01bFF41798a0BcF287b996046Ca68b395DbC1071")).toBe(true);
     expect(set.has(OUSDT)).toBe(true);
   });
 
   it("populates the Base V1/V2 poison set", () => {
     const set = CHAIN_CONSTANTS[8453].oracle.v1v2ConnectorBlacklist;
     expect(set.has(OUSDT)).toBe(true);
-    expect(set.has("0x5d3a1ff2b6bab83b63cd9ad0787074081a52ef34")).toBe(true);
+    // 0x5d3a1Ff... is in the priceConnectors list but works individually on
+    // both V1 and V2 — the discriminator probe shows dropping oUSDT alone is
+    // sufficient. Keep this address out of the blacklist.
+    expect(set.has("0x5d3a1Ff2b6BAb83b63cd9AD0787074081a52ef34")).toBe(false);
   });
 
   it("populates Mode and Fraxtal V2 poison sets with oUSDT", () => {
@@ -129,10 +132,14 @@ describe("oracle.v1v2ConnectorBlacklist (#688)", () => {
     }
   });
 
-  it("uses lowercase addresses (matches RpcGateway's case-insensitive compare)", () => {
+  it("uses casing that matches the chain's priceConnectors entries", () => {
+    // RpcGateway compares with `!==` (case-sensitive), so every blacklist
+    // entry must be present verbatim in priceConnectors to actually filter.
     for (const chainId of [10, 8453, 34443, 252]) {
-      for (const a of CHAIN_CONSTANTS[chainId].oracle.v1v2ConnectorBlacklist) {
-        expect(a).toBe(a.toLowerCase());
+      const chain = CHAIN_CONSTANTS[chainId];
+      const known = new Set(chain.oracle.priceConnectors.map((c) => c.address));
+      for (const a of chain.oracle.v1v2ConnectorBlacklist) {
+        expect(known.has(a)).toBe(true);
       }
     }
   });

--- a/test/Constants.test.ts
+++ b/test/Constants.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { nfpmForCLPool, toChecksumAddress } from "../src/Constants";
+import {
+  CHAIN_CONSTANTS,
+  nfpmForCLPool,
+  toChecksumAddress,
+} from "../src/Constants";
 
 describe("nfpmForCLPool", () => {
   const OP_CL_FACTORY_OLD = toChecksumAddress(
@@ -86,5 +90,50 @@ describe("nfpmForCLPool", () => {
     ).toBeNull();
     // Optimism factory on wrong chain
     expect(nfpmForCLPool(8453, OP_CL_FACTORY_OLD)).toBeNull();
+  });
+});
+
+describe("oracle.v1v2ConnectorBlacklist (#688)", () => {
+  // Empirically determined connectors that revert V1/V2
+  // `getManyRatesWithConnectors`. Lowercased per filter contract in
+  // src/Effects/RpcGateway.ts.
+  const OUSDT = "0x1217bfe6c773eec6cc4a38b5dc45b92292b6e189";
+
+  it("populates the OP V1/V2 poison set", () => {
+    const set = CHAIN_CONSTANTS[10].oracle.v1v2ConnectorBlacklist;
+    expect(set.has("0x01bff41798a0bcf287b996046ca68b395dbc1071")).toBe(true);
+    expect(set.has(OUSDT)).toBe(true);
+  });
+
+  it("populates the Base V1/V2 poison set", () => {
+    const set = CHAIN_CONSTANTS[8453].oracle.v1v2ConnectorBlacklist;
+    expect(set.has(OUSDT)).toBe(true);
+    expect(set.has("0x5d3a1ff2b6bab83b63cd9ad0787074081a52ef34")).toBe(true);
+  });
+
+  it("populates Mode and Fraxtal V2 poison sets with oUSDT", () => {
+    expect(
+      CHAIN_CONSTANTS[34443].oracle.v1v2ConnectorBlacklist.has(OUSDT),
+    ).toBe(true);
+    expect(CHAIN_CONSTANTS[252].oracle.v1v2ConnectorBlacklist.has(OUSDT)).toBe(
+      true,
+    );
+  });
+
+  it("leaves V3-only chains with an empty blacklist", () => {
+    // Celo, Soneium, Unichain, Ink, Metal, Swell, Superseed never call V1/V2.
+    for (const chainId of [42220, 1868, 130, 57073, 1750, 1923, 5330]) {
+      expect(CHAIN_CONSTANTS[chainId].oracle.v1v2ConnectorBlacklist.size).toBe(
+        0,
+      );
+    }
+  });
+
+  it("uses lowercase addresses (matches RpcGateway's case-insensitive compare)", () => {
+    for (const chainId of [10, 8453, 34443, 252]) {
+      for (const a of CHAIN_CONSTANTS[chainId].oracle.v1v2ConnectorBlacklist) {
+        expect(a).toBe(a.toLowerCase());
+      }
+    }
   });
 });

--- a/test/Effects/Token.test.ts
+++ b/test/Effects/Token.test.ts
@@ -108,6 +108,7 @@ describe("Token Effects", () => {
         getAddress: () => TEST_ORACLE_ADDRESS,
         getPrice: vi.fn(),
         priceConnectors: options.priceConnectors ?? [],
+        v1v2ConnectorBlacklist: new Set<string>(),
       },
       stablecoins: new Set<string>(),
     };
@@ -443,13 +444,15 @@ describe("Token Effects", () => {
         startBlock: 0,
         getType: vi.fn(() => {
           getTypeCallCount++;
-          // First getType is when building fallback; second is inside fetchTokenPrice
+          // First getType is in RpcGateway (drives blacklist gate + fallback);
+          // second is inside fetchTokenPrice — that's where we want to throw.
           if (getTypeCallCount === 2) throw new Error("getType failure");
           return PriceOracleType.V3;
         }),
         getAddress: () => TEST_ORACLE_ADDRESS,
         getPrice: vi.fn(),
         priceConnectors: [],
+        v1v2ConnectorBlacklist: new Set<string>(),
       };
 
       setupChainConstants(PriceOracleType.V3, {});

--- a/test/EventHandlers/Voter/DistributeRewardEmissionsUSD.test.ts
+++ b/test/EventHandlers/Voter/DistributeRewardEmissionsUSD.test.ts
@@ -1,0 +1,208 @@
+import type { Token } from "generated";
+import { MockDb, Voter } from "generated/src/TestHelpers.gen";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  CHAIN_CONSTANTS,
+  PoolId,
+  TokenId,
+  toChecksumAddress,
+} from "../../../src/Constants";
+import { setupCommon } from "../Pool/common";
+
+/**
+ * Regression test for issue #673 — `totalEmissionsUSD` was reported as $0 on
+ * every pool across every chain. The acceptance criteria require asserting
+ * that `totalEmissionsUSD = emission * reward-token price`, and that the
+ * conversion uses the reward token's price (VELO / xVELO / AERO), not the
+ * pool's token0/token1 prices.
+ *
+ * Unlike the existing DistributeReward suite (which spies on
+ * `findPoolByGaugeAddress` and is therefore `it.skip`'d because vi.spyOn
+ * can't intercept tsx-loaded modules in envio v3 alpha.18), this test wires
+ * the pool's `gaugeAddress` to the event's gauge param so the real
+ * `findPoolByGaugeAddress` lookup succeeds via mockDb. That lets the full
+ * `Voter.DistributeReward` handler run end-to-end through
+ * `mockDb.processEvents` without spying.
+ */
+describe("Voter.DistributeReward → totalEmissionsUSD regression (#673)", () => {
+  const chainId = 10; // Optimism
+  const voterAddress = toChecksumAddress(
+    "0x41C914ee0c7E1A5edCD0295623e6dC557B5aBf3C",
+  );
+  const poolAddress = toChecksumAddress(
+    "0x478946BcD4a5a22b316470F5486fAfb928C0bA25",
+  );
+  const gaugeAddress = toChecksumAddress(
+    "0xa75127121d28a9bf848f3b70e7eea26570aa7700",
+  );
+  const blockNumber = 128357873;
+  const blockTimestamp = 1_700_000_000;
+  const rewardTokenAddress = CHAIN_CONSTANTS[chainId].rewardToken(blockNumber);
+
+  let originalChainConstants: (typeof CHAIN_CONSTANTS)[typeof chainId];
+
+  beforeEach(() => {
+    originalChainConstants = CHAIN_CONSTANTS[chainId];
+    CHAIN_CONSTANTS[chainId] = {
+      ...originalChainConstants,
+      rewardToken: vi.fn().mockReturnValue(rewardTokenAddress),
+    };
+  });
+
+  afterEach(() => {
+    CHAIN_CONSTANTS[chainId] = originalChainConstants;
+    vi.restoreAllMocks();
+  });
+
+  function makeRewardToken(overrides?: Partial<Token>): Token {
+    return {
+      id: TokenId(chainId, rewardTokenAddress),
+      address: rewardTokenAddress,
+      symbol: "VELO",
+      name: "VELO",
+      chainId,
+      decimals: 18n,
+      pricePerUSDNew: 2n * 10n ** 18n, // $2
+      isWhitelisted: true,
+      // Match block timestamp so refreshTokenPrice is a no-op (avoids real RPC).
+      lastUpdatedTimestamp: new Date(blockTimestamp * 1000),
+      ...overrides,
+    } as Token;
+  }
+
+  function makeDistributeRewardEvent(amount: bigint) {
+    return Voter.DistributeReward.createMockEvent({
+      gauge: gaugeAddress,
+      amount,
+      mockEventData: {
+        block: {
+          number: blockNumber,
+          timestamp: blockTimestamp,
+          hash: "0xblockhash",
+        },
+        chainId,
+        logIndex: 0,
+        srcAddress: voterAddress,
+      },
+    });
+  }
+
+  it("writes totalEmissionsUSD = emission * reward-token price when price is non-zero", async () => {
+    const { createMockLiquidityPoolAggregator } = setupCommon();
+    const liquidityPool = createMockLiquidityPoolAggregator({
+      id: PoolId(chainId, poolAddress),
+      chainId,
+      poolAddress,
+      gaugeAddress, // critical: lets findPoolByGaugeAddress resolve via mockDb
+      totalEmissions: 0n,
+      totalEmissionsUSD: 0n,
+      gaugeIsAlive: true,
+    });
+
+    const rewardToken = makeRewardToken();
+    const amountEmitted = 1000n * 10n ** 18n; // 1000 VELO
+    const expectedEmissionsUSD = 2000n * 10n ** 18n; // 1000 * $2
+
+    let db = MockDb.createMockDb();
+    db = db.entities.Token.set(rewardToken);
+    db = db.entities.LiquidityPoolAggregator.set(liquidityPool);
+
+    const resultDB = await db.processEvents([
+      makeDistributeRewardEvent(amountEmitted),
+    ]);
+
+    const updatedPool = resultDB.entities.LiquidityPoolAggregator.get(
+      PoolId(chainId, poolAddress),
+    );
+    expect(updatedPool?.totalEmissions).toBe(amountEmitted);
+    expect(updatedPool?.totalEmissionsUSD).toBe(expectedEmissionsUSD);
+  });
+
+  it("uses the reward token's price (not the pool's token0/token1 prices) for USD conversion", async () => {
+    // Pool tokens (token0=USDT @ $1, token1=USDC @ $1) come from setupCommon().
+    // Reward token = VELO @ $7. If the handler accidentally used token0 or token1's
+    // price, the USD result would be 1000 * $1 = $1000 (matching neither $7000
+    // nor a decimals-mismatched USDC variant), so the $7000 expectation forces
+    // the right token to be picked.
+    const {
+      createMockLiquidityPoolAggregator,
+      mockToken0Data,
+      mockToken1Data,
+    } = setupCommon();
+    const liquidityPool = createMockLiquidityPoolAggregator({
+      id: PoolId(chainId, poolAddress),
+      chainId,
+      poolAddress,
+      gaugeAddress,
+      totalEmissions: 0n,
+      totalEmissionsUSD: 0n,
+      gaugeIsAlive: true,
+    });
+
+    const rewardToken = makeRewardToken({
+      pricePerUSDNew: 7n * 10n ** 18n,
+    });
+    const amountEmitted = 1000n * 10n ** 18n;
+
+    let db = MockDb.createMockDb();
+    // Seed pool tokens too — proving the handler doesn't fall back to them.
+    db = db.entities.Token.set(mockToken0Data);
+    db = db.entities.Token.set(mockToken1Data);
+    db = db.entities.Token.set(rewardToken);
+    db = db.entities.LiquidityPoolAggregator.set(liquidityPool);
+
+    const resultDB = await db.processEvents([
+      makeDistributeRewardEvent(amountEmitted),
+    ]);
+
+    const updatedPool = resultDB.entities.LiquidityPoolAggregator.get(
+      PoolId(chainId, poolAddress),
+    );
+    expect(updatedPool?.totalEmissionsUSD).toBe(7000n * 10n ** 18n);
+  });
+
+  it("leaves totalEmissionsUSD at 0 when the reward token's price is 0 and refresh stays at 0 (#673 root cause)", async () => {
+    // Documents the deployed-indexer symptom: when the oracle can't price the
+    // reward token, `totalEmissions` increments correctly but `totalEmissionsUSD`
+    // stays 0. Fixing the upstream symptom is an oracle-layer concern (issues
+    // #669 / #677), not a logic bug in this handler — this test pins the
+    // contract so future regressions surface here.
+    //
+    // To make refreshTokenPrice a no-op against a $0-priced token, set
+    // `lastUpdatedTimestamp` more than 30 days before the event: the
+    // PriceOracle backoff (`THIRTY_DAYS_MS`) stops retrying past that point.
+    const { createMockLiquidityPoolAggregator } = setupCommon();
+    const liquidityPool = createMockLiquidityPoolAggregator({
+      id: PoolId(chainId, poolAddress),
+      chainId,
+      poolAddress,
+      gaugeAddress,
+      totalEmissions: 0n,
+      totalEmissionsUSD: 0n,
+      gaugeIsAlive: true,
+    });
+
+    const THIRTY_ONE_DAYS_S = 31 * 24 * 60 * 60;
+    const rewardToken = makeRewardToken({
+      pricePerUSDNew: 0n,
+      lastUpdatedTimestamp: new Date(
+        (blockTimestamp - THIRTY_ONE_DAYS_S) * 1000,
+      ),
+    });
+    const amountEmitted = 1000n * 10n ** 18n;
+
+    let db = MockDb.createMockDb();
+    db = db.entities.Token.set(rewardToken);
+    db = db.entities.LiquidityPoolAggregator.set(liquidityPool);
+
+    const resultDB = await db.processEvents([
+      makeDistributeRewardEvent(amountEmitted),
+    ]);
+
+    const updatedPool = resultDB.entities.LiquidityPoolAggregator.get(
+      PoolId(chainId, poolAddress),
+    );
+    expect(updatedPool?.totalEmissions).toBe(amountEmitted);
+    expect(updatedPool?.totalEmissionsUSD).toBe(0n);
+  });
+});

--- a/test/PriceOracle.test.ts
+++ b/test/PriceOracle.test.ts
@@ -222,6 +222,109 @@ describe("PriceOracle", () => {
       });
     });
 
+    describe("Issue #673: pre-oracle stranding regression", () => {
+      // Reward tokens (VELO/OP, AERO/Base, XVELO/OP) were stuck at $0 with
+      // 2023 timestamps because their Token entities are created before the
+      // chain's oracle deploys. While the oracle is unreachable, the price
+      // refresh keeps returning 0; with timestamp preservation, the 30-day
+      // backoff trips before the oracle ever runs, stranding the token.
+      // Fix: only preserve the timestamp once the oracle has actually been
+      // queryable at this block.
+
+      it("advances lastUpdatedTimestamp when oracle is not yet deployed (lets the 30-day clock count from oracle deploy, not creation)", async () => {
+        vi.mocked(mockContext.Token?.set)?.mockClear();
+
+        const preOracleBlock = startBlock - 1;
+        // Mock effects: getTokenDetails works, getTokenPrice returns $0 (the
+        // ORACLE_DEPLOYED gate inside handleGetTokenPrice does the same in prod).
+        vi.mocked(mockContext.effect)?.mockImplementation(
+          async (effect: unknown, _input: unknown) => {
+            const name = (effect as { name?: string }).name;
+            if (name === "getTokenPrice") {
+              return { pricePerUSDNew: 0n };
+            }
+            if (name === "getTokenDetails") {
+              return { name: "VELO", decimals: 18, symbol: "VELO" };
+            }
+            return {};
+          },
+        );
+
+        const creationDate = new Date(blockDatetime.getTime());
+        const fetchedToken = {
+          ...mockToken0Data,
+          pricePerUSDNew: 0n,
+          lastUpdatedTimestamp: creationDate,
+        };
+        // 1 hour later, still pre-oracle
+        const blockTimestamp = blockDatetime.getTime() / 1000 + 60 * 60;
+
+        await PriceOracle.refreshTokenPrice(
+          fetchedToken,
+          preOracleBlock,
+          blockTimestamp,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        expect(updatedToken.pricePerUSDNew).toBe(0n);
+        // Critical: timestamp must move forward so the 30-day backoff resets.
+        expect(updatedToken.lastUpdatedTimestamp.getTime()).toBe(
+          blockTimestamp * 1000,
+        );
+        expect(updatedToken.lastUpdatedTimestamp.getTime()).toBeGreaterThan(
+          creationDate.getTime(),
+        );
+      });
+
+      it("preserves lastUpdatedTimestamp once oracle is deployed and price stays $0 (existing 30-day backoff behavior intact)", async () => {
+        vi.mocked(mockContext.Token?.set)?.mockClear();
+
+        const postOracleBlock = startBlock + 1;
+        vi.mocked(mockContext.effect)?.mockImplementation(
+          async (effect: unknown, _input: unknown) => {
+            const name = (effect as { name?: string }).name;
+            if (name === "getTokenPrice") {
+              return { pricePerUSDNew: 0n };
+            }
+            if (name === "getTokenDetails") {
+              return { name: "VELO", decimals: 18, symbol: "VELO" };
+            }
+            return {};
+          },
+        );
+
+        const earlierTimestamp = new Date(
+          blockDatetime.getTime() - 5 * 24 * 60 * 60 * 1000,
+        );
+        const fetchedToken = {
+          ...mockToken0Data,
+          pricePerUSDNew: 0n,
+          lastUpdatedTimestamp: earlierTimestamp,
+        };
+        const blockTimestamp = blockDatetime.getTime() / 1000;
+
+        await PriceOracle.refreshTokenPrice(
+          fetchedToken,
+          postOracleBlock,
+          blockTimestamp,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        expect(updatedToken.pricePerUSDNew).toBe(0n);
+        // Post-oracle preservation must still apply — bounds RPC waste for
+        // genuinely unpriceable tokens.
+        expect(updatedToken.lastUpdatedTimestamp.getTime()).toBe(
+          earlierTimestamp.getTime(),
+        );
+      });
+    });
+
     describe("when pricePerUSDNew is 0n for more than 30 days (unpriceable)", () => {
       beforeEach(async () => {
         vi.mocked(mockContext.Token?.set)?.mockClear();


### PR DESCRIPTION
## Summary

- **Fix**: in `src/PriceOracle.ts`, gate the timestamp-preservation branch in `refreshTokenPrice` on `blockNumber >= oracle.startBlock`. Pre-deploy refreshes now advance the `lastUpdatedTimestamp` instead of pinning it to token creation, so the 30-day backoff clock starts from the moment the oracle actually becomes queryable.
- **Regression test (voter)**: `test/EventHandlers/Voter/DistributeRewardEmissionsUSD.test.ts` — pins `totalEmissionsUSD = emission * reward-token price` end-to-end through `mockDb.processEvents`, including the wrong-token-price guard and the $0-price degenerate case.
- **Regression test (oracle)**: two new cases in `test/PriceOracle.test.ts` — pre-oracle stranding (timestamp must advance) and post-oracle preservation (existing 30-day backoff still bounds RPC).

## Root cause (issue #673)

`createTokenEntity` writes the Token at first sight with `pricePerUSDNew = 0n` and `lastUpdatedTimestamp = blockDatetime`. For chains where this happens before `oracle.startBlock`:

1. `handleGetTokenPrice` returns `0n` early (the `ORACLE_DEPLOYED` gate).
2. The `0 → 0` branch in `refreshTokenPrice` was preserving the original timestamp.
3. After 30 days from creation, `shouldRefresh` flipped to `false` permanently.
4. By the time the oracle deployed (often weeks later), refresh never fired again.

Live evidence captured against the deployed indexer (2026-05-07):

| Token | chain | `pricePerUSDNew` | `lastUpdatedTimestamp` |
|---|---|---|---|
| AERO | Base (8453) | `0` | `2023-08-28T02:43:35Z` |
| VELO | OP (10) | `0` | `2023-06-22T00:09:31Z` |
| XVELO | OP (10) | `0` | `2023-06-22T00:08:57Z` |

Result: every reward-token USD multiplication landed on `0`, so `totalEmissionsUSD` was `$0` on every pool.

## Acceptance criteria mapping

- [x] Identify where `totalEmissionsUSD` should be set → `Voter.DistributeReward` → `computeVoterDistributeValues` (unchanged).
- [x] Verify USD conversion uses the reward token's price (not pool token0/token1) → covered by `DistributeRewardEmissionsUSD.test.ts`.
- [x] Add regression test for `totalEmissionsUSD = emission * reward-token price` → same file.
- [ ] Confirm on fresh reindex → required after merge; the fix is no-op against the currently-deployed (stuck) state.

## Test plan

- [x] `vitest run test/PriceOracle.test.ts` — 22 pass
- [x] `vitest run test/EventHandlers/Voter/DistributeRewardEmissionsUSD.test.ts` — 3 pass
- [x] `pnpm test` — 1177 pass, 32 skipped (matches main)
- [x] `pnpm qa --write` — clean
- [x] `tsc --noEmit` — clean
- [ ] Fresh reindex of OP + Base; confirm `totalEmissionsUSD > 0` on a sampled pool with non-zero emissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added connector token blacklist for V1/V2 oracle queries to prevent failures when querying unsupported tokens.

* **Bug Fixes**
  * Fixed zero-price token timestamp handling to prevent premature backoff triggers during oracle deployment transitions.
  * Corrected reward token price calculations in reward emission USD computations.

* **Tests**
  * Added regression test suites validating connector blacklist configurations, reward distribution with varying token prices, and timestamp behavior for zero-price tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->