### PR TITLE
fix(price-overrides): blacklist 67 inflated-price tokens on Base (closes #701)

### DIFF
--- a/src/PriceOverrides.ts
+++ b/src/PriceOverrides.ts
@@ -12,6 +12,13 @@ export interface RebindTarget {
  * lifetime totals. For these, the only correct price is 0 — pool-USD calcs already
  * route through the counterparty when one side is $0.
  *
+ * **Operational pattern.** When a token surfaces with `pricePerUSDNew > 10^28`
+ * (i.e. > $10B per whole token in 1e18-fixed), add it to the blacklist below.
+ * Pair with re-indexing or a one-shot SQL update zeroing the token's
+ * `pricePerUSDNew` for fast cleanup. Reproducible enumeration:
+ *
+ *     Token(where: {pricePerUSDNew: {_gt: "10000000000000000000000000000"}})
+ *
  * Issue #669: $Manatee (no real market; tBTC/$Manatee pool routes price through
  * tBTC and produces $76K-$92K; alETH/$Manatee disagrees with alUSD/$Manatee by 10x).
  * Issue #669: SQUID (oracle returns 0 at every stable read; the $13B contaminated
@@ -19,6 +26,8 @@ export interface RebindTarget {
  * Issue #671: ION/Lisk (one-sided pool 11.2M ION + 0.24 WETH; oracle reports $17
  * but the pool's own reserve ratio implies ~$5e-5, inflating TVL to $196M for a
  * pool with $22K lifetime volume across 24K swaps — no real swappable market).
+ * Issue #701: 67 scam tokens on Base (chainId 8453, all `decimals: 18`, most
+ * spoofing canonical USDC/USDT/AERO against unrelated addresses).
  */
 const BLACKLIST: ReadonlySet<string> = new Set([
   TokenId(10, toChecksumAddress("0x7909Bda52eAf7C3cc12745E727Eb527a485241D8")), // $Manatee / Optimism
@@ -30,6 +39,275 @@ const BLACKLIST: ReadonlySet<string> = new Set([
     1135,
     toChecksumAddress("0x3f608A49a3ab475dA7fBb167C1Be6b7a45cD7013"),
   ), // ION / Lisk
+  // Issue #701: scam tokens on Base (chainId 8453) with pricePerUSDNew > 10^28
+  TokenId(
+    8453,
+    toChecksumAddress("0x3D6039ce21339BbBc0e107eab061F1E3073f7275"),
+  ), // NANO
+  TokenId(
+    8453,
+    toChecksumAddress("0x8c90376d6885Ac25B49950C5ba415Dffc7aeF6E8"),
+  ), // aixbtKTA
+  TokenId(
+    8453,
+    toChecksumAddress("0xf511B81FC660DEfD2f287A602f04CB79c8336b26"),
+  ), // BDEX
+  TokenId(
+    8453,
+    toChecksumAddress("0x70ca28A35fD265Fd2e173a44ebB0703620FE1324"),
+  ), // BNET
+  TokenId(
+    8453,
+    toChecksumAddress("0x0DE6506f5a746CbC8DD6FFC8938abB11351AC982"),
+  ), // USDC (spoof)
+  TokenId(
+    8453,
+    toChecksumAddress("0x792A85aAdBEB80D5056C33DdDCD51B0A0022e107"),
+  ), // SAKI
+  TokenId(
+    8453,
+    toChecksumAddress("0xeBe5Df7466DB12D0330DA9765cD8FD9CCF12339a"),
+  ), // BNK
+  TokenId(
+    8453,
+    toChecksumAddress("0x8C5eB7F2bf696D4597602A393AC3ceCA9027e895"),
+  ), // GNLR
+  TokenId(
+    8453,
+    toChecksumAddress("0x0F76d71d7eDB9AAA7bEA55deA5B6BcD13B7A3D99"),
+  ), // AIKTA
+  TokenId(
+    8453,
+    toChecksumAddress("0xD8505Ee4448ADEd9e713F5EE1e91e8e94F2A0AfB"),
+  ), // CRACKCAT
+  TokenId(
+    8453,
+    toChecksumAddress("0xc440DA3E466584AC53248bB9B2e1582daA722a56"),
+  ), // I
+  TokenId(
+    8453,
+    toChecksumAddress("0x68599B5731a99B0C955af01b2B438bBa94831E2C"),
+  ), // Ss
+  TokenId(
+    8453,
+    toChecksumAddress("0x98d1e64b41b2A597E28c96c84A037Ac2053394D2"),
+  ), // GLX
+  TokenId(
+    8453,
+    toChecksumAddress("0x3cA1B6f5B3E15594814C8f138F59718a1605FF26"),
+  ), // SUP
+  TokenId(
+    8453,
+    toChecksumAddress("0x52Db46082ce6031347449A278748527e0075B5Ac"),
+  ), // AERO (spoof)
+  TokenId(
+    8453,
+    toChecksumAddress("0xC63Df6ae11c286A845ABd86D7bBF7F857fe03581"),
+  ), // PARA
+  TokenId(
+    8453,
+    toChecksumAddress("0x86Ab61f37ADdBd516c83F1Bd285ff3Af6C94307b"),
+  ), // TINY
+  TokenId(
+    8453,
+    toChecksumAddress("0xb755Ef27C3460E48456919de524CF11b85F7933b"),
+  ), // Tuka
+  TokenId(
+    8453,
+    toChecksumAddress("0x36cd0A846ce825ca3523b5620A8da19b9B115373"),
+  ), // Pika
+  TokenId(
+    8453,
+    toChecksumAddress("0xEe6f6B1D6fa031d9BA5364C4E7EDfaF3686A3007"),
+  ), // Pussy
+  TokenId(
+    8453,
+    toChecksumAddress("0xff074a9dA79111d5BcABeF677A83ed3eFAa3f1c8"),
+  ), // Tt
+  TokenId(
+    8453,
+    toChecksumAddress("0xFaff18d1D45cCAfE482Cde113f9BCc317c5Cc6f0"),
+  ), // OMNI
+  TokenId(
+    8453,
+    toChecksumAddress("0x40806af123C65463B681cECb1Ca562D0243bCf92"),
+  ), // A00
+  TokenId(
+    8453,
+    toChecksumAddress("0xcea5A57E7Eb5DD96535306Dc014160b4d681B7a4"),
+  ), // USDT (spoof)
+  TokenId(
+    8453,
+    toChecksumAddress("0x311CCc0Afede966F5b9C6541547E6D879eF0f445"),
+  ), // USDT (spoof)
+  TokenId(
+    8453,
+    toChecksumAddress("0x2066f06415aED56Ae01141179f8f346EE89A25Fd"),
+  ), // NOISE
+  TokenId(
+    8453,
+    toChecksumAddress("0xbEdF2be6B0c156a4cF79fB32804BDEb2aF195154"),
+  ), // 1
+  TokenId(
+    8453,
+    toChecksumAddress("0x5529b77F8fb04Ae87937c71b5332Cf703123F645"),
+  ), // USDC (spoof)
+  TokenId(
+    8453,
+    toChecksumAddress("0x51D209f7572D3e0C4c6aa57fA7200Cf2530B6b78"),
+  ), // USDC (spoof)
+  TokenId(
+    8453,
+    toChecksumAddress("0x166498c6306C97AE461eDA6604d8b720E096CD1a"),
+  ), // USDC (spoof)
+  TokenId(
+    8453,
+    toChecksumAddress("0x5AEe166fd2717C976fe391d54c7f007a89E53c28"),
+  ), // USDC (spoof)
+  TokenId(
+    8453,
+    toChecksumAddress("0x439bC289E64FcDE439D078fb5ba486F5eAA866B6"),
+  ), // USDC (spoof)
+  TokenId(
+    8453,
+    toChecksumAddress("0x0E934D350D86A96E5fcE518fb6864def3c23f5C4"),
+  ), // QBOT
+  TokenId(
+    8453,
+    toChecksumAddress("0x519B6cdB545c490CEabc4Ba433f93Bd285069366"),
+  ), // USDC (spoof)
+  TokenId(
+    8453,
+    toChecksumAddress("0x2771ea0E3B9EbF15BA2AC08161aEF0Fb2218AD63"),
+  ), // KP
+  TokenId(
+    8453,
+    toChecksumAddress("0xFAF7D3dCFceB09D80115eb2735Fb521F4b41f7C5"),
+  ), // USDC (spoof)
+  TokenId(
+    8453,
+    toChecksumAddress("0x94c35cb889bdCb5ca105eCe80AF9DDD818eEf4e3"),
+  ), // USDC (spoof)
+  TokenId(
+    8453,
+    toChecksumAddress("0x9Bfe697C9BB235F459B5D13199A10Af334700633"),
+  ), // AWEAVE
+  TokenId(
+    8453,
+    toChecksumAddress("0x83bac924674eDFdf88C5CEf3f6f1b36c8550406C"),
+  ), // USDC (spoof)
+  TokenId(
+    8453,
+    toChecksumAddress("0x793af6963d96A2E4F0CE077C2e2e7fd6b1c9975a"),
+  ), // USDC (spoof)
+  TokenId(
+    8453,
+    toChecksumAddress("0x66f8052CA8a44c02853aE0163e817dE43beCBe11"),
+  ), // USDC (spoof)
+  TokenId(
+    8453,
+    toChecksumAddress("0x9c3000608DF1d4aCf0c3595B3AB976A6C67e9FF9"),
+  ), // HDAEMO
+  TokenId(
+    8453,
+    toChecksumAddress("0x3D9b7201354C8FDbdD8CDd29ec32Ca2b96cC358D"),
+  ), // USDC (spoof)
+  TokenId(
+    8453,
+    toChecksumAddress("0xCDF708FDEb8298900191e93a850eaE35f465C34a"),
+  ), // USDC (spoof)
+  TokenId(
+    8453,
+    toChecksumAddress("0x36CA7F2C710Be7b8E3EADd7Ac32dE89CBADDCeb6"),
+  ), // MATRXA
+  TokenId(
+    8453,
+    toChecksumAddress("0x253aa0E92BfB40efeC61c4DeCDC59B0b8c868b93"),
+  ), // CR
+  TokenId(
+    8453,
+    toChecksumAddress("0x314c54adB6eF01734874f4FbbE4d60Dc4CC79364"),
+  ), // CID
+  TokenId(
+    8453,
+    toChecksumAddress("0x1c5Ba8eaf0D74D51F8A97e91c03d2140845b9516"),
+  ), // VT
+  TokenId(
+    8453,
+    toChecksumAddress("0x2220c7490F3e432Ec54E0Df8FbBd5fD9Be4584B1"),
+  ), // MIWP
+  TokenId(
+    8453,
+    toChecksumAddress("0x0F9e807d9b2136eE030D27B7d192f16b0DeDf884"),
+  ), // ECTRUT
+  TokenId(
+    8453,
+    toChecksumAddress("0x06AE7175f9E0e9F58709067fE4D56F9b1CEA4248"),
+  ), // ARG307
+  TokenId(
+    8453,
+    toChecksumAddress("0x78E0096BE1021a408dcA71E9585C4d81D0E57D5f"),
+  ), // PEAOIN
+  TokenId(
+    8453,
+    toChecksumAddress("0x88d582BB02b893A2079913b4d7771AB99cf68d73"),
+  ), // KICK
+  TokenId(
+    8453,
+    toChecksumAddress("0xdf6054939edb69f609597b63cddd1C8ACeA5E535"),
+  ), // CHD
+  TokenId(
+    8453,
+    toChecksumAddress("0xBCC91a44385A7F47c23628dDeCc3BfdE1c0CabC7"),
+  ), // THE
+  TokenId(
+    8453,
+    toChecksumAddress("0x89428C1e3B80dd646d53f14981dC135B6A244478"),
+  ), // FNK
+  TokenId(
+    8453,
+    toChecksumAddress("0x7473952537Bc9D6adcE13a9c7a3b88717e483517"),
+  ), // LIFI
+  TokenId(
+    8453,
+    toChecksumAddress("0x74b7b4Fc4Fae950b13933DD221E88da3408a72c4"),
+  ), // CTA
+  TokenId(
+    8453,
+    toChecksumAddress("0x440bB8afDbc1857d17A2c16f2391401cb677c3bb"),
+  ), // HAL
+  TokenId(
+    8453,
+    toChecksumAddress("0xcD42BA66cE8Aa8a195E36D85a1174f1f0cfe4049"),
+  ), // VM
+  TokenId(
+    8453,
+    toChecksumAddress("0xE28Fe7dE7c50C202AC6074F990fedab4565e8570"),
+  ), // ROBOTAXI
+  TokenId(
+    8453,
+    toChecksumAddress("0x9944326D25810904b3e498d56b2e6A5996E33242"),
+  ), // vAMM-HELLA/WETH
+  TokenId(
+    8453,
+    toChecksumAddress("0xf83cde146AC35E99dd61b6448f7aD9a4534133cc"),
+  ), // EBERT
+  TokenId(
+    8453,
+    toChecksumAddress("0x6a40D8Fc348552deE9fC0C2a0C7aE0CBE2764F4c"),
+  ), // MR
+  TokenId(
+    8453,
+    toChecksumAddress("0xc13223E6D86fb2E3E78CC3476F1d9DeC39F4E86c"),
+  ), // DVC
+  TokenId(
+    8453,
+    toChecksumAddress("0xc3472ddA969e162D1d3753d7b240A28996A0E9a4"),
+  ), // TT
+  TokenId(
+    8453,
+    toChecksumAddress("0xEBCc3B60ED7bD906463BFafEbF5F9b19b5b0Cb7c"),
+  ), // ARASH
 ]);
 
 /**

--- a/src/PriceOverrides.ts
+++ b/src/PriceOverrides.ts
@@ -26,8 +26,9 @@ export interface RebindTarget {
  * Issue #671: ION/Lisk (one-sided pool 11.2M ION + 0.24 WETH; oracle reports $17
  * but the pool's own reserve ratio implies ~$5e-5, inflating TVL to $196M for a
  * pool with $22K lifetime volume across 24K swaps — no real swappable market).
- * Issue #701: 67 scam tokens on Base (chainId 8453, all `decimals: 18`, most
- * spoofing canonical USDC/USDT/AERO against unrelated addresses).
+ * Issue #701: 67 inflated-price tokens on Base (chainId 8453, all
+ * `decimals: 18`, many sharing symbols with canonical USDC/USDT/AERO at
+ * unrelated addresses).
  */
 const BLACKLIST: ReadonlySet<string> = new Set([
   TokenId(10, toChecksumAddress("0x7909Bda52eAf7C3cc12745E727Eb527a485241D8")), // $Manatee / Optimism
@@ -39,7 +40,7 @@ const BLACKLIST: ReadonlySet<string> = new Set([
     1135,
     toChecksumAddress("0x3f608A49a3ab475dA7fBb167C1Be6b7a45cD7013"),
   ), // ION / Lisk
-  // Issue #701: scam tokens on Base (chainId 8453) with pricePerUSDNew > 10^28
+  // Issue #701: inflated-price tokens on Base (chainId 8453) with pricePerUSDNew > 10^28
   TokenId(
     8453,
     toChecksumAddress("0x3D6039ce21339BbBc0e107eab061F1E3073f7275"),

--- a/test/PriceOverrides.test.ts
+++ b/test/PriceOverrides.test.ts
@@ -49,12 +49,15 @@ describe("PriceOverrides", () => {
     });
 
     it.each([
-      ["NANO", "0x3D6039ce21339BbBc0e107eab061F1E3073f7275"], // highest-magnitude scam
-      ["AERO (spoof)", "0x52Db46082ce6031347449A278748527e0075B5Ac"], // spoofs canonical AERO
+      ["NANO", "0x3D6039ce21339BbBc0e107eab061F1E3073f7275"], // highest-magnitude entry
+      ["AERO (symbol collision)", "0x52Db46082ce6031347449A278748527e0075B5Ac"], // shares symbol with canonical AERO
       ["ARASH", "0xEBCc3B60ED7bD906463BFafEbF5F9b19b5b0Cb7c"], // lowest-magnitude entry
-    ])("returns true for %s (Base scam token, issue #701)", (_, address) => {
-      expect(isBlacklistedToken(8453, toChecksumAddress(address))).toBe(true);
-    });
+    ])(
+      "returns true for %s (Base inflated-price token, issue #701)",
+      (_, address) => {
+        expect(isBlacklistedToken(8453, toChecksumAddress(address))).toBe(true);
+      },
+    );
 
     it("does not blacklist the canonical AERO on Base", () => {
       expect(

--- a/test/PriceOverrides.test.ts
+++ b/test/PriceOverrides.test.ts
@@ -39,11 +39,28 @@ describe("PriceOverrides", () => {
       ).toBe(false);
     });
 
-    it("returns false when the chain has no blacklist entries", () => {
+    it("scopes the lookup by chainId (Manatee/Optimism is not blacklisted on Base)", () => {
       expect(
         isBlacklistedToken(
           8453,
           toChecksumAddress("0x7909Bda52eAf7C3cc12745E727Eb527a485241D8"),
+        ),
+      ).toBe(false);
+    });
+
+    it.each([
+      ["NANO", "0x3D6039ce21339BbBc0e107eab061F1E3073f7275"], // highest-magnitude scam
+      ["AERO (spoof)", "0x52Db46082ce6031347449A278748527e0075B5Ac"], // spoofs canonical AERO
+      ["ARASH", "0xEBCc3B60ED7bD906463BFafEbF5F9b19b5b0Cb7c"], // lowest-magnitude entry
+    ])("returns true for %s (Base scam token, issue #701)", (_, address) => {
+      expect(isBlacklistedToken(8453, toChecksumAddress(address))).toBe(true);
+    });
+
+    it("does not blacklist the canonical AERO on Base", () => {
+      expect(
+        isBlacklistedToken(
+          8453,
+          toChecksumAddress("0x940181a94A35A4569E4529A3CDfB74e38FD98631"),
         ),
       ).toBe(false);
     });


### PR DESCRIPTION
## Summary

Operational mitigation for the inflated volume/TVL stats on Base: blacklists the **67 tokens currently storing `pricePerUSDNew > 10^28`** (i.e. > \$10B per whole token in 1e18-fixed). Verified via the Hasura query in #701 — all 67 are on Base (chainId `8453`), all `decimals: 18`, all `isWhitelisted: false`, and many share symbols with canonical USDC/USDT/AERO at unrelated addresses.

Once merged + redeployed, `isBlacklistedToken` returns `true` at `PriceOracle.ts:133` for each, the token's `pricePerUSDNew` is forced to `0n`, and downstream USD math correctly excludes them.

- `src/PriceOverrides.ts` — adds the 67 entries plus a new `## Operational pattern` block in the header documenting the `>10^28` discovery heuristic and the reproducible GraphQL query, so future inflations can be triaged the same way.
- `test/PriceOverrides.test.ts` — adds sanity coverage for representative new entries (highest-magnitude NANO, the AERO symbol collision, lowest-magnitude ARASH) and confirms canonical AERO on Base is **not** swept up. The previously-misleading "chain has no blacklist entries" test description is renamed to reflect that it asserts chainId-scoped lookup.

Pairs with #N2a (structural volume-formula fix) and #N2b (first-fetch spike check) which target the **future** root cause; this PR cleans up the **existing** 67 inflated-price entries.

## Acceptance criteria

- [x] All 67 listed addresses added to the Base (chainId 8453) blacklist in \`src/PriceOverrides.ts\`.
- [ ] After deploy + reindex (or after a one-shot \`UPDATE \"Token\" SET \"pricePerUSDNew\" = 0 WHERE \"chainId\" = 8453 AND \"address\" IN (...)\` backfill), Hasura query \`Token(where: {pricePerUSDNew: {_gt: \"10000000000000000000000000000\"}})\` returns 0 rows on Base. *Verifiable post-deploy.*
- [ ] \`LiquidityPoolAggregator\` rows with \`totalVolumeUSD > 10^50\` reduce to a small expected set (WETH/USDC CL \`0xb2cc224c1c9feE385f8ad6a55b4d94E92359DC59\` stays at ~\$169.4B as the control). *Verifiable post-deploy.*
- [x] Documentation comment in \`PriceOverrides.ts\` calls out the discovery heuristic (\`pricePerUSDNew > 10^28\`) and the operational pattern for future additions.

## Test plan

- [x] \`pnpm qa --write\` — biome clean, no fixes pending
- [x] \`pnpm envio codegen && tsc --noEmit\` — zero TypeScript errors
- [x] \`pnpm test\` — 100 test files, 1225 tests passing (33 skipped), 0 failures
- [x] \`PriceOverrides.test.ts\` — 22/22 passing (4 new: NANO/AERO-symbol-collision/ARASH blacklisted; canonical AERO not blacklisted)
- [ ] **Post-deploy:** run the Hasura query from the issue body against the production endpoint, confirm 0 rows on Base
- [ ] **Post-deploy:** verify the inflated \`LiquidityPoolAggregator\` rows for the colliding-symbol USDC/AERO pools drop to plausible values; canonical WETH/USDC stays at ~\$169.4B

## Reproducible enumeration

\`\`\`bash
curl -sS -X POST -H 'Content-Type: application/json' \\
  -d '{\"query\":\"{ Token(where: {pricePerUSDNew: {_gt: \\\"10000000000000000000000000000\\\"}}, order_by: {pricePerUSDNew: desc}, limit: 500) { id chainId address symbol decimals pricePerUSDNew isWhitelisted } }\"}' \\
  https://velodrome-finance-ec327a5.dedicated.hyperindex.xyz/v1/graphql
\`\`\`

Closes #701.

🤖 Generated with [Claude Code](https://claude.com/claude-code)