### PR TITLE
fix(price-oracle): heal empty symbol/name from transient RPC failure (#672)

### DIFF
--- a/src/PriceOracle.ts
+++ b/src/PriceOracle.ts
@@ -89,11 +89,17 @@ export async function refreshTokenPrice(
     return token;
   }
 
+  // Issue #672: heal empty symbol/name from a transient RPC failure at token
+  // creation. ERC20 metadata is otherwise treated as immutable, so a single
+  // failure during createTokenEntity persists `?` (empty symbol) forever.
+  const healedMetadata = await maybeHealMetadata(token, chainId, context);
+
   // Issue #669: blacklist + canonical rebind override the oracle for known-bad
   // (chain, token) pairs. See src/PriceOverrides.ts for rationale per token.
   if (isBlacklistedToken(chainId, token.address)) {
     const updated: Token = {
       ...token,
+      ...healedMetadata,
       pricePerUSDNew: 0n,
       lastUpdatedTimestamp: new Date(blockTimestampMs),
     };
@@ -136,6 +142,7 @@ export async function refreshTokenPrice(
 
     const updated: Token = {
       ...token,
+      ...healedMetadata,
       pricePerUSDNew: sourcePrice,
       lastUpdatedTimestamp: new Date(blockTimestampMs),
     };
@@ -159,7 +166,9 @@ export async function refreshTokenPrice(
     // Cache key is based on input parameters, so rounding must happen before effect call
     const roundedBlockNumber = roundBlockToInterval(blockNumber, chainId);
 
-    // ERC20 metadata is immutable; populated once at token creation, not refreshed here.
+    // ERC20 metadata is mostly immutable, but symbol/name may have been
+    // persisted as empty due to a transient RPC failure at createTokenEntity
+    // time (issue #672). Heal happens above this try block; price fetch below.
     const priceData = await context.effect(getTokenPrice, {
       tokenAddress: token.address,
       chainId,
@@ -209,6 +218,7 @@ export async function refreshTokenPrice(
       // This ensures we don't keep trying to refresh too frequently
       const updatedToken: Token = {
         ...token,
+        ...healedMetadata,
         lastUpdatedTimestamp: new Date(blockTimestampMs),
       };
       context.Token.set(updatedToken);
@@ -217,6 +227,7 @@ export async function refreshTokenPrice(
 
     const updatedToken: Token = {
       ...token,
+      ...healedMetadata,
       pricePerUSDNew: currentPrice,
       // Preserve original timestamp when price stays $0 so 30-day backoff timer
       // tracks from creation/last non-zero price, not from last refresh attempt.
@@ -243,5 +254,48 @@ export async function refreshTokenPrice(
     );
     // Return original token if refresh fails - this preserves the last known price
     return token;
+  }
+}
+
+/**
+ * Re-fetches ERC20 metadata when the stored Token entity has an empty symbol or
+ * name (issue #672). createTokenEntity calls getTokenDetails exactly once per
+ * pool's PoolCreated event, so a transient RPC failure persists `?` (empty
+ * symbol) on the Token forever. The Effect already bypasses cache on empty
+ * results, so a fresh call retries the underlying RPC.
+ *
+ * Returns an overlay containing only the fields that were empty on `token` and
+ * came back non-empty from the RPC. Callers spread it: `{ ...token, ...healed }`.
+ * Failures are logged but never thrown — metadata is display-only and must not
+ * abort the price refresh.
+ *
+ * @param token - Existing Token entity (read-only).
+ * @param chainId - Chain to query.
+ * @param context - Envio handler context for the effect call and logging.
+ * @returns `{ symbol?, name? }` overlay; empty object if no heal applied.
+ */
+async function maybeHealMetadata(
+  token: Token,
+  chainId: number,
+  context: handlerContext,
+): Promise<{ symbol?: string; name?: string }> {
+  if (token.symbol && token.name) {
+    return {};
+  }
+
+  try {
+    const details = await context.effect(getTokenDetails, {
+      contractAddress: token.address,
+      chainId,
+    });
+    const overlay: { symbol?: string; name?: string } = {};
+    if (!token.symbol && details.symbol) overlay.symbol = details.symbol;
+    if (!token.name && details.name) overlay.name = details.name;
+    return overlay;
+  } catch (error) {
+    context.log.error(
+      `Error refreshing token metadata for ${token.address} on chain ${chainId}: ${error}`,
+    );
+    return {};
   }
 }

--- a/test/PriceOracle.test.ts
+++ b/test/PriceOracle.test.ts
@@ -468,6 +468,251 @@ describe("PriceOracle", () => {
       });
     });
 
+    describe("Metadata heal: empty symbol/name (issue #672)", () => {
+      // Issue #672: Soneium pools display tokens with `?` (empty symbol). Root
+      // cause is a transient RPC failure during the single createTokenEntity
+      // call when the pool's PoolCreated event was first seen — the empty
+      // symbol/name was persisted and never re-fetched, since ERC20 metadata
+      // was treated as immutable. Heal path: whenever refreshTokenPrice runs
+      // and observes an empty symbol or name, re-fetch via getTokenDetails
+      // and overlay the healed fields onto the Token entity.
+      const oneHourAndOneMinuteAgo = () =>
+        new Date(blockDatetime.getTime() - 61 * 60 * 1000);
+
+      beforeEach(() => {
+        vi.mocked(mockContext.Token?.set)?.mockClear();
+        vi.mocked(mockContext.effect)?.mockClear();
+        vi.mocked(mockContext.log?.error)?.mockClear();
+      });
+
+      it("heals empty symbol on refresh by calling getTokenDetails and writing the value", async () => {
+        const fetchedToken = {
+          ...mockToken0Data,
+          symbol: "",
+          name: "Tether USD",
+          lastUpdatedTimestamp: oneHourAndOneMinuteAgo(),
+        };
+        await PriceOracle.refreshTokenPrice(
+          fetchedToken,
+          blockNumber,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        expect(updatedToken.symbol).toBe("TEST");
+        // getTokenDetails must have been invoked
+        const detailsCall = vi
+          .mocked(mockContext.effect)
+          ?.mock.calls.find(
+            (c) => (c[0] as { name?: string }).name === "getTokenDetails",
+          );
+        expect(detailsCall).toBeDefined();
+      });
+
+      it("does NOT call getTokenDetails when symbol and name are already populated", async () => {
+        const fetchedToken = {
+          ...mockToken0Data,
+          symbol: "USDT",
+          name: "Tether USD",
+          lastUpdatedTimestamp: oneHourAndOneMinuteAgo(),
+        };
+        await PriceOracle.refreshTokenPrice(
+          fetchedToken,
+          blockNumber,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        const detailsCall = vi
+          .mocked(mockContext.effect)
+          ?.mock.calls.find(
+            (c) => (c[0] as { name?: string }).name === "getTokenDetails",
+          );
+        expect(detailsCall).toBeUndefined();
+      });
+
+      it("preserves the existing empty symbol when getTokenDetails still returns empty", async () => {
+        vi.mocked(mockContext.effect)?.mockImplementation(
+          async (effect: unknown, _input: unknown) => {
+            const name = (effect as { name?: string }).name;
+            if (name === "getTokenDetails") {
+              return { name: "", decimals: 18, symbol: "" };
+            }
+            if (name === "getTokenPrice") {
+              return { pricePerUSDNew: 2n * 10n ** 18n };
+            }
+            return {};
+          },
+        );
+
+        const fetchedToken = {
+          ...mockToken0Data,
+          symbol: "",
+          name: "",
+          lastUpdatedTimestamp: oneHourAndOneMinuteAgo(),
+        };
+        await PriceOracle.refreshTokenPrice(
+          fetchedToken,
+          blockNumber,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        expect(updatedToken.symbol).toBe("");
+        expect(updatedToken.name).toBe("");
+      });
+
+      it("does NOT abort price refresh when getTokenDetails throws", async () => {
+        vi.mocked(mockContext.effect)?.mockImplementation(
+          async (effect: unknown, _input: unknown) => {
+            const name = (effect as { name?: string }).name;
+            if (name === "getTokenDetails") {
+              throw new Error("RPC down");
+            }
+            if (name === "getTokenPrice") {
+              return { pricePerUSDNew: 2n * 10n ** 18n };
+            }
+            return {};
+          },
+        );
+
+        const fetchedToken = {
+          ...mockToken0Data,
+          symbol: "",
+          name: "",
+          lastUpdatedTimestamp: oneHourAndOneMinuteAgo(),
+        };
+        await PriceOracle.refreshTokenPrice(
+          fetchedToken,
+          blockNumber,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        // Price should still update; symbol/name preserved as empty
+        expect(updatedToken.pricePerUSDNew).toBe(2n * 10n ** 18n);
+        expect(updatedToken.symbol).toBe("");
+        // Metadata error should be logged
+        expect(vi.mocked(mockContext.log?.error)).toHaveBeenCalledWith(
+          expect.stringContaining("Error refreshing token metadata"),
+        );
+      });
+
+      it("heals symbol on the blacklist path (token forced to 0 still gets symbol)", async () => {
+        const MANATEE_OP = toChecksumAddress(
+          "0x7909Bda52eAf7C3cc12745E727Eb527a485241D8",
+        );
+        vi.mocked(mockContext.effect)?.mockImplementation(
+          async (effect: unknown, _input: unknown) => {
+            const name = (effect as { name?: string }).name;
+            if (name === "getTokenDetails") {
+              return { name: "$Manatee", decimals: 18, symbol: "MANATEE" };
+            }
+            return {};
+          },
+        );
+
+        const fetchedToken = {
+          ...mockToken0Data,
+          address: MANATEE_OP,
+          symbol: "",
+          name: "",
+          pricePerUSDNew: 388_328n * 10n ** 18n,
+          lastUpdatedTimestamp: oneHourAndOneMinuteAgo(),
+        };
+        await PriceOracle.refreshTokenPrice(
+          fetchedToken,
+          blockNumber,
+          blockDatetime.getTime() / 1000,
+          10,
+          mockContext as handlerContext,
+        );
+
+        const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        expect(updatedToken.symbol).toBe("MANATEE");
+        expect(updatedToken.pricePerUSDNew).toBe(0n);
+      });
+
+      it("heals symbol on the rebind path", async () => {
+        const RSETH_SWELL = toChecksumAddress(
+          "0xc3eaCf0612346366Db554c991D7858716db09f58",
+        );
+        const WRSETH_BASE = toChecksumAddress(
+          "0xEDfa23602D0EC14714057867A78d01e94176BEA0",
+        );
+        const sourcePrice = 2_443n * 10n ** 18n;
+
+        vi.mocked(mockContext.Token?.get)?.mockImplementation(async (id) => {
+          if (id === `8453-${WRSETH_BASE}`) {
+            return { pricePerUSDNew: sourcePrice } as Token;
+          }
+          return undefined;
+        });
+        vi.mocked(mockContext.effect)?.mockImplementation(
+          async (effect: unknown, _input: unknown) => {
+            const name = (effect as { name?: string }).name;
+            if (name === "getTokenDetails") {
+              return { name: "rsETH", decimals: 18, symbol: "rsETH" };
+            }
+            return {};
+          },
+        );
+
+        const fetchedToken = {
+          ...mockToken0Data,
+          address: RSETH_SWELL,
+          symbol: "",
+          name: "",
+          lastUpdatedTimestamp: oneHourAndOneMinuteAgo(),
+        };
+        await PriceOracle.refreshTokenPrice(
+          fetchedToken,
+          blockNumber,
+          blockDatetime.getTime() / 1000,
+          1923,
+          mockContext as handlerContext,
+        );
+
+        const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        expect(updatedToken.symbol).toBe("rsETH");
+        expect(updatedToken.pricePerUSDNew).toBe(sourcePrice);
+      });
+
+      it("heals empty name when symbol is already populated", async () => {
+        const fetchedToken = {
+          ...mockToken0Data,
+          symbol: "USDT",
+          name: "",
+          lastUpdatedTimestamp: oneHourAndOneMinuteAgo(),
+        };
+        await PriceOracle.refreshTokenPrice(
+          fetchedToken,
+          blockNumber,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        expect(updatedToken.name).toBe("Test Token");
+        // Existing non-empty symbol must not be overwritten
+        expect(updatedToken.symbol).toBe("USDT");
+      });
+    });
+
     describe("when price fetch fails", () => {
       let originalToken: Token;
       beforeEach(async () => {


### PR DESCRIPTION
## Summary

- `createTokenEntity` calls `getTokenDetails` exactly once per pool's `PoolCreated` event. If the RPC returned `{ symbol: "", name: "" }` (Soneium hits this), the empty value persists forever because ERC20 metadata was treated as immutable.
- `refreshTokenPrice` now calls `maybeHealMetadata` whenever it runs; if `Token.symbol` or `Token.name` is empty, it re-fetches `getTokenDetails` and overlays the populated fields onto the entity.
- Heal applies across all three paths (blacklist, rebind, regular oracle) so the symbol still gets corrected on tokens whose price is overridden.
- Failures are logged but never thrown — display-only metadata must not abort price refresh.

## Investigation notes (closes #672)

All 8 affected Soneium pools resolve to tokens whose **on-chain symbols are valid**:

| Stored as | On-chain | Address |
|---|---|---|
| `?` ($1) | `oUSDT` | `0x1217BfE6…E189` |
| `?` ($1) | `USDC.e` | `0xbA9986D2…C369` |
| `?` ($2.32K) | `WETH` | `0x4200…0006` |
| `?` ($79.21K) | `SolvBTC` | `0x541FD749…8B77` |
| `?` ($1) | `HBI` | `0x651076B5…2352` |
| `?` ($0) | `ASTR` / `nsASTR` | `0x2CAE934a…9441` / `0xc6747689…4337` |

So this is a persistence bug, not a chain-config or oracle bug. Connector list and prices are correct (the headline-inflated USD totals are residual Pattern 2/3 contamination, already addressed in #669/#670 and resolved on reindex per the issue's acceptance criteria).

## Test plan

- [x] `vitest run test/PriceOracle.test.ts` — 27 pass (7 new heal cases + 20 pre-existing)
- [x] `pnpm test` — 1184 pass / 32 skipped / 0 fail
- [x] `tsc --noEmit` — clean
- [x] `pnpm qa --write` — clean
- [ ] Reindex Soneium and confirm `Token.symbol` populates within the first hourly refresh tick after token observation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved token metadata handling: symbol and name fields are now automatically refreshed when empty during price oracle updates.

* **Tests**
  * Added comprehensive test coverage for token metadata refresh functionality across various update paths and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->