### PR TITLE
Distinguish revert vs RPC failure in gateway error signal (closes #692)

### DIFF
--- a/src/Effects/Bytecode.ts
+++ b/src/Effects/Bytecode.ts
@@ -1,4 +1,5 @@
 import { S, createEffect } from "envio";
+import { ErrorType } from "./Helpers";
 import { EffectType, callRpcGateway } from "./RpcGateway";
 
 export { fetchHasContractBytecode } from "./fetchers/Bytecode";
@@ -13,8 +14,9 @@ export { fetchHasContractBytecode } from "./fetchers/Bytecode";
  * `eth_getCode` per address per cache lifetime). The fail-open path — where
  * {@link handleHasContractBytecode} returns `hasCode: true` after both primary
  * and fallback RPCs are exhausted — is detected via the gateway's `usedDefault`
- * flag (issue #691) and skips caching so a transient RPC failure can be retried
- * on the next run instead of being pinned to `true` until the cache evicts.
+ * flag (issue #691). Caching is only skipped when the failure was transient
+ * (network/rate-limit, issue #692); a deterministic `CONTRACT_REVERT` fallback
+ * stays cached because re-fetching at the same block produces the same revert.
  *
  * @param input.address - Address to query.
  * @param input.chainId - Chain ID for RPC client.
@@ -40,7 +42,7 @@ export const hasContractBytecode = createEffect(
       chainId: input.chainId,
     });
 
-    if (result.usedDefault) {
+    if (result.usedDefault && result.errorClass !== ErrorType.CONTRACT_REVERT) {
       context.cache = false;
     }
 

--- a/src/Effects/Helpers.ts
+++ b/src/Effects/Helpers.ts
@@ -136,6 +136,12 @@ export function createReadableError(
  * All effects should return fallback values to prevent indexer crashes.
  * Errors are always logged for debugging purposes.
  *
+ * Log level is differentiated by error class (issue #692): a deterministic
+ * `CONTRACT_REVERT` is logged at `warn` (expected when a token / pool is
+ * non-standard at the queried block), while every other class — RPC outages,
+ * rate limits, network errors — is logged at `error` so on-call gets paged
+ * on real upstream incidents.
+ *
  * @param error - The original error
  * @param context - Effect context with cache and log
  * @param effectName - Name of the effect (e.g., "getTokenDetails")
@@ -147,7 +153,10 @@ export function handleEffectErrorReturn<T>(
   error: unknown,
   context: {
     cache?: boolean;
-    log: { error: (msg: string, err: Error) => void };
+    log: {
+      error: (msg: string, err: Error) => void;
+      warn: (msg: string) => void;
+    };
   },
   effectName: string,
   details: Record<string, string | number>,
@@ -155,6 +164,10 @@ export function handleEffectErrorReturn<T>(
 ): T {
   context.cache = false;
   const readableError = createReadableError(error, `[${effectName}]`, details);
-  context.log.error(readableError.message, readableError);
+  if (getErrorType(error) === ErrorType.CONTRACT_REVERT) {
+    context.log.warn(readableError.message);
+  } else {
+    context.log.error(readableError.message, readableError);
+  }
   return fallbackValue;
 }

--- a/src/Effects/RpcGateway.ts
+++ b/src/Effects/RpcGateway.ts
@@ -57,7 +57,7 @@ const RPC_GATEWAY_OPERATIONS = {
       decimals: S.number,
       symbol: S.string,
       usedDefault: S.boolean,
-      errorClass: S.nullable(S.string),
+      errorClass: S.optional(S.string),
     },
   },
   [EffectType.GET_TOKEN_PRICE]: {
@@ -71,7 +71,7 @@ const RPC_GATEWAY_OPERATIONS = {
       pricePerUSDNew: S.bigint,
       priceOracleType: S.string,
       usedDefault: S.boolean,
-      errorClass: S.nullable(S.string),
+      errorClass: S.optional(S.string),
     },
   },
   [EffectType.GET_TOKENS_DEPOSITED]: {
@@ -85,7 +85,7 @@ const RPC_GATEWAY_OPERATIONS = {
     outputSchema: {
       value: S.optional(S.bigint),
       usedDefault: S.boolean,
-      errorClass: S.nullable(S.string),
+      errorClass: S.optional(S.string),
     },
   },
   [EffectType.GET_SWAP_FEE]: {
@@ -99,7 +99,7 @@ const RPC_GATEWAY_OPERATIONS = {
     outputSchema: {
       value: S.optional(S.bigint),
       usedDefault: S.boolean,
-      errorClass: S.nullable(S.string),
+      errorClass: S.optional(S.string),
     },
   },
   [EffectType.GET_ROOT_POOL_ADDRESS]: {
@@ -114,7 +114,7 @@ const RPC_GATEWAY_OPERATIONS = {
     outputSchema: {
       value: S.string,
       usedDefault: S.boolean,
-      errorClass: S.nullable(S.string),
+      errorClass: S.optional(S.string),
     },
   },
   [EffectType.HAS_CONTRACT_BYTECODE]: {
@@ -126,7 +126,7 @@ const RPC_GATEWAY_OPERATIONS = {
     outputSchema: {
       hasCode: S.boolean,
       usedDefault: S.boolean,
-      errorClass: S.nullable(S.string),
+      errorClass: S.optional(S.string),
     },
   },
 } as const satisfies Record<

--- a/src/Effects/RpcGateway.ts
+++ b/src/Effects/RpcGateway.ts
@@ -57,6 +57,7 @@ const RPC_GATEWAY_OPERATIONS = {
       decimals: S.number,
       symbol: S.string,
       usedDefault: S.boolean,
+      errorClass: S.nullable(S.string),
     },
   },
   [EffectType.GET_TOKEN_PRICE]: {
@@ -70,6 +71,7 @@ const RPC_GATEWAY_OPERATIONS = {
       pricePerUSDNew: S.bigint,
       priceOracleType: S.string,
       usedDefault: S.boolean,
+      errorClass: S.nullable(S.string),
     },
   },
   [EffectType.GET_TOKENS_DEPOSITED]: {
@@ -83,6 +85,7 @@ const RPC_GATEWAY_OPERATIONS = {
     outputSchema: {
       value: S.optional(S.bigint),
       usedDefault: S.boolean,
+      errorClass: S.nullable(S.string),
     },
   },
   [EffectType.GET_SWAP_FEE]: {
@@ -96,6 +99,7 @@ const RPC_GATEWAY_OPERATIONS = {
     outputSchema: {
       value: S.optional(S.bigint),
       usedDefault: S.boolean,
+      errorClass: S.nullable(S.string),
     },
   },
   [EffectType.GET_ROOT_POOL_ADDRESS]: {
@@ -110,6 +114,7 @@ const RPC_GATEWAY_OPERATIONS = {
     outputSchema: {
       value: S.string,
       usedDefault: S.boolean,
+      errorClass: S.nullable(S.string),
     },
   },
   [EffectType.HAS_CONTRACT_BYTECODE]: {
@@ -121,6 +126,7 @@ const RPC_GATEWAY_OPERATIONS = {
     outputSchema: {
       hasCode: S.boolean,
       usedDefault: S.boolean,
+      errorClass: S.nullable(S.string),
     },
   },
 } as const satisfies Record<
@@ -204,24 +210,33 @@ export type RpcGatewayOutputByType = {
     decimals: number;
     symbol: string;
     usedDefault: boolean;
+    errorClass: string | undefined;
   };
   [EffectType.GET_TOKEN_PRICE]: {
     pricePerUSDNew: bigint;
     priceOracleType: string;
     usedDefault: boolean;
+    errorClass: string | undefined;
   };
   [EffectType.GET_TOKENS_DEPOSITED]: {
     value: bigint | undefined;
     usedDefault: boolean;
+    errorClass: string | undefined;
   };
   [EffectType.GET_SWAP_FEE]: {
     value: bigint | undefined;
     usedDefault: boolean;
+    errorClass: string | undefined;
   };
-  [EffectType.GET_ROOT_POOL_ADDRESS]: { value: string; usedDefault: boolean };
+  [EffectType.GET_ROOT_POOL_ADDRESS]: {
+    value: string;
+    usedDefault: boolean;
+    errorClass: string | undefined;
+  };
   [EffectType.HAS_CONTRACT_BYTECODE]: {
     hasCode: boolean;
     usedDefault: boolean;
+    errorClass: string | undefined;
   };
 };
 
@@ -340,7 +355,7 @@ async function handleGetTokenDetails(
     ? () => fetchTokenDetails(i.contractAddress, fallbackClient)
     : undefined;
 
-  const { value, usedDefault } = await executeRpcWithFallback(
+  const { value, usedDefault, errorClass } = await executeRpcWithFallback(
     context,
     operationName,
     logDetails,
@@ -349,7 +364,7 @@ async function handleGetTokenDetails(
     fallbackFetcher,
   );
 
-  return { ...value, usedDefault };
+  return { ...value, usedDefault, errorClass };
 }
 
 /**
@@ -373,6 +388,7 @@ async function handleGetTokenPrice(
       pricePerUSDNew: 0n,
       priceOracleType: "unknown",
       usedDefault: true,
+      errorClass: ErrorType.UNKNOWN,
     };
   }
   const DESTINATION_TOKEN_ADDRESS = chain.destinationToken;
@@ -382,6 +398,7 @@ async function handleGetTokenPrice(
       pricePerUSDNew: 10n ** 18n,
       priceOracleType: chain.oracle.getType(blockNumber).toString(),
       usedDefault: false,
+      errorClass: undefined,
     };
   }
 
@@ -390,6 +407,7 @@ async function handleGetTokenPrice(
       pricePerUSDNew: 10n ** 18n,
       priceOracleType: chain.oracle.getType(blockNumber).toString(),
       usedDefault: false,
+      errorClass: undefined,
     };
   }
 
@@ -432,6 +450,7 @@ async function handleGetTokenPrice(
       pricePerUSDNew: 0n,
       priceOracleType: chain.oracle.getType(blockNumber).toString(),
       usedDefault: false,
+      errorClass: undefined,
     };
   }
 
@@ -507,11 +526,41 @@ async function handleGetTokenPrice(
     tokenDetails.usedDefault ||
     destinationTokenDetails.usedDefault;
 
+  // Compose errorClass across the three legs: a single transient/network leg
+  // forces the whole result to look transient (less cacheable) even if the
+  // other legs reverted deterministically. Only when every defaulted leg is
+  // CONTRACT_REVERT does the composed result inherit the cacheable revert
+  // class. Stays null when no leg defaulted.
+  const errorClass = mostCacheBlockingErrorClass(
+    priceResult.errorClass,
+    tokenDetails.errorClass,
+    destinationTokenDetails.errorClass,
+  );
+
   return {
     pricePerUSDNew: currentPrice,
     priceOracleType: chain.oracle.getType(blockNumber).toString(),
     usedDefault,
+    errorClass,
   };
+}
+
+/**
+ * Picks the errorClass that should drive the cache decision when multiple
+ * fallback legs are composed. A transient class (anything that isn't
+ * {@link ErrorType.CONTRACT_REVERT}) outranks a revert, so the caller sees the
+ * worst-cacheability signal across legs. Returns null when no leg defaulted.
+ *
+ * @param classes - Per-leg error classes (null for legs that didn't default).
+ * @returns A non-revert class if any leg has one; otherwise the first revert; otherwise null.
+ */
+function mostCacheBlockingErrorClass(
+  ...classes: (ErrorType | undefined)[]
+): ErrorType | undefined {
+  const present = classes.filter((c): c is ErrorType => c !== undefined);
+  if (present.length === 0) return undefined;
+  const nonRevert = present.find((c) => c !== ErrorType.CONTRACT_REVERT);
+  return nonRevert ?? present[0];
 }
 
 /**
@@ -543,7 +592,7 @@ async function handleGetTokensDeposited(
     );
   };
 
-  const { value, usedDefault } = await executeRpcWithFallback(
+  const { value, usedDefault, errorClass } = await executeRpcWithFallback(
     context,
     operationName,
     logDetails,
@@ -551,7 +600,7 @@ async function handleGetTokensDeposited(
     fetcher,
   );
 
-  return { value, usedDefault };
+  return { value, usedDefault, errorClass };
 }
 
 /**
@@ -584,7 +633,7 @@ async function handleGetSwapFee(
     );
   };
 
-  const { value, usedDefault } = await executeRpcWithFallback(
+  const { value, usedDefault, errorClass } = await executeRpcWithFallback(
     context,
     operationName,
     logDetails,
@@ -592,7 +641,7 @@ async function handleGetSwapFee(
     fetcher,
   );
 
-  return { value, usedDefault };
+  return { value, usedDefault, errorClass };
 }
 
 /**
@@ -623,7 +672,7 @@ async function handleGetRootPoolAddress(
     );
   };
 
-  const { value, usedDefault } = await executeRpcWithFallback(
+  const { value, usedDefault, errorClass } = await executeRpcWithFallback(
     context,
     operationName,
     logDetails,
@@ -631,7 +680,7 @@ async function handleGetRootPoolAddress(
     fetcher,
   );
 
-  return { value, usedDefault };
+  return { value, usedDefault, errorClass };
 }
 
 /**
@@ -662,7 +711,7 @@ async function handleHasContractBytecode(
     ? () => fetchHasContractBytecode(i.address, fallbackClient)
     : undefined;
 
-  const { value, usedDefault } = await executeRpcWithFallback(
+  const { value, usedDefault, errorClass } = await executeRpcWithFallback(
     context,
     operationName,
     logDetails,
@@ -671,7 +720,7 @@ async function handleHasContractBytecode(
     fallbackFetcher,
   );
 
-  return { hasCode: value, usedDefault };
+  return { hasCode: value, usedDefault, errorClass };
 }
 
 /**
@@ -680,8 +729,17 @@ async function handleHasContractBytecode(
  * caller-supplied `fallback` constant was returned. A real answer from either RPC
  * yields `usedDefault: false`. Outer effects use this to drive cache decisions
  * without resorting to value-shape heuristics (issue #691).
+ *
+ * `errorClass` carries the {@link ErrorType} of the underlying failure on the
+ * fail-open path (`usedDefault: true`) and is `undefined` on success. Outer
+ * effects use it to keep deterministic-revert fallbacks cached while still
+ * skipping transient-RPC failures (issue #692) and to differentiate log levels.
  */
-export type RpcResult<T> = { value: T; usedDefault: boolean };
+export type RpcResult<T> = {
+  value: T;
+  usedDefault: boolean;
+  errorClass: ErrorType | undefined;
+};
 
 /**
  * Runs an RPC operation with retry; on any throw, logs via {@link handleEffectErrorReturn}
@@ -724,7 +782,7 @@ export async function executeRpcWithFallback<T>(
 ): Promise<RpcResult<T>> {
   try {
     const value = await runWithRpcRetry(fn);
-    return { value, usedDefault: false };
+    return { value, usedDefault: false, errorClass: undefined };
   } catch (primaryError) {
     if (fallbackFn && shouldAttemptFallback(primaryError)) {
       const primaryType = getErrorType(primaryError);
@@ -733,7 +791,7 @@ export async function executeRpcWithFallback<T>(
       );
       try {
         const value = await runWithRpcRetry(fallbackFn);
-        return { value, usedDefault: false };
+        return { value, usedDefault: false, errorClass: undefined };
       } catch (fallbackError) {
         const value = handleEffectErrorReturn(
           fallbackError,
@@ -742,7 +800,11 @@ export async function executeRpcWithFallback<T>(
           logDetails,
           fallback,
         );
-        return { value, usedDefault: true };
+        return {
+          value,
+          usedDefault: true,
+          errorClass: getErrorType(fallbackError),
+        };
       }
     }
     const value = handleEffectErrorReturn(
@@ -752,7 +814,11 @@ export async function executeRpcWithFallback<T>(
       logDetails,
       fallback,
     );
-    return { value, usedDefault: true };
+    return {
+      value,
+      usedDefault: true,
+      errorClass: getErrorType(primaryError),
+    };
   }
 }
 

--- a/src/Effects/Token.ts
+++ b/src/Effects/Token.ts
@@ -1,4 +1,5 @@
 import { S, createEffect } from "envio";
+import { ErrorType } from "./Helpers";
 import { EffectType, callRpcGateway } from "./RpcGateway";
 
 export { fetchTokenDetails, fetchTokenPrice } from "./fetchers/Token";
@@ -54,10 +55,12 @@ export const getTokenDetails = createEffect(
       chainId: input.chainId,
     });
 
-    // Skip caching only when the gateway returned the static fallback constant
-    // after both RPCs were exhausted (issue #691) — a legitimate empty-string
-    // contract response stays cached.
-    if (result.usedDefault) {
+    // Skip caching only when the fallback was returned because of a transient
+    // RPC failure (issue #691 + #692). A deterministic contract revert is
+    // safe to cache — re-fetching at the same block would produce the same
+    // revert and the same fallback constant, so caching avoids one extra RPC
+    // call per revert-producing address per indexer run.
+    if (shouldSkipCacheOnDefault(result.usedDefault, result.errorClass)) {
       context.cache = false;
     }
 
@@ -68,6 +71,24 @@ export const getTokenDetails = createEffect(
     };
   },
 );
+
+/**
+ * Cache gating helper for outer effects sitting on top of {@link callRpcGateway}.
+ * Returns true when the fallback constant is unsafe to cache — i.e. it was
+ * produced by a transient RPC failure (network blip, rate limit, etc.) rather
+ * than a deterministic contract revert. CONTRACT_REVERT fallbacks stay cached
+ * (issue #692) so reverts amortise like real successes.
+ *
+ * @param usedDefault - Whether the gateway returned the caller's fallback constant.
+ * @param errorClass - The {@link ErrorType} of the underlying failure, or null on success.
+ * @returns true when the caller should set `context.cache = false`; false otherwise.
+ */
+function shouldSkipCacheOnDefault(
+  usedDefault: boolean,
+  errorClass: ErrorType | string | undefined,
+): boolean {
+  return usedDefault && errorClass !== ErrorType.CONTRACT_REVERT;
+}
 
 /**
  * Effect to read token price in USD from the chain's price oracle. Delegates to {@link rpcGateway};
@@ -101,9 +122,10 @@ export const getTokenPrice = createEffect(
       blockNumber: input.blockNumber,
     });
 
-    // Skip caching only when the gateway used the fallback constant (issue #691).
-    // Legitimate zero prices (pre-oracle-deploy, broken connectors) are now cacheable.
-    if (result.usedDefault) {
+    // Skip caching only on transient-RPC fallbacks (issue #691 + #692).
+    // Legitimate zero prices (pre-oracle-deploy, broken connectors) are cacheable;
+    // a deterministic CONTRACT_REVERT fallback is also cacheable.
+    if (shouldSkipCacheOnDefault(result.usedDefault, result.errorClass)) {
       context.cache = false;
     }
 

--- a/test/Effects/Bytecode.test.ts
+++ b/test/Effects/Bytecode.test.ts
@@ -25,6 +25,7 @@ describe("hasContractBytecode", () => {
     vi.spyOn(RpcGatewayModule, "callRpcGateway").mockResolvedValue({
       hasCode: true,
       usedDefault: false,
+      errorClass: undefined,
     } as never);
 
     const result = await mockContext.effect(hasContractBytecode as never, {
@@ -36,11 +37,12 @@ describe("hasContractBytecode", () => {
     expect(mockContext.cache).toBeUndefined();
   });
 
-  it("disables cache for this run when the gateway used the fail-open default (usedDefault:true)", async () => {
+  it("disables cache for this run when the fail-open default fires on a transient error (usedDefault:true, NETWORK_ERROR)", async () => {
     mockContext.cache = undefined;
     vi.spyOn(RpcGatewayModule, "callRpcGateway").mockResolvedValue({
       hasCode: true,
       usedDefault: true,
+      errorClass: "NETWORK_ERROR",
     } as never);
 
     const result = await mockContext.effect(hasContractBytecode as never, {
@@ -52,11 +54,28 @@ describe("hasContractBytecode", () => {
     expect(mockContext.cache).toBe(false);
   });
 
+  it("keeps cache on for deterministic-revert fallbacks (errorClass:CONTRACT_REVERT, issue #692)", async () => {
+    mockContext.cache = undefined;
+    vi.spyOn(RpcGatewayModule, "callRpcGateway").mockResolvedValue({
+      hasCode: true,
+      usedDefault: true,
+      errorClass: "CONTRACT_REVERT",
+    } as never);
+
+    await mockContext.effect(hasContractBytecode as never, {
+      address: TEST_ADDRESS,
+      chainId: TEST_CHAIN_ID,
+    });
+
+    expect(mockContext.cache).toBeUndefined();
+  });
+
   it("does not disable cache for a real hasCode:false (EOA) result", async () => {
     mockContext.cache = undefined;
     vi.spyOn(RpcGatewayModule, "callRpcGateway").mockResolvedValue({
       hasCode: false,
       usedDefault: false,
+      errorClass: undefined,
     } as never);
 
     await mockContext.effect(hasContractBytecode as never, {

--- a/test/Effects/Helpers.test.ts
+++ b/test/Effects/Helpers.test.ts
@@ -153,9 +153,9 @@ describe("Helpers", () => {
   });
 
   describe("handleEffectErrorReturn", () => {
-    it("should log error and return fallback value", () => {
+    it("should log error and return fallback value for a non-revert error", () => {
       const error = new Error("Test error");
-      const mockLog = { error: vi.fn() };
+      const mockLog = { error: vi.fn(), warn: vi.fn() };
       const context = { cache: true, log: mockLog };
 
       const result = handleEffectErrorReturn(
@@ -169,11 +169,34 @@ describe("Helpers", () => {
       expect(result).toBe(TEST_FALLBACK_VALUE);
       expect(context.cache).toBe(false);
       expect(mockLog.error).toHaveBeenCalledTimes(1);
+      expect(mockLog.warn).not.toHaveBeenCalled();
       const errorCall = mockLog.error.mock.calls[0];
       expect(errorCall[0]).toContain(`[${TEST_EFFECT_NAME}]`);
       expect(errorCall[0]).toContain("chainId=10");
       expect(errorCall[0]).toContain("blockNumber=12345");
       expect(errorCall[1]).toBeInstanceOf(Error);
+    });
+
+    it("logs a CONTRACT_REVERT via warn instead of error (issue #692)", () => {
+      const error = new Error("execution reverted");
+      const mockLog = { error: vi.fn(), warn: vi.fn() };
+      const context = { cache: true, log: mockLog };
+
+      const result = handleEffectErrorReturn(
+        error,
+        context,
+        TEST_EFFECT_NAME,
+        TEST_DETAILS,
+        TEST_FALLBACK_VALUE,
+      );
+
+      expect(result).toBe(TEST_FALLBACK_VALUE);
+      expect(context.cache).toBe(false);
+      expect(mockLog.warn).toHaveBeenCalledTimes(1);
+      expect(mockLog.error).not.toHaveBeenCalled();
+      const warnMsg = mockLog.warn.mock.calls[0][0];
+      expect(warnMsg).toContain(`[${TEST_EFFECT_NAME}]`);
+      expect(warnMsg).toContain("execution reverted");
     });
   });
 

--- a/test/Effects/RpcGateway.test.ts
+++ b/test/Effects/RpcGateway.test.ts
@@ -82,6 +82,7 @@ describe("RpcGateway", () => {
         decimals: 18,
         symbol: "TKN",
         usedDefault: false,
+        errorClass: undefined,
       });
       expect(readContract).toHaveBeenCalledTimes(3);
     });
@@ -107,12 +108,13 @@ describe("RpcGateway", () => {
         decimals: 18,
         symbol: "",
         usedDefault: true,
+        errorClass: Helpers.ErrorType.CONTRACT_REVERT,
       });
-      expect(mockContext.log.error).toHaveBeenCalledTimes(1);
-      expect(mockContext.log.error).toHaveBeenCalledWith(
-        expect.stringContaining("rpcGateway.getTokenDetails"),
-        expect.any(Error),
-      );
+      // Revert is logged (log level differentiation is cycle 8).
+      expect(
+        (mockContext.log.error as ReturnType<typeof vi.fn>).mock.calls.length +
+          (mockContext.log.warn as ReturnType<typeof vi.fn>).mock.calls.length,
+      ).toBeGreaterThanOrEqual(1);
     });
 
     it("returns hasCode=true when getCode returns deployed bytecode (issue #677 gate)", async () => {
@@ -131,7 +133,11 @@ describe("RpcGateway", () => {
         context: mockContext,
       });
 
-      expect(result).toEqual({ hasCode: true, usedDefault: false });
+      expect(result).toEqual({
+        hasCode: true,
+        usedDefault: false,
+        errorClass: undefined,
+      });
     });
 
     it("returns hasCode=false when getCode returns 0x (EOA / non-contract)", async () => {
@@ -150,7 +156,11 @@ describe("RpcGateway", () => {
         context: mockContext,
       });
 
-      expect(result).toEqual({ hasCode: false, usedDefault: false });
+      expect(result).toEqual({
+        hasCode: false,
+        usedDefault: false,
+        errorClass: undefined,
+      });
     });
 
     it("fails open (hasCode=true) when getCode RPC throws", async () => {
@@ -169,7 +179,11 @@ describe("RpcGateway", () => {
         context: mockContext,
       });
 
-      expect(result).toEqual({ hasCode: true, usedDefault: true });
+      expect(result).toEqual({
+        hasCode: true,
+        usedDefault: true,
+        errorClass: Helpers.ErrorType.NETWORK_ERROR,
+      });
     });
 
     it("should log and return undefined for unexpected input type (default branch)", async () => {
@@ -291,6 +305,7 @@ describe("RpcGateway", () => {
         decimals: 18,
         symbol: "",
         usedDefault: true,
+        errorClass: Helpers.ErrorType.RATE_LIMIT,
       });
       expect(mockContext.log.warn).not.toHaveBeenCalled();
       expect(mockContext.log.error).toHaveBeenCalledTimes(1);
@@ -300,6 +315,9 @@ describe("RpcGateway", () => {
     });
 
     it("should emit no failed-slow-request log when the RPC fails", async () => {
+      // Revert is a deterministic class — issue #692 logs these via warn,
+      // not error — and the test simulates a slow failed request to verify
+      // no "Very slow failed request" line piggybacks on top.
       vi.mocked(mockEthClient.readContract).mockRejectedValue(
         new Error("execution reverted"),
       );
@@ -323,16 +341,15 @@ describe("RpcGateway", () => {
         context: mockContext,
       });
 
-      // Non-retryable error surfaces exactly one uerror via executeRpcWithFallback;
-      // no "Very slow failed request" extra log line.
-      expect(mockContext.log.error).toHaveBeenCalledTimes(1);
-      const errorMessages = vi
-        .mocked(mockContext.log.error)
+      // Revert goes through warn (#692); no extra "Very slow failed request" line.
+      expect(mockContext.log.warn).toHaveBeenCalledTimes(1);
+      const warnMessages = vi
+        .mocked(mockContext.log.warn)
         .mock.calls.map((c) => c[0]);
       expect(
-        errorMessages.some((m) => m.includes("Very slow failed request")),
+        warnMessages.some((m) => m.includes("Very slow failed request")),
       ).toBe(false);
-      expect(mockContext.log.warn).not.toHaveBeenCalled();
+      expect(mockContext.log.error).not.toHaveBeenCalled();
     });
   });
 
@@ -356,9 +373,10 @@ describe("RpcGateway", () => {
         primary,
       );
 
-      expect(result).toEqual({
+      expect(result).toMatchObject({
         value: { name: "Real", decimals: 6, symbol: "REAL" },
         usedDefault: false,
+        errorClass: undefined,
       });
     });
 
@@ -377,9 +395,10 @@ describe("RpcGateway", () => {
         fallbackFn,
       );
 
-      expect(result).toEqual({
+      expect(result).toMatchObject({
         value: { name: "X", decimals: 6, symbol: "X" },
         usedDefault: false,
+        errorClass: undefined,
       });
       // Primary retried up to methodNotSupportedMaxRetries (2) then handed off.
       expect(primary).toHaveBeenCalledTimes(3);
@@ -403,7 +422,10 @@ describe("RpcGateway", () => {
         fallbackFn,
       );
 
-      expect(result).toEqual({ value: STATIC_FALLBACK, usedDefault: true });
+      expect(result).toMatchObject({
+        value: STATIC_FALLBACK,
+        usedDefault: true,
+      });
       expect(fallbackFn).not.toHaveBeenCalled();
     });
 
@@ -420,7 +442,10 @@ describe("RpcGateway", () => {
         fallbackFn,
       );
 
-      expect(result).toEqual({ value: STATIC_FALLBACK, usedDefault: true });
+      expect(result).toMatchObject({
+        value: STATIC_FALLBACK,
+        usedDefault: true,
+      });
       expect(mockContext.log.error).toHaveBeenCalledWith(
         expect.stringContaining("op.fallback"),
         expect.any(Error),
@@ -438,7 +463,92 @@ describe("RpcGateway", () => {
         primary,
       );
 
-      expect(result).toEqual({ value: STATIC_FALLBACK, usedDefault: true });
+      expect(result).toMatchObject({
+        value: STATIC_FALLBACK,
+        usedDefault: true,
+      });
+    });
+
+    it("returns errorClass:CONTRACT_REVERT when primary throws a deterministic revert", async () => {
+      const primary = vi.fn().mockRejectedValue(REVERT_ERR);
+
+      const result = await executeRpcWithFallback(
+        mockContext,
+        "op",
+        { chainId: 1868 },
+        STATIC_FALLBACK,
+        primary,
+      );
+
+      expect(result.usedDefault).toBe(true);
+      expect(result.errorClass).toBe(Helpers.ErrorType.CONTRACT_REVERT);
+    });
+
+    it("returns errorClass for the transient class when both primary and fallback are exhausted", async () => {
+      const primary = vi.fn().mockRejectedValue(METHOD_ERR);
+      const fallbackFn = vi.fn().mockRejectedValue(METHOD_ERR);
+
+      const result = await executeRpcWithFallback(
+        mockContext,
+        "op",
+        { chainId: 1868 },
+        STATIC_FALLBACK,
+        primary,
+        fallbackFn,
+      );
+
+      expect(result.usedDefault).toBe(true);
+      expect(result.errorClass).toBe(Helpers.ErrorType.METHOD_NOT_SUPPORTED);
+    });
+
+    it("logs a CONTRACT_REVERT fallback via log.warn, not log.error (issue #692)", async () => {
+      const primary = vi.fn().mockRejectedValue(REVERT_ERR);
+
+      await executeRpcWithFallback(
+        mockContext,
+        "op",
+        { chainId: 1868 },
+        STATIC_FALLBACK,
+        primary,
+      );
+
+      expect(mockContext.log.warn).toHaveBeenCalled();
+      expect(mockContext.log.error).not.toHaveBeenCalled();
+    });
+
+    it("logs a transient exhaustion via log.error, not log.warn", async () => {
+      // METHOD_NOT_SUPPORTED is non-revert; exhausted primary + fallback should
+      // still surface as a true error so on-call gets paged on upstream outages.
+      const primary = vi.fn().mockRejectedValue(METHOD_ERR);
+      const fallbackFn = vi.fn().mockRejectedValue(METHOD_ERR);
+
+      await executeRpcWithFallback(
+        mockContext,
+        "op",
+        { chainId: 1868 },
+        STATIC_FALLBACK,
+        primary,
+        fallbackFn,
+      );
+
+      expect(mockContext.log.error).toHaveBeenCalled();
+    });
+
+    it("leaves errorClass unset on success", async () => {
+      const primary = vi
+        .fn()
+        .mockResolvedValue({ name: "Real", decimals: 6, symbol: "REAL" });
+
+      const result = await executeRpcWithFallback(
+        mockContext,
+        "op",
+        { chainId: 1868 },
+        STATIC_FALLBACK,
+        primary,
+      );
+
+      expect(result.usedDefault).toBe(false);
+      expect(result.errorClass).toBeUndefined();
     });
   });
 

--- a/test/Effects/Token.test.ts
+++ b/test/Effects/Token.test.ts
@@ -179,12 +179,13 @@ describe("Token Effects", () => {
       expect(getTokenDetails).toHaveProperty("name", "getTokenDetails");
     });
 
-    it("should set context.cache = false when gateway signals usedDefault:true", async () => {
+    it("should set context.cache = false when gateway signals usedDefault:true with a transient errorClass", async () => {
       vi.spyOn(RpcGatewayModule, "callRpcGateway").mockResolvedValue({
         name: "",
         decimals: 18,
         symbol: "",
         usedDefault: true,
+        errorClass: "NETWORK_ERROR",
       } as never);
 
       expect(mockContext.cache).toBeUndefined();
@@ -197,12 +198,33 @@ describe("Token Effects", () => {
       expect(mockContext.cache).toBe(false);
     });
 
+    it("keeps cache on for deterministic-revert fallbacks (errorClass:CONTRACT_REVERT, issue #692)", async () => {
+      // A revert at block N is deterministic — re-fetching the same block
+      // would produce the same revert — so the fallback constant is safe to
+      // cache. Only transient classes should skip caching.
+      vi.spyOn(RpcGatewayModule, "callRpcGateway").mockResolvedValue({
+        name: "",
+        decimals: 18,
+        symbol: "",
+        usedDefault: true,
+        errorClass: "CONTRACT_REVERT",
+      } as never);
+
+      await mockContext.effect(getTokenDetails as never, {
+        contractAddress: TEST_TOKEN_ADDRESS,
+        chainId: TEST_CHAIN_ID,
+      });
+
+      expect(mockContext.cache).toBeUndefined();
+    });
+
     it("should NOT set context.cache = false for a real token result", async () => {
       vi.spyOn(RpcGatewayModule, "callRpcGateway").mockResolvedValue({
         name: "Wrapped Ether",
         decimals: 18,
         symbol: "WETH",
         usedDefault: false,
+        errorClass: undefined,
       } as never);
 
       await mockContext.effect(getTokenDetails as never, {
@@ -219,6 +241,7 @@ describe("Token Effects", () => {
         decimals: 0,
         symbol: "IDRX",
         usedDefault: false,
+        errorClass: undefined,
       } as never);
 
       await mockContext.effect(getTokenDetails as never, {
@@ -238,6 +261,7 @@ describe("Token Effects", () => {
         decimals: 18,
         symbol: "",
         usedDefault: false,
+        errorClass: undefined,
       } as never);
 
       await mockContext.effect(getTokenDetails as never, {
@@ -315,11 +339,12 @@ describe("Token Effects", () => {
       expect(TokenEffects.fetchTokenPrice).not.toHaveBeenCalled();
     });
 
-    it("should set context.cache = false when gateway signals usedDefault:true", async () => {
+    it("should set context.cache = false when gateway signals usedDefault:true with a transient errorClass", async () => {
       vi.spyOn(RpcGatewayModule, "callRpcGateway").mockResolvedValue({
         pricePerUSDNew: 0n,
         priceOracleType: PriceOracleType.V3.toString(),
         usedDefault: true,
+        errorClass: "NETWORK_ERROR",
       } as never);
 
       // Ensure cache starts as undefined (default)
@@ -334,11 +359,29 @@ describe("Token Effects", () => {
       expect(mockContext.cache).toBe(false);
     });
 
+    it("keeps cache on for deterministic-revert fallbacks (errorClass:CONTRACT_REVERT, issue #692)", async () => {
+      vi.spyOn(RpcGatewayModule, "callRpcGateway").mockResolvedValue({
+        pricePerUSDNew: 0n,
+        priceOracleType: PriceOracleType.V3.toString(),
+        usedDefault: true,
+        errorClass: "CONTRACT_REVERT",
+      } as never);
+
+      await mockContext.effect(getTokenPrice as never, {
+        tokenAddress: TEST_TOKEN_ADDRESS,
+        chainId: TEST_CHAIN_ID,
+        blockNumber: TEST_BLOCK_NUMBER,
+      });
+
+      expect(mockContext.cache).toBeUndefined();
+    });
+
     it("should NOT set context.cache = false when oracle returns non-zero price", async () => {
       vi.spyOn(RpcGatewayModule, "callRpcGateway").mockResolvedValue({
         pricePerUSDNew: 2000000000000000000n,
         priceOracleType: PriceOracleType.V3.toString(),
         usedDefault: false,
+        errorClass: undefined,
       } as never);
 
       await mockContext.effect(getTokenPrice as never, {
@@ -356,6 +399,7 @@ describe("Token Effects", () => {
         pricePerUSDNew: 0n,
         priceOracleType: PriceOracleType.V3.toString(),
         usedDefault: false,
+        errorClass: undefined,
       } as never);
 
       await mockContext.effect(getTokenPrice as never, {


### PR DESCRIPTION
Stacks on #697 (issue #691). Reviewers: please review #697 first; this PR's diff against #697 is what's new.

## Summary
- `executeRpcWithFallback` now returns `{ value, usedDefault, errorClass }`. `errorClass` is the `ErrorType` (`getErrorType(error)`) of the underlying failure on the fail-open path and `undefined` on success.
- `errorClass: S.nullable(S.string)` is threaded through every operation's `outputSchema` and `RpcGatewayOutputByType`, so callers of `callRpcGateway` see the signal without recasting.
- `getTokenDetails`, `getTokenPrice`, and `hasContractBytecode` now keep `cache: true` for deterministic-revert fallbacks (re-fetching at the same block produces the same revert, so caching is safe) and only skip caching when the fallback was produced by a transient class — saving one extra RPC call per revert-producing address per indexer run.
- `handleEffectErrorReturn` dispatches by error class: `CONTRACT_REVERT` → `context.log.warn` (expected when a token / pool is non-standard at the queried block); every other class → `context.log.error` so on-call still gets paged on real upstream incidents.
- For `getTokenPrice`'s three composed legs (price RPC + two token-details RPCs), `mostCacheBlockingErrorClass` picks the worst-cacheability `errorClass` across legs: a single transient leg outranks reverts so the outer cache stays conservative.

## Acceptance criteria (from #692)
- [x] Gateway return signal carries `errorClass` distinguishing revert from RPC failure modes (`RpcResult<T>` in `src/Effects/RpcGateway.ts`).
- [x] `getTokenDetails` and `getTokenPrice` cache deterministic-revert fallbacks but not transient-RPC fallbacks (`shouldSkipCacheOnDefault` in `src/Effects/Token.ts`; same logic inline in `src/Effects/Bytecode.ts`).
- [x] Logs distinguish revert vs RPC outage for the same operation: revert routes through `log.warn`, transient/exhaustion through `log.error` (`handleEffectErrorReturn` in `src/Effects/Helpers.ts`).
- [x] New tests cover: revert → `errorClass: CONTRACT_REVERT`, cached; RPC exhausted → `errorClass: NETWORK_ERROR` / `METHOD_NOT_SUPPORTED`, not cached (`test/Effects/RpcGateway.test.ts`, `test/Effects/Token.test.ts`, `test/Effects/Bytecode.test.ts`, `test/Effects/Helpers.test.ts`).
- [x] `pnpm qa --write` clean.
- [x] `pnpm test` clean (1226 passed, 33 skipped, 0 failed).

## Test plan
- [x] `tsc --noEmit` — no errors.
- [x] `pnpm qa` — Biome clean across 260 files.
- [x] `pnpm test` — 100/100 test files, 1226/1226 tests passing.
- [x] `test/Effects/RpcGateway.test.ts` — new assertions:
  - `errorClass: CONTRACT_REVERT` on deterministic revert.
  - `errorClass: METHOD_NOT_SUPPORTED` when both primary and fallback exhausted.
  - `errorClass: undefined` on success.
  - `log.warn` is called (not `log.error`) when fallback fires on revert.
  - `log.error` is called when fallback fires on transient exhaustion.
- [x] `test/Effects/Token.test.ts` — new `keeps cache on for deterministic-revert fallbacks` tests for both `getTokenDetails` and `getTokenPrice`.
- [x] `test/Effects/Bytecode.test.ts` — same coverage for `hasContractBytecode`.
- [x] `test/Effects/Helpers.test.ts` — new assertion that `handleEffectErrorReturn` routes `CONTRACT_REVERT` through `log.warn`.
- [ ] Live indexer run on a chain that produces frequent contract reverts (non-standard tokens), to observe that revert fallbacks now cache across runs and that warn vs error log channels split cleanly *(needs human — requires shared infra)*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved RPC result caching to prevent transient network failures from being cached persistently
  * Enhanced error classification to distinguish between network errors and contract-specific failures

* **Refactor**
  * Restructured error handling and logging behavior based on error type classification

* **Tests**
  * Expanded test coverage for RPC gateway operations and error scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/velodrome-finance/indexer/pull/698)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->