### PR TITLE
Fix #676: unstick $0-trapped tokens with a uniform 1h refresh throttle

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -38,18 +38,6 @@ export const SECONDS_IN_A_DAY = BigInt(86400);
 export const SECONDS_IN_A_WEEK = BigInt(604800);
 export const SECONDS_IN_FOUR_YEARS = BigInt(126144000);
 
-/**
- * Chains with historically broken oracle connectors that cached $0 prices.
- * Used by refreshTokenPrice to bypass the effect cache on these chains.
- * TEMPORARY: Remove after one full reindex with fixed connectors.
- */
-export const AFFECTED_CHAINS: ReadonlySet<number> = new Set([
-  42220, // Celo
-  1923, // Swell
-  252, // Fraxtal
-  1868, // Soneium
-]);
-
 /** Snapshot interval: 1 hour in milliseconds (for epoch-aligned snapshots) */
 export const SNAPSHOT_INTERVAL_IN_MS = 60 * 60 * 1000;
 

--- a/src/PriceOracle.ts
+++ b/src/PriceOracle.ts
@@ -1,7 +1,6 @@
 import type { Token, handlerContext } from "generated";
 import { estimateBlockAtTimestamp } from "./ChainBlockTime";
 import {
-  AFFECTED_CHAINS,
   CHAIN_CONSTANTS,
   MS_IN_AN_HOUR,
   PriceOracleType,
@@ -12,7 +11,6 @@ import {
   getTokenPrice,
   roundBlockToInterval,
 } from "./Effects/Index";
-import { EffectType, rpcGateway } from "./Effects/RpcGateway";
 import { getRebindTarget, isBlacklistedToken } from "./PriceOverrides";
 import { setTokenPriceSnapshot } from "./Snapshots/TokenPriceSnapshot";
 export interface TokenPriceData {
@@ -50,18 +48,19 @@ export async function createTokenEntity(
 }
 
 /**
- * Refreshes a token's price data if the update interval has passed.
+ * Refreshes a token's price subject to a uniform 1-hour throttle, dispatching
+ * to blacklist, cross-chain rebind, or on-chain oracle paths as configured.
  *
- * This function checks if enough time has passed since the last update (1 hour),
- * and if so, fetches new price data for the token. The token entity is updated
- * in the database with the new price and timestamp.
+ * `lastUpdatedTimestamp` is bumped on every attempt — including those that
+ * return $0 — so the throttle advances and we don't re-hit the oracle on every
+ * subsequent event for stuck tokens.
  *
- * @param {Token} token - The token entity to refresh
- * @param {number} blockNumber - The block number to fetch price data from
- * @param {number} blockTimestamp - The timestamp of the block in seconds
- * @param {number} chainId - The chain ID where the token exists
- * @param {any} context - The database context for updating entities
- * @returns {Promise<Token>} The updated token entity
+ * @param token - The token entity to refresh.
+ * @param blockNumber - Block at which to fetch price (rounded to an hourly bucket for cache hits).
+ * @param blockTimestamp - Block timestamp in seconds.
+ * @param chainId - Chain the token lives on.
+ * @param context - Envio handler context.
+ * @returns The updated token entity (or the unchanged input when throttled).
  */
 export async function refreshTokenPrice(
   token: Token,
@@ -71,19 +70,14 @@ export async function refreshTokenPrice(
   context: handlerContext,
 ): Promise<Token> {
   const blockTimestampMs = blockTimestamp * 1000;
-  const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 
-  // Refresh logic:
-  // - Missing timestamp → always refresh
-  // - $0 price for <30 days → retry (connector fix or Change A may self-heal)
-  // - $0 price for >30 days → stop retrying (accepted as unpriceable, bounds RPC waste)
-  // - Non-zero price → refresh on hourly interval
+  // Issue #676: uniform 1-hour throttle for all tokens (regardless of current
+  // price). RPC cost is bounded by the throttle plus Envio's hourly-rounded
+  // effect cache key on `getTokenPrice`. Safe because we always bump
+  // `lastUpdatedTimestamp` below, so the throttle advances even on $0 results.
   const shouldRefresh =
     !token.lastUpdatedTimestamp ||
-    (token.pricePerUSDNew === 0n
-      ? blockTimestampMs - token.lastUpdatedTimestamp.getTime() < THIRTY_DAYS_MS
-      : blockTimestampMs - token.lastUpdatedTimestamp.getTime() >=
-        MS_IN_AN_HOUR);
+    blockTimestampMs - token.lastUpdatedTimestamp.getTime() >= MS_IN_AN_HOUR;
 
   if (!shouldRefresh) {
     return token;
@@ -174,20 +168,7 @@ export async function refreshTokenPrice(
       chainId,
       blockNumber: roundedBlockNumber,
     });
-    // TEMPORARY: Bypass effect cache for affected chains with $0 cached results.
-    // These chains had broken oracle connectors that cached $0 prices permanently.
-    // The rpcGateway effect (cache: false) re-fetches from now-fixed connectors.
-    // Remove after one full reindex with fixed connectors.
-    let currentPrice = priceData.pricePerUSDNew;
-    if (currentPrice === 0n && AFFECTED_CHAINS.has(chainId)) {
-      const bypassResult = (await context.effect(rpcGateway, {
-        type: EffectType.GET_TOKEN_PRICE,
-        tokenAddress: token.address,
-        chainId,
-        blockNumber: roundedBlockNumber,
-      })) as { pricePerUSDNew: bigint; priceOracleType: string };
-      currentPrice = bypassResult.pricePerUSDNew;
-    }
+    const currentPrice = priceData.pricePerUSDNew;
 
     // If price fetch returned 0, it could mean:
     // 1. No price path exists in the oracle (token not configured)
@@ -205,17 +186,15 @@ export async function refreshTokenPrice(
       blockTimestampMs - token.lastUpdatedTimestamp.getTime() <
         7 * 24 * 60 * 60 * 1000;
 
-    // We already know that Oracle V1 is a bit unreliable (we tested for WETH on Optimism and it kept failing)
-    // Oracle V2 is also a bit unreliable and either way it is just used for a few blocks
-    // So the main errors that we should be concerned about (and that impact most recent data) is those involving Oracle V3
-    // This also reduces the initial spam when deploying the indexer
+    // V3 last-known-price fallback: V3 is the modern, mostly-reliable oracle,
+    // but does throw transient $0 reads. Earlier V1/V2 windows are short and
+    // unreliable enough that fallback there would mask real failures, so we
+    // only trust the stored price as a substitute when V3 is the active oracle.
     if (
       shouldUseLastKnownPrice &&
       CHAIN_CONSTANTS[chainId].oracle.getType(blockNumber) ===
         PriceOracleType.V3
     ) {
-      // Return token with existing price, but update timestamp to current block
-      // This ensures we don't keep trying to refresh too frequently
       const updatedToken: Token = {
         ...token,
         ...healedMetadata,
@@ -225,21 +204,11 @@ export async function refreshTokenPrice(
       return updatedToken;
     }
 
-    // Issue #673: only preserve the timestamp once the oracle has actually
-    // been queryable. For tokens whose entity is created before
-    // `oracle.startBlock`, every pre-deploy refresh returns $0 and would
-    // otherwise pin the timestamp at creation — letting the 30-day backoff
-    // trip before the oracle ever runs and stranding reward tokens at $0.
-    const oracleDeployed =
-      blockNumber >= CHAIN_CONSTANTS[chainId].oracle.startBlock;
     const updatedToken: Token = {
       ...token,
       ...healedMetadata,
       pricePerUSDNew: currentPrice,
-      lastUpdatedTimestamp:
-        oracleDeployed && currentPrice === 0n && token.pricePerUSDNew === 0n
-          ? token.lastUpdatedTimestamp
-          : new Date(blockTimestampMs),
+      lastUpdatedTimestamp: new Date(blockTimestampMs),
     };
     context.Token.set(updatedToken);
 

--- a/test/Aggregators/LiquidityPoolAggregator.test.ts
+++ b/test/Aggregators/LiquidityPoolAggregator.test.ts
@@ -1240,17 +1240,18 @@ describe("LiquidityPoolAggregator Functions", () => {
       expect(mockTokenSet).not.toHaveBeenCalled();
     });
 
-    it("should always refresh token prices when pricePerUSDNew is 0", async () => {
-      const recentTimestamp = new Date(); // Recent timestamp
+    it("refreshes a $0 token once the hourly throttle has elapsed (#676 — no more 30-day trap)", async () => {
+      const now = new Date();
+      const overOneHourAgo = new Date(now.getTime() - 61 * 60 * 1000);
       token0 = {
         ...token0,
         pricePerUSDNew: 0n,
-        lastUpdatedTimestamp: recentTimestamp,
+        lastUpdatedTimestamp: overOneHourAgo,
       };
       // Ensure token1 has recent timestamp so it won't be refreshed
       token1 = {
         ...token1,
-        lastUpdatedTimestamp: recentTimestamp,
+        lastUpdatedTimestamp: now,
       };
 
       // Update the mock to return the updated tokens
@@ -1322,12 +1323,11 @@ describe("LiquidityPoolAggregator Functions", () => {
       );
 
       expect(result).not.toBeNull();
-      // token0 should be refreshed even though timestamp is recent
+      // token0 was $0 + stale → refresh fires
       expect(result?.token0Instance.pricePerUSDNew).toBe(newPrice0);
-      // token1 should not be refreshed (recent timestamp and non-zero price)
+      // token1 has a recent timestamp → throttled
       expect(result?.token1Instance.pricePerUSDNew).toBe(token1.pricePerUSDNew);
 
-      // Token.set should be called only for token0
       const mockTokenSet = vi.mocked(mockContext.Token?.set);
       expect(mockTokenSet).toHaveBeenCalledTimes(1);
     });

--- a/test/Aggregators/LiquidityPoolAggregator.test.ts
+++ b/test/Aggregators/LiquidityPoolAggregator.test.ts
@@ -1241,7 +1241,7 @@ describe("LiquidityPoolAggregator Functions", () => {
     });
 
     it("refreshes a $0 token once the hourly throttle has elapsed (#676 — no more 30-day trap)", async () => {
-      const now = new Date();
+      const now = new Date("2024-01-01T12:00:00Z");
       const overOneHourAgo = new Date(now.getTime() - 61 * 60 * 1000);
       token0 = {
         ...token0,
@@ -1263,7 +1263,7 @@ describe("LiquidityPoolAggregator Functions", () => {
       });
 
       const blockNumber = 1000000;
-      const blockTimestamp = Math.floor(Date.now() / 1000);
+      const blockTimestamp = Math.floor(now.getTime() / 1000);
       const newPrice0 = 1000000n; // $1.00
 
       // Mock effect to return new price and token details

--- a/test/EventHandlers/Voter/DistributeRewardEmissionsUSD.test.ts
+++ b/test/EventHandlers/Voter/DistributeRewardEmissionsUSD.test.ts
@@ -169,8 +169,8 @@ describe("Voter.DistributeReward → totalEmissionsUSD regression (#673)", () =>
     // contract so future regressions surface here.
     //
     // To make refreshTokenPrice a no-op against a $0-priced token, set
-    // `lastUpdatedTimestamp` more than 30 days before the event: the
-    // PriceOracle backoff (`THIRTY_DAYS_MS`) stops retrying past that point.
+    // `lastUpdatedTimestamp` to the block time so the 1-hour throttle skips
+    // the RPC call and the stored $0 price is what feeds the USD calc.
     const { createMockLiquidityPoolAggregator } = setupCommon();
     const liquidityPool = createMockLiquidityPoolAggregator({
       id: PoolId(chainId, poolAddress),
@@ -182,12 +182,9 @@ describe("Voter.DistributeReward → totalEmissionsUSD regression (#673)", () =>
       gaugeIsAlive: true,
     });
 
-    const THIRTY_ONE_DAYS_S = 31 * 24 * 60 * 60;
     const rewardToken = makeRewardToken({
       pricePerUSDNew: 0n,
-      lastUpdatedTimestamp: new Date(
-        (blockTimestamp - THIRTY_ONE_DAYS_S) * 1000,
-      ),
+      lastUpdatedTimestamp: new Date(blockTimestamp * 1000),
     });
     const amountEmitted = 1000n * 10n ** 18n;
 

--- a/test/PriceOracle.test.ts
+++ b/test/PriceOracle.test.ts
@@ -195,9 +195,13 @@ describe("PriceOracle", () => {
       });
     });
 
-    describe("when pricePerUSDNew is 0n", () => {
-      let updatedToken: Token;
+    describe("when pricePerUSDNew is 0n and <1h has passed", () => {
+      // Issue #676: $0 tokens are now subject to the same 1-hour throttle as
+      // non-zero tokens. The effect cache rounds to hourly block buckets, so
+      // within an hour we'd hit the cache anyway — gating here avoids the
+      // extra Token.set and snapshot write.
       beforeEach(async () => {
+        vi.mocked(mockContext.Token?.set)?.mockClear();
         const fetchedToken = {
           ...mockToken0Data,
           pricePerUSDNew: 0n,
@@ -211,52 +215,41 @@ describe("PriceOracle", () => {
           chainId,
           mockContext as handlerContext,
         );
-        updatedToken = vi.mocked(mockContext.Token?.set)?.mock
-          .lastCall?.[0] as Token;
       });
-      it("should refresh price even if less than 1 hour has passed", async () => {
-        expect(vi.mocked(mockContext.Token?.set)).toHaveBeenCalled();
-        expect(updatedToken.pricePerUSDNew).toBe(
-          mockTokenPriceData.pricePerUSDNew,
-        );
+      it("does not refresh while inside the 1-hour throttle window", () => {
+        expect(vi.mocked(mockContext.Token?.set)).not.toHaveBeenCalled();
+        expect(
+          vi.mocked(mockContext.TokenPriceSnapshot?.set),
+        ).not.toHaveBeenCalled();
       });
     });
 
-    describe("Issue #673: pre-oracle stranding regression", () => {
-      // Reward tokens (VELO/OP, AERO/Base, XVELO/OP) were stuck at $0 with
-      // 2023 timestamps because their Token entities are created before the
-      // chain's oracle deploys. While the oracle is unreachable, the price
-      // refresh keeps returning 0; with timestamp preservation, the 30-day
-      // backoff trips before the oracle ever runs, stranding the token.
-      // Fix: only preserve the timestamp once the oracle has actually been
-      // queryable at this block.
+    describe("lastUpdatedTimestamp advances on every $0 attempt", () => {
+      // Issue #676: the 1-hour throttle is gated on lastUpdatedTimestamp, so
+      // it must move forward even when the oracle keeps returning $0 —
+      // otherwise an active $0 token would be re-refreshed on every event,
+      // wasting writes. This also subsumes the #673 pre-oracle fix (timestamp
+      // no longer needs an oracle-deployed gate; it always advances).
+      const zeroPriceEffects = async (effect: unknown, _input: unknown) => {
+        const name = (effect as { name?: string }).name;
+        if (name === "getTokenPrice") return { pricePerUSDNew: 0n };
+        if (name === "getTokenDetails") {
+          return { name: "VELO", decimals: 18, symbol: "VELO" };
+        }
+        return {};
+      };
 
-      it("advances lastUpdatedTimestamp when oracle is not yet deployed (lets the 30-day clock count from oracle deploy, not creation)", async () => {
+      it("advances the timestamp when oracle is not yet deployed (#673 regression)", async () => {
         vi.mocked(mockContext.Token?.set)?.mockClear();
+        vi.mocked(mockContext.effect)?.mockImplementation(zeroPriceEffects);
 
         const preOracleBlock = startBlock - 1;
-        // Mock effects: getTokenDetails works, getTokenPrice returns $0 (the
-        // ORACLE_DEPLOYED gate inside handleGetTokenPrice does the same in prod).
-        vi.mocked(mockContext.effect)?.mockImplementation(
-          async (effect: unknown, _input: unknown) => {
-            const name = (effect as { name?: string }).name;
-            if (name === "getTokenPrice") {
-              return { pricePerUSDNew: 0n };
-            }
-            if (name === "getTokenDetails") {
-              return { name: "VELO", decimals: 18, symbol: "VELO" };
-            }
-            return {};
-          },
-        );
-
         const creationDate = new Date(blockDatetime.getTime());
         const fetchedToken = {
           ...mockToken0Data,
           pricePerUSDNew: 0n,
           lastUpdatedTimestamp: creationDate,
         };
-        // 1 hour later, still pre-oracle
         const blockTimestamp = blockDatetime.getTime() / 1000 + 60 * 60;
 
         await PriceOracle.refreshTokenPrice(
@@ -270,32 +263,16 @@ describe("PriceOracle", () => {
         const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
           .lastCall?.[0] as Token;
         expect(updatedToken.pricePerUSDNew).toBe(0n);
-        // Critical: timestamp must move forward so the 30-day backoff resets.
         expect(updatedToken.lastUpdatedTimestamp.getTime()).toBe(
           blockTimestamp * 1000,
         );
-        expect(updatedToken.lastUpdatedTimestamp.getTime()).toBeGreaterThan(
-          creationDate.getTime(),
-        );
       });
 
-      it("preserves lastUpdatedTimestamp once oracle is deployed and price stays $0 (existing 30-day backoff behavior intact)", async () => {
+      it("advances the timestamp post-oracle when price stays $0 (so the throttle ticks forward)", async () => {
         vi.mocked(mockContext.Token?.set)?.mockClear();
+        vi.mocked(mockContext.effect)?.mockImplementation(zeroPriceEffects);
 
         const postOracleBlock = startBlock + 1;
-        vi.mocked(mockContext.effect)?.mockImplementation(
-          async (effect: unknown, _input: unknown) => {
-            const name = (effect as { name?: string }).name;
-            if (name === "getTokenPrice") {
-              return { pricePerUSDNew: 0n };
-            }
-            if (name === "getTokenDetails") {
-              return { name: "VELO", decimals: 18, symbol: "VELO" };
-            }
-            return {};
-          },
-        );
-
         const earlierTimestamp = new Date(
           blockDatetime.getTime() - 5 * 24 * 60 * 60 * 1000,
         );
@@ -317,16 +294,20 @@ describe("PriceOracle", () => {
         const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
           .lastCall?.[0] as Token;
         expect(updatedToken.pricePerUSDNew).toBe(0n);
-        // Post-oracle preservation must still apply — bounds RPC waste for
-        // genuinely unpriceable tokens.
         expect(updatedToken.lastUpdatedTimestamp.getTime()).toBe(
-          earlierTimestamp.getTime(),
+          blockTimestamp * 1000,
         );
       });
     });
 
-    describe("when pricePerUSDNew is 0n for more than 30 days (unpriceable)", () => {
-      beforeEach(async () => {
+    describe("Issue #676: $0 tokens stale for >30d are still retried (hourly throttle only)", () => {
+      // The previous 30-day $0 backoff trapped tokens whose first price
+      // attempt happened during a broken-oracle window (e.g. WETH/USDC/OP on
+      // Optimism, stuck at $0 since 2023). Replaced with a uniform 1-hour
+      // throttle: cost is bounded by Envio's effect cache (hourly-rounded
+      // block buckets) and the 1-hour gate, so we no longer need to "stop
+      // retrying" — every hourly window gets a fresh fetch attempt.
+      it("retries the oracle when a $0 token has been stale for 31 days", async () => {
         vi.mocked(mockContext.Token?.set)?.mockClear();
 
         const thirtyOneDaysAgo = new Date(
@@ -345,10 +326,13 @@ describe("PriceOracle", () => {
           chainId,
           mockContext as handlerContext,
         );
-      });
-      it("should NOT retry price fetch after 30-day backoff", async () => {
-        // Token.set should not be called — shouldRefresh returns false
-        expect(vi.mocked(mockContext.Token?.set)).not.toHaveBeenCalled();
+
+        const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        expect(vi.mocked(mockContext.Token?.set)).toHaveBeenCalled();
+        expect(updatedToken.pricePerUSDNew).toBe(
+          mockTokenPriceData.pricePerUSDNew,
+        );
       });
     });
 
@@ -868,163 +852,6 @@ describe("PriceOracle", () => {
         );
         expect(errorRelatedCalls).toHaveLength(0);
       });
-    });
-  });
-
-  describe("rpcGateway bypass for affected chains (Change C)", () => {
-    const CELO_CHAIN_ID = 42220;
-    const celoStartBlock = CHAIN_CONSTANTS[CELO_CHAIN_ID].oracle.startBlock;
-    const celoBlockNumber = celoStartBlock + 1;
-    const celoToken = {
-      ...mockToken0Data,
-      id: `${CELO_CHAIN_ID}-${mockToken0Data.address}`,
-      chainId: CELO_CHAIN_ID,
-      pricePerUSDNew: 0n,
-      lastUpdatedTimestamp: new Date(blockDatetime.getTime()),
-    };
-
-    it("should call rpcGateway bypass when getTokenPrice returns $0 on affected chain", async () => {
-      const bypassPrice = 5n * 10n ** 18n;
-      vi.mocked(mockContext.effect)?.mockImplementation(
-        async (effect: unknown, _input: unknown) => {
-          const name = (effect as { name?: string }).name;
-          if (name === "getTokenPrice") {
-            return { pricePerUSDNew: 0n, priceOracleType: "v3" };
-          }
-          if (name === "getTokenDetails") {
-            return { name: "CELO", decimals: 18, symbol: "CELO" };
-          }
-          if (name === "rpcGateway") {
-            return { pricePerUSDNew: bypassPrice, priceOracleType: "v3" };
-          }
-          return {};
-        },
-      );
-
-      await PriceOracle.refreshTokenPrice(
-        celoToken,
-        celoBlockNumber,
-        blockDatetime.getTime() / 1000,
-        CELO_CHAIN_ID,
-        mockContext as handlerContext,
-      );
-
-      // 2 effect calls: getTokenPrice + rpcGateway bypass
-      expect(vi.mocked(mockContext.effect)).toHaveBeenCalledTimes(2);
-      const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
-        .lastCall?.[0] as Token;
-      expect(updatedToken.pricePerUSDNew).toBe(bypassPrice);
-    });
-
-    it("should NOT call rpcGateway bypass when getTokenPrice returns non-zero on affected chain", async () => {
-      const nonZeroToken = {
-        ...celoToken,
-        pricePerUSDNew: 1n * 10n ** 18n,
-        lastUpdatedTimestamp: new Date(
-          blockDatetime.getTime() - 61 * 60 * 1000,
-        ),
-      };
-      vi.mocked(mockContext.effect)?.mockImplementation(
-        async (effect: unknown, _input: unknown) => {
-          const name = (effect as { name?: string }).name;
-          if (name === "getTokenPrice") {
-            return { pricePerUSDNew: 3n * 10n ** 18n, priceOracleType: "v3" };
-          }
-          if (name === "getTokenDetails") {
-            return { name: "CELO", decimals: 18, symbol: "CELO" };
-          }
-          if (name === "rpcGateway") {
-            throw new Error("rpcGateway bypass should not be called");
-          }
-          return {};
-        },
-      );
-
-      await PriceOracle.refreshTokenPrice(
-        nonZeroToken,
-        celoBlockNumber,
-        blockDatetime.getTime() / 1000,
-        CELO_CHAIN_ID,
-        mockContext as handlerContext,
-      );
-
-      // 1 effect call: getTokenPrice (no rpcGateway bypass)
-      expect(vi.mocked(mockContext.effect)).toHaveBeenCalledTimes(1);
-    });
-
-    it("should NOT call rpcGateway bypass on unaffected chains even with $0 price", async () => {
-      const optimismToken = {
-        ...mockToken0Data,
-        pricePerUSDNew: 0n,
-        lastUpdatedTimestamp: new Date(blockDatetime.getTime()),
-      };
-      vi.mocked(mockContext.effect)?.mockImplementation(
-        async (effect: unknown, _input: unknown) => {
-          const name = (effect as { name?: string }).name;
-          if (name === "getTokenPrice") {
-            return { pricePerUSDNew: 0n, priceOracleType: "v3" };
-          }
-          if (name === "getTokenDetails") {
-            return { name: "Test Token", decimals: 18, symbol: "TEST" };
-          }
-          if (name === "rpcGateway") {
-            throw new Error("rpcGateway bypass should not be called");
-          }
-          return {};
-        },
-      );
-
-      await PriceOracle.refreshTokenPrice(
-        optimismToken,
-        blockNumber,
-        blockDatetime.getTime() / 1000,
-        chainId, // Optimism - not affected
-        mockContext as handlerContext,
-      );
-
-      // 1 effect call: getTokenPrice (no rpcGateway bypass)
-      expect(vi.mocked(mockContext.effect)).toHaveBeenCalledTimes(1);
-    });
-
-    it("should use last known price when bypass also returns $0 on affected chain", async () => {
-      const previousPrice = 3n * 10n ** 18n;
-      const tokenWithPreviousPrice = {
-        ...celoToken,
-        pricePerUSDNew: previousPrice,
-        lastUpdatedTimestamp: new Date(
-          blockDatetime.getTime() - 2 * 60 * 60 * 1000,
-        ),
-      };
-      vi.mocked(mockContext.effect)?.mockImplementation(
-        async (effect: unknown, _input: unknown) => {
-          const name = (effect as { name?: string }).name;
-          if (name === "getTokenPrice") {
-            return { pricePerUSDNew: 0n, priceOracleType: "v3" };
-          }
-          if (name === "getTokenDetails") {
-            return { name: "CELO", decimals: 18, symbol: "CELO" };
-          }
-          if (name === "rpcGateway") {
-            return { pricePerUSDNew: 0n, priceOracleType: "v3" };
-          }
-          return {};
-        },
-      );
-
-      await PriceOracle.refreshTokenPrice(
-        tokenWithPreviousPrice,
-        celoBlockNumber,
-        blockDatetime.getTime() / 1000,
-        CELO_CHAIN_ID,
-        mockContext as handlerContext,
-      );
-
-      // Bypass was called (2 effect calls: getTokenPrice + rpcGateway) but also returned $0
-      expect(vi.mocked(mockContext.effect)).toHaveBeenCalledTimes(2);
-      const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
-        .lastCall?.[0] as Token;
-      // Should fall back to last known price (7-day fallback in V3 path)
-      expect(updatedToken.pricePerUSDNew).toBe(previousPrice);
     });
   });
 


### PR DESCRIPTION
Closes #676.

## Summary

The 30-day `$0` backoff in `refreshTokenPrice` was meant to bound RPC waste on permanently unpriceable tokens. In practice it trapped every Optimism major (WETH, USDC, USDT, OP, VELO, DAI) at `$0` with `lastUpdatedTimestamp` from 2023 — they hit the broken-oracle window at deploy, the 30-day clock expired before the connectors were fixed, and they were never refreshed again. `Token.pricePerUSDNew` feeds every TVL/snapshot path that doesn't go through the live swap oracle, so Optimism's chain-level TVL has been under-reported ever since.

## Approach

Rather than a tiered allow-list (whitelisted/connector/neither), this is a deeper simplification: **every `refreshTokenPrice` call is event-triggered**, so the function is in the wrong place to decide "is this token dead". The 30-day gate is dropped in favour of a uniform 1-hour throttle. RPC cost is bounded by two existing mechanisms:

1. **Envio's effect cache** — `getTokenPrice` is keyed on `(token, chainId, hourly-rounded block)`; calls within the same hour bucket hit the cache.
2. **The 1-hour throttle** at function entry, gated on `lastUpdatedTimestamp`.

`lastUpdatedTimestamp` is always bumped on attempt (even when the oracle returns `$0`), so the throttle advances. This subsumes the #673 `oracleDeployed`-conditioned preservation and the `AFFECTED_CHAINS` cache-bypass workaround — both become dead code.

Worst-case RPC: ~5.5 RPCs/sec across all chains if every one of the ~20k currently-trapped tokens fires every hour. The global limit is 20k/sec. Three orders of magnitude of headroom.

## Changes

- `src/PriceOracle.ts` — collapse `shouldRefresh` to the throttle; drop the `AFFECTED_CHAINS` bypass branch; drop the `oracleDeployed` timestamp-preservation; refresh the function's JSDoc.
- `src/Constants.ts` — delete `AFFECTED_CHAINS`.
- `test/PriceOracle.test.ts` — invert the buggy `should NOT retry after 30-day backoff` test; consolidate `#673`'s pre/post-oracle preservation tests into "always-advance" characterisations; delete the `rpcGateway bypass for affected chains (Change C)` describe block.
- `test/Aggregators/LiquidityPoolAggregator.test.ts` — update the `$0` token refresh test for the new throttle semantics.
- `test/EventHandlers/Voter/DistributeRewardEmissionsUSD.test.ts` — `#673` regression test no longer relies on the 30-day backoff to gate the refresh; uses the 1-hour throttle instead.

Net diff: +77 / -296.

## Acceptance criteria (from #676)

- [x] Whitelisted tokens on Optimism refresh hourly on fresh reindex *(satisfied by the general rule)*
- [x] Connector tokens refresh hourly regardless of price history *(satisfied by the general rule)*
- [x] `AFFECTED_CHAINS` cache-bypass branch removed from `PriceOracle.ts` and the set removed from `Constants.ts`
- [ ] Optimism chain TVL on dashboards reflects actual on-chain value *(needs human — requires a fresh reindex against the deployed indexer)*

## Test plan

- [x] `tsc --noEmit` clean
- [x] `pnpm qa --write` clean
- [x] `pnpm test` — 1195 passed / 32 skipped / 0 failed
- [ ] Deploy + reindex Optimism, confirm WETH (`0x4200…0006`) `pricePerUSDNew` is non-zero and `lastUpdatedTimestamp` is fresh *(needs human — requires deployed indexer)*
- [ ] Spot-check Optimism chain TVL on dashboards post-reindex *(needs human — requires deployed indexer)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Standardized token price refresh throttling to uniform 1-hour intervals across all chains for more consistent behavior.
  * Improved oracle price recovery handling when prices are unavailable.
  * Simplified chain-specific price refresh logic for better reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/velodrome-finance/indexer/pull/693)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->