### PR TITLE
Fix V3 fallback staleness clock aliasing (#694)

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -352,7 +352,8 @@ type Token {
   chainId: Int! @index
   decimals: BigInt! @config(precision: 76) # number of decimals
   pricePerUSDNew: BigInt! @config(precision: 76) # price of token per USD
-  lastUpdatedTimestamp: Timestamp! # timestamp of last update
+  lastUpdatedTimestamp: Timestamp! # timestamp of last refresh attempt (used by 1-hour throttle)
+  lastSuccessfulPriceTimestamp: Timestamp # timestamp of last non-zero oracle write (used by 7-day fallback staleness window, #694)
   isWhitelisted: Boolean! # whether the token is whitelisted
 }
 

--- a/src/EventHandlers/Voter/SuperchainLeafVoter.ts
+++ b/src/EventHandlers/Voter/SuperchainLeafVoter.ts
@@ -165,6 +165,7 @@ SuperchainLeafVoter.WhitelistToken.handler(async ({ event, context }) => {
       decimals: BigInt(tokenDetails.decimals),
       isWhitelisted: event.params._bool,
       lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
+      lastSuccessfulPriceTimestamp: undefined,
     };
     context.Token.set(updatedToken);
   } catch (error) {

--- a/src/EventHandlers/Voter/Voter.ts
+++ b/src/EventHandlers/Voter/Voter.ts
@@ -449,6 +449,7 @@ Voter.WhitelistToken.handler(async ({ event, context }) => {
       decimals: BigInt(tokenDetails.decimals),
       isWhitelisted: event.params._bool,
       lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
+      lastSuccessfulPriceTimestamp: undefined,
     };
     context.Token.set(updatedToken);
   } catch (error) {

--- a/src/EventHandlers/VotingReward/VotingRewardSharedLogic.ts
+++ b/src/EventHandlers/VotingReward/VotingRewardSharedLogic.ts
@@ -1,5 +1,6 @@
 import type {
   LiquidityPoolAggregator,
+  Token,
   UserStatsPerPool,
   handlerContext,
 } from "generated";
@@ -127,7 +128,7 @@ export async function processVotingRewardClaimRewards(
       }),
     ]);
 
-    const newToken = {
+    const newToken: Token = {
       id: TokenId(data.chainId, data.reward),
       address: data.reward,
       name: rewardTokenDetails.name,
@@ -136,6 +137,10 @@ export async function processVotingRewardClaimRewards(
       decimals: BigInt(rewardTokenDetails.decimals),
       pricePerUSDNew: priceData.pricePerUSDNew,
       lastUpdatedTimestamp: new Date(data.timestamp * 1000),
+      lastSuccessfulPriceTimestamp:
+        priceData.pricePerUSDNew > 0n
+          ? new Date(data.timestamp * 1000)
+          : undefined,
       isWhitelisted: true,
     };
 

--- a/src/PriceOracle.ts
+++ b/src/PriceOracle.ts
@@ -80,6 +80,7 @@ export async function createTokenEntity(
     decimals: BigInt(tokenDetails.decimals),
     pricePerUSDNew: BigInt(0),
     lastUpdatedTimestamp: blockDatetime,
+    lastSuccessfulPriceTimestamp: undefined,
     isWhitelisted: false,
   };
 
@@ -91,9 +92,17 @@ export async function createTokenEntity(
  * Refreshes a token's price subject to a uniform 1-hour throttle, dispatching
  * to blacklist, cross-chain rebind, or on-chain oracle paths as configured.
  *
- * `lastUpdatedTimestamp` is bumped on every attempt — including those that
- * return $0 — so the throttle advances and we don't re-hit the oracle on every
- * subsequent event for stuck tokens.
+ * Two clocks are tracked independently (issue #694):
+ *
+ * - `lastUpdatedTimestamp` advances on EVERY refresh attempt (including $0
+ *   reads and fallback writes). It drives the 1-hour throttle at the top of
+ *   this function, ensuring we don't re-hit the oracle on every subsequent
+ *   event for stuck tokens.
+ * - `lastSuccessfulPriceTimestamp` advances ONLY when a non-zero price is
+ *   persisted (main oracle write or rebind with a priced source). It drives
+ *   the 7-day staleness window guarding the V3 last-known-price fallback —
+ *   so once a token enters fallback, the window can actually expire even
+ *   with hourly retries.
  *
  * @param token - The token entity to refresh.
  * @param blockNumber - Block at which to fetch price (rounded to an hourly bucket for cache hits).
@@ -179,6 +188,10 @@ export async function refreshTokenPrice(
       ...healedMetadata,
       pricePerUSDNew: sourcePrice,
       lastUpdatedTimestamp: new Date(blockTimestampMs),
+      lastSuccessfulPriceTimestamp:
+        sourcePrice > 0n
+          ? new Date(blockTimestampMs)
+          : token.lastSuccessfulPriceTimestamp,
     };
     context.Token.set(updated);
     if (sourcePrice > 0n) {
@@ -208,7 +221,7 @@ export async function refreshTokenPrice(
       chainId,
       blockNumber: roundedBlockNumber,
     });
-    const currentPrice = priceData.pricePerUSDNew;
+    let currentPrice = priceData.pricePerUSDNew;
 
     // Issue #668: reject refreshes that jump ≥10× vs a still-fresh accepted
     // anchor. First-fetch (anchor == 0) and stale-anchor (anchor older than
@@ -237,13 +250,19 @@ export async function refreshTokenPrice(
     // If we have a previous non-zero price, use it as fallback.
     // This works in harmony with Envio's effect caching - if the effect cache has a previous
     // successful result, it will be used. But if it returns 0, we fall back to the token's stored price.
+    //
+    // Issue #694: gate the staleness window on `lastSuccessfulPriceTimestamp`,
+    // not `lastUpdatedTimestamp`. The latter advances on every attempt
+    // (including fallback writes), which previously made the window
+    // effectively never expire while a token was stuck in fallback.
     const shouldUseLastKnownPrice =
       currentPrice === 0n &&
       token.pricePerUSDNew > 0n &&
-      token.lastUpdatedTimestamp &&
-      // Only use last known price if it's relatively recent (within 7 days)
-      // This prevents using very stale prices but allows for temporary oracle issues
-      blockTimestampMs - token.lastUpdatedTimestamp.getTime() <
+      token.lastSuccessfulPriceTimestamp &&
+      // Only use last known price if the LAST SUCCESSFUL write is relatively
+      // recent (within 7 days). This prevents using very stale prices but
+      // allows for temporary oracle issues.
+      blockTimestampMs - token.lastSuccessfulPriceTimestamp.getTime() <
         7 * 24 * 60 * 60 * 1000;
 
     // V3 last-known-price fallback: V3 is the modern, mostly-reliable oracle,
@@ -259,6 +278,8 @@ export async function refreshTokenPrice(
         ...token,
         ...healedMetadata,
         lastUpdatedTimestamp: new Date(blockTimestampMs),
+        // lastSuccessfulPriceTimestamp deliberately NOT bumped: this write
+        // doesn't represent a fresh oracle success (#694).
       };
       context.Token.set(updatedToken);
       return updatedToken;
@@ -269,6 +290,10 @@ export async function refreshTokenPrice(
       ...healedMetadata,
       pricePerUSDNew: currentPrice,
       lastUpdatedTimestamp: new Date(blockTimestampMs),
+      lastSuccessfulPriceTimestamp:
+        currentPrice > 0n
+          ? new Date(blockTimestampMs)
+          : token.lastSuccessfulPriceTimestamp,
     };
     context.Token.set(updatedToken);
 

--- a/test/EventHandlers/CLFactory.test.ts
+++ b/test/EventHandlers/CLFactory.test.ts
@@ -101,6 +101,7 @@ describe("CLFactory Events", () => {
         chainId: chainId,
         isWhitelisted: false,
         lastUpdatedTimestamp: new Date(1000000 * 1000),
+        lastSuccessfulPriceTimestamp: undefined,
       }),
     );
 
@@ -1144,6 +1145,7 @@ describe("CLFactory.PoolCreated ↔ CLPoolPendingInitialize buffer", () => {
         chainId: chainId,
         isWhitelisted: false,
         lastUpdatedTimestamp: new Date(1000000 * 1000),
+        lastSuccessfulPriceTimestamp: undefined,
       }),
     );
   });

--- a/test/EventHandlers/CLFactory/CLFactoryPoolCreatedLogic.test.ts
+++ b/test/EventHandlers/CLFactory/CLFactoryPoolCreatedLogic.test.ts
@@ -39,6 +39,7 @@ describe("CLFactoryPoolCreatedLogic", () => {
         chainId: 10,
         isWhitelisted: false,
         lastUpdatedTimestamp: new Date(1000000 * 1000),
+        lastSuccessfulPriceTimestamp: undefined,
       }),
     );
   });

--- a/test/EventHandlers/Gauges/GaugeSharedLogic.test.ts
+++ b/test/EventHandlers/Gauges/GaugeSharedLogic.test.ts
@@ -147,6 +147,7 @@ describe("GaugeSharedLogic", () => {
       decimals: 18n,
       pricePerUSDNew: 1000000000000000000n, // 1 USD in 18 decimals
       lastUpdatedTimestamp: mockTimestamp,
+      lastSuccessfulPriceTimestamp: mockTimestamp,
       isWhitelisted: true,
     };
 

--- a/test/EventHandlers/Pool/common.ts
+++ b/test/EventHandlers/Pool/common.ts
@@ -70,6 +70,7 @@ export function setupCommon() {
     chainId: CHAIN_ID,
     isWhitelisted: true,
     lastUpdatedTimestamp: new Date(),
+    lastSuccessfulPriceTimestamp: new Date(),
   };
 
   const mockToken1Data: Token = {
@@ -82,6 +83,7 @@ export function setupCommon() {
     chainId: CHAIN_ID,
     isWhitelisted: true,
     lastUpdatedTimestamp: new Date(),
+    lastSuccessfulPriceTimestamp: new Date(),
   };
 
   // Not annotated as LiquidityPoolAggregator to avoid readonly bigint[] vs bigint[] mismatch

--- a/test/PriceOracle.test.ts
+++ b/test/PriceOracle.test.ts
@@ -1062,6 +1062,171 @@ describe("PriceOracle", () => {
       });
     });
 
+    // Issue #694: V3 last-known-price fallback used `lastUpdatedTimestamp`
+    // for two purposes — the 1-hour throttle and the 7-day staleness window
+    // guarding the fallback. Because every refresh attempt (including those
+    // that fall back) bumps `lastUpdatedTimestamp`, the 7-day window was
+    // effectively reset each hour. Once a token entered fallback, the stored
+    // non-zero price would pin indefinitely even if the oracle never
+    // recovered. Fix: introduce `lastSuccessfulPriceTimestamp`, only bumped
+    // on non-zero oracle writes; fallback's staleness window reads from it.
+    describe("V3 fallback staleness (issue #694)", () => {
+      // V3 oracle on Optimism starts at block 125484892. Use a post-V3 block
+      // so the V3 fallback branch in refreshTokenPrice is exercised.
+      const v3Block = 125484893;
+      const oneHourOneMinuteAgo = () =>
+        new Date(blockDatetime.getTime() - 61 * 60 * 1000);
+
+      beforeEach(() => {
+        vi.mocked(mockContext.Token?.set)?.mockClear();
+        vi.mocked(mockContext.TokenPriceSnapshot?.set)?.mockClear();
+      });
+
+      it("applies the V3 fallback when the last successful price is recent (<7d) even though lastUpdatedTimestamp keeps advancing", async () => {
+        const anchorPrice = 2n * 10n ** 18n;
+        const recentSuccess = new Date(
+          blockDatetime.getTime() - 2 * 24 * 60 * 60 * 1000,
+        );
+        vi.mocked(mockContext.effect)?.mockImplementation(async (effect) => {
+          if ((effect as { name?: string }).name === "getTokenPrice") {
+            return { pricePerUSDNew: 0n };
+          }
+          return {};
+        });
+
+        const fetchedToken = {
+          ...mockToken0Data,
+          pricePerUSDNew: anchorPrice,
+          // Throttle clock is recent (1h ago), but the LAST SUCCESSFUL write
+          // was 2 days ago — fallback should apply.
+          lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+          lastSuccessfulPriceTimestamp: recentSuccess,
+        };
+
+        await PriceOracle.refreshTokenPrice(
+          fetchedToken,
+          v3Block,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        expect(updatedToken.pricePerUSDNew).toBe(anchorPrice);
+        // Throttle clock advances on every attempt (existing behavior)
+        expect(updatedToken.lastUpdatedTimestamp.getTime()).toBe(
+          blockDatetime.getTime(),
+        );
+        // Last successful timestamp must NOT advance on a fallback write
+        expect(updatedToken.lastSuccessfulPriceTimestamp?.getTime()).toBe(
+          recentSuccess.getTime(),
+        );
+      });
+
+      it("stops re-pinning once last successful price is older than 7 days, even with hourly retries (regression)", async () => {
+        const anchorPrice = 2n * 10n ** 18n;
+        const eightDaysAgo = new Date(
+          blockDatetime.getTime() - 8 * 24 * 60 * 60 * 1000,
+        );
+        vi.mocked(mockContext.effect)?.mockImplementation(async (effect) => {
+          if ((effect as { name?: string }).name === "getTokenPrice") {
+            return { pricePerUSDNew: 0n };
+          }
+          return {};
+        });
+
+        const fetchedToken = {
+          ...mockToken0Data,
+          pricePerUSDNew: anchorPrice,
+          // Throttle clock has been ticking forward hourly under fallback —
+          // imagine the most recent retry was 1h+1min ago. lastSuccessful
+          // hasn't moved since the last real oracle hit, which is now 8d old.
+          lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+          lastSuccessfulPriceTimestamp: eightDaysAgo,
+        };
+
+        await PriceOracle.refreshTokenPrice(
+          fetchedToken,
+          v3Block,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        // 7-day window has expired — fallback must NOT apply. Write 0.
+        expect(updatedToken.pricePerUSDNew).toBe(0n);
+      });
+
+      it("bumps lastSuccessfulPriceTimestamp on a successful non-zero write", async () => {
+        const newPrice = 3n * 10n ** 18n;
+        vi.mocked(mockContext.effect)?.mockImplementation(async (effect) => {
+          if ((effect as { name?: string }).name === "getTokenPrice") {
+            return { pricePerUSDNew: newPrice };
+          }
+          return {};
+        });
+
+        const fetchedToken = {
+          ...mockToken0Data,
+          pricePerUSDNew: 0n,
+          lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+          lastSuccessfulPriceTimestamp: undefined,
+        };
+
+        await PriceOracle.refreshTokenPrice(
+          fetchedToken,
+          v3Block,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        expect(updatedToken.pricePerUSDNew).toBe(newPrice);
+        expect(updatedToken.lastSuccessfulPriceTimestamp?.getTime()).toBe(
+          blockDatetime.getTime(),
+        );
+      });
+
+      it("does NOT bump lastSuccessfulPriceTimestamp when oracle returns 0 and no fallback is used", async () => {
+        // First-priced token: anchor is 0 (never priced), oracle still 0 →
+        // shouldn't qualify as a successful write.
+        const earlierTimestamp = new Date(
+          blockDatetime.getTime() - 2 * 60 * 60 * 1000,
+        );
+        vi.mocked(mockContext.effect)?.mockImplementation(async (effect) => {
+          if ((effect as { name?: string }).name === "getTokenPrice") {
+            return { pricePerUSDNew: 0n };
+          }
+          return {};
+        });
+
+        const fetchedToken = {
+          ...mockToken0Data,
+          pricePerUSDNew: 0n,
+          lastUpdatedTimestamp: earlierTimestamp,
+          lastSuccessfulPriceTimestamp: undefined,
+        };
+
+        await PriceOracle.refreshTokenPrice(
+          fetchedToken,
+          v3Block,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        expect(updatedToken.pricePerUSDNew).toBe(0n);
+        expect(updatedToken.lastSuccessfulPriceTimestamp).toBeUndefined();
+      });
+    });
+
     describe("when price fetch fails", () => {
       let originalToken: Token;
       beforeEach(async () => {


### PR DESCRIPTION
## Summary
- Add `lastSuccessfulPriceTimestamp` to the `Token` schema (nullable `Timestamp`); only bumped when a non-zero price is persisted (oracle main path or rebind with a priced source).
- Switch the V3 last-known-price fallback's 7-day staleness check in `refreshTokenPrice` from `lastUpdatedTimestamp` to the new field — so the window can actually expire under sustained $0 reads. Throttle clock (the 1h check at the top) keeps reading `lastUpdatedTimestamp`.
- Wire the new field through the other `Token.set` call sites (createTokenEntity, Voter/SuperchainLeafVoter whitelist, VotingReward bootstrap).
- Add 4 regression tests in `test/PriceOracle.test.ts` covering: fallback applies when last success is fresh, fallback expires after 7 days even with hourly retries, non-zero writes bump the new field, and $0 writes don't.
- Drive-by: change a stray `const currentPrice` → `let currentPrice` in `refreshTokenPrice` so the #668 spike-rejection guard no longer throws at runtime (it was reassigning a `const`, which was masking 3 #668 tests via the surrounding try/catch).

## Acceptance criteria (from #694)
- [x] New field on `Token` tracking time of last non-zero oracle write — `lastSuccessfulPriceTimestamp` (schema.graphql:356).
- [x] V3 fallback's 7-day guard reads the new field, not `lastUpdatedTimestamp` — `shouldUseLastKnownPrice` in src/PriceOracle.ts.
- [x] Throttle clock (`MS_IN_AN_HOUR` check) continues to read `lastUpdatedTimestamp` — unchanged at the top of `refreshTokenPrice`.
- [x] Regression test: \$0 transient under V3 fallback eventually stops re-pinning after 7 days, even with hourly retries — \"stops re-pinning once last successful price is older than 7 days\" in test/PriceOracle.test.ts.

## Test plan
- [x] \`tsc --noEmit\` clean
- [x] \`pnpm qa --write\` clean (no fixes applied)
- [x] \`pnpm test\` — 1215 passed, 33 skipped (99 files)
- [x] New regression tests fail against the unfixed code path (verified RED → GREEN during TDD)
- [ ] Indexer deploy absorbs a reindex window so all `Token` rows pick up the new field *(needs human — operational decision per issue body)*

## Note on the drive-by
PR #689 left `currentPrice` declared `const` but reassigned inside the spike-rejection branch, which throws a TypeError when the branch is hit and is caught by the surrounding try/catch — silently nuking 3 #668 tests on `main`. Flipping it to `let` restores the intended behavior; no test changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced token price staleness tracking by introducing separate timestamp records for refresh attempts and successful price writes, enabling more accurate fallback pricing behavior during extended oracle outages.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/velodrome-finance/indexer/pull/696)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->