### PR TITLE
fix(cl-pool): bump liquidityInRange on in-range Mint/Burn (closes #703)

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -47,7 +47,7 @@ type LiquidityPoolAggregator {
   observationCardinalityNext: BigInt @config(precision: 76) # oracle observation cardinality
   sqrtPriceX96: BigInt @config(precision: 76) # current sqrt price (Q96 fixed point) - updated from Swap/Initialize events
   tick: BigInt @config(precision: 24) # current tick - updated from Swap/Initialize events
-  liquidityInRange: BigInt @config(precision: 76) # total in-range liquidity L from Swap events
+  liquidityInRange: BigInt @config(precision: 76) # active-tick in-range liquidity L. Recomputed on Swap; bumped on Mint/Burn when tickLower <= currentTick < tickUpper.
   stakedLiquidityInRange: BigInt @config(precision: 76) # staked in-range liquidity L (running counter from tick-based tracking)
   stakedReserve0: BigInt @config(precision: 76) # staked reserves in token0 raw units (running counter)
   stakedReserve1: BigInt @config(precision: 76) # staked reserves in token1 raw units (running counter)
@@ -188,7 +188,7 @@ type LiquidityPoolAggregatorSnapshot {
   observationCardinalityNext: BigInt @config(precision: 76) # oracle observation cardinality
   sqrtPriceX96: BigInt @config(precision: 76) # current sqrt price (Q96 fixed point) - updated from Swap/Initialize events
   tick: BigInt @config(precision: 24) # current tick - updated from Swap/Initialize events
-  liquidityInRange: BigInt @config(precision: 76) # total in-range liquidity L from Swap events
+  liquidityInRange: BigInt @config(precision: 76) # active-tick in-range liquidity L. Recomputed on Swap; bumped on Mint/Burn when tickLower <= currentTick < tickUpper.
   stakedLiquidityInRange: BigInt @config(precision: 76) # staked in-range liquidity L
   stakedReserve0: BigInt @config(precision: 76) # staked reserves in token0 raw units
   stakedReserve1: BigInt @config(precision: 76) # staked reserves in token1 raw units

--- a/src/Aggregators/LiquidityPoolAggregator.ts
+++ b/src/Aggregators/LiquidityPoolAggregator.ts
@@ -76,7 +76,14 @@ export interface LiquidityPoolAggregatorDiff {
   observationCardinalityNext: bigint;
   sqrtPriceX96: bigint;
   tick: bigint;
+  // Absolute (replace) write of liquidityInRange — Swap is authoritative because
+  // event.params.liquidity reflects the pool's post-swap on-chain liquidity()
+  // (it captures any tick-crossings that happened during the swap).
   liquidityInRange: bigint;
+  // Incremental (sum-with-current) write — emitted by in-range CL Mint/Burn so
+  // L-changes outside swaps no longer wait for the next swap to be reflected.
+  // If both are present in the same diff, the absolute write wins (see #703).
+  incrementalLiquidityInRange: bigint;
   stakedLiquidityInRange: bigint;
   incrementalStakedReserve0: bigint;
   incrementalStakedReserve1: bigint;
@@ -378,7 +385,16 @@ export async function updateLiquidityPoolAggregator(
       diff.observationCardinalityNext ?? current.observationCardinalityNext,
     sqrtPriceX96: diff.sqrtPriceX96 ?? current.sqrtPriceX96,
     tick: diff.tick ?? current.tick,
-    liquidityInRange: diff.liquidityInRange ?? current.liquidityInRange,
+    // Issue #703: Swap is authoritative (absolute write captures any tick
+    // crossings); in-range Mint/Burn supply an incremental delta so L changes
+    // are reflected without waiting for the next swap. Absolute wins if both
+    // are set in the same diff. `current.liquidityInRange` is nullable on the
+    // entity (see schema.graphql:50); coalesce to 0n so a pre-first-swap pool
+    // can still accept Mint/Burn increments.
+    liquidityInRange:
+      diff.liquidityInRange ??
+      (diff.incrementalLiquidityInRange ?? 0n) +
+        (current.liquidityInRange ?? 0n),
     stakedLiquidityInRange:
       diff.stakedLiquidityInRange ?? current.stakedLiquidityInRange,
     stakedReserve0:

--- a/src/EventHandlers/CLPool/CLPoolBurnLogic.ts
+++ b/src/EventHandlers/CLPool/CLPoolBurnLogic.ts
@@ -13,15 +13,23 @@ export interface CLPoolBurnResult {
 }
 
 /**
- * Processes a CLPool Burn event: updates reserves and tracks burned principal
- * so the Collect handler can isolate actual swap fees.
+ * Processes a CLPool Burn event: updates reserves, tracks burned principal
+ * so the Collect handler can isolate actual swap fees, and — when the burned
+ * position is in-range against the pool's current tick — decrements
+ * `liquidityInRange` by the burned L so the field tracks the on-chain
+ * `liquidity()` getter between swaps.
+ *
+ * The in-range gate matches Uniswap v3 semantics:
+ * `tickLower <= aggregator.tick < tickUpper` (lower inclusive, upper exclusive).
+ * Swap remains authoritative on `liquidityInRange` (see CLPoolSwapLogic);
+ * see velodrome-finance/indexer#703.
  *
  * @param event - The CLPool Burn event
- * @param liquidityPoolAggregator - Current pool aggregator state
+ * @param liquidityPoolAggregator - Current pool aggregator state (provides current tick)
  * @param token0Instance - Token0 entity for USD pricing
  * @param token1Instance - Token1 entity for USD pricing
  * @param context - Handler context for entity reads/writes
- * @returns Pool diff with reserve decrements and updated TVL
+ * @returns Pool diff with reserve decrements, updated TVL, and (if in range) negative incrementalLiquidityInRange
  */
 export async function processCLPoolBurn(
   event: CLPool_Burn_event,
@@ -47,11 +55,18 @@ export async function processCLPoolBurn(
   // These accumulate until the position owner calls collect().
   await trackBurnedPrincipal(event, context);
 
-  const liquidityPoolDiff = {
+  const currentTick = liquidityPoolAggregator.tick;
+  const isInRange =
+    currentTick !== undefined &&
+    event.params.tickLower <= currentTick &&
+    currentTick < event.params.tickUpper;
+
+  const liquidityPoolDiff: Partial<LiquidityPoolAggregatorDiff> = {
     incrementalReserve0: -event.params.amount0,
     incrementalReserve1: -event.params.amount1,
     currentTotalLiquidityUSD: currentTotalLiquidityUSD,
     lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
+    ...(isInRange ? { incrementalLiquidityInRange: -event.params.amount } : {}),
   };
 
   return {

--- a/src/EventHandlers/CLPool/CLPoolMintLogic.ts
+++ b/src/EventHandlers/CLPool/CLPoolMintLogic.ts
@@ -10,6 +10,22 @@ export interface CLPoolMintResult {
   liquidityPoolDiff: Partial<LiquidityPoolAggregatorDiff>;
 }
 
+/**
+ * Processes a CLPool Mint event: updates reserves and, when the position is
+ * in-range against the pool's current tick, bumps `liquidityInRange` by the
+ * minted L so the field tracks the on-chain `liquidity()` getter between swaps.
+ *
+ * The in-range gate matches Uniswap v3 semantics:
+ * `tickLower <= aggregator.tick < tickUpper` (lower inclusive, upper exclusive).
+ * Swap remains authoritative on `liquidityInRange` and resets the absolute
+ * value (see CLPoolSwapLogic). See velodrome-finance/indexer#703.
+ *
+ * @param event - The CLPool Mint event
+ * @param liquidityPoolAggregator - Current pool aggregator state (provides current tick)
+ * @param token0Instance - Token0 entity for USD pricing
+ * @param token1Instance - Token1 entity for USD pricing
+ * @returns Pool diff with reserve increments and, if in range, incrementalLiquidityInRange
+ */
 export function processCLPoolMint(
   event: CLPool_Mint_event,
   liquidityPoolAggregator: LiquidityPoolAggregator,
@@ -27,11 +43,18 @@ export function processCLPoolMint(
     token1Instance,
   );
 
-  const liquidityPoolDiff = {
+  const currentTick = liquidityPoolAggregator.tick;
+  const isInRange =
+    currentTick !== undefined &&
+    event.params.tickLower <= currentTick &&
+    currentTick < event.params.tickUpper;
+
+  const liquidityPoolDiff: Partial<LiquidityPoolAggregatorDiff> = {
     incrementalReserve0: event.params.amount0,
     incrementalReserve1: event.params.amount1,
     currentTotalLiquidityUSD: currentTotalLiquidityUSD,
     lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
+    ...(isInRange ? { incrementalLiquidityInRange: event.params.amount } : {}),
   };
 
   return {

--- a/test/Aggregators/LiquidityPoolAggregator.test.ts
+++ b/test/Aggregators/LiquidityPoolAggregator.test.ts
@@ -308,6 +308,111 @@ describe("LiquidityPoolAggregator Functions", () => {
       expect(setCalls.at(-1)?.[0]?.totalLiquidityUSD).toBe(100n);
     });
 
+    // Regression test for issue #703: liquidityInRange must mirror the CL pool's
+    // on-chain liquidity() getter. Swap writes the absolute value (authoritative
+    // reset); in-range Mint/Burn supply incrementalLiquidityInRange to bump it
+    // without waiting for the next swap.
+    describe("liquidityInRange (issue #703)", () => {
+      it("applies incrementalLiquidityInRange on top of current value", async () => {
+        await updateLiquidityPoolAggregator(
+          { incrementalLiquidityInRange: 1_000_000n },
+          {
+            ...(liquidityPoolAggregator as LiquidityPoolAggregator),
+            liquidityInRange: 5_000_000n,
+          },
+          timestamp,
+          mockContext as handlerContext,
+          10,
+          blockNumber,
+        );
+
+        const poolStore = mockContext.LiquidityPoolAggregator;
+        if (!poolStore) {
+          throw new Error(
+            "test setup: LiquidityPoolAggregator store must exist",
+          );
+        }
+        const setCalls = vi.mocked(poolStore.set).mock.calls;
+        const updated = setCalls.at(-1)?.[0] as LiquidityPoolAggregator;
+        expect(updated.liquidityInRange).toBe(6_000_000n);
+      });
+
+      it("absolute liquidityInRange (Swap authoritative reset) wins over incrementalLiquidityInRange", async () => {
+        await updateLiquidityPoolAggregator(
+          {
+            liquidityInRange: 42n,
+            incrementalLiquidityInRange: 1_000_000n,
+          },
+          {
+            ...(liquidityPoolAggregator as LiquidityPoolAggregator),
+            liquidityInRange: 5_000_000n,
+          },
+          timestamp,
+          mockContext as handlerContext,
+          10,
+          blockNumber,
+        );
+
+        const poolStore = mockContext.LiquidityPoolAggregator;
+        if (!poolStore) {
+          throw new Error(
+            "test setup: LiquidityPoolAggregator store must exist",
+          );
+        }
+        const setCalls = vi.mocked(poolStore.set).mock.calls;
+        const updated = setCalls.at(-1)?.[0] as LiquidityPoolAggregator;
+        expect(updated.liquidityInRange).toBe(42n);
+      });
+
+      it("preserves current liquidityInRange when diff supplies neither field", async () => {
+        await updateLiquidityPoolAggregator(
+          {},
+          {
+            ...(liquidityPoolAggregator as LiquidityPoolAggregator),
+            liquidityInRange: 5_000_000n,
+          },
+          timestamp,
+          mockContext as handlerContext,
+          10,
+          blockNumber,
+        );
+
+        const poolStore = mockContext.LiquidityPoolAggregator;
+        if (!poolStore) {
+          throw new Error(
+            "test setup: LiquidityPoolAggregator store must exist",
+          );
+        }
+        const setCalls = vi.mocked(poolStore.set).mock.calls;
+        const updated = setCalls.at(-1)?.[0] as LiquidityPoolAggregator;
+        expect(updated.liquidityInRange).toBe(5_000_000n);
+      });
+
+      it("decrements via negative incrementalLiquidityInRange (Burn semantics)", async () => {
+        await updateLiquidityPoolAggregator(
+          { incrementalLiquidityInRange: -700_000n },
+          {
+            ...(liquidityPoolAggregator as LiquidityPoolAggregator),
+            liquidityInRange: 5_000_000n,
+          },
+          timestamp,
+          mockContext as handlerContext,
+          10,
+          blockNumber,
+        );
+
+        const poolStore = mockContext.LiquidityPoolAggregator;
+        if (!poolStore) {
+          throw new Error(
+            "test setup: LiquidityPoolAggregator store must exist",
+          );
+        }
+        const setCalls = vi.mocked(poolStore.set).mock.calls;
+        const updated = setCalls.at(-1)?.[0] as LiquidityPoolAggregator;
+        expect(updated.liquidityInRange).toBe(4_300_000n);
+      });
+    });
+
     it("should preserve hasStakes=true when a full-unstake diff leaves hasStakes undefined (one-way latch)", async () => {
       // Simulates the NFPMCommonLogic path where the edge list becomes empty
       // after a full unstake: the producer passes `hasStakes: undefined` (see

--- a/test/EventHandlers/CLPool/CLPoolBurnLogic.test.ts
+++ b/test/EventHandlers/CLPool/CLPoolBurnLogic.test.ts
@@ -131,6 +131,71 @@ describe("CLPoolBurnLogic", () => {
       expect(setCall.pendingPrincipal1).toBe(500000n); // 200000 + 300000
     });
 
+    it("should decrement liquidityInRange when tickLower <= aggregator.tick < tickUpper (in-range)", async () => {
+      // mockEvent uses tickLower=-1000n, tickUpper=1000n; default aggregator.tick=0n is in range.
+      const inRangeAggregator: LiquidityPoolAggregator = {
+        ...mockLiquidityPoolAggregator,
+        tick: 0n,
+        liquidityInRange: 5_000_000n,
+      };
+      const ctx = createMockContext();
+
+      const result = await processCLPoolBurn(
+        mockEvent,
+        inRangeAggregator,
+        mockToken0,
+        mockToken1,
+        ctx,
+      );
+
+      // event.params.amount = 1_000_000n — decremented from in-range L
+      expect(result.liquidityPoolDiff.incrementalLiquidityInRange).toBe(
+        -1000000n,
+      );
+      expect(result.liquidityPoolDiff.liquidityInRange).toBeUndefined();
+    });
+
+    it("should not touch liquidityInRange on burn when out of range (tick below tickLower)", async () => {
+      const belowAggregator: LiquidityPoolAggregator = {
+        ...mockLiquidityPoolAggregator,
+        tick: -5000n,
+      };
+      const ctx = createMockContext();
+
+      const result = await processCLPoolBurn(
+        mockEvent,
+        belowAggregator,
+        mockToken0,
+        mockToken1,
+        ctx,
+      );
+
+      expect(
+        result.liquidityPoolDiff.incrementalLiquidityInRange,
+      ).toBeUndefined();
+      expect(result.liquidityPoolDiff.liquidityInRange).toBeUndefined();
+    });
+
+    it("should not touch liquidityInRange on burn when tick at tickUpper (exclusive)", async () => {
+      const atUpperAggregator: LiquidityPoolAggregator = {
+        ...mockLiquidityPoolAggregator,
+        tick: 1000n,
+      };
+      const ctx = createMockContext();
+
+      const result = await processCLPoolBurn(
+        mockEvent,
+        atUpperAggregator,
+        mockToken0,
+        mockToken1,
+        ctx,
+      );
+
+      expect(
+        result.liquidityPoolDiff.incrementalLiquidityInRange,
+      ).toBeUndefined();
+    });
+
     it("should handle different token decimals correctly", async () => {
       const tokenWithDifferentDecimals: Token = {
         ...mockToken0,

--- a/test/EventHandlers/CLPool/CLPoolMintLogic.test.ts
+++ b/test/EventHandlers/CLPool/CLPoolMintLogic.test.ts
@@ -150,5 +150,81 @@ describe("CLPoolMintLogic", () => {
         5000000000000000000n,
       );
     });
+
+    it("should increment liquidityInRange when tickLower <= aggregator.tick < tickUpper (in-range)", () => {
+      // mockEvent uses tickLower=100000, tickUpper=200000.
+      // Place aggregator.tick mid-range so the position contributes its full L.
+      const inRangeAggregator = {
+        ...mockLiquidityPoolAggregator,
+        tick: 150000n,
+        liquidityInRange: 7_000_000_000n,
+      } as LiquidityPoolAggregator;
+
+      const result = processCLPoolMint(
+        mockEvent,
+        inRangeAggregator,
+        mockToken0,
+        mockToken1,
+      );
+
+      // event.params.amount = 1e18 — full L contribution
+      expect(result.liquidityPoolDiff.incrementalLiquidityInRange).toBe(
+        1000000000000000000n,
+      );
+      // Swap-authoritative replace must NOT be set on Mint
+      expect(result.liquidityPoolDiff.liquidityInRange).toBeUndefined();
+    });
+
+    it("should not touch liquidityInRange when position is out of range (tick below tickLower)", () => {
+      // Default mockLiquidityPoolAggregator.tick = 0n, tickLower = 100000n → below.
+      const result = processCLPoolMint(
+        mockEvent,
+        mockLiquidityPoolAggregator,
+        mockToken0,
+        mockToken1,
+      );
+
+      expect(
+        result.liquidityPoolDiff.incrementalLiquidityInRange,
+      ).toBeUndefined();
+      expect(result.liquidityPoolDiff.liquidityInRange).toBeUndefined();
+    });
+
+    it("should not touch liquidityInRange when position is out of range (tick at or above tickUpper)", () => {
+      // tickUpper is exclusive: tick === tickUpper means out-of-range above.
+      const aboveAggregator = {
+        ...mockLiquidityPoolAggregator,
+        tick: 200000n,
+      } as LiquidityPoolAggregator;
+
+      const result = processCLPoolMint(
+        mockEvent,
+        aboveAggregator,
+        mockToken0,
+        mockToken1,
+      );
+
+      expect(
+        result.liquidityPoolDiff.incrementalLiquidityInRange,
+      ).toBeUndefined();
+    });
+
+    it("should include the boundary at tickLower (inclusive)", () => {
+      const atLowerAggregator = {
+        ...mockLiquidityPoolAggregator,
+        tick: 100000n,
+      } as LiquidityPoolAggregator;
+
+      const result = processCLPoolMint(
+        mockEvent,
+        atLowerAggregator,
+        mockToken0,
+        mockToken1,
+      );
+
+      expect(result.liquidityPoolDiff.incrementalLiquidityInRange).toBe(
+        1000000000000000000n,
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary

- The aggregator's `liquidityInRange` should mirror the CL pool's on-chain `liquidity()` getter — the sum of L for all positions where `tickLower ≤ currentTick < tickUpper`. Before this fix, only `CLPool.Swap` wrote it (`liquidityInRange = event.params.liquidity`), so in-range Mint/Burn that change L without an accompanying swap were silently dropped until the next swap reset the field.
- Adds `incrementalLiquidityInRange` to the `LiquidityPoolAggregatorDiff` and wires it in. In-range CL Mint emits `+event.params.amount`; in-range CL Burn emits `-event.params.amount`. The aggregator merge prefers an absolute `liquidityInRange` write (Swap's authoritative reset still wins if both fields appear in the same diff).
- Schema comments on `liquidityInRange` (entity + snapshot) refreshed to describe the new semantics.

In-range gate: `tickLower ≤ aggregator.tick < tickUpper` (lower inclusive, upper exclusive — matches Uniswap v3 semantics).

Closes #703.

## Test plan

- [x] `vitest run test/EventHandlers/CLPool/CLPoolMintLogic.test.ts test/EventHandlers/CLPool/CLPoolBurnLogic.test.ts test/Aggregators/LiquidityPoolAggregator.test.ts` — 64 pass (5 new in-range / out-of-range / boundary / merge-precedence cases)
- [x] `tsc --noEmit` — no errors
- [x] `pnpm qa-fix-unsafe` — biome clean
- [x] Full `pnpm test` — only flakes on parallel-heavy `VeNFT.test.ts` / `NFPM.test.ts` hook timeouts; both pass deterministically when run targeted, and neither touches CL Mint/Burn/Aggregator paths
- [ ] Post-deploy spot-check: Hasura `liquidityInRange` for `0xb2cc224c1c9feE385f8ad6a55b4d94E92359DC59` (WETH/USDC, Base) within ±1% of on-chain `liquidity()` at the same block

🤖 Generated with [Claude Code](https://claude.com/claude-code)