### PR TITLE
Clamp negative CL reserves at the aggregator accumulator path

### DIFF
--- a/src/Aggregators/LiquidityPoolAggregator.ts
+++ b/src/Aggregators/LiquidityPoolAggregator.ts
@@ -267,11 +267,35 @@ export async function updateLiquidityPoolAggregator(
     diff.stakedTickEdgeNets = undefined;
   }
 
+  // Clamp reserve0 / reserve1 to >= 0n at the accumulator path (issue #702).
+  // Reserves are LP-deposited capital and must never go negative; a Burn
+  // larger than the cumulative Mint we observed would otherwise drive the
+  // stored field negative permanently, breaking downstream Hasura consumers.
+  // Clamp-and-continue (not skip-on-underflow) because reserves are pure
+  // derived state; logged under [NEG_RESERVE_GUARD] with prior reserve,
+  // delta, and clamped value.
+  const reserve0Delta = diff.incrementalReserve0 ?? 0n;
+  const reserve0Sum = current.reserve0 + reserve0Delta;
+  const clampedReserve0 = reserve0Sum < 0n ? 0n : reserve0Sum;
+  if (reserve0Sum < 0n) {
+    context.log.warn(
+      `[NEG_RESERVE_GUARD][updateLiquidityPoolAggregator] field=reserve0 poolAddress=${current.poolAddress} chainId=${current.chainId} priorReserve=${current.reserve0} delta=${reserve0Delta} clampedTo=${clampedReserve0}`,
+    );
+  }
+  const reserve1Delta = diff.incrementalReserve1 ?? 0n;
+  const reserve1Sum = current.reserve1 + reserve1Delta;
+  const clampedReserve1 = reserve1Sum < 0n ? 0n : reserve1Sum;
+  if (reserve1Sum < 0n) {
+    context.log.warn(
+      `[NEG_RESERVE_GUARD][updateLiquidityPoolAggregator] field=reserve1 poolAddress=${current.poolAddress} chainId=${current.chainId} priorReserve=${current.reserve1} delta=${reserve1Delta} clampedTo=${clampedReserve1}`,
+    );
+  }
+
   let updated: LiquidityPoolAggregator = {
     ...current,
     // Handle cumulative fields by adding diff values to current values
-    reserve0: (diff.incrementalReserve0 ?? 0n) + current.reserve0,
-    reserve1: (diff.incrementalReserve1 ?? 0n) + current.reserve1,
+    reserve0: clampedReserve0,
+    reserve1: clampedReserve1,
     totalLPTokenSupply:
       (diff.incrementalTotalLPSupply ?? 0n) + current.totalLPTokenSupply,
     totalLiquidityUSD:
@@ -496,22 +520,6 @@ export async function updateLiquidityPoolAggregator(
     if ((updated.stakedReserve1 ?? 0n) < 0n) {
       context.log.warn(
         `[NEGATIVE_STAKED_RESERVE_DRIFT][updateLiquidityPoolAggregator] Pool ${current.poolAddress} on chain ${current.chainId} stakedReserve1 is negative at snapshot epoch: ${updated.stakedReserve1 ?? 0n}. Staked reserves are LP-deposited capital and should never go below zero.`,
-      );
-    }
-
-    // Soft invariant (issue #674): reserve0/reserve1 track LP-deposited capital
-    // and should never go below zero. Logged at each snapshot epoch boundary
-    // while still negative (≤1/hour per pool) so a persistent drift stays
-    // visible in recent logs without flooding them and without aborting the
-    // indexer or mutating state.
-    if (updated.reserve0 < 0n) {
-      context.log.warn(
-        `[NEGATIVE_RESERVE_DRIFT][updateLiquidityPoolAggregator] Pool ${current.poolAddress} on chain ${current.chainId} reserve0 is negative (${updated.reserve0}). Reserves are LP-deposited capital and should never go below zero.`,
-      );
-    }
-    if (updated.reserve1 < 0n) {
-      context.log.warn(
-        `[NEGATIVE_RESERVE_DRIFT][updateLiquidityPoolAggregator] Pool ${current.poolAddress} on chain ${current.chainId} reserve1 is negative (${updated.reserve1}). Reserves are LP-deposited capital and should never go below zero.`,
       );
     }
 

--- a/test/Aggregators/LiquidityPoolAggregator.test.ts
+++ b/test/Aggregators/LiquidityPoolAggregator.test.ts
@@ -478,117 +478,183 @@ describe("LiquidityPoolAggregator Functions", () => {
       });
     });
 
-    // Regression test for issue #674: pool reserves should never go negative.
-    // The aggregator emits a warning under [NEGATIVE_RESERVE_DRIFT] at each
-    // snapshot epoch boundary while still negative (≤1/hour per pool) so a
-    // persistent drift stays visible in recent logs without flooding them and
-    // without aborting the indexer. Concentrated on Superseed (chain 5330)
-    // but the warning is chain-agnostic.
-    describe("negative reserve drift warning (issue #674)", () => {
-      const previousEpoch = () =>
-        new Date(timestamp.getTime() - 2 * 60 * 60 * 1000);
+    // Regression test for issue #702: pool reserves must never persist negative.
+    // The aggregator clamps reserve0 / reserve1 to >= 0n at the accumulator
+    // path and emits [NEG_RESERVE_GUARD] with {poolAddress, chainId,
+    // priorReserve, delta, clampedTo} each time the clamp fires.
+    describe("negative reserve clamp guard (issue #702)", () => {
+      const sameEpochAsTimestamp = () => timestamp;
 
-      const negativeReserveWarnings = () => {
+      const negReserveGuardLogs = () => {
         const warnMock = vi.mocked(mockContext.log?.warn);
         const calls = warnMock?.mock.calls ?? [];
         return calls.filter((args) =>
-          String(args[0] ?? "").includes("[NEGATIVE_RESERVE_DRIFT]"),
+          String(args[0] ?? "").includes("[NEG_RESERVE_GUARD]"),
         );
       };
 
-      it("warns at snapshot epoch when reserve0 is negative", async () => {
+      const lastSet = (): LiquidityPoolAggregator => {
+        const setMock = vi.mocked(mockContext.LiquidityPoolAggregator?.set);
+        return setMock?.mock.lastCall?.[0] as LiquidityPoolAggregator;
+      };
+
+      it("clamps reserve0 to 0n and logs guard when delta would drive it negative", async () => {
         await updateLiquidityPoolAggregator(
           { incrementalReserve0: -100n },
           {
             ...(liquidityPoolAggregator as LiquidityPoolAggregator),
             reserve0: 50n,
             reserve1: 1000n,
-            lastSnapshotTimestamp: previousEpoch(),
-            lastUpdatedTimestamp: previousEpoch(),
+            lastSnapshotTimestamp: sameEpochAsTimestamp(),
+            lastUpdatedTimestamp: sameEpochAsTimestamp(),
           },
           timestamp,
           mockContext as handlerContext,
-          5330,
+          8453,
           blockNumber,
         );
 
-        expect(negativeReserveWarnings().length).toBe(1);
+        expect(lastSet().reserve0).toBe(0n);
+        expect(lastSet().reserve1).toBe(1000n);
+
+        const logs = negReserveGuardLogs();
+        expect(logs.length).toBe(1);
+        const msg = String(logs[0]?.[0] ?? "");
+        expect(msg).toContain("reserve0");
+        expect(msg).toContain("priorReserve=50");
+        expect(msg).toContain("delta=-100");
+        expect(msg).toContain("clampedTo=0");
+        // chainId in the log is the pool entity's chainId, not the eventChainId
+        // parameter — those agree in practice (a reserve diff comes from the
+        // pool's own chain) and the pool's chainId is what Hasura consumers query.
+        expect(msg).toContain(
+          `chainId=${(liquidityPoolAggregator as LiquidityPoolAggregator).chainId}`,
+        );
       });
 
-      it("warns at snapshot epoch when reserve1 is negative", async () => {
+      it("clamps reserve1 to 0n and logs guard when delta would drive it negative", async () => {
         await updateLiquidityPoolAggregator(
           { incrementalReserve1: -100n },
           {
             ...(liquidityPoolAggregator as LiquidityPoolAggregator),
             reserve0: 1000n,
             reserve1: 50n,
-            lastSnapshotTimestamp: previousEpoch(),
-            lastUpdatedTimestamp: previousEpoch(),
+            lastSnapshotTimestamp: sameEpochAsTimestamp(),
+            lastUpdatedTimestamp: sameEpochAsTimestamp(),
           },
           timestamp,
           mockContext as handlerContext,
-          5330,
+          8453,
           blockNumber,
         );
 
-        expect(negativeReserveWarnings().length).toBe(1);
+        expect(lastSet().reserve0).toBe(1000n);
+        expect(lastSet().reserve1).toBe(0n);
+
+        const logs = negReserveGuardLogs();
+        expect(logs.length).toBe(1);
+        expect(String(logs[0]?.[0] ?? "")).toContain("reserve1");
       });
 
-      it("does not warn at snapshot epoch when reserves stay non-negative", async () => {
+      it("does not clamp or log when reserves stay non-negative", async () => {
         await updateLiquidityPoolAggregator(
           { incrementalReserve0: -50n, incrementalReserve1: -50n },
           {
             ...(liquidityPoolAggregator as LiquidityPoolAggregator),
             reserve0: 100n,
             reserve1: 100n,
-            lastSnapshotTimestamp: previousEpoch(),
-            lastUpdatedTimestamp: previousEpoch(),
+            lastSnapshotTimestamp: sameEpochAsTimestamp(),
+            lastUpdatedTimestamp: sameEpochAsTimestamp(),
           },
           timestamp,
           mockContext as handlerContext,
-          5330,
+          8453,
           blockNumber,
         );
 
-        expect(negativeReserveWarnings().length).toBe(0);
+        expect(lastSet().reserve0).toBe(50n);
+        expect(lastSet().reserve1).toBe(50n);
+        expect(negReserveGuardLogs().length).toBe(0);
       });
 
-      it("re-warns at snapshot epoch when reserves are still negative from a prior epoch", async () => {
+      it("clamps both reserves independently and logs once per field", async () => {
         await updateLiquidityPoolAggregator(
-          { incrementalReserve0: -10n, incrementalReserve1: -10n },
+          { incrementalReserve0: -200n, incrementalReserve1: -200n },
           {
             ...(liquidityPoolAggregator as LiquidityPoolAggregator),
-            reserve0: -100n,
-            reserve1: -100n,
-            lastSnapshotTimestamp: previousEpoch(),
-            lastUpdatedTimestamp: previousEpoch(),
+            reserve0: 100n,
+            reserve1: 100n,
+            lastSnapshotTimestamp: sameEpochAsTimestamp(),
+            lastUpdatedTimestamp: sameEpochAsTimestamp(),
           },
           timestamp,
           mockContext as handlerContext,
-          5330,
+          8453,
           blockNumber,
         );
 
-        expect(negativeReserveWarnings().length).toBe(2);
+        expect(lastSet().reserve0).toBe(0n);
+        expect(lastSet().reserve1).toBe(0n);
+        expect(negReserveGuardLogs().length).toBe(2);
       });
 
-      it("does not warn when negative but inside the same snapshot epoch (rate-limit gate)", async () => {
+      // Distinguishes the new clamp from the prior snapshot-epoch warn: the
+      // clamp fires on every update that would underflow, not only at hour
+      // boundaries, so a Burn-larger-than-Mint mid-epoch still gets caught.
+      it("clamps mid-epoch (no snapshot boundary required)", async () => {
         await updateLiquidityPoolAggregator(
-          { incrementalReserve0: -10n, incrementalReserve1: -10n },
+          { incrementalReserve0: -500n },
           {
             ...(liquidityPoolAggregator as LiquidityPoolAggregator),
-            reserve0: -100n,
-            reserve1: -100n,
-            lastSnapshotTimestamp: timestamp,
-            lastUpdatedTimestamp: timestamp,
+            reserve0: 100n,
+            reserve1: 100n,
+            // lastSnapshotTimestamp === timestamp → no snapshot this call.
+            lastSnapshotTimestamp: sameEpochAsTimestamp(),
+            lastUpdatedTimestamp: sameEpochAsTimestamp(),
           },
           timestamp,
           mockContext as handlerContext,
-          5330,
+          8453,
           blockNumber,
         );
 
-        expect(negativeReserveWarnings().length).toBe(0);
+        expect(lastSet().reserve0).toBe(0n);
+        expect(negReserveGuardLogs().length).toBe(1);
+      });
+
+      // AC item 2: Burn-larger-than-Mint scenario produces clamped reserves
+      // and a working USD path. We exercise the aggregator directly with the
+      // diff a CL Burn would produce; the Burn handler's USD calc is tested
+      // separately in CLPoolBurnLogic.test.ts.
+      it("clamps when Burn delta exceeds cumulative Mint and downstream USD is computed", async () => {
+        // currentTotalLiquidityUSD comes from the producer (Burn handler) and
+        // is passed through unchanged; the aggregator does not recompute it
+        // from reserves. We assert the diff value lands on the entity.
+        await updateLiquidityPoolAggregator(
+          {
+            incrementalReserve0: -1000n,
+            incrementalReserve1: -1000n,
+            currentTotalLiquidityUSD: 0n,
+          },
+          {
+            ...(liquidityPoolAggregator as LiquidityPoolAggregator),
+            isCL: true,
+            reserve0: 100n,
+            reserve1: 100n,
+            totalLiquidityUSD: 5000n,
+            lastSnapshotTimestamp: sameEpochAsTimestamp(),
+            lastUpdatedTimestamp: sameEpochAsTimestamp(),
+          },
+          timestamp,
+          mockContext as handlerContext,
+          8453,
+          blockNumber,
+        );
+
+        expect(lastSet().reserve0).toBe(0n);
+        expect(lastSet().reserve1).toBe(0n);
+        expect(lastSet().totalLiquidityUSD).toBe(0n);
+        expect(negReserveGuardLogs().length).toBe(2);
       });
     });
   });


### PR DESCRIPTION
Closes #702

## Summary
- Clamps `reserve0` / `reserve1` to `>= 0n` in `updateLiquidityPoolAggregator` so a Burn (or out-of-range Swap) larger than the cumulative Mint we observed can no longer drive the stored field negative.
- Emits a structured `[NEG_RESERVE_GUARD]` warn with `field`, `poolAddress`, `chainId`, `priorReserve`, `delta`, `clampedTo` each time the clamp fires, so the missed Mint is traceable from logs without indexer churn.
- Removes the post-hoc `[NEGATIVE_RESERVE_DRIFT]` snapshot-epoch warn (added in #680). That tag was diagnostic-only and is dead code now that reserves can't go negative. The `[NEGATIVE_STAKED_RESERVE_DRIFT]` warn (#666) is untouched — staked reserves drift through different paths.
- Replaces the `describe("negative reserve drift warning")` block with 6 tests covering: reserve0 clamp + full log content, reserve1 clamp + log content, non-negative passthrough, dual-underflow (two logs), mid-epoch firing (no snapshot boundary required), and Burn-larger-than-Mint with downstream USD passthrough.

## Out of scope
- **On-chain reconciliation effect** (issue AC #3) — intentionally deferred. The clamp prevents new negative-reserve rows from forming; an on-chain effect to reconcile pre-existing drift via `pool.liquidity()` + `slot0()` is a separate piece of work and is not part of this PR.

## Test plan
- [x] `pnpm vitest run test/Aggregators/LiquidityPoolAggregator.test.ts` — 46/46 pass
- [x] `pnpm qa --write` — biome clean, no fixes applied
- [x] `tsc --noEmit` — no type errors
- [ ] Post-deploy + reindex: Hasura `_or: [{reserve0:{_lt:"0"}}, {reserve1:{_lt:"0"}}]` returns 0 CL rows for newly-touched pools *(needs human — requires deploy)*
- [ ] Pools with no further activity may retain pre-existing negative reserves until a future event touches them; consider whether a one-time backfill is needed *(needs human — operational decision)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)