### PR TITLE
fix(helpers): cap swap-USD when token decimals are malformed (#668)

### DIFF
--- a/src/Helpers.ts
+++ b/src/Helpers.ts
@@ -73,6 +73,14 @@ export function calculateTokenAmountUSD(
   tokenDecimals: number,
   pricePerUSDNew: bigint,
 ): bigint {
+  // Issue #668: reject malformed (decimals, price) tuples whose implied per-raw-unit
+  // USD exceeds $1 — no real ERC20 has a smallest unit worth more than $1, so this
+  // only triggers when a token's decimals were lost (typically persisted as 0
+  // instead of 18 after an RPC failure). One such token can otherwise warp
+  // lifetime swap-USD totals into the quadrillions.
+  if (pricePerUSDNew > TEN_TO_THE_18_BI * 10n ** BigInt(tokenDecimals)) {
+    return 0n;
+  }
   const normalizedAmount = normalizeTokenAmountTo1e18(amount, tokenDecimals);
   return multiplyBase1e18(normalizedAmount, pricePerUSDNew);
 }

--- a/test/Helpers.test.ts
+++ b/test/Helpers.test.ts
@@ -5,9 +5,10 @@ import {
 } from "@uniswap/v3-sdk";
 import type { LiquidityPoolAggregator, Token, handlerContext } from "generated";
 import JSBI from "jsbi";
-import { toChecksumAddress } from "../src/Constants";
+import { TEN_TO_THE_18_BI, toChecksumAddress } from "../src/Constants";
 import {
   calculatePositionAmountsFromLiquidity,
+  calculateTokenAmountUSD,
   calculateTotalUSD,
   calculateWhitelistedFeesUSD,
   computeLiquidityDeltaFromAmounts,
@@ -107,6 +108,64 @@ describe("Helpers", () => {
 
       expect(logError).toHaveBeenCalledTimes(1);
       expect(logError).toHaveBeenCalledWith("Test message: string error");
+    });
+  });
+
+  describe("calculateTokenAmountUSD precision-overflow guard (issue #668)", () => {
+    it("returns 0n when implied per-raw-unit USD exceeds $1 (decimals=0 misread of 18-decimal token)", () => {
+      // Simulates an 18-decimal token like wstETH whose decimals were persisted as 0
+      // due to an RPC failure. With decimals=0, the normalize path leaves the raw
+      // 1e18 amount untouched and multiplies by ~$4500 → ~$4.5e21 instead of ~$4500.
+      const oneRawUnitOf18Decimal = 10n ** 18n;
+      const wronglyZeroDecimals = 0;
+      const wstEthIshPrice = 4500n * TEN_TO_THE_18_BI;
+      expect(
+        calculateTokenAmountUSD(
+          oneRawUnitOf18Decimal,
+          wronglyZeroDecimals,
+          wstEthIshPrice,
+        ),
+      ).toBe(0n);
+    });
+
+    it("does not zap a legitimate decimals=0 token priced under $1 (e.g. IDRX)", () => {
+      // IDRX (Indonesian rupiah stablecoin) legitimately has decimals=0; its
+      // per-raw-unit price is ~$0.00006, well below the $1 cap.
+      const idrxRawAmount = 1_000_000n;
+      const idrxPrice = 60_000_000_000_000n; // ~$6e-5 in 1e18-base
+      const usd = calculateTokenAmountUSD(idrxRawAmount, 0, idrxPrice);
+      expect(usd).toBe((idrxRawAmount * idrxPrice) / TEN_TO_THE_18_BI);
+    });
+
+    it("preserves existing USD math for typical 18-decimal tokens within bounds", () => {
+      const amount = 5n * TEN_TO_THE_18_BI; // 5 tokens
+      const decimals = 18;
+      const price = 1n * TEN_TO_THE_18_BI; // $1
+      expect(calculateTokenAmountUSD(amount, decimals, price)).toBe(
+        5n * TEN_TO_THE_18_BI,
+      );
+    });
+
+    it("isolates one corrupted token in calculateTotalUSD (the swap-USD entry point)", () => {
+      // Simulates the Fraxtal scenario: a legitimately-priced token0 paired with
+      // a token1 whose decimals were misread as 0. Only token1's contribution is
+      // zeroed; token0's USD must still flow through. Pre-fix, token1 alone
+      // would warp the swap's USD into 1e21+.
+      const { mockToken0Data, mockToken1Data } = setupCommon();
+      const corruptedToken1: Token = {
+        ...mockToken1Data,
+        decimals: 0n,
+        pricePerUSDNew: 4500n * TEN_TO_THE_18_BI,
+      };
+      const amount0 = 3n * TEN_TO_THE_18_BI; // $3 from token0
+      const amount1 = 10n ** 18n; // would be $4.5e21 without the guard
+      const total = calculateTotalUSD(
+        amount0,
+        amount1,
+        mockToken0Data,
+        corruptedToken1,
+      );
+      expect(total).toBe(3n * TEN_TO_THE_18_BI);
     });
   });
 


### PR DESCRIPTION
## Summary
- Five Fraxtal pools (chain `252`) had lifetime `totalVolumeUSD` / `totalFeesGeneratedUSD` warped into quadrillion-range — implied per-swap USD `1e19`–`1e25`, ~`1e15×` larger than physically possible. Root cause: at least one route token (likely `wstETH` / `ezETH` / `sfrxETH`) persisted with `decimals=0`, after which the swap-USD path normalized as if 18-decimal and inflated the result by `1e18`.
- Add a sanity cap inside `calculateTokenAmountUSD` (the single chokepoint for swap, fee, and reserve USD math): if the implied per-raw-unit USD (`pricePerUSDNew / 10^tokenDecimals`) exceeds **$1**, zero the contribution. No real ERC20 has a smallest unit worth more than $1, so legitimately priced tokens — including 0-decimal stablecoins like IDRX (~$0.00006/unit) — pass through untouched. Anything tripping the cap is malformed and would otherwise poison aggregates.

## Out of scope
- The `getTokenDetails` failure mode that lets `decimals=0` get persisted in the first place — separate issue.
- Pattern-2 price-spike contamination on other chains — separate issue.

## Test plan
- [x] New unit tests cover: 18-decimal token misread as 0 → zaps; legitimate `decimals=0` low-priced token → not zapped; normal 18-decimal swap → unchanged; one-corrupted-token swap routed through `calculateTotalUSD` keeps the healthy side's USD.
- [x] Full project test suite (`pnpm test`) — 1176 passing, 0 regressions.
- [x] `tsc --noEmit` clean, `pnpm qa --write` clean.
- [ ] Operational: verify a fresh reindex produces sane lifetime totals on the 5 affected Fraxtal pools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)