### PR TITLE
feat(venft): index permanent locks via LockPermanent/UnlockPermanent (closes #704)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -56,8 +56,10 @@ contracts:
     events:
       - event: Deposit
       - event: DepositManaged
+      - event: LockPermanent
       - event: Merge
       - event: Split
+      - event: UnlockPermanent
       - event: WithdrawManaged
       - event: Withdraw
       - event: Transfer

--- a/schema.graphql
+++ b/schema.graphql
@@ -414,6 +414,7 @@ type VeNFTState {
   tokenId: BigInt! @config(precision: 76)
   owner: String!
   locktime: BigInt! @config(precision: 76)
+  isPermanent: Boolean!
   lastUpdatedTimestamp: Timestamp!
   totalValueLocked: BigInt! @config(precision: 76)
   isAlive: Boolean!
@@ -428,6 +429,7 @@ type VeNFTStateSnapshot {
   tokenId: BigInt! @index
   owner: String! @index
   locktime: BigInt! @config(precision: 76)
+  isPermanent: Boolean!
   lastUpdatedTimestamp: Timestamp!
   totalValueLocked: BigInt! @config(precision: 76)
   isAlive: Boolean!

--- a/src/Aggregators/VeNFTState.ts
+++ b/src/Aggregators/VeNFTState.ts
@@ -10,6 +10,7 @@ export interface VeNFTStateDiff {
   tokenId: bigint;
   owner: string;
   locktime: bigint;
+  isPermanent: boolean;
   incrementalTotalValueLocked: bigint;
   isAlive: boolean;
   lastUpdatedTimestamp: Date;
@@ -57,6 +58,7 @@ export async function updateVeNFTState(
     tokenId: diff.tokenId ?? current.tokenId,
     owner: diff.owner ?? current.owner,
     locktime: diff.locktime ?? current.locktime, // lockTime of the deposit action
+    isPermanent: diff.isPermanent ?? current.isPermanent,
     lastUpdatedTimestamp: timestamp,
     totalValueLocked:
       (diff.incrementalTotalValueLocked ?? 0n) + current.totalValueLocked,

--- a/src/EventHandlers/VeNFT/VeNFT.ts
+++ b/src/EventHandlers/VeNFT/VeNFT.ts
@@ -4,9 +4,11 @@ import {
   handleMintTransfer,
   processVeNFTDeposit,
   processVeNFTDepositManaged,
+  processVeNFTLockPermanent,
   processVeNFTMerge,
   processVeNFTSplit,
   processVeNFTTransfer,
+  processVeNFTUnlockPermanent,
   processVeNFTWithdraw,
   processVeNFTWithdrawManaged,
 } from "./VeNFTLogic";
@@ -117,6 +119,36 @@ VeNFT.DepositManaged.handler(async ({ event, context }) => {
   }
 
   await processVeNFTDepositManaged(event, tokenState, managedState, context);
+});
+
+VeNFT.LockPermanent.handler(async ({ event, context }) => {
+  const veNFTState = await context.VeNFTState.get(
+    VeNFTId(event.chainId, event.params._tokenId),
+  );
+
+  if (!veNFTState) {
+    context.log.error(
+      `[VeNFT.LockPermanent] VeNFTState ${event.params._tokenId} not found during VeNFT lockPermanent on chain ${event.chainId}`,
+    );
+    return;
+  }
+
+  await processVeNFTLockPermanent(event, veNFTState, context);
+});
+
+VeNFT.UnlockPermanent.handler(async ({ event, context }) => {
+  const veNFTState = await context.VeNFTState.get(
+    VeNFTId(event.chainId, event.params._tokenId),
+  );
+
+  if (!veNFTState) {
+    context.log.error(
+      `[VeNFT.UnlockPermanent] VeNFTState ${event.params._tokenId} not found during VeNFT unlockPermanent on chain ${event.chainId}`,
+    );
+    return;
+  }
+
+  await processVeNFTUnlockPermanent(event, veNFTState, context);
 });
 
 VeNFT.WithdrawManaged.handler(async ({ event, context }) => {

--- a/src/EventHandlers/VeNFT/VeNFTLogic.ts
+++ b/src/EventHandlers/VeNFT/VeNFTLogic.ts
@@ -2,9 +2,11 @@ import type {
   VeNFTState,
   VeNFT_DepositManaged_event,
   VeNFT_Deposit_event,
+  VeNFT_LockPermanent_event,
   VeNFT_Merge_event,
   VeNFT_Split_event,
   VeNFT_Transfer_event,
+  VeNFT_UnlockPermanent_event,
   VeNFT_WithdrawManaged_event,
   VeNFT_Withdraw_event,
   handlerContext,
@@ -76,6 +78,60 @@ export async function processVeNFTWithdraw(
 }
 
 /**
+ * Processes a VeNFT LockPermanent event: marks the position as a permanent lock
+ * and zeroes locktime. The on-chain contract sets `end = 0` for permanent locks,
+ * so downstream consumers should rely on `isPermanent` (not `locktime`) to detect
+ * permanently-locked positions.
+ *
+ * @param event - The VeNFT LockPermanent event payload (_owner, _tokenId, amount, _ts).
+ * @param currentVeNFTState - The existing VeNFTState entity for this token.
+ * @param context - Handler context for storage and logging.
+ * @returns Resolves when the state has been persisted (no value).
+ */
+export async function processVeNFTLockPermanent(
+  event: VeNFT_LockPermanent_event,
+  currentVeNFTState: VeNFTState,
+  context: handlerContext,
+): Promise<void> {
+  const timestamp = new Date(event.block.timestamp * 1000);
+
+  const veNFTStateDiff = {
+    locktime: 0n,
+    isPermanent: true,
+    lastUpdatedTimestamp: timestamp,
+  };
+
+  await updateVeNFTState(veNFTStateDiff, currentVeNFTState, timestamp, context);
+}
+
+/**
+ * Processes a VeNFT UnlockPermanent event: flips the position back to a standard
+ * timed lock by clearing `isPermanent` and restoring `locktime` to the contract's
+ * post-unlock value (`block.timestamp + MAXTIME` rounded down to week boundaries,
+ * mirroring `_unlockPermanent` in VotingEscrow).
+ *
+ * @param event - The VeNFT UnlockPermanent event payload (_owner, _tokenId, amount, _ts).
+ * @param currentVeNFTState - The existing VeNFTState entity for this token.
+ * @param context - Handler context for storage and logging.
+ * @returns Resolves when the state has been persisted (no value).
+ */
+export async function processVeNFTUnlockPermanent(
+  event: VeNFT_UnlockPermanent_event,
+  currentVeNFTState: VeNFTState,
+  context: handlerContext,
+): Promise<void> {
+  const timestamp = new Date(event.block.timestamp * 1000);
+
+  const veNFTStateDiff = {
+    locktime: getStandardLockEnd(event.params._ts),
+    isPermanent: false,
+    lastUpdatedTimestamp: timestamp,
+  };
+
+  await updateVeNFTState(veNFTStateDiff, currentVeNFTState, timestamp, context);
+}
+
+/**
  * Processes a VeNFT Transfer event: reassigns all of the token's pool votes from the previous
  * owner to the new owner in UserStatsPerPool (see reassignVeNFTVotesOnTransfer), then updates
  * VeNFTState with the new owner, isAlive (false if burn), and lastUpdatedTimestamp.
@@ -142,16 +198,17 @@ async function reconcileVeNFTState(
 }
 
 /**
- * Reconstructs the lock end for a token leaving a managed position.
+ * Reconstructs a standard four-year lock end from an event timestamp.
  *
- * The voting escrow contract restores the withdrawn token to a standard
- * four-year lock aligned to week boundaries. The event exposes the withdrawal
- * timestamp, so the indexer reproduces the contract's rounding logic here.
+ * The voting escrow contract uses the same `ts + MAXTIME` rounded down to week
+ * boundaries when restoring a standard lock in two flows: `_withdrawManaged`
+ * (token leaving a managed position) and `_unlockPermanent` (flipping a
+ * permanent lock back to timed). The indexer mirrors that math here.
  *
- * @param ts - The withdrawal timestamp emitted by `WithdrawManaged`.
+ * @param ts - The block timestamp emitted by the originating event.
  * @returns The reconstructed lock end, rounded down to the nearest week.
  */
-function getManagedWithdrawLocktime(ts: bigint): bigint {
+function getStandardLockEnd(ts: bigint): bigint {
   return ((ts + SECONDS_IN_FOUR_YEARS) / SECONDS_IN_A_WEEK) * SECONDS_IN_A_WEEK;
 }
 
@@ -328,7 +385,7 @@ export async function processVeNFTWithdrawManaged(
 
   const tokenVeNFTStateDiff = {
     totalValueLocked: event.params._weight,
-    locktime: getManagedWithdrawLocktime(event.params._ts),
+    locktime: getStandardLockEnd(event.params._ts),
     isAlive: true,
   };
 
@@ -381,6 +438,7 @@ export async function handleMintTransfer(
       // TVL-changing flows such as Split emit Transfer before the amount-carrying event.
       // Create the shell here and let the follow-up VeNFT event reconcile TVL.
       locktime: 0n,
+      isPermanent: false,
       lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
       totalValueLocked: 0n,
       isAlive: true,

--- a/src/Snapshots/VeNFTStateSnapshot.ts
+++ b/src/Snapshots/VeNFTStateSnapshot.ts
@@ -32,6 +32,7 @@ export function createVeNFTStateSnapshot(
     tokenId: entity.tokenId,
     owner: entity.owner,
     locktime: entity.locktime,
+    isPermanent: entity.isPermanent,
     lastUpdatedTimestamp: entity.lastUpdatedTimestamp,
     totalValueLocked: entity.totalValueLocked,
     isAlive: entity.isAlive,

--- a/test/Aggregators/VeNFTState.test.ts
+++ b/test/Aggregators/VeNFTState.test.ts
@@ -26,6 +26,7 @@ describe("VeNFTState", () => {
     tokenId: 1n,
     owner: toChecksumAddress("0x1111111111111111111111111111111111111111"),
     locktime: 100n,
+    isPermanent: false,
     lastUpdatedTimestamp: new Date(10000 * 1000),
     totalValueLocked: 100n,
     isAlive: true,
@@ -193,6 +194,72 @@ describe("VeNFTState", () => {
       });
     });
 
+    describe("when updating with permanent-lock diff", () => {
+      it("flips isPermanent to true and zeroes locktime", async () => {
+        const lockDiff = {
+          isPermanent: true,
+          locktime: 0n,
+        };
+
+        await updateVeNFTState(
+          lockDiff,
+          mockVeNFTState,
+          timestamp,
+          mockContext as handlerContext,
+        );
+
+        const mockSet = vi.mocked(getVeNFTStateStore(mockContext).set);
+        const result = mockSet?.mock.calls[0]?.[0] as VeNFTState;
+        expect(result.isPermanent).toBe(true);
+        expect(result.locktime).toBe(0n);
+      });
+
+      it("restores isPermanent to false on unlock", async () => {
+        const permanentState: VeNFTState = {
+          ...mockVeNFTState,
+          isPermanent: true,
+          locktime: 0n,
+        };
+        const unlockDiff = {
+          isPermanent: false,
+          locktime: 9999n,
+        };
+
+        await updateVeNFTState(
+          unlockDiff,
+          permanentState,
+          timestamp,
+          mockContext as handlerContext,
+        );
+
+        const mockSet = vi.mocked(getVeNFTStateStore(mockContext).set);
+        const result = mockSet?.mock.calls[0]?.[0] as VeNFTState;
+        expect(result.isPermanent).toBe(false);
+        expect(result.locktime).toBe(9999n);
+      });
+
+      it("preserves isPermanent when diff does not provide it", async () => {
+        const permanentState: VeNFTState = {
+          ...mockVeNFTState,
+          isPermanent: true,
+          locktime: 0n,
+        };
+        const incrementOnly = { incrementalTotalValueLocked: 5n };
+
+        await updateVeNFTState(
+          incrementOnly,
+          permanentState,
+          timestamp,
+          mockContext as handlerContext,
+        );
+
+        const mockSet = vi.mocked(getVeNFTStateStore(mockContext).set);
+        const result = mockSet?.mock.calls[0]?.[0] as VeNFTState;
+        expect(result.isPermanent).toBe(true);
+        expect(result.locktime).toBe(0n);
+      });
+    });
+
     describe("when updating with burn diff", () => {
       let result: VeNFTState;
       beforeEach(async () => {
@@ -231,6 +298,7 @@ describe("VeNFTState", () => {
             "0x0000000000000000000000000000000000000000",
           ),
           locktime: 0n,
+          isPermanent: false,
           lastUpdatedTimestamp: new Date(0),
           totalValueLocked: 0n,
           isAlive: false,

--- a/test/EventHandlers/Pool/common.ts
+++ b/test/EventHandlers/Pool/common.ts
@@ -309,6 +309,7 @@ export function setupCommon() {
     tokenId: 1n,
     owner: normalizedDefaultUserAddress,
     locktime: 0n,
+    isPermanent: false,
     lastUpdatedTimestamp: new Date(900000 * 1000),
     totalValueLocked: 0n,
     isAlive: true,

--- a/test/EventHandlers/VeNFT.test.ts
+++ b/test/EventHandlers/VeNFT.test.ts
@@ -22,6 +22,7 @@ describe("VeNFT Events", () => {
     isAlive: true,
     lastUpdatedTimestamp: new Date(),
     locktime: 1n,
+    isPermanent: false,
     owner: toChecksumAddress("0x2222222222222222222222222222222222222222"),
     totalValueLocked: 1n,
     lastSnapshotTimestamp: undefined as Date | undefined,

--- a/test/EventHandlers/VeNFT/VeNFTLogic.test.ts
+++ b/test/EventHandlers/VeNFT/VeNFTLogic.test.ts
@@ -5,9 +5,11 @@ import type {
   VeNFTState,
   VeNFT_DepositManaged_event,
   VeNFT_Deposit_event,
+  VeNFT_LockPermanent_event,
   VeNFT_Merge_event,
   VeNFT_Split_event,
   VeNFT_Transfer_event,
+  VeNFT_UnlockPermanent_event,
   VeNFT_WithdrawManaged_event,
   VeNFT_Withdraw_event,
   handlerContext,
@@ -55,6 +57,7 @@ describe("VeNFTLogic", () => {
     tokenId: 1n,
     owner: toChecksumAddress("0x1111111111111111111111111111111111111111"),
     locktime: 100n,
+    isPermanent: false,
     lastUpdatedTimestamp: new Date(10000 * 1000),
     totalValueLocked: 100n,
     isAlive: true,
@@ -580,6 +583,124 @@ describe("VeNFTLogic", () => {
           owner: undefined,
         },
         managedState,
+        timestamp,
+        mockContext,
+      );
+    });
+  });
+
+  describe("processVeNFTLockPermanent", () => {
+    const createMockLockPermanentEvent = (): VeNFT_LockPermanent_event =>
+      ({
+        params: {
+          _owner: toChecksumAddress(
+            "0x1111111111111111111111111111111111111111",
+          ),
+          _tokenId: 1n,
+          amount: 1000n,
+          _ts: 200n,
+        },
+        block: {
+          timestamp: 1000000,
+          number: 123456,
+          hash: "0x1234",
+        },
+        chainId: 10,
+        logIndex: 1,
+        srcAddress: toChecksumAddress(
+          "0x3333333333333333333333333333333333333333",
+        ),
+        transaction: { hash: "0xabcd" },
+      }) as VeNFT_LockPermanent_event;
+
+    beforeEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("flips the lock to permanent and zeroes locktime", async () => {
+      const event = createMockLockPermanentEvent();
+      const timestamp = new Date(event.block.timestamp * 1000);
+      const updateSpy = vi
+        .spyOn(VeNFTStateAggregator, "updateVeNFTState")
+        .mockResolvedValue(undefined);
+
+      await VeNFTLogic.processVeNFTLockPermanent(
+        event,
+        mockVeNFTState,
+        mockContext,
+      );
+
+      expect(updateSpy).toHaveBeenCalledWith(
+        {
+          locktime: 0n,
+          isPermanent: true,
+          lastUpdatedTimestamp: timestamp,
+        },
+        mockVeNFTState,
+        timestamp,
+        mockContext,
+      );
+    });
+  });
+
+  describe("processVeNFTUnlockPermanent", () => {
+    const createMockUnlockPermanentEvent = (
+      ts: bigint,
+    ): VeNFT_UnlockPermanent_event =>
+      ({
+        params: {
+          _owner: toChecksumAddress(
+            "0x1111111111111111111111111111111111111111",
+          ),
+          _tokenId: 1n,
+          amount: 1000n,
+          _ts: ts,
+        },
+        block: {
+          timestamp: 1000000,
+          number: 123456,
+          hash: "0x1234",
+        },
+        chainId: 10,
+        logIndex: 1,
+        srcAddress: toChecksumAddress(
+          "0x3333333333333333333333333333333333333333",
+        ),
+        transaction: { hash: "0xabcd" },
+      }) as VeNFT_UnlockPermanent_event;
+
+    beforeEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("clears isPermanent and restores a week-aligned 4-year locktime", async () => {
+      const ts = 1_700_000_000n;
+      const event = createMockUnlockPermanentEvent(ts);
+      const permanentState: VeNFTState = {
+        ...mockVeNFTState,
+        isPermanent: true,
+        locktime: 0n,
+      };
+      const timestamp = new Date(event.block.timestamp * 1000);
+      const expectedLocktime =
+        ((ts + SECONDS_IN_FOUR_YEARS) / SECONDS_IN_A_WEEK) * SECONDS_IN_A_WEEK;
+      const updateSpy = vi
+        .spyOn(VeNFTStateAggregator, "updateVeNFTState")
+        .mockResolvedValue(undefined);
+
+      await VeNFTLogic.processVeNFTUnlockPermanent(
+        event,
+        permanentState,
+        mockContext,
+      );
+
+      expect(updateSpy).toHaveBeenCalledWith(
+        {
+          locktime: expectedLocktime,
+          isPermanent: false,
+          lastUpdatedTimestamp: timestamp,
+        },
+        permanentState,
         timestamp,
         mockContext,
       );

--- a/test/Snapshots/VeNFTStateSnapshot.test.ts
+++ b/test/Snapshots/VeNFTStateSnapshot.test.ts
@@ -59,6 +59,16 @@ describe("VeNFTStateSnapshot", () => {
       expect(snapshot.locktime).toBe(entity.locktime);
       expect(snapshot.isAlive).toBe(false);
     });
+
+    it("should propagate isPermanent into the snapshot", () => {
+      const entity = common.createMockVeNFTState({
+        isPermanent: true,
+        locktime: 0n,
+      });
+      const snapshot = createVeNFTStateSnapshot(entity, baseTimestamp);
+      expect(snapshot.isPermanent).toBe(true);
+      expect(snapshot.locktime).toBe(0n);
+    });
   });
 
   it("should compute snapshot epoch correctly (floor timestamp to interval boundary)", async () => {


### PR DESCRIPTION
## Summary

- Adds `isPermanent: Boolean!` to `VeNFTState` and `VeNFTStateSnapshot`, so permanent locks (`end = 0` on-chain) are no longer indistinguishable from never-initialised Transfer shells.
- Subscribes to `LockPermanent` / `UnlockPermanent` on the VeNFT contract (already configured for both OP `0xFAf8...787d` and Base `0xeBf4...e6B4`).
- Adds `processVeNFTLockPermanent` (sets `isPermanent=true`, `locktime=0n`) and `processVeNFTUnlockPermanent` (clears `isPermanent`, restores a week-aligned 4y locktime via the same math the contract uses in `_unlockPermanent`).
- Renames the locktime helper `getManagedWithdrawLocktime` → `getStandardLockEnd` since it now serves two callers.

Closes #704.

## Notes

- The optional one-time `locked()` backfill effect described in the issue was intentionally skipped — chronological replay of `LockPermanent` events on a reindex sets the flag correctly, and burned/empty shells remain `isPermanent=false` by default.
- Pre-existing tests run on the new schema by spreading the updated mock fixture (`mockVeNFTStateData.isPermanent = false`) — no behavioural assertions had to change.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `pnpm qa` clean
- [x] Targeted Vitest run green: `test/EventHandlers/VeNFT/VeNFTLogic.test.ts`, `test/Aggregators/VeNFTState.test.ts`, `test/Snapshots/VeNFTStateSnapshot.test.ts` (41 passing)
- [ ] Post-deploy: spot-check Hasura `VeNFTState(where: {isPermanent: {_eq: true}})` against on-chain `locked()` for tokenId 100, 1000 on Base
- [ ] Post-deploy: confirm pre-existing `locktime=0` rows partition correctly between permanent locks and burned shells

🤖 Generated with [Claude Code](https://claude.com/claude-code)