### PR TITLE
fix(nfp): clamp NonFungiblePosition.liquidity at zero (#706)

### DIFF
--- a/src/Aggregators/NonFungiblePosition.ts
+++ b/src/Aggregators/NonFungiblePosition.ts
@@ -24,6 +24,12 @@ export interface NonFungiblePositionDiff {
  * Uses spread operator to handle immutable entities.
  * Most fields are set to absolute values (directly substituted), except liquidity which is incremental.
  * Takes an epoch-aligned snapshot when entering a new snapshot epoch.
+ *
+ * Liquidity writes are clamped to `>= 0n` (issue #706 latent guard). If a Decrease
+ * arrives without a matching Increase — HyperSync gap, reorg, or periphery vault
+ * firing Decrease without Increase — the raw subtraction would persist as negative.
+ * The clamp emits a `[NEG_NFP_LIQUIDITY_GUARD]` error log so the signal stays
+ * visible without aborting the indexer.
  */
 export function updateNonFungiblePosition(
   diff: Partial<NonFungiblePositionDiff>,
@@ -31,6 +37,16 @@ export function updateNonFungiblePosition(
   context: handlerContext,
   timestamp: Date,
 ): void {
+  const delta = diff.incrementalLiquidity ?? 0n;
+  const rawLiquidity = current.liquidity + delta;
+  let clampedLiquidity = rawLiquidity;
+  if (rawLiquidity < 0n) {
+    context.log.error(
+      `[NEG_NFP_LIQUIDITY_GUARD] tokenId=${current.tokenId} chain=${current.chainId} prior=${current.liquidity} delta=${delta} clampedTo=0`,
+    );
+    clampedLiquidity = 0n;
+  }
+
   let nonFungiblePosition: NonFungiblePosition = {
     ...current,
     tokenId: diff.tokenId ?? current.tokenId,
@@ -40,7 +56,7 @@ export function updateNonFungiblePosition(
     tickLower: diff.tickLower ?? current.tickLower,
     token0: diff.token0 ?? current.token0,
     token1: diff.token1 ?? current.token1,
-    liquidity: (diff.incrementalLiquidity ?? 0n) + current.liquidity,
+    liquidity: clampedLiquidity,
     mintTransactionHash:
       diff.mintTransactionHash ?? current.mintTransactionHash,
     mintLogIndex: diff.mintLogIndex ?? current.mintLogIndex,

--- a/test/Aggregators/NonFungiblePosition.test.ts
+++ b/test/Aggregators/NonFungiblePosition.test.ts
@@ -162,5 +162,43 @@ describe("NonFungiblePosition", () => {
         expect(mockContext.NonFungiblePositionSnapshot?.set).toHaveBeenCalled();
       });
     });
+
+    describe("when decrement exceeds current liquidity (issue #706 latent guard)", () => {
+      let result: NonFungiblePosition;
+      beforeEach(async () => {
+        const overdraftDiff = {
+          // -2x current liquidity: simulates a Decrease without a matching Increase
+          // (HyperSync gap, reorg, or periphery vault firing Decrease without Increase).
+          incrementalLiquidity: -2000000000000000000n,
+          lastUpdatedTimestamp: timestamp,
+          lastSnapshotTimestamp: undefined,
+        };
+
+        updateNonFungiblePosition(
+          overdraftDiff,
+          mockNonFungiblePosition,
+          mockContext as handlerContext,
+          timestamp,
+        );
+        const mockSet = vi.mocked(mockContext.NonFungiblePosition?.set);
+        result = mockSet?.mock.calls[0]?.[0] as NonFungiblePosition;
+      });
+
+      it("clamps liquidity to 0n instead of going negative", () => {
+        expect(result.liquidity).toBe(0n);
+      });
+
+      it("emits a [NEG_NFP_LIQUIDITY_GUARD] error log with diagnostic fields", () => {
+        const error = vi.mocked(mockContext.log?.error);
+        expect(error).toHaveBeenCalledTimes(1);
+        const msg = error?.mock.calls[0]?.[0] as string;
+        expect(msg).toContain("[NEG_NFP_LIQUIDITY_GUARD]");
+        expect(msg).toContain("tokenId=1");
+        expect(msg).toContain("chain=10");
+        expect(msg).toContain("prior=1000000000000000000");
+        expect(msg).toContain("delta=-2000000000000000000");
+        expect(msg).toContain("clampedTo=0");
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Clamp the incremental `liquidity` write in `updateNonFungiblePosition` (`src/Aggregators/NonFungiblePosition.ts:43`) to `>= 0n`.
- On attempted negative write, emit a `[NEG_NFP_LIQUIDITY_GUARD]` **error** log with `tokenId`, `chain`, `prior`, `delta`, `clampedTo` — no abort, no state mutation beyond the clamp.
- Mirrors the defense-in-depth patterns at `GaugeSharedLogic.ts:418` and `LiquidityPoolAggregator.ts:484-514`.

Latent today (no observed negative `liquidity` rows in production), filed as hygiene. Scenarios that could trigger the guard: HyperSync gap missing an Increase, reorg, or a periphery vault firing Decrease without Increase.

**Naming note**: issue #706 refers to the field as `pendingPrincipal`, but `NonFungiblePosition` has only `liquidity` — there is no `pendingPrincipal` field on this entity. The fix targets the bug pattern at the cited file/line (`NonFungiblePosition.ts:43`, the `incrementalLiquidity`-accumulated field), which is `liquidity`. Log marker renamed from the issue's literal `[NEG_PENDING_PRINCIPAL_GUARD]` to `[NEG_NFP_LIQUIDITY_GUARD]` so the tag accurately describes the field being clamped.

Closes #706.

## Test plan

- [x] New unit test: Decrease with `incrementalLiquidity` exceeding `current.liquidity` → field clamps to `0n`, `[NEG_NFP_LIQUIDITY_GUARD]` error fires with all five diagnostic fields.
- [x] Existing happy-path tests for `updateNonFungiblePosition` (transfer / increase / decrease) unchanged and still passing.
- [x] Full suite: `pnpm test` → 1223 passed, 33 skipped, 0 failed.
- [x] `pnpm qa --write` clean; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved handling of liquidity updates to prevent invalid negative states. When a liquidity decrease would result in negative liquidity, the position now correctly clamps the value to zero and emits a diagnostic error log with relevant details for troubleshooting.

## Tests
* Added comprehensive test coverage for edge cases involving large liquidity decreases that exceed available liquidity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/velodrome-finance/indexer/pull/711)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->