### PR TITLE
Bound first-fetch oracle reads against canonical baseline (closes #700)

### DIFF
--- a/src/Effects/RpcGateway.ts
+++ b/src/Effects/RpcGateway.ts
@@ -65,6 +65,11 @@ const RPC_GATEWAY_OPERATIONS = {
       tokenAddress: S.string,
       chainId: S.number,
       blockNumber: S.number,
+      // Issue #700: when true, skip the per-chain price-connector list and
+      // quote only via the canonical set ([SYSTEM, WETH, USDC]). Used by
+      // refreshTokenPrice to cross-check a first-fetch candidate against a
+      // path that can't be poisoned by an illiquid connector pool.
+      canonicalOnly: S.boolean,
     },
     outputSchema: {
       pricePerUSDNew: S.bigint,
@@ -156,6 +161,7 @@ type RpcGatewayInputPayloadByType = {
     tokenAddress: string;
     chainId: number;
     blockNumber: number;
+    canonicalOnly: boolean;
   };
   [EffectType.GET_TOKENS_DEPOSITED]: {
     rewardTokenAddress: string;
@@ -457,6 +463,15 @@ async function handleGetTokenPrice(
     if (blacklist.size > 0) {
       connectors = connectors.filter((a) => !blacklist.has(a));
     }
+  }
+
+  // Issue #700: canonical-only mode strips the per-chain priceConnectors so
+  // the oracle quote only travels via [SYSTEM, WETH, USDC] (appended inside
+  // fetchTokenPrice). Used by refreshTokenPrice to bootstrap-check a
+  // first-fetch candidate against a path that can't be poisoned by an
+  // illiquid connector pool.
+  if (i.canonicalOnly) {
+    connectors = [];
   }
 
   const operationName = rpcGatewayOpName(EffectType.GET_TOKEN_PRICE);

--- a/src/Effects/Token.ts
+++ b/src/Effects/Token.ts
@@ -76,6 +76,7 @@ export const getTokenDetails = createEffect(
  * @param input.tokenAddress - Token to price.
  * @param input.chainId - Chain ID for oracle and RPC.
  * @param input.blockNumber - Block at which to read (often rounded via {@link roundBlockToInterval}).
+ * @param input.canonicalOnly - When `true`, skip the per-chain priceConnectors list and quote only via the canonical [SYSTEM, WETH, USDC] set (issue #700). Used by refreshTokenPrice's first-fetch bootstrap check. The effect's input is part of its cache key, so canonical-only and full-path reads occupy distinct cache slots.
  * @returns Promise resolving to { pricePerUSDNew, priceOracleType }.
  */
 export const getTokenPrice = createEffect(
@@ -85,6 +86,7 @@ export const getTokenPrice = createEffect(
       tokenAddress: S.string,
       chainId: S.number,
       blockNumber: S.number,
+      canonicalOnly: S.boolean,
     },
     output: {
       pricePerUSDNew: S.bigint,
@@ -99,6 +101,7 @@ export const getTokenPrice = createEffect(
       tokenAddress: input.tokenAddress,
       chainId: input.chainId,
       blockNumber: input.blockNumber,
+      canonicalOnly: input.canonicalOnly,
     });
 
     // Skip caching only when the gateway used the fallback constant (issue #691).

--- a/src/EventHandlers/VotingReward/VotingRewardSharedLogic.ts
+++ b/src/EventHandlers/VotingReward/VotingRewardSharedLogic.ts
@@ -125,6 +125,7 @@ export async function processVotingRewardClaimRewards(
         tokenAddress: data.reward,
         chainId: data.chainId,
         blockNumber: roundedBlockNumber, // Use rounded block for cache key
+        canonicalOnly: false,
       }),
     ]);
 

--- a/src/PriceOracle.ts
+++ b/src/PriceOracle.ts
@@ -31,6 +31,25 @@ const PRICE_SPIKE_RATIO_THRESHOLD = 10n;
 const PRICE_SPIKE_STALENESS_MS = 14 * 24 * 60 * 60 * 1000;
 
 /**
+ * Returns true when two positive bigints diverge by ≥ {@link PRICE_SPIKE_RATIO_THRESHOLD}
+ * in either direction (a ≥ T·b or b ≥ T·a). Zero inputs are treated as
+ * non-divergent — callers handle the zero case explicitly because its
+ * meaning differs by site (first-fetch exemption vs. unverifiable canonical).
+ *
+ * @param a - First positive bigint.
+ * @param b - Second positive bigint.
+ * @returns Whether the ratio between a and b is ≥10× in either direction.
+ */
+function ratioDivergesBy10x(a: bigint, b: bigint): boolean {
+  return (
+    a > 0n &&
+    b > 0n &&
+    (a >= b * PRICE_SPIKE_RATIO_THRESHOLD ||
+      b >= a * PRICE_SPIKE_RATIO_THRESHOLD)
+  );
+}
+
+/**
  * Creates and persists a Token entity at first sight, gated on the address
  * actually being a contract on-chain.
  *
@@ -178,6 +197,7 @@ export async function refreshTokenPrice(
           tokenAddress: rebindTarget.address,
           chainId: rebindTarget.chainId,
           blockNumber: sourceBlockRounded,
+          canonicalOnly: false,
         });
         sourcePrice = prefetched.pricePerUSDNew;
       }
@@ -220,6 +240,7 @@ export async function refreshTokenPrice(
       tokenAddress: token.address,
       chainId,
       blockNumber: roundedBlockNumber,
+      canonicalOnly: false,
     });
     let currentPrice = priceData.pricePerUSDNew;
 
@@ -231,16 +252,42 @@ export async function refreshTokenPrice(
     const anchorAgeMs = token.lastUpdatedTimestamp
       ? blockTimestampMs - token.lastUpdatedTimestamp.getTime()
       : Number.POSITIVE_INFINITY;
-    const ratioExceeds =
-      anchorPrice > 0n &&
-      currentPrice > 0n &&
-      (currentPrice >= anchorPrice * PRICE_SPIKE_RATIO_THRESHOLD ||
-        anchorPrice >= currentPrice * PRICE_SPIKE_RATIO_THRESHOLD);
-    if (ratioExceeds && anchorAgeMs < PRICE_SPIKE_STALENESS_MS) {
+    if (
+      ratioDivergesBy10x(anchorPrice, currentPrice) &&
+      anchorAgeMs < PRICE_SPIKE_STALENESS_MS
+    ) {
       context.log.warn(
         `[priceSpikeRejected] ${token.address} chain=${chainId} anchor=${anchorPrice} candidate=${currentPrice}`,
       );
       currentPrice = anchorPrice;
+    }
+
+    // Issue #700: bootstrap-from-canonical guard. The ratio rejector above is
+    // exempt for first-fetch (anchor == 0) because there's no prior accepted
+    // price to anchor against — but that lets a poisoned full-connector path
+    // (e.g. an illiquid pool with a one-wei trade) write a wildly inflated
+    // first price, which then propagates into every downstream USD aggregate.
+    // Cross-check the candidate against an oracle read using only the
+    // canonical connectors ([SYSTEM, WETH, USDC]). If the canonical path
+    // returns 0n or the two answers diverge by ≥10×, treat the first-fetch
+    // candidate as untrusted and write 0n.
+    if (anchorPrice === 0n && currentPrice > 0n) {
+      const canonical = await context.effect(getTokenPrice, {
+        tokenAddress: token.address,
+        chainId,
+        blockNumber: roundedBlockNumber,
+        canonicalOnly: true,
+      });
+      const canonicalPrice = canonical.pricePerUSDNew;
+      if (
+        canonicalPrice === 0n ||
+        ratioDivergesBy10x(currentPrice, canonicalPrice)
+      ) {
+        context.log.warn(
+          `[bootstrapPathRejected] ${token.address} chain=${chainId} candidate=${currentPrice} canonical=${canonicalPrice}`,
+        );
+        currentPrice = 0n;
+      }
     }
 
     // If price fetch returned 0, it could mean:

--- a/test/PriceOracle.test.ts
+++ b/test/PriceOracle.test.ts
@@ -1062,6 +1062,190 @@ describe("PriceOracle", () => {
       });
     });
 
+    // Issue #700: the ≥10× spike rejector (issue #668) exempts first-fetch
+    // reads because there is no prior accepted price to anchor against. That
+    // exemption lets a poisoned full-connector oracle path (e.g. an illiquid
+    // pool with a one-wei trade) write a wildly inflated first price, which
+    // then propagates into every downstream USD aggregate. Bootstrap-from-
+    // canonical: on first-fetch, cross-check the candidate against an oracle
+    // read using only the canonical connectors (USDC, WETH, system token);
+    // reject if the canonical path returns 0n or the two answers diverge by
+    // ≥10×.
+    describe("first-fetch bootstrap-from-canonical (issue #700)", () => {
+      const oneHourOneMinuteAgo = () =>
+        new Date(blockDatetime.getTime() - 61 * 60 * 1000);
+
+      beforeEach(() => {
+        vi.mocked(mockContext.Token?.set)?.mockClear();
+        vi.mocked(mockContext.TokenPriceSnapshot?.set)?.mockClear();
+        vi.mocked(mockContext.log?.warn)?.mockClear();
+      });
+
+      it("rejects a first-fetch when canonical-only diverges by ≥10× from the full-path candidate", async () => {
+        // Anchor is 0n (first-fetch). Full-path oracle returns 1.5e23
+        // (poisoned by an illiquid connector pool). Canonical-only oracle
+        // returns 1e18 (~$1, the real price). 1.5e23 vs 1e18 is a 1.5e5×
+        // divergence — must reject, leaving the stored price at 0n.
+        const poisonedPrice = 15n * 10n ** 22n; // 1.5e23
+        const canonicalPrice = 1n * 10n ** 18n;
+
+        vi.mocked(mockContext.effect)?.mockImplementation(
+          async (effect, input) => {
+            if ((effect as { name?: string }).name === "getTokenPrice") {
+              if ((input as { canonicalOnly?: boolean }).canonicalOnly) {
+                return { pricePerUSDNew: canonicalPrice };
+              }
+              return { pricePerUSDNew: poisonedPrice };
+            }
+            return {};
+          },
+        );
+
+        const fetchedToken = {
+          ...mockToken0Data,
+          pricePerUSDNew: 0n,
+          lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+        };
+
+        await PriceOracle.refreshTokenPrice(
+          fetchedToken,
+          blockNumber,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        expect(updatedToken.pricePerUSDNew).toBe(0n);
+        const warnCall = vi.mocked(mockContext.log?.warn)?.mock.lastCall;
+        expect(warnCall?.[0]).toContain("[bootstrapPathRejected]");
+      });
+
+      it("rejects a first-fetch when canonical-only returns 0n (unreachable canonical path)", async () => {
+        // Full-path returns a non-zero candidate, but the canonical-only
+        // oracle has no route — likely a token that only quotes through the
+        // pathological pool. Treat as unverifiable → leave at 0n.
+        const candidatePrice = 5n * 10n ** 21n;
+
+        vi.mocked(mockContext.effect)?.mockImplementation(
+          async (effect, input) => {
+            if ((effect as { name?: string }).name === "getTokenPrice") {
+              if ((input as { canonicalOnly?: boolean }).canonicalOnly) {
+                return { pricePerUSDNew: 0n };
+              }
+              return { pricePerUSDNew: candidatePrice };
+            }
+            return {};
+          },
+        );
+
+        const fetchedToken = {
+          ...mockToken0Data,
+          pricePerUSDNew: 0n,
+          lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+        };
+
+        await PriceOracle.refreshTokenPrice(
+          fetchedToken,
+          blockNumber,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        expect(updatedToken.pricePerUSDNew).toBe(0n);
+        const warnCall = vi.mocked(mockContext.log?.warn)?.mock.lastCall;
+        expect(warnCall?.[0]).toContain("[bootstrapPathRejected]");
+      });
+
+      it("accepts a first-fetch (WETH-like) when canonical and full-path agree within 10×", async () => {
+        // Real-world bootstrap path: a freshly-tracked token whose full-path
+        // and canonical-only oracle reads both return 2.275e21 (~$2,275 per
+        // unit, mirrors a WETH bootstrap). Stored price must land at the
+        // candidate value.
+        const realPrice = 2275n * 10n ** 18n; // 2.275e21
+
+        vi.mocked(mockContext.effect)?.mockImplementation(
+          async (effect, _input) => {
+            if ((effect as { name?: string }).name === "getTokenPrice") {
+              return { pricePerUSDNew: realPrice };
+            }
+            return {};
+          },
+        );
+
+        const fetchedToken = {
+          ...mockToken0Data,
+          pricePerUSDNew: 0n,
+          lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+        };
+
+        await PriceOracle.refreshTokenPrice(
+          fetchedToken,
+          blockNumber,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        expect(updatedToken.pricePerUSDNew).toBe(realPrice);
+        const warnCalls = vi.mocked(mockContext.log?.warn)?.mock.calls ?? [];
+        for (const call of warnCalls) {
+          expect(call?.[0] ?? "").not.toContain("[bootstrapPathRejected]");
+        }
+      });
+
+      it("only invokes the canonical-only cross-check on first-fetch, not on subsequent refreshes", async () => {
+        // Established token (anchor > 0n) must NOT trigger the second oracle
+        // call. Guarantees the bootstrap guard doesn't double the RPC budget
+        // for the steady-state case.
+        const anchorPrice = 2n * 10n ** 18n;
+        const newPrice = 3n * 10n ** 18n;
+
+        const effectCalls: Array<{ name: string; canonicalOnly: boolean }> = [];
+        vi.mocked(mockContext.effect)?.mockImplementation(
+          async (effect, input) => {
+            const name = (effect as { name?: string }).name ?? "";
+            if (name === "getTokenPrice") {
+              effectCalls.push({
+                name,
+                canonicalOnly: Boolean(
+                  (input as { canonicalOnly?: boolean }).canonicalOnly,
+                ),
+              });
+              return { pricePerUSDNew: newPrice };
+            }
+            return {};
+          },
+        );
+
+        const fetchedToken = {
+          ...mockToken0Data,
+          pricePerUSDNew: anchorPrice,
+          lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+        };
+
+        await PriceOracle.refreshTokenPrice(
+          fetchedToken,
+          blockNumber,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        const priceCalls = effectCalls.filter(
+          (c) => c.name === "getTokenPrice",
+        );
+        expect(priceCalls).toHaveLength(1);
+        expect(priceCalls[0]?.canonicalOnly).toBe(false);
+      });
+    });
+
     // Issue #694: V3 last-known-price fallback used `lastUpdatedTimestamp`
     // for two purposes — the 1-hour throttle and the 7-day staleness window
     // guarding the fallback. Because every refresh attempt (including those


### PR DESCRIPTION
## Summary

Closes #700.

The ≥10× spike rejector added in #689 exempts first-fetch reads (`anchorPrice == 0n`) because there's no prior accepted price to anchor against. That exemption lets a poisoned full-connector oracle path (e.g. an illiquid pool with a one-wei trade) write a wildly inflated first price, which then propagates into every downstream USD aggregate via the swap-volume formula. This PR is the upstream/first-fetch half of the volume-inflation problem; #689 covered the steady-state half.

**Approach — option (a) from the issue, bootstrap-from-canonical:**
On first-fetch, cross-check the candidate against an oracle read using only the canonical connectors (`[SYSTEM, WETH, USDC]`). If canonical returns `0n` or the two answers diverge by ≥10×, write `0n` and emit a `[bootstrapPathRejected]` warn. The canonical-only mode threads through the RPC gateway (`canonicalOnly: boolean` on `GET_TOKEN_PRICE`) and the `getTokenPrice` effect; the effect's input is part of its cache key, so canonical-only and full-path reads occupy distinct cache slots.

Why option (a) over (b) AMM-implied or (c) hard ceiling: (b) is chicken-and-egg when the counter token is also unpriced; (c) is arbitrary. Option (a) reuses the existing oracle plumbing — only the connector list changes — so there's no new RPC shape, just an extra read on the first-fetch path.

**Refactor:** extracted `ratioDivergesBy10x(a, b)` to deduplicate the ≥10× check shared by the #668 spike rejector (`src/PriceOracle.ts:255-260`) and the new #700 bootstrap guard (`src/PriceOracle.ts:282-285`).

**Cost:** one extra `getTokenPrice` RPC per token, fired only when `anchorPrice == 0n && currentPrice > 0n` (first-fetch with a non-zero candidate). After the first successful write, the guard is skipped. Envio's hourly-rounded cache key amortizes retries within the hour. Bounded by token count.

## Test plan

- [x] `./node_modules/.bin/vitest run test/PriceOracle.test.ts` — 42 tests pass, including 4 new under `describe(\"first-fetch bootstrap-from-canonical (issue #700)\")`:
  - rejects a first-fetch when canonical-only diverges by ≥10× from the full-path candidate (full=1.5e23, canonical=1e18)
  - rejects a first-fetch when canonical-only returns 0n (unreachable canonical path)
  - accepts a first-fetch (WETH-like) when canonical and full-path agree (2.275e21)
  - only invokes the canonical-only cross-check on first-fetch, not on subsequent refreshes (RPC budget guard)
- [x] `./node_modules/.bin/tsc --noEmit` — clean
- [x] `./node_modules/.bin/biome check` — clean
- [ ] Backfill sanity on a chain with pathological first-fetch tokens *(needs human — requires running the indexer against historical state)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)