### PR TITLE
chore(schema): drop dead UserStatsPerPool.currentLiquidityUSD (closes #705)

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -225,7 +225,6 @@ type UserStatsPerPool {
   chainId: Int!
 
   # Liquidity metrics
-  currentLiquidityUSD: BigInt! @config(precision: 76) # current net liquidity position in USD
   lpBalance: BigInt! @config(precision: 76) # user's LP token balance (tracked from Transfer events)
   totalLiquidityAddedUSD: BigInt! @config(precision: 76) # cumulative USD value of liquidity added (from IncreaseLiquidity events and Transfer ADD attribution)
   totalLiquidityAddedToken0: BigInt! @config(precision: 76) # cumulative raw token0 amount added (sum of event.params.amount0 from IncreaseLiquidity + Transfer ADD). May differ from removed due to price movement between deposit and withdrawal
@@ -290,7 +289,6 @@ type UserStatsPerPoolSnapshot {
   timestamp: Timestamp! @index
 
   # Liquidity metrics
-  currentLiquidityUSD: BigInt! @config(precision: 76)
   lpBalance: BigInt! @config(precision: 76)
   totalLiquidityAddedUSD: BigInt! @config(precision: 76)
   totalLiquidityAddedToken0: BigInt! @config(precision: 76)

--- a/src/Aggregators/UserStatsPerPool.ts
+++ b/src/Aggregators/UserStatsPerPool.ts
@@ -11,7 +11,6 @@ import { setUserStatsPerPoolSnapshot } from "../Snapshots/UserStatsPerPoolSnapsh
 import type { PoolData } from "./LiquidityPoolAggregator";
 
 export interface UserStatsPerPoolDiff {
-  incrementalCurrentLiquidityUSD: bigint;
   incrementalLpBalance: bigint;
   incrementalTotalLiquidityAddedUSD: bigint;
   incrementalTotalLiquidityAddedToken0: bigint;
@@ -126,7 +125,6 @@ export function createUserStatsPerPoolEntity(
     chainId: chainId,
 
     // Liquidity metrics
-    currentLiquidityUSD: 0n,
     lpBalance: 0n,
     totalLiquidityAddedUSD: 0n,
     totalLiquidityAddedToken0: 0n,
@@ -201,10 +199,6 @@ export async function updateUserStatsPerPool(
 ): Promise<UserStatsPerPool> {
   let updated: UserStatsPerPool = {
     ...current,
-    currentLiquidityUSD:
-      diff.incrementalCurrentLiquidityUSD !== undefined
-        ? current.currentLiquidityUSD + diff.incrementalCurrentLiquidityUSD
-        : current.currentLiquidityUSD,
     totalLiquidityAddedUSD:
       diff.incrementalTotalLiquidityAddedUSD !== undefined
         ? current.totalLiquidityAddedUSD +

--- a/src/Snapshots/UserStatsPerPoolSnapshot.ts
+++ b/src/Snapshots/UserStatsPerPoolSnapshot.ts
@@ -35,7 +35,6 @@ export function createUserStatsPerPoolSnapshot(
     poolAddress: entity.poolAddress,
     chainId: entity.chainId,
     timestamp: epoch,
-    currentLiquidityUSD: entity.currentLiquidityUSD,
     lpBalance: entity.lpBalance,
     totalLiquidityAddedUSD: entity.totalLiquidityAddedUSD,
     totalLiquidityAddedToken0: entity.totalLiquidityAddedToken0,

--- a/test/Aggregators/UserStatsPerPoolLiquidity.test.ts
+++ b/test/Aggregators/UserStatsPerPoolLiquidity.test.ts
@@ -35,14 +35,12 @@ describe("UserStatsPerPool Liquidity Logic", () => {
   });
 
   describe("Liquidity Addition Logic", () => {
-    it("should handle positive liquidity addition correctly", async () => {
+    it("should accumulate totalLiquidityAddedUSD on a single addition", async () => {
       const userStats = createMockUserStats();
-      const netLiquidityAddedUSD = 1000n;
 
       const result = await updateUserStatsPerPool(
         {
-          incrementalCurrentLiquidityUSD: netLiquidityAddedUSD,
-          incrementalTotalLiquidityAddedUSD: netLiquidityAddedUSD,
+          incrementalTotalLiquidityAddedUSD: 1000n,
           lastActivityTimestamp: mockTimestamp,
         },
         userStats,
@@ -50,7 +48,6 @@ describe("UserStatsPerPool Liquidity Logic", () => {
         mockTimestamp,
       );
 
-      expect(result.currentLiquidityUSD).toBe(1000n);
       expect(result.totalLiquidityAddedUSD).toBe(1000n);
       expect(result.totalLiquidityRemovedUSD).toBe(0n);
       expect(mockContext.UserStatsPerPoolSnapshot.set).toHaveBeenCalledWith(
@@ -58,20 +55,17 @@ describe("UserStatsPerPool Liquidity Logic", () => {
           userAddress: mockUserAddress,
           poolAddress: mockPoolAddress,
           chainId: mockChainId,
-          currentLiquidityUSD: 1000n,
           totalLiquidityAddedUSD: 1000n,
           totalLiquidityRemovedUSD: 0n,
         }),
       );
     });
 
-    it("should handle multiple liquidity additions correctly", async () => {
+    it("should accumulate totalLiquidityAddedUSD across multiple additions", async () => {
       let userStats = createMockUserStats();
 
-      // First addition
       userStats = await updateUserStatsPerPool(
         {
-          incrementalCurrentLiquidityUSD: 1000n,
           incrementalTotalLiquidityAddedUSD: 1000n,
           lastActivityTimestamp: mockTimestamp,
         },
@@ -80,14 +74,10 @@ describe("UserStatsPerPool Liquidity Logic", () => {
         mockTimestamp,
       );
 
-      expect(userStats.currentLiquidityUSD).toBe(1000n);
       expect(userStats.totalLiquidityAddedUSD).toBe(1000n);
-      expect(userStats.totalLiquidityRemovedUSD).toBe(0n);
 
-      // Second addition
       userStats = await updateUserStatsPerPool(
         {
-          incrementalCurrentLiquidityUSD: 500n,
           incrementalTotalLiquidityAddedUSD: 500n,
           lastActivityTimestamp: mockTimestamp,
         },
@@ -96,20 +86,17 @@ describe("UserStatsPerPool Liquidity Logic", () => {
         mockTimestamp,
       );
 
-      expect(userStats.currentLiquidityUSD).toBe(1500n);
       expect(userStats.totalLiquidityAddedUSD).toBe(1500n);
       expect(userStats.totalLiquidityRemovedUSD).toBe(0n);
     });
   });
 
   describe("Liquidity Removal Logic", () => {
-    it("should handle negative liquidity removal correctly", async () => {
+    it("should accumulate totalLiquidityRemovedUSD on a single removal", async () => {
       const userStats = createMockUserStats();
-      const netLiquidityRemovedUSD = -500n;
 
       const result = await updateUserStatsPerPool(
         {
-          incrementalCurrentLiquidityUSD: netLiquidityRemovedUSD,
           incrementalTotalLiquidityRemovedUSD: 500n,
           lastActivityTimestamp: mockTimestamp,
         },
@@ -118,18 +105,15 @@ describe("UserStatsPerPool Liquidity Logic", () => {
         mockTimestamp,
       );
 
-      expect(result.currentLiquidityUSD).toBe(-500n);
       expect(result.totalLiquidityAddedUSD).toBe(0n);
       expect(result.totalLiquidityRemovedUSD).toBe(500n);
     });
 
-    it("should handle multiple liquidity removals correctly", async () => {
+    it("should accumulate totalLiquidityRemovedUSD across multiple removals", async () => {
       let userStats = createMockUserStats();
 
-      // First removal
       userStats = await updateUserStatsPerPool(
         {
-          incrementalCurrentLiquidityUSD: -300n,
           incrementalTotalLiquidityRemovedUSD: 300n,
           lastActivityTimestamp: mockTimestamp,
         },
@@ -138,14 +122,10 @@ describe("UserStatsPerPool Liquidity Logic", () => {
         mockTimestamp,
       );
 
-      expect(userStats.currentLiquidityUSD).toBe(-300n);
-      expect(userStats.totalLiquidityAddedUSD).toBe(0n);
       expect(userStats.totalLiquidityRemovedUSD).toBe(300n);
 
-      // Second removal
       userStats = await updateUserStatsPerPool(
         {
-          incrementalCurrentLiquidityUSD: -200n,
           incrementalTotalLiquidityRemovedUSD: 200n,
           lastActivityTimestamp: mockTimestamp,
         },
@@ -154,20 +134,17 @@ describe("UserStatsPerPool Liquidity Logic", () => {
         mockTimestamp,
       );
 
-      expect(userStats.currentLiquidityUSD).toBe(-500n);
-      expect(userStats.totalLiquidityAddedUSD).toBe(0n);
       expect(userStats.totalLiquidityRemovedUSD).toBe(500n);
+      expect(userStats.totalLiquidityAddedUSD).toBe(0n);
     });
   });
 
   describe("Mixed Liquidity Operations", () => {
-    it("should handle adding then removing liquidity correctly", async () => {
+    it("should track adds and removes independently", async () => {
       let userStats = createMockUserStats();
 
-      // Add liquidity
       userStats = await updateUserStatsPerPool(
         {
-          incrementalCurrentLiquidityUSD: 1000n,
           incrementalTotalLiquidityAddedUSD: 1000n,
           lastActivityTimestamp: mockTimestamp,
         },
@@ -176,14 +153,8 @@ describe("UserStatsPerPool Liquidity Logic", () => {
         mockTimestamp,
       );
 
-      expect(userStats.currentLiquidityUSD).toBe(1000n);
-      expect(userStats.totalLiquidityAddedUSD).toBe(1000n);
-      expect(userStats.totalLiquidityRemovedUSD).toBe(0n);
-
-      // Remove some liquidity
       userStats = await updateUserStatsPerPool(
         {
-          incrementalCurrentLiquidityUSD: -300n,
           incrementalTotalLiquidityRemovedUSD: 300n,
           lastActivityTimestamp: mockTimestamp,
         },
@@ -192,54 +163,15 @@ describe("UserStatsPerPool Liquidity Logic", () => {
         mockTimestamp,
       );
 
-      expect(userStats.currentLiquidityUSD).toBe(700n);
       expect(userStats.totalLiquidityAddedUSD).toBe(1000n);
       expect(userStats.totalLiquidityRemovedUSD).toBe(300n);
     });
 
-    it("should handle removing then adding liquidity correctly", async () => {
+    it("should handle interleaved add/remove operations", async () => {
       let userStats = createMockUserStats();
 
-      // Remove liquidity (should be 0 since we start with 0)
       userStats = await updateUserStatsPerPool(
         {
-          incrementalCurrentLiquidityUSD: -500n,
-          incrementalTotalLiquidityRemovedUSD: 500n,
-          lastActivityTimestamp: mockTimestamp,
-        },
-        userStats,
-        mockContext,
-        mockTimestamp,
-      );
-
-      expect(userStats.currentLiquidityUSD).toBe(-500n);
-      expect(userStats.totalLiquidityAddedUSD).toBe(0n);
-      expect(userStats.totalLiquidityRemovedUSD).toBe(500n);
-
-      // Add liquidity
-      userStats = await updateUserStatsPerPool(
-        {
-          incrementalCurrentLiquidityUSD: 800n,
-          incrementalTotalLiquidityAddedUSD: 800n,
-          lastActivityTimestamp: mockTimestamp,
-        },
-        userStats,
-        mockContext,
-        mockTimestamp,
-      );
-
-      expect(userStats.currentLiquidityUSD).toBe(300n);
-      expect(userStats.totalLiquidityAddedUSD).toBe(800n);
-      expect(userStats.totalLiquidityRemovedUSD).toBe(500n);
-    });
-
-    it("should handle complex liquidity operations correctly", async () => {
-      let userStats = createMockUserStats();
-
-      // Add 1000
-      userStats = await updateUserStatsPerPool(
-        {
-          incrementalCurrentLiquidityUSD: 1000n,
           incrementalTotalLiquidityAddedUSD: 1000n,
           lastActivityTimestamp: mockTimestamp,
         },
@@ -248,10 +180,8 @@ describe("UserStatsPerPool Liquidity Logic", () => {
         mockTimestamp,
       );
 
-      // Remove 200
       userStats = await updateUserStatsPerPool(
         {
-          incrementalCurrentLiquidityUSD: -200n,
           incrementalTotalLiquidityRemovedUSD: 200n,
           lastActivityTimestamp: mockTimestamp,
         },
@@ -260,10 +190,8 @@ describe("UserStatsPerPool Liquidity Logic", () => {
         mockTimestamp,
       );
 
-      // Add 500
       userStats = await updateUserStatsPerPool(
         {
-          incrementalCurrentLiquidityUSD: 500n,
           incrementalTotalLiquidityAddedUSD: 500n,
           lastActivityTimestamp: mockTimestamp,
         },
@@ -272,10 +200,8 @@ describe("UserStatsPerPool Liquidity Logic", () => {
         mockTimestamp,
       );
 
-      // Remove 100
       userStats = await updateUserStatsPerPool(
         {
-          incrementalCurrentLiquidityUSD: -100n,
           incrementalTotalLiquidityRemovedUSD: 100n,
           lastActivityTimestamp: mockTimestamp,
         },
@@ -284,18 +210,16 @@ describe("UserStatsPerPool Liquidity Logic", () => {
         mockTimestamp,
       );
 
-      expect(userStats.currentLiquidityUSD).toBe(1200n); // 1000 - 200 + 500 - 100
       expect(userStats.totalLiquidityAddedUSD).toBe(1500n); // 1000 + 500
       expect(userStats.totalLiquidityRemovedUSD).toBe(300n); // 200 + 100
     });
   });
 
   describe("Edge Cases", () => {
-    it("should handle zero liquidity change", async () => {
+    it("should leave totals unchanged when no liquidity diffs are passed", async () => {
       const userStats = createMockUserStats();
       const result = await updateUserStatsPerPool(
         {
-          incrementalCurrentLiquidityUSD: 0n,
           lastActivityTimestamp: mockTimestamp,
         },
         userStats,
@@ -303,7 +227,6 @@ describe("UserStatsPerPool Liquidity Logic", () => {
         mockTimestamp,
       );
 
-      expect(result.currentLiquidityUSD).toBe(0n);
       expect(result.totalLiquidityAddedUSD).toBe(0n);
       expect(result.totalLiquidityRemovedUSD).toBe(0n);
     });
@@ -314,7 +237,6 @@ describe("UserStatsPerPool Liquidity Logic", () => {
 
       const result = await updateUserStatsPerPool(
         {
-          incrementalCurrentLiquidityUSD: largeAmount,
           incrementalTotalLiquidityAddedUSD: largeAmount,
           lastActivityTimestamp: mockTimestamp,
         },
@@ -323,7 +245,6 @@ describe("UserStatsPerPool Liquidity Logic", () => {
         mockTimestamp,
       );
 
-      expect(result.currentLiquidityUSD).toBe(largeAmount);
       expect(result.totalLiquidityAddedUSD).toBe(largeAmount);
       expect(result.totalLiquidityRemovedUSD).toBe(0n);
     });

--- a/test/Aggregators/Users.test.ts
+++ b/test/Aggregators/Users.test.ts
@@ -35,7 +35,6 @@ describe("UserStatsPerPool Aggregator", () => {
       expect(userStats.userAddress).toBe(mockUserAddress);
       expect(userStats.poolAddress).toBe(mockPoolAddress);
       expect(userStats.chainId).toBe(mockChainId);
-      expect(userStats.currentLiquidityUSD).toBe(0n);
       expect(userStats.totalLiquidityAddedUSD).toBe(0n);
       expect(userStats.totalLiquidityRemovedUSD).toBe(0n);
       expect(userStats.totalFeesContributedUSD).toBe(0n);
@@ -88,7 +87,6 @@ describe("UserStatsPerPool Aggregator", () => {
 
       const netLiquidityAddedUSD = 1000n;
       const diff = {
-        incrementalCurrentLiquidityUSD: netLiquidityAddedUSD,
         incrementalTotalLiquidityAddedUSD: netLiquidityAddedUSD,
         lastActivityTimestamp: mockTimestamp,
       };
@@ -100,7 +98,6 @@ describe("UserStatsPerPool Aggregator", () => {
         mockTimestamp,
       );
 
-      expect(result.currentLiquidityUSD).toBe(netLiquidityAddedUSD);
       expect(result.totalLiquidityAddedUSD).toBe(netLiquidityAddedUSD);
       expect(result.totalLiquidityRemovedUSD).toBe(0n);
       expect(result.lastActivityTimestamp).toEqual(mockTimestamp);
@@ -110,7 +107,6 @@ describe("UserStatsPerPool Aggregator", () => {
           userAddress: mockUserAddress,
           poolAddress: mockPoolAddress,
           chainId: mockChainId,
-          currentLiquidityUSD: netLiquidityAddedUSD,
           totalLiquidityAddedUSD: netLiquidityAddedUSD,
           totalLiquidityRemovedUSD: 0n,
         }),
@@ -132,9 +128,7 @@ describe("UserStatsPerPool Aggregator", () => {
         mockTimestamp,
       );
 
-      const netLiquidityRemovedUSD = -500n;
       const diff = {
-        incrementalCurrentLiquidityUSD: netLiquidityRemovedUSD,
         incrementalTotalLiquidityRemovedUSD: 500n,
         lastActivityTimestamp: mockTimestamp,
       };
@@ -146,7 +140,6 @@ describe("UserStatsPerPool Aggregator", () => {
         mockTimestamp,
       );
 
-      expect(result.currentLiquidityUSD).toBe(netLiquidityRemovedUSD);
       expect(result.totalLiquidityAddedUSD).toBe(0n);
       expect(result.totalLiquidityRemovedUSD).toBe(500n);
       expect(result.lastActivityTimestamp).toEqual(mockTimestamp);
@@ -155,7 +148,6 @@ describe("UserStatsPerPool Aggregator", () => {
           userAddress: mockUserAddress,
           poolAddress: mockPoolAddress,
           chainId: mockChainId,
-          currentLiquidityUSD: netLiquidityRemovedUSD,
           totalLiquidityAddedUSD: 0n,
           totalLiquidityRemovedUSD: 500n,
         }),
@@ -398,7 +390,6 @@ describe("UserStatsPerPool Aggregator", () => {
       );
 
       const diff = {
-        incrementalCurrentLiquidityUSD: 2000n,
         incrementalTotalLiquidityAddedUSD: 2000n,
         incrementalTotalFeesContributedUSD: 500n,
         incrementalNumberOfSwaps: 2n,
@@ -415,7 +406,6 @@ describe("UserStatsPerPool Aggregator", () => {
         mockTimestamp,
       );
 
-      expect(result.currentLiquidityUSD).toBe(2000n);
       expect(result.totalLiquidityAddedUSD).toBe(2000n);
       expect(result.totalLiquidityRemovedUSD).toBe(0n);
       expect(result.totalFeesContributedUSD).toBe(500n);
@@ -429,7 +419,6 @@ describe("UserStatsPerPool Aggregator", () => {
           userAddress: mockUserAddress,
           poolAddress: mockPoolAddress,
           chainId: mockChainId,
-          currentLiquidityUSD: 2000n,
           totalLiquidityAddedUSD: 2000n,
           totalFeesContributedUSD: 500n,
           numberOfSwaps: 2n,
@@ -446,7 +435,6 @@ describe("UserStatsPerPool Aggregator", () => {
         userAddress: mockUserAddress,
         poolAddress: mockPoolAddress,
         chainId: mockChainId,
-        currentLiquidityUSD: 2000n,
         totalLiquidityAddedUSD: 2000n,
         totalFeesContributedUSD: 1000n,
         totalFeesContributed0: 500n,
@@ -468,7 +456,6 @@ describe("UserStatsPerPool Aggregator", () => {
       });
 
       const diff = {
-        incrementalCurrentLiquidityUSD: 1000n, // Adding more liquidity
         incrementalTotalLiquidityAddedUSD: 1000n,
         incrementalTotalFeesContributedUSD: 500n,
         incrementalNumberOfSwaps: 1n,
@@ -483,7 +470,6 @@ describe("UserStatsPerPool Aggregator", () => {
         mockTimestamp,
       );
 
-      expect(result.currentLiquidityUSD).toBe(3000n); // 2000 + 1000
       expect(result.totalLiquidityAddedUSD).toBe(3000n); // 2000 + 1000
       expect(result.totalLiquidityRemovedUSD).toBe(0n); // No removal
       expect(result.totalFeesContributedUSD).toBe(1500n); // 1000 + 500
@@ -497,7 +483,6 @@ describe("UserStatsPerPool Aggregator", () => {
           userAddress: mockUserAddress,
           poolAddress: mockPoolAddress,
           chainId: mockChainId,
-          currentLiquidityUSD: 3000n,
           totalLiquidityAddedUSD: 3000n,
           totalFeesContributedUSD: 1500n,
           numberOfSwaps: 6n,
@@ -918,7 +903,6 @@ describe("UserStatsPerPool Aggregator", () => {
         userAddress: mockUserAddress,
         poolAddress: mockPoolAddress,
         chainId: mockChainId,
-        currentLiquidityUSD: 2000n,
         totalLiquidityAddedUSD: 2000n,
         totalFeesContributedUSD: 1000n,
         totalFeesContributed0: 500n,
@@ -940,7 +924,6 @@ describe("UserStatsPerPool Aggregator", () => {
       });
 
       const diff = {
-        incrementalCurrentLiquidityUSD: -500n, // Removing liquidity
         incrementalTotalLiquidityRemovedUSD: 500n,
         lastActivityTimestamp: mockTimestamp,
       };
@@ -952,7 +935,6 @@ describe("UserStatsPerPool Aggregator", () => {
         mockTimestamp,
       );
 
-      expect(result.currentLiquidityUSD).toBe(1500n); // 2000 - 500
       expect(result.totalLiquidityAddedUSD).toBe(2000n); // Unchanged
       expect(result.totalLiquidityRemovedUSD).toBe(500n); // 0 + 500
       expect(result.lastActivityTimestamp).toEqual(mockTimestamp);
@@ -961,7 +943,6 @@ describe("UserStatsPerPool Aggregator", () => {
           userAddress: mockUserAddress,
           poolAddress: mockPoolAddress,
           chainId: mockChainId,
-          currentLiquidityUSD: 1500n,
           totalLiquidityAddedUSD: 2000n,
           totalLiquidityRemovedUSD: 500n,
         }),

--- a/test/EventHandlers/Gauges/GaugeSharedLogic.test.ts
+++ b/test/EventHandlers/Gauges/GaugeSharedLogic.test.ts
@@ -128,7 +128,6 @@ describe("GaugeSharedLogic", () => {
       userAddress: mockUserAddress,
       poolAddress: mockPoolAddress,
       chainId: mockChainId,
-      currentLiquidityUSD: 1000000000000000000000n, // 1K USD in 18 decimals
       totalLiquidityAddedUSD: 1000000000000000000000n,
       firstActivityTimestamp: mockTimestamp,
       lastActivityTimestamp: mockTimestamp,

--- a/test/EventHandlers/Pool/Fees.test.ts
+++ b/test/EventHandlers/Pool/Fees.test.ts
@@ -161,7 +161,6 @@ describe("Pool Fees Event", () => {
         "0x3333333333333333333333333333333333333333",
       ),
       chainId: 10,
-      currentLiquidityUSD: 2000n,
       totalLiquidityAddedUSD: 2000n,
       totalFeesContributedUSD: 2000n,
       totalFeesContributed0: 1000n,

--- a/test/EventHandlers/Pool/common.ts
+++ b/test/EventHandlers/Pool/common.ts
@@ -245,7 +245,6 @@ export function setupCommon() {
     chainId: CHAIN_ID,
 
     // Liquidity metrics
-    currentLiquidityUSD: 0n,
     totalLiquidityAddedUSD: 0n,
     totalLiquidityAddedToken0: 0n,
     totalLiquidityAddedToken1: 0n,


### PR DESCRIPTION
## Summary

Removes `UserStatsPerPool.currentLiquidityUSD` (and its mirror on `UserStatsPerPoolSnapshot`) — a public schema field that has been **always `0n` in production** since PR #483 (commit `7dabbf2`, 2026-01-22) removed its writers but left the column, accumulator branch, and initialiser behind.

Closes #705.

### What changes

- `schema.graphql`: drops `currentLiquidityUSD` from `UserStatsPerPool` and `UserStatsPerPoolSnapshot`.
- `src/Aggregators/UserStatsPerPool.ts`: drops `incrementalCurrentLiquidityUSD` from `UserStatsPerPoolDiff`, the initialiser entry, and the no-op accumulator branch.
- `src/Snapshots/UserStatsPerPoolSnapshot.ts`: drops the snapshot-writer line.
- Test fixtures and assertions in 5 test files updated.

Diff: 8 files changed, +9 / −119.

### Deprecation notice

This is a **breaking schema change**. The field was already useless (`0n`) but downstream consumers querying for it will now get a GraphQL error instead of `0`.

The indexer already exposes all the raw data needed to compute a user's V2 LP USD and unstaked CL position USD externally:

**V2 LP USD** for a user in a pool, from `UserStatsPerPool` + `LiquidityPoolAggregator`:

```
(UserStatsPerPool.lpBalance × Pool.totalLiquidityUSD) / Pool.totalSupply
```

**Unstaked CL position USD** for an NFT — derive on-demand from `NonFungiblePosition` (`liquidity`, `tickLower`, `tickUpper`, `token0`, `token1`, `owner`, `isStakedInGauge`), `LiquidityPoolAggregator.sqrtPriceX96`, and `Token.{decimals, pricePerUSDNew}` using the V3 amounts-from-L closed-form. This is the intentional design — see the comment at `schema.graphql:369`: *"amount0, amount1, amountUSD are derived fields computed on-demand from liquidity + sqrtPriceX96 + ticks"*. Filter `isStakedInGauge: false` to get unstaked positions only.

Sum unstaked CL USD across a user's positions in a pool to recover the per-pool unstaked total that this field was meant to represent.

## ⚠️ HITL required

Per the issue: this is a breaking removal of a public schema field. Before merge, please confirm:

- [ ] No internal Hasura dashboard reads `UserStatsPerPool.currentLiquidityUSD` or `UserStatsPerPoolSnapshot.currentLiquidityUSD` (likely none — the field has always been `0n` — but worth a quick check).
- [ ] No external consumer is known to depend on this field.

If anything reads it, please flag here and we can coordinate a cut-over plan instead.

## Test plan

- [x] `pnpm envio codegen` clean
- [x] `tsc --noEmit` — no errors
- [x] `pnpm qa-fix-unsafe` — clean
- [x] Touched test files all pass (58/58):
  - `test/Aggregators/UserStatsPerPoolLiquidity.test.ts` (rewritten — still covers `totalLiquidityAddedUSD` / `totalLiquidityRemovedUSD` accumulator branches)
  - `test/Aggregators/Users.test.ts`
  - `test/EventHandlers/Gauges/GaugeSharedLogic.test.ts`
  - `test/EventHandlers/Pool/Fees.test.ts`
- [x] Full `pnpm test`: **1217 passed / 33 skipped / 3 pre-existing flakes** — `Helpers > sleep` (4ms timing), `Pool/Sync.test.ts × 2` (`beforeEach` 10s timeout + missing `eventHandlersRegistration` import). None reference `currentLiquidityUSD`; all three predate this branch.
- [ ] Reviewer to verify no Hasura/dashboard consumer

🤖 Generated with [Claude Code](https://claude.com/claude-code)