### PR TITLE
docs(schema): explain feeProtocol0/1 are governance-gated (closes #708)

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -42,8 +42,15 @@ type LiquidityPoolAggregator {
   lastSnapshotTimestamp: Timestamp! # timestamp of last snapshot
 
   # CL Pool specific fields
-  feeProtocol0: BigInt @config(precision: 76) # current fee protocol for token0
-  feeProtocol1: BigInt @config(precision: 76) # current fee protocol for token1
+  # protocol fee % for token0. Set via SetFeeProtocol (governance-gated admin call).
+  # Uniformly 0 across all Slipstream pools as of 2026-05: Aerodrome/Velodrome
+  # governance has not activated protocol fees. The handler (src/EventHandlers/CLPool.ts)
+  # is wired correctly; the field will populate only when (and if) governance turns the
+  # toggle on. Slipstream's slot0() does not pack feeProtocol and the pool exposes no
+  # feeProtocol() getter, so the on-chain SetFeeProtocol event is the only source.
+  feeProtocol0: BigInt @config(precision: 76)
+  # As feeProtocol0, for token1.
+  feeProtocol1: BigInt @config(precision: 76)
   observationCardinalityNext: BigInt @config(precision: 76) # oracle observation cardinality
   sqrtPriceX96: BigInt @config(precision: 76) # current sqrt price (Q96 fixed point) - updated from Swap/Initialize events
   tick: BigInt @config(precision: 24) # current tick - updated from Swap/Initialize events
@@ -183,8 +190,15 @@ type LiquidityPoolAggregatorSnapshot {
   timestamp: Timestamp! # timestamp of last update
 
   # CL Pool specific fields
-  feeProtocol0: BigInt @config(precision: 76) # current fee protocol for token0
-  feeProtocol1: BigInt @config(precision: 76) # current fee protocol for token1
+  # protocol fee % for token0. Set via SetFeeProtocol (governance-gated admin call).
+  # Uniformly 0 across all Slipstream pools as of 2026-05: Aerodrome/Velodrome
+  # governance has not activated protocol fees. The handler (src/EventHandlers/CLPool.ts)
+  # is wired correctly; the field will populate only when (and if) governance turns the
+  # toggle on. Slipstream's slot0() does not pack feeProtocol and the pool exposes no
+  # feeProtocol() getter, so the on-chain SetFeeProtocol event is the only source.
+  feeProtocol0: BigInt @config(precision: 76)
+  # As feeProtocol0, for token1.
+  feeProtocol1: BigInt @config(precision: 76)
   observationCardinalityNext: BigInt @config(precision: 76) # oracle observation cardinality
   sqrtPriceX96: BigInt @config(precision: 76) # current sqrt price (Q96 fixed point) - updated from Swap/Initialize events
   tick: BigInt @config(precision: 24) # current tick - updated from Swap/Initialize events


### PR DESCRIPTION
## Summary

- Documents on both `LiquidityPoolAggregator` and `LiquidityPoolAggregatorSnapshot` that `feeProtocol0`/`feeProtocol1` are uniformly `0` because the Slipstream `SetFeeProtocol` governance toggle has never fired across any of the 12 chains (≥0 events sampled).
- Comments call out that the handler in `src/EventHandlers/CLPool.ts` is correct and the field will populate when (and if) governance activates protocol fees.
- No code changes — schema comment edit only, per the acceptance criteria of #708.

## Test plan

- [x] `grep "feeProtocol" schema.graphql` shows the new multi-line doc block on both entities.
- [x] `git diff HEAD~1 HEAD --stat` reports only `schema.graphql` changed (+18/-4).
- [x] No changes to `src/EventHandlers/CLPool.ts` or any handler/aggregator.

Closes #708.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified protocol fee field descriptions with detailed information about governance mechanisms and on-chain event sourcing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/velodrome-finance/indexer/pull/710)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->