### PR TITLE
fix(price-oracle): canonical-rebind SolvBTC/Ink + blacklist XAUt0/Ink, KING/Swell (#721)

### DIFF
--- a/src/PriceOverrides.ts
+++ b/src/PriceOverrides.ts
@@ -29,6 +29,13 @@ export interface RebindTarget {
  * Issue #701: 67 inflated-price tokens on Base (chainId 8453, all
  * `decimals: 18`, many sharing symbols with canonical USDC/USDT/AERO at
  * unrelated addresses).
+ * Issue #721: XAUt0/Ink (gold-pegged, on-chain oracle reports ~$4.7K vs ~$2.5K
+ * spot; no canonical XAUt0 is priced on any indexed chain, so cross-chain rebind
+ * isn't available — blacklist is the only honest valuation until a priced source
+ * appears in the indexer footprint).
+ * Issue #721: KING/Swell (on-chain oracle reports $222 with no canonical
+ * cross-chain source identified; blacklist pending ground-truth pricing
+ * investigation and an eventual de-whitelist).
  */
 const BLACKLIST: ReadonlySet<string> = new Set([
   TokenId(10, toChecksumAddress("0x7909Bda52eAf7C3cc12745E727Eb527a485241D8")), // $Manatee / Optimism
@@ -40,6 +47,14 @@ const BLACKLIST: ReadonlySet<string> = new Set([
     1135,
     toChecksumAddress("0x3f608A49a3ab475dA7fBb167C1Be6b7a45cD7013"),
   ), // ION / Lisk
+  TokenId(
+    57073,
+    toChecksumAddress("0xF50258D3c1dd88946C567920B986A12e65b50dAc"),
+  ), // XAUt0 / Ink (issue #721)
+  TokenId(
+    1923,
+    toChecksumAddress("0xc2606AADe4bdd978a4fa5a6edb3b66657acEe6F8"),
+  ), // KING / Swell (issue #721)
   // Issue #701: inflated-price tokens on Base (chainId 8453) with pricePerUSDNew > 10^28
   TokenId(
     8453,
@@ -359,6 +374,25 @@ const REBINDS: ReadonlyArray<{
         chainId: 1923,
         address: toChecksumAddress(
           "0xc3eaCf0612346366Db554c991D7858716db09f58",
+        ),
+      },
+    ],
+  },
+  {
+    // Issue #721: SolvBTC on Ink -> SolvBTC on Base. Same Solv-issued 1:1 BTC
+    // wrapper; Base is whitelisted in Aerodrome and carries a deep SolvBTC/cbBTC
+    // pool that prices it cleanly. Ink's local oracle reports ~$450K vs ~$100K
+    // spot — driving $5.19B + $17.06M phantom TVL across two kBTC/SolvBTC CL
+    // pools because SolvBTC is whitelisted on Ink as a price anchor.
+    source: {
+      chainId: 8453,
+      address: toChecksumAddress("0x3B86Ad95859b6AB773f55f8d94B4b9d443EE931f"),
+    },
+    targets: [
+      {
+        chainId: 57073,
+        address: toChecksumAddress(
+          "0xaE4EFbc7736f963982aACb17EFA37fCBAb924cB3",
         ),
       },
     ],

--- a/src/PriceOverrides.ts
+++ b/src/PriceOverrides.ts
@@ -398,10 +398,12 @@ const REBINDS: ReadonlyArray<{
     ],
   },
   {
-    // Issue #721 follow-up: ezETH on Swell/Ink/Fraxtal/Mode/Base -> ezETH on
-    // Optimism. Renzo's ezETH is deployed at the same address across chains
-    // (`0x2416092f143378750bb29b79eD961ab195CcEea5`); Optimism's local oracle
-    // prices it cleanly at ~$2.5K while Swell reports $257 (~10x deflation).
+    // Issue #721 follow-up: ezETH on Swell/Ink -> ezETH on Optimism.
+    // Renzo's ezETH is deployed at the same address across chains
+    // (`0x2416092f143378750bb29b79eD961ab195CcEea5`). Optimism's local oracle
+    // prices it cleanly (~$2.5K); Swell reports $257 (~10x deflation) and Ink
+    // reports $0. Mode prices cleanly locally (~$2.4K) so no rebind needed;
+    // Fraxtal/Base ezETH entries are stale (no fresh exposure today).
     // Source chain is Optimism because CHAIN_ANCHORS only covers OP + Base.
     source: {
       chainId: 10,

--- a/src/PriceOverrides.ts
+++ b/src/PriceOverrides.ts
@@ -398,6 +398,31 @@ const REBINDS: ReadonlyArray<{
     ],
   },
   {
+    // Issue #721 follow-up: ezETH on Swell/Ink/Fraxtal/Mode/Base -> ezETH on
+    // Optimism. Renzo's ezETH is deployed at the same address across chains
+    // (`0x2416092f143378750bb29b79eD961ab195CcEea5`); Optimism's local oracle
+    // prices it cleanly at ~$2.5K while Swell reports $257 (~10x deflation).
+    // Source chain is Optimism because CHAIN_ANCHORS only covers OP + Base.
+    source: {
+      chainId: 10,
+      address: toChecksumAddress("0x2416092f143378750bb29b79eD961ab195CcEea5"),
+    },
+    targets: [
+      {
+        chainId: 1923,
+        address: toChecksumAddress(
+          "0x2416092f143378750bb29b79eD961ab195CcEea5",
+        ),
+      },
+      {
+        chainId: 57073,
+        address: toChecksumAddress(
+          "0x2416092f143378750bb29b79eD961ab195CcEea5",
+        ),
+      },
+    ],
+  },
+  {
     // XVELO on every superchain -> canonical VELO on Optimism
     source: {
       chainId: 10,

--- a/test/PriceOverrides.test.ts
+++ b/test/PriceOverrides.test.ts
@@ -30,24 +30,6 @@ describe("PriceOverrides", () => {
       ).toBe(true);
     });
 
-    it("returns true for XAUt0 on Ink", () => {
-      expect(
-        isBlacklistedToken(
-          57073,
-          toChecksumAddress("0xF50258D3c1dd88946C567920B986A12e65b50dAc"),
-        ),
-      ).toBe(true);
-    });
-
-    it("returns true for KING on Swell", () => {
-      expect(
-        isBlacklistedToken(
-          1923,
-          toChecksumAddress("0xc2606AADe4bdd978a4fa5a6edb3b66657acEe6F8"),
-        ),
-      ).toBe(true);
-    });
-
     it("returns false for tokens not in the blacklist", () => {
       expect(
         isBlacklistedToken(
@@ -100,24 +82,10 @@ describe("PriceOverrides", () => {
     const WRSETH_BASE = toChecksumAddress(
       "0xEDfa23602D0EC14714057867A78d01e94176BEA0",
     );
-    const SOLVBTC_INK = toChecksumAddress(
-      "0xaE4EFbc7736f963982aACb17EFA37fCBAb924cB3",
-    );
-    const SOLVBTC_BASE = toChecksumAddress(
-      "0x3B86Ad95859b6AB773f55f8d94B4b9d443EE931f",
-    );
-
     it("rebinds rsETH/Swell to wrsETH/Base", () => {
       expect(getRebindTarget(1923, RSETH_SWELL)).toEqual({
         chainId: 8453,
         address: WRSETH_BASE,
-      });
-    });
-
-    it("rebinds SolvBTC/Ink to SolvBTC/Base", () => {
-      expect(getRebindTarget(57073, SOLVBTC_INK)).toEqual({
-        chainId: 8453,
-        address: SOLVBTC_BASE,
       });
     });
 

--- a/test/PriceOverrides.test.ts
+++ b/test/PriceOverrides.test.ts
@@ -30,6 +30,24 @@ describe("PriceOverrides", () => {
       ).toBe(true);
     });
 
+    it("returns true for XAUt0 on Ink", () => {
+      expect(
+        isBlacklistedToken(
+          57073,
+          toChecksumAddress("0xF50258D3c1dd88946C567920B986A12e65b50dAc"),
+        ),
+      ).toBe(true);
+    });
+
+    it("returns true for KING on Swell", () => {
+      expect(
+        isBlacklistedToken(
+          1923,
+          toChecksumAddress("0xc2606AADe4bdd978a4fa5a6edb3b66657acEe6F8"),
+        ),
+      ).toBe(true);
+    });
+
     it("returns false for tokens not in the blacklist", () => {
       expect(
         isBlacklistedToken(
@@ -82,11 +100,24 @@ describe("PriceOverrides", () => {
     const WRSETH_BASE = toChecksumAddress(
       "0xEDfa23602D0EC14714057867A78d01e94176BEA0",
     );
+    const SOLVBTC_INK = toChecksumAddress(
+      "0xaE4EFbc7736f963982aACb17EFA37fCBAb924cB3",
+    );
+    const SOLVBTC_BASE = toChecksumAddress(
+      "0x3B86Ad95859b6AB773f55f8d94B4b9d443EE931f",
+    );
 
     it("rebinds rsETH/Swell to wrsETH/Base", () => {
       expect(getRebindTarget(1923, RSETH_SWELL)).toEqual({
         chainId: 8453,
         address: WRSETH_BASE,
+      });
+    });
+
+    it("rebinds SolvBTC/Ink to SolvBTC/Base", () => {
+      expect(getRebindTarget(57073, SOLVBTC_INK)).toEqual({
+        chainId: 8453,
+        address: SOLVBTC_BASE,
       });
     });
 


### PR DESCRIPTION
## Summary

Closes #721. Addresses three of the four whitelisted inflated tokens flagged in the issue (rsETH/Swell was already rebound via PR #683).

| Chain | Symbol | Address | Decision | Why |
|---|---|---|---|---|
| Swell (1923) | rsETH | `0xc3eaCf06...` | **No change** | Already rebound to wrsETH/Base (PR #683) |
| Ink (57073) | **SolvBTC** | `0xaE4EFbc7...` | **Cross-chain rebind → SolvBTC/Base** (`0x3B86Ad95...`) | Same Solv-issued 1:1 BTC wrapper; Base SolvBTC is whitelisted in Aerodrome and prices cleanly via the deep SolvBTC/cbBTC pool. Cross-chain prefetch (PR #683) supports Base as a source. |
| Ink (57073) | **XAUt0** | `0xF50258D3...` | **Blacklist** | No canonical XAUt0 is priced on any indexed chain — cross-chain rebind isn't available today. Blacklist is the only honest valuation until a priced source enters the indexer footprint. |
| Swell (1923) | **KING** | `0xc2606AAD...` | **Blacklist** | No canonical cross-chain source identified. Per issue #721 AC: "if no canonical source exists, document the decision (de-whitelist vs blacklist vs accept current)" — going with blacklist + future de-whitelist recommendation, awaiting ground-truth pricing investigation. |

## Why this matters

Whitelisted tokens act as price anchors for other tokens routed through the same pool path. Ink SolvBTC alone drives **$5.19B + $17.06M phantom TVL** across two kBTC/SolvBTC CL pools because its local oracle reports ~$450K vs ~$100K BTC spot. Same shape as PR #682 (ION/Lisk) and PR #716 (Base blacklist), but for the whitelisted Tier-1 cases that need canonical-rebind where a canonical exists.

## Files

- `src/PriceOverrides.ts` — adds SolvBTC/Ink rebind entry; adds XAUt0/Ink + KING/Swell to BLACKLIST; documents both #721 entries in the header
- `test/PriceOverrides.test.ts` — adds rebind + blacklist tests for the three new entries

## Acceptance criteria

- [x] Canonical-rebind entries keyed by `(chainId, address)` for the cases where a canonical exists (rsETH already shipped; SolvBTC added)
- [x] For KING/Swell: blacklist decision documented in header comment with rationale and de-whitelist follow-up note
- [x] For XAUt0/Ink: blacklist decision documented (no canonical priced in indexed chain set)
- [x] Cross-chain rebind path (PR #683) verified — unit test asserts `getRebindTarget(57073, SOLVBTC_INK) → {8453, SOLVBTC_BASE}`; pre-existing rsETH test still passes
- [x] `pnpm test` clean (1262 passed / 33 skipped)
- [x] `pnpm qa --write` clean (biome: no fixes applied)
- [x] `tsc --noEmit` clean
- [ ] Post-deploy: reindex Swell + Ink and confirm pools driven by these tokens show realistic TVL (cross-check against DefiLlama)
- [ ] Post-deploy: re-run `\$CLAUDE_JOB_DIR/scan_inflated_v3.py` and confirm zero remaining WL Tier-1 hits

## Notes on partial coverage

Issue #721 ideally wants **all four** tokens canonical-rebound (not blacklisted), since whitelisted tokens are used as anchors and blacklisting them collapses pool TVL to the counterparty side. However:

- XAUt0/Ink: no Tether-Gold variant is indexed on Optimism or Base (the only chains with `CHAIN_ANCHORS` for cross-chain prefetch). A rebind has no valid target today.
- KING/Swell: issue itself flags as "TBD — needs spot-check"; in autonomous mode, the safe + already-permitted-by-AC fallback is blacklist + de-whitelist documentation.

If a canonical XAUt0 or KING source surfaces later, swapping `BLACKLIST` → `REBINDS` is a two-line change.

## Test plan

- [x] Red: new tests in `test/PriceOverrides.test.ts` fail without implementation
- [x] Green: tests pass after the BLACKLIST + REBINDS entries
- [x] `pnpm test` — full suite passes
- [x] `tsc --noEmit` clean
- [x] `pnpm qa --write` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pricing configuration to include new cross-chain price-binding rules, enabling more accurate asset pricing across multiple blockchain networks.
  * Expanded token blacklist with additional entries for improved price override handling.

* **Tests**
  * Enhanced test coverage with new test cases validating cross-chain pricing configuration scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/velodrome-finance/indexer/pull/723)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->