### PR TITLE
fix(price-oracle): reject ≥10× transient spikes against fresh anchor (#668)

### DIFF
--- a/src/PriceOracle.ts
+++ b/src/PriceOracle.ts
@@ -20,6 +20,17 @@ export interface TokenPriceData {
   decimals: bigint;
 }
 
+// Issue #668: receiver-side guard against transient absurd oracle reads. The
+// Fraxtal V3 oracle has historically returned values 15–30 OOM away from the
+// surrounding baseline for sfrxETH and FXB20291231; persisting any one of
+// those readings permanently poisons cumulative pool aggregates because
+// volume/fees are append-only. We treat the on-chain oracle as untrusted
+// input: any refresh whose ratio against the last accepted price exceeds
+// 10× is rejected as long as the anchor is still fresh (≤ 14 days). See the
+// issue body for the heuristic calibration.
+const PRICE_SPIKE_RATIO_THRESHOLD = 10n;
+const PRICE_SPIKE_STALENESS_MS = 14 * 24 * 60 * 60 * 1000;
+
 export async function createTokenEntity(
   tokenAddress: string,
   chainId: number,
@@ -187,6 +198,26 @@ export async function refreshTokenPrice(
         blockNumber: roundedBlockNumber,
       })) as { pricePerUSDNew: bigint; priceOracleType: string };
       currentPrice = bypassResult.pricePerUSDNew;
+    }
+
+    // Issue #668: reject refreshes that jump ≥10× vs a still-fresh accepted
+    // anchor. First-fetch (anchor == 0) and stale-anchor (anchor older than
+    // PRICE_SPIKE_STALENESS_MS) are exempt — neither shape can be a transient
+    // oracle glitch poisoning a previously-good baseline.
+    const anchorPrice = token.pricePerUSDNew;
+    const anchorAgeMs = token.lastUpdatedTimestamp
+      ? blockTimestampMs - token.lastUpdatedTimestamp.getTime()
+      : Number.POSITIVE_INFINITY;
+    const ratioExceeds =
+      anchorPrice > 0n &&
+      currentPrice > 0n &&
+      (currentPrice >= anchorPrice * PRICE_SPIKE_RATIO_THRESHOLD ||
+        anchorPrice >= currentPrice * PRICE_SPIKE_RATIO_THRESHOLD);
+    if (ratioExceeds && anchorAgeMs < PRICE_SPIKE_STALENESS_MS) {
+      context.log.warn(
+        `[priceSpikeRejected] ${token.address} chain=${chainId} anchor=${anchorPrice} candidate=${currentPrice}`,
+      );
+      currentPrice = anchorPrice;
     }
 
     // If price fetch returned 0, it could mean:

--- a/test/PriceOracle.test.ts
+++ b/test/PriceOracle.test.ts
@@ -816,6 +816,265 @@ describe("PriceOracle", () => {
       });
     });
 
+    // Issue #668: transient absurd oracle reads (e.g. Fraxtal V3 returning
+    // ~$7.59e30 per sfrxETH on 2024-12-18) permanently poison cumulative
+    // pool aggregates. The receiver-side guard rejects refreshes whose ratio
+    // against the last accepted price exceeds PRICE_SPIKE_RATIO_THRESHOLD,
+    // provided the anchor is still fresh. See the issue body for the
+    // calibration of 10× and the 14-day staleness window.
+    describe("price-spike rejection (issue #668)", () => {
+      const oneHourOneMinuteAgo = () =>
+        new Date(blockDatetime.getTime() - 61 * 60 * 1000);
+
+      beforeEach(() => {
+        vi.mocked(mockContext.Token?.set)?.mockClear();
+        vi.mocked(mockContext.TokenPriceSnapshot?.set)?.mockClear();
+        vi.mocked(mockContext.log?.warn)?.mockClear();
+      });
+
+      it("rejects an UP-spike (≥10×) and persists the previous accepted price", async () => {
+        // Anchor at $1; oracle returns $100 — 100× jump, must be rejected.
+        // Also pins the [priceSpikeRejected] warn line that downstream
+        // observability (alerts, log scans) is expected to grep for.
+        const anchorPrice = 1n * 10n ** 18n;
+        const spikePrice = 100n * 10n ** 18n;
+
+        vi.mocked(mockContext.effect)?.mockImplementation(async (effect) => {
+          if ((effect as { name?: string }).name === "getTokenPrice") {
+            return { pricePerUSDNew: spikePrice };
+          }
+          return {};
+        });
+
+        const fetchedToken = {
+          ...mockToken0Data,
+          pricePerUSDNew: anchorPrice,
+          lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+        };
+
+        await PriceOracle.refreshTokenPrice(
+          fetchedToken,
+          blockNumber,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        expect(updatedToken.pricePerUSDNew).toBe(anchorPrice);
+        const warnCall = vi.mocked(mockContext.log?.warn)?.mock.lastCall;
+        expect(warnCall?.[0]).toContain("[priceSpikeRejected]");
+      });
+
+      it("rejects an exact 10× boundary jump", async () => {
+        // Boundary case: candidate is exactly 10× the anchor. Spec is "≥10×",
+        // so this must still reject. Regression guard against off-by-one
+        // boundary regressions.
+        const anchorPrice = 1n * 10n ** 18n;
+        const boundaryPrice = 10n * 10n ** 18n;
+
+        vi.mocked(mockContext.effect)?.mockImplementation(async (effect) => {
+          if ((effect as { name?: string }).name === "getTokenPrice") {
+            return { pricePerUSDNew: boundaryPrice };
+          }
+          return {};
+        });
+
+        await PriceOracle.refreshTokenPrice(
+          {
+            ...mockToken0Data,
+            pricePerUSDNew: anchorPrice,
+            lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+          },
+          blockNumber,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        expect(updatedToken.pricePerUSDNew).toBe(anchorPrice);
+      });
+
+      it("accepts a sub-threshold jump (5×) as a normal price update", async () => {
+        // Anchor at $1; oracle returns $5 — under 10× threshold, must accept.
+        const anchorPrice = 1n * 10n ** 18n;
+        const newPrice = 5n * 10n ** 18n;
+
+        vi.mocked(mockContext.effect)?.mockImplementation(async (effect) => {
+          if ((effect as { name?: string }).name === "getTokenPrice") {
+            return { pricePerUSDNew: newPrice };
+          }
+          return {};
+        });
+
+        const fetchedToken = {
+          ...mockToken0Data,
+          pricePerUSDNew: anchorPrice,
+          lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+        };
+
+        await PriceOracle.refreshTokenPrice(
+          fetchedToken,
+          blockNumber,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        expect(updatedToken.pricePerUSDNew).toBe(newPrice);
+      });
+
+      it("accepts a first-fetch (anchor == 0) as ground truth regardless of magnitude", async () => {
+        // No prior accepted price — accept whatever the oracle returns.
+        const newPrice = 1000n * 10n ** 18n; // $1000
+
+        vi.mocked(mockContext.effect)?.mockImplementation(async (effect) => {
+          if ((effect as { name?: string }).name === "getTokenPrice") {
+            return { pricePerUSDNew: newPrice };
+          }
+          return {};
+        });
+
+        const fetchedToken = {
+          ...mockToken0Data,
+          pricePerUSDNew: 0n,
+          lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+        };
+
+        await PriceOracle.refreshTokenPrice(
+          fetchedToken,
+          blockNumber,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        expect(updatedToken.pricePerUSDNew).toBe(newPrice);
+      });
+
+      it("accepts a 10×+ jump when the anchor is older than the staleness window", async () => {
+        // Anchor 15 days old (> 14d window) — slow legitimate drift can't be
+        // permanently frozen. A 100× jump is accepted because the prior
+        // anchor is no longer trusted as a recent baseline.
+        const anchorPrice = 1n * 10n ** 18n;
+        const newPrice = 100n * 10n ** 18n;
+        const fifteenDaysAgo = new Date(
+          blockDatetime.getTime() - 15 * 24 * 60 * 60 * 1000,
+        );
+
+        vi.mocked(mockContext.effect)?.mockImplementation(async (effect) => {
+          if ((effect as { name?: string }).name === "getTokenPrice") {
+            return { pricePerUSDNew: newPrice };
+          }
+          return {};
+        });
+
+        const fetchedToken = {
+          ...mockToken0Data,
+          pricePerUSDNew: anchorPrice,
+          lastUpdatedTimestamp: fifteenDaysAgo,
+        };
+
+        await PriceOracle.refreshTokenPrice(
+          fetchedToken,
+          blockNumber,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        expect(updatedToken.pricePerUSDNew).toBe(newPrice);
+      });
+
+      it("accepts the recovery snapshot once the oracle returns to baseline", async () => {
+        // Sequence mirrors sfrxETH around 2024-12-18: anchor $1, oracle
+        // briefly returns $100 (rejected, anchor preserved), then returns
+        // ~$1.02 (1.02× — accepted).
+        const anchorPrice = 1n * 10n ** 18n;
+        const spikePrice = 100n * 10n ** 18n;
+        const recoveryPrice = 102n * 10n ** 16n; // $1.02
+
+        // First refresh — spike, rejected.
+        vi.mocked(mockContext.effect)?.mockImplementation(async (effect) => {
+          if ((effect as { name?: string }).name === "getTokenPrice") {
+            return { pricePerUSDNew: spikePrice };
+          }
+          return {};
+        });
+        const afterSpike = await PriceOracle.refreshTokenPrice(
+          {
+            ...mockToken0Data,
+            pricePerUSDNew: anchorPrice,
+            lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+          },
+          blockNumber,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+        expect(afterSpike.pricePerUSDNew).toBe(anchorPrice);
+
+        // Second refresh — recovery, accepted. Use the returned token shape
+        // so the anchor reflects what was actually persisted.
+        vi.mocked(mockContext.effect)?.mockImplementation(async (effect) => {
+          if ((effect as { name?: string }).name === "getTokenPrice") {
+            return { pricePerUSDNew: recoveryPrice };
+          }
+          return {};
+        });
+        const oneHourLater = blockDatetime.getTime() / 1000 + 61 * 60;
+        const afterRecovery = await PriceOracle.refreshTokenPrice(
+          afterSpike,
+          blockNumber,
+          oneHourLater,
+          chainId,
+          mockContext as handlerContext,
+        );
+        expect(afterRecovery.pricePerUSDNew).toBe(recoveryPrice);
+      });
+
+      it("rejects a DOWN-spike (≥10×) symmetrically", async () => {
+        // Anchor at $100; oracle returns $1 — 100× drop, must be rejected.
+        // Mirrors FXB20291231's Jan 2 2025 collapse to constant 485 wei.
+        const anchorPrice = 100n * 10n ** 18n;
+        const spikePrice = 1n * 10n ** 18n;
+
+        vi.mocked(mockContext.effect)?.mockImplementation(async (effect) => {
+          if ((effect as { name?: string }).name === "getTokenPrice") {
+            return { pricePerUSDNew: spikePrice };
+          }
+          return {};
+        });
+
+        const fetchedToken = {
+          ...mockToken0Data,
+          pricePerUSDNew: anchorPrice,
+          lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+        };
+
+        await PriceOracle.refreshTokenPrice(
+          fetchedToken,
+          blockNumber,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        expect(updatedToken.pricePerUSDNew).toBe(anchorPrice);
+      });
+    });
+
     describe("when price fetch fails", () => {
       let originalToken: Token;
       beforeEach(async () => {


### PR DESCRIPTION
## Summary

- Adds a receiver-side guard in `refreshTokenPrice` (`src/PriceOracle.ts`) that rejects any oracle reading whose ratio against the last accepted price exceeds **10×**, provided the anchor is still fresh (≤ 14 days). First-fetch (anchor `== 0`) and stale anchors are exempt.
- Fixes #668. The Fraxtal V3 oracle has historically returned values 15–30 orders of magnitude away from the surrounding baseline for sfrxETH and FXB20291231; persisting any single one of those readings permanently poisons cumulative pool aggregates (volume/fees are append-only). Pre-fix, four sfrxETH-routed Fraxtal pools showed `totalVolumeUSD` between `$3.37e24` and `$2.89e30`.
- Heuristic calibration (full table in the issue): 10× sits 1 orders of magnitude above the largest legitimate observed consecutive jump (≤ 5×) and 1 orders of magnitude below the smallest observed spike (3.13 orders of magnitude). 14-day window covers the longest sustained anomaly we saw (Dec 20–26, 2024 at ~6 days) with margin.

## Test plan

- [x] `vitest run test/PriceOracle.test.ts` — 6 new cases under `price-spike rejection (issue #668)`: UP-spike, DOWN-spike, sub-threshold accept, first-fetch accept, stale-anchor accept, recovery sequence
- [x] `pnpm test` — full suite (98 files / 1188 tests) green
- [x] `tsc --noEmit` clean
- [x] `biome check --write` clean
- [ ] Reindex Fraxtal end-to-end and verify the 4 affected pools fall within the post-fix estimate ranges in the issue body. Out of scope for this PR (re-runs typically take a day on this dataset); will be tracked alongside the ticket.

## Out of scope

- Root-causing the Fraxtal V3 oracle's misbehaviour (Dec 18 / 20 / 26 / 28 2024, Jan 2 2025). Upstream of the indexer; we defend at the receiver.
- Pool `0x78b070…CBf3` (v2 XVELO/frxETH at `$3.48e8`) — different pattern, no sfrxETH/FXB route. Separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added safeguards against price anomalies. The system now rejects price updates that deviate more than 10× from the previously accepted price, unless the reference price is older than 14 days or the token is being priced for the first time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->