### PR TITLE
refactor!: rename LiquidityPoolAggregator → Pool entity (closes #709)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ pnpm envio stop           # Stop the indexer
 ### Key Directories
 
 - **`src/EventHandlers/`** - Event handler registrations and business logic. Top-level files (e.g. `Pool.ts`, `CLPool.ts`) register handlers; subdirectories contain the actual logic (e.g. `Pool/PoolSwapLogic.ts`, `CLPool/CLPoolSwapLogic.ts`).
-- **`src/Aggregators/`** - Derived entity computations. `LiquidityPoolAggregator.ts` is the central aggregator (~24KB) that computes pool-level metrics (TVL, volume, fees, votes, emissions). Other aggregators: `UserStatsPerPool.ts`, `NonFungiblePosition.ts`, `VeNFTState.ts`, `VeNFTPoolVote.ts`, `ALMLPWrapper.ts`.
+- **`src/Aggregators/`** - Derived entity computations. `Pool.ts` is the central aggregator (~24KB) that computes pool-level metrics (TVL, volume, fees, votes, emissions). Other aggregators: `UserStatsPerPool.ts`, `NonFungiblePosition.ts`, `VeNFTState.ts`, `VeNFTPoolVote.ts`, `ALMLPWrapper.ts`.
 - **`src/Snapshots/`** - Hourly snapshot creation for all aggregated entities. Uses `Shared.ts` for common epoch-alignment logic.
 - **`src/Effects/`** - External calls (RPC, API) wrapped in Envio's Effect API for preload compatibility. `RpcGateway.ts` handles multi-chain RPC calls, `Token.ts` fetches token details/prices.
 - **`src/Constants.ts`** - Chain-specific constants, factory addresses, price connectors, RPC client setup. Exports `toChecksumAddress()`, chain constants map (`CHAIN_CONSTANTS`), and precision constants.
@@ -89,7 +89,7 @@ Every exported function in `src/**/*.ts` carries a JSDoc block with:
 - `@param name - description` for every parameter
 - `@returns description` — even for `Promise<void>`, summarize what was staged/written (e.g. "Promise that resolves once the upsert is staged")
 
-Match the style already in `src/Aggregators/LiquidityPoolAggregator.ts`, `src/EventHandlers/Gauges/GaugeSharedLogic.ts`, and `src/EventHandlers/CLGaugeFactory/CLGaugeFactorySharedLogic.ts`.
+Match the style already in `src/Aggregators/Pool.ts`, `src/EventHandlers/Gauges/GaugeSharedLogic.ts`, and `src/EventHandlers/CLGaugeFactory/CLGaugeFactorySharedLogic.ts`.
 
 ## Testing
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,4 +1,4 @@
-type LiquidityPoolAggregator {
+type Pool {
   id: ID! # Format: {chainId}-{poolAddress} (PoolId)
   chainId: Int!
   poolAddress: String! # address of the pool
@@ -137,7 +137,7 @@ type LiquidityPoolAggregator {
 }
 
 # Snapshot of the LiquidityPool entity
-type LiquidityPoolAggregatorSnapshot {
+type PoolSnapshot {
   id: ID! # Format: {chainId}-{poolAddress}-{epochMs} (PoolId-epochMs, epochMs from getSnapshotEpoch)
   chainId: Int! # chain id
   name: String! # name of the pool
@@ -228,7 +228,7 @@ type LiquidityPoolAggregatorSnapshot {
   currentFee: BigInt! @config(precision: 76) # Current fee for pool (base + dynamic)
 
   # Unstaked Fee fields
-  unstakedFee: BigInt @config(precision: 24) # Raw customFee value last emitted by an UnstakedFeeModule for this pool (see LiquidityPoolAggregator for semantics)
+  unstakedFee: BigInt @config(precision: 24) # Raw customFee value last emitted by an UnstakedFeeModule for this pool (see Pool for semantics)
 }
 
 # Entity for tracking user activity and positions in specific pools
@@ -561,8 +561,7 @@ type PoolLauncherPool {
   newLocker: String! # target locker from migration
   lastMigratedAt: Timestamp!
 
-  poolStats: [LiquidityPoolAggregator!]!
-    @derivedFrom(field: "poolLauncherPoolId")
+  poolStats: [Pool!]! @derivedFrom(field: "poolLauncherPoolId")
 }
 
 type PoolLauncherConfig {
@@ -674,7 +673,7 @@ type PendingVote {
 }
 
 # Deferred CL pool initialization state: stored when CLPool.Initialize fires
-# BEFORE CLFactory.PoolCreated has created the LiquidityPoolAggregator.
+# BEFORE CLFactory.PoolCreated has created the Pool.
 # Aerodrome Slipstream emits Initialize from the pool inside the same tx as
 # (and at a LOWER log index than) PoolCreated from the factory, so Envio
 # delivers Initialize first. PoolCreated reads this buffer when constructing
@@ -687,7 +686,7 @@ type CLPoolPendingInitialize {
   tick: BigInt! @config(precision: 24)
 }
 
-# Deferred RootPool->LeafPool mapping: stored when RootPoolCreated fires but no LiquidityPoolAggregator exists yet
+# Deferred RootPool->LeafPool mapping: stored when RootPoolCreated fires but no Pool exists yet
 type PendingRootPoolMapping {
   id: ID! # Format: {rootChainId}-{rootPoolAddress}
   rootChainId: Int! # Chain ID where the root pool exists (typically Optimism)
@@ -696,7 +695,7 @@ type PendingRootPoolMapping {
   token0: String! # Address of token0 in the root/leaf pool
   token1: String! # Address of token1 in the root/leaf pool
   tickSpacing: BigInt! @config(precision: 24) # Tick spacing assigned for the pool
-  rootPoolMatchingHash: String! @index # {leafChainId}_{token0}_{token1}_{tickSpacing}  # Used for quick matching in LiquidityPoolAggregator
+  rootPoolMatchingHash: String! @index # {leafChainId}_{token0}_{token1}_{tickSpacing}  # Used for quick matching in Pool
 }
 
 # Deferred distribution: stored when DistributeReward fires for a root gauge but RootPool_LeafPool mapping does not exist yet
@@ -819,7 +818,7 @@ type ALMLPWrapperTransferInTx {
 # SetUpkeepManager events. Last-writer-wins — the row reflects the most recent
 # keeper / upkeep manager addresses.
 #
-# Redistributed and Deposited events are folded into LiquidityPoolAggregator
+# Redistributed and Deposited events are folded into Pool
 # counters (totalEmissionsRedistributed / totalEmissionsForfeited) via a
 # gauge→pool lookup; they have no dedicated entity.
 type RedistributorConfig {

--- a/src/Aggregators/Pool.ts
+++ b/src/Aggregators/Pool.ts
@@ -1,16 +1,12 @@
-import type {
-  CLGaugeConfig,
-  LiquidityPoolAggregator,
-  Token,
-  handlerContext,
-} from "generated";
+import type { CLGaugeConfig, Token, handlerContext } from "generated";
 import { PoolId, TokenId, isKnownSinkRootPool } from "../Constants";
 import { getSwapFee } from "../Effects/Index";
+import type { Pool } from "../EntityTypes";
 import { calculateTotalUSD, generatePoolName } from "../Helpers";
 import { refreshTokenPrice } from "../PriceOracle";
 import {
   getSnapshotEpoch,
-  setLiquidityPoolAggregatorSnapshot,
+  setPoolSnapshot,
   shouldSnapshot,
 } from "../Snapshots/Index";
 
@@ -29,7 +25,7 @@ export type DynamicFeeConfig = {
   scalingFactor: bigint;
 };
 
-export interface LiquidityPoolAggregatorDiff {
+export interface PoolDiff {
   incrementalReserve0: bigint;
   incrementalReserve1: bigint;
   incrementalTotalLPSupply: bigint;
@@ -102,7 +98,7 @@ export interface LiquidityPoolAggregatorDiff {
   // aggregator just takes the result.
   //
   // Typed `readonly bigint[]` so callers can pass the value straight from the
-  // `LiquidityPoolAggregator` entity (whose array fields are readonly in
+  // `Pool` entity (whose array fields are readonly in
   // envio.d.ts) without a copy.
   stakedTickEdges: readonly bigint[];
   stakedTickEdgeNets: readonly bigint[];
@@ -128,7 +124,7 @@ export interface LiquidityPoolAggregatorDiff {
 export interface PoolData {
   token0Instance: Token;
   token1Instance: Token;
-  liquidityPoolAggregator: LiquidityPoolAggregator;
+  liquidityPoolAggregator: Pool;
 }
 
 export enum LoadPoolDataOrRootCLPoolFailureReason {
@@ -178,11 +174,11 @@ export function isMissingRootPoolMapping(
  * @returns The updated liquidity pool aggregator, or the original if chain mismatch occurs
  */
 export async function updateDynamicFeePools(
-  liquidityPoolAggregator: LiquidityPoolAggregator,
+  liquidityPoolAggregator: Pool,
   context: handlerContext,
   eventChainId: number,
   blockNumber: number,
-): Promise<LiquidityPoolAggregator> {
+): Promise<Pool> {
   const poolAddress = liquidityPoolAggregator.poolAddress;
   const chainId = liquidityPoolAggregator.chainId;
 
@@ -213,16 +209,16 @@ export async function updateDynamicFeePools(
   }
 
   // Update the current fee in the pool entity
-  const updatedLiquidityPoolAggregator = {
+  const updatedPool = {
     ...liquidityPoolAggregator,
     currentFee,
   };
 
-  return updatedLiquidityPoolAggregator;
+  return updatedPool;
 }
 
 /**
- * Updates the state of a LiquidityPoolAggregator with new data and manages snapshots.
+ * Updates the state of a Pool with new data and manages snapshots.
  *
  * This function applies a set of changes (diff) to the current state of a liquidity pool
  * aggregator. It updates the last updated timestamp and, when a new epoch boundary is crossed,
@@ -235,9 +231,9 @@ export async function updateDynamicFeePools(
  * @param eventChainId - The chain ID of the event that triggered the update.
  * @param blockNumber - The block number of the event that triggered the update.
  */
-export async function updateLiquidityPoolAggregator(
-  diff: Partial<LiquidityPoolAggregatorDiff>,
-  current: LiquidityPoolAggregator,
+export async function updatePool(
+  diff: Partial<PoolDiff>,
+  current: Pool,
   timestamp: Date,
   context: handlerContext,
   eventChainId: number,
@@ -256,7 +252,7 @@ export async function updateLiquidityPoolAggregator(
   const netsSet = diff.stakedTickEdgeNets !== undefined;
   if (edgesSet !== netsSet) {
     context.log.error(
-      `[STAKED_TICK_DRIFT][updateLiquidityPoolAggregator] stakedTickEdges and stakedTickEdgeNets must be updated together (parallel arrays) for pool ${current.poolAddress} on chain ${current.chainId}. Got edges=${edgesSet ? "set" : "unset"}, nets=${netsSet ? "set" : "unset"}. Dropping both from this update; aggregator retains the prior consistent pair.`,
+      `[STAKED_TICK_DRIFT][updatePool] stakedTickEdges and stakedTickEdgeNets must be updated together (parallel arrays) for pool ${current.poolAddress} on chain ${current.chainId}. Got edges=${edgesSet ? "set" : "unset"}, nets=${netsSet ? "set" : "unset"}. Dropping both from this update; aggregator retains the prior consistent pair.`,
     );
     diff.stakedTickEdges = undefined;
     diff.stakedTickEdgeNets = undefined;
@@ -268,7 +264,7 @@ export async function updateLiquidityPoolAggregator(
   ) {
     context.log.error(
       // biome-ignore lint/style/noNonNullAssertion: edgesSet/netsSet narrow above
-      `[STAKED_TICK_DRIFT][updateLiquidityPoolAggregator] stakedTickEdges/stakedTickEdgeNets length mismatch for pool ${current.poolAddress} on chain ${current.chainId}: edges.length=${diff.stakedTickEdges!.length}, nets.length=${diff.stakedTickEdgeNets!.length}. Dropping both from this update; aggregator retains the prior consistent pair.`,
+      `[STAKED_TICK_DRIFT][updatePool] stakedTickEdges/stakedTickEdgeNets length mismatch for pool ${current.poolAddress} on chain ${current.chainId}: edges.length=${diff.stakedTickEdges!.length}, nets.length=${diff.stakedTickEdgeNets!.length}. Dropping both from this update; aggregator retains the prior consistent pair.`,
     );
     diff.stakedTickEdges = undefined;
     diff.stakedTickEdgeNets = undefined;
@@ -286,7 +282,7 @@ export async function updateLiquidityPoolAggregator(
   const clampedReserve0 = reserve0Sum < 0n ? 0n : reserve0Sum;
   if (reserve0Sum < 0n) {
     context.log.warn(
-      `[NEG_RESERVE_GUARD][updateLiquidityPoolAggregator] field=reserve0 poolAddress=${current.poolAddress} chainId=${current.chainId} priorReserve=${current.reserve0} delta=${reserve0Delta} clampedTo=${clampedReserve0}`,
+      `[NEG_RESERVE_GUARD][updatePool] field=reserve0 poolAddress=${current.poolAddress} chainId=${current.chainId} priorReserve=${current.reserve0} delta=${reserve0Delta} clampedTo=${clampedReserve0}`,
     );
   }
   const reserve1Delta = diff.incrementalReserve1 ?? 0n;
@@ -294,11 +290,11 @@ export async function updateLiquidityPoolAggregator(
   const clampedReserve1 = reserve1Sum < 0n ? 0n : reserve1Sum;
   if (reserve1Sum < 0n) {
     context.log.warn(
-      `[NEG_RESERVE_GUARD][updateLiquidityPoolAggregator] field=reserve1 poolAddress=${current.poolAddress} chainId=${current.chainId} priorReserve=${current.reserve1} delta=${reserve1Delta} clampedTo=${clampedReserve1}`,
+      `[NEG_RESERVE_GUARD][updatePool] field=reserve1 poolAddress=${current.poolAddress} chainId=${current.chainId} priorReserve=${current.reserve1} delta=${reserve1Delta} clampedTo=${clampedReserve1}`,
     );
   }
 
-  let updated: LiquidityPoolAggregator = {
+  let updated: Pool = {
     ...current,
     // Handle cumulative fields by adding diff values to current values
     reserve0: clampedReserve0,
@@ -502,7 +498,7 @@ export async function updateLiquidityPoolAggregator(
       }
     }
 
-    setLiquidityPoolAggregatorSnapshot(updated, timestamp, context);
+    setPoolSnapshot(updated, timestamp, context);
 
     // Soft invariant (issue #670): real swap fee tiers cap at ~1% of volume,
     // so totalFeesGeneratedUSD > 5% of totalVolumeUSD signals fee/volume
@@ -515,7 +511,7 @@ export async function updateLiquidityPoolAggregator(
       updated.totalFeesGeneratedUSD * 20n > updated.totalVolumeUSD
     ) {
       context.log.warn(
-        `[FEE_VOLUME_DIVERGENCE][updateLiquidityPoolAggregator] Pool ${current.poolAddress} on chain ${current.chainId} totalFeesGeneratedUSD (${updated.totalFeesGeneratedUSD}) exceeds 5% of totalVolumeUSD (${updated.totalVolumeUSD}). Real fee tiers cap at ~1%; this likely indicates a fee/volume USD-path divergence.`,
+        `[FEE_VOLUME_DIVERGENCE][updatePool] Pool ${current.poolAddress} on chain ${current.chainId} totalFeesGeneratedUSD (${updated.totalFeesGeneratedUSD}) exceeds 5% of totalVolumeUSD (${updated.totalVolumeUSD}). Real fee tiers cap at ~1%; this likely indicates a fee/volume USD-path divergence.`,
       );
     }
 
@@ -530,12 +526,12 @@ export async function updateLiquidityPoolAggregator(
     // pattern from #679 and the [NEGATIVE_RESERVE_DRIFT] tag from #674.
     if ((updated.stakedReserve0 ?? 0n) < 0n) {
       context.log.warn(
-        `[NEGATIVE_STAKED_RESERVE_DRIFT][updateLiquidityPoolAggregator] Pool ${current.poolAddress} on chain ${current.chainId} stakedReserve0 is negative at snapshot epoch: ${updated.stakedReserve0 ?? 0n}. Staked reserves are LP-deposited capital and should never go below zero.`,
+        `[NEGATIVE_STAKED_RESERVE_DRIFT][updatePool] Pool ${current.poolAddress} on chain ${current.chainId} stakedReserve0 is negative at snapshot epoch: ${updated.stakedReserve0 ?? 0n}. Staked reserves are LP-deposited capital and should never go below zero.`,
       );
     }
     if ((updated.stakedReserve1 ?? 0n) < 0n) {
       context.log.warn(
-        `[NEGATIVE_STAKED_RESERVE_DRIFT][updateLiquidityPoolAggregator] Pool ${current.poolAddress} on chain ${current.chainId} stakedReserve1 is negative at snapshot epoch: ${updated.stakedReserve1 ?? 0n}. Staked reserves are LP-deposited capital and should never go below zero.`,
+        `[NEGATIVE_STAKED_RESERVE_DRIFT][updatePool] Pool ${current.poolAddress} on chain ${current.chainId} stakedReserve1 is negative at snapshot epoch: ${updated.stakedReserve1 ?? 0n}. Staked reserves are LP-deposited capital and should never go below zero.`,
       );
     }
 
@@ -546,7 +542,7 @@ export async function updateLiquidityPoolAggregator(
     };
   }
 
-  context.LiquidityPoolAggregator.set(updated);
+  context.Pool.set(updated);
 }
 
 /**
@@ -570,8 +566,7 @@ export async function loadPoolData(
 ): Promise<PoolData | null> {
   const poolId = PoolId(chainId, poolAddress);
   // Load liquidity pool aggregator and token instances efficiently
-  const liquidityPoolAggregator =
-    await context.LiquidityPoolAggregator.get(poolId);
+  const liquidityPoolAggregator = await context.Pool.get(poolId);
 
   // Load token instances concurrently using the pool's token IDs
   const [token0Instance, token1Instance] = await Promise.all([
@@ -586,7 +581,7 @@ export async function loadPoolData(
   // Handle missing data errors
   if (!liquidityPoolAggregator) {
     context.log.error(
-      `[loadPoolData] LiquidityPoolAggregator ${poolId} not found on chain ${chainId}`,
+      `[loadPoolData] Pool ${poolId} not found on chain ${chainId}`,
     );
     return null;
   }
@@ -739,13 +734,13 @@ export async function findPoolByField(
   chainId: number,
   context: handlerContext,
   field: PoolAddressField,
-): Promise<LiquidityPoolAggregator | null> {
-  const pools = await context.LiquidityPoolAggregator.getWhere({
+): Promise<Pool | null> {
+  const pools = await context.Pool.getWhere({
     [field]: { _eq: address },
   });
 
   const matchingPool = (pools ?? []).find(
-    (pool: LiquidityPoolAggregator) => pool.chainId === chainId,
+    (pool: Pool) => pool.chainId === chainId,
   );
   return matchingPool ?? null;
 }
@@ -761,7 +756,7 @@ export async function findPoolByGaugeAddress(
   gaugeAddress: string,
   chainId: number,
   context: handlerContext,
-): Promise<LiquidityPoolAggregator | null> {
+): Promise<Pool | null> {
   return findPoolByField(
     gaugeAddress,
     chainId,
@@ -771,11 +766,11 @@ export async function findPoolByGaugeAddress(
 }
 
 /**
- * Creates a new LiquidityPoolAggregator entity with default values
+ * Creates a new Pool entity with default values
  * @param params - Parameters for creating the pool entity
- * @returns A new LiquidityPoolAggregator entity
+ * @returns A new Pool entity
  */
-export function createLiquidityPoolAggregatorEntity(params: {
+export function createPoolEntity(params: {
   poolAddress: string;
   chainId: number;
   isCL: boolean;
@@ -794,7 +789,7 @@ export function createLiquidityPoolAggregatorEntity(params: {
   nfpmAddress?: string | null;
   baseFee: bigint;
   currentFee: bigint;
-}): LiquidityPoolAggregator {
+}): Pool {
   const {
     poolAddress,
     chainId,

--- a/src/Aggregators/UserStatsPerPool.ts
+++ b/src/Aggregators/UserStatsPerPool.ts
@@ -8,7 +8,7 @@ import {
 import { computeNonCLStakedUSD, concentratedLiquidityToUSD } from "../Helpers";
 import { getSnapshotEpoch, shouldSnapshot } from "../Snapshots/Shared";
 import { setUserStatsPerPoolSnapshot } from "../Snapshots/UserStatsPerPoolSnapshot";
-import type { PoolData } from "./LiquidityPoolAggregator";
+import type { PoolData } from "./Pool";
 
 export interface UserStatsPerPoolDiff {
   incrementalLpBalance: bigint;
@@ -187,7 +187,7 @@ export function createUserStatsPerPoolEntity(
 
 /**
  * Generic function to update UserStatsPerPool with any combination of fields
- * Similar to updateLiquidityPoolAggregator pattern.
+ * Similar to updatePool pattern.
  * Takes an epoch-aligned snapshot when entering a new snapshot epoch.
  */
 export async function updateUserStatsPerPool(
@@ -402,8 +402,7 @@ export async function updateUserStatsPerPool(
       let token1Instance = preloadedPoolData?.token1Instance;
       if (!poolEntity) {
         const poolId = PoolId(updated.chainId, updated.poolAddress);
-        poolEntity =
-          (await context.LiquidityPoolAggregator.get(poolId)) ?? undefined;
+        poolEntity = (await context.Pool.get(poolId)) ?? undefined;
         if (poolEntity) {
           [token0Instance, token1Instance] = await Promise.all([
             context.Token.get(poolEntity.token0_id),

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -867,7 +867,7 @@ export const TokenId = (chainId: number, address: string) =>
   `${chainId}-${address}`;
 
 /**
- * Create a unique ID for a pool on a specific chain as used by LiquidityPoolAggregator.
+ * Create a unique ID for a pool on a specific chain as used by Pool.
  * Pool address must be EIP-55 checksum-cased (Envio's `event.params.*` already are).
  * Callers must NOT pre-lowercase — that triggers the silent miss documented in #633.
  * @param chainId
@@ -1140,13 +1140,13 @@ export const CLPositionPendingPrincipalId = (
   tickUpper: bigint,
 ) => `${chainId}-${poolAddress}-${owner}-${tickLower}-${tickUpper}`;
 
-/** Snapshot ID for LiquidityPoolAggregatorSnapshot. epochMs = getSnapshotEpoch(timestamp).getTime()
+/** Snapshot ID for PoolSnapshot. epochMs = getSnapshotEpoch(timestamp).getTime()
  * @param chainId - Chain ID of the pool
  * @param poolAddress - Address of the pool (must be EIP-55 checksum-cased; do not pre-lowercase)
  * @param epochMs - Epoch timestamp in milliseconds
  * @returns string Combined pool ID.
  */
-export const LiquidityPoolAggregatorSnapshotId = (
+export const PoolSnapshotId = (
   chainId: number,
   poolAddress: string,
   epochMs: number,

--- a/src/EntityTypes.ts
+++ b/src/EntityTypes.ts
@@ -1,0 +1,8 @@
+// Re-export of GraphQL entity types whose names collide with contract namespaces
+// in the `generated` barrel. After renaming the entities to `Pool`/`PoolSnapshot`
+// (issue #709), the top-level `Pool` value re-export from the V2 Pool contract
+// shadows the `Pool` type re-export at the package boundary — TypeScript's
+// `export type *` does not merge with a sibling value-only re-export of the
+// same name. Importing the types directly from `generated/src/Types` sidesteps
+// that, so this module exists as the single project-side path for those types.
+export type { Pool, PoolSnapshot } from "../generated/src/Types";

--- a/src/EventHandlers/ALM/LPWrapperLogic.ts
+++ b/src/EventHandlers/ALM/LPWrapperLogic.ts
@@ -55,12 +55,11 @@ export async function calculateLiquidityFromAmounts(
   try {
     // Load pool entity to get sqrtPriceX96
     const poolId = PoolId(chainId, poolAddress);
-    const liquidityPoolAggregator =
-      await context.LiquidityPoolAggregator.get(poolId);
+    const liquidityPoolAggregator = await context.Pool.get(poolId);
 
     if (!liquidityPoolAggregator) {
       context.log.error(
-        `[ALMLPWrapper.${eventType}] LiquidityPoolAggregator ${poolId} not found on chain ${chainId}. Skipping liquidity update.`,
+        `[ALMLPWrapper.${eventType}] Pool ${poolId} not found on chain ${chainId}. Skipping liquidity update.`,
       );
       return updatedLiquidity;
     }
@@ -306,8 +305,7 @@ export async function processDepositEvent(
 
   // Compute ΔL from event amounts (getLiquidityForAmounts) then wrapper.liquidity += ΔL
   const poolId = PoolId(chainId, pool);
-  const liquidityPoolAggregator =
-    await context.LiquidityPoolAggregator.get(poolId);
+  const liquidityPoolAggregator = await context.Pool.get(poolId);
   const sqrtPriceX96 = liquidityPoolAggregator?.sqrtPriceX96;
 
   let updatedLiquidity = ALMLPWrapperEntity.liquidity;
@@ -409,8 +407,7 @@ export async function processWithdrawEvent(
 
   // Compute ΔL from event amounts (getLiquidityForAmounts) then wrapper.liquidity -= ΔL
   const poolId = PoolId(chainId, pool);
-  const liquidityPoolAggregator =
-    await context.LiquidityPoolAggregator.get(poolId);
+  const liquidityPoolAggregator = await context.Pool.get(poolId);
   const sqrtPriceX96 = liquidityPoolAggregator?.sqrtPriceX96;
 
   let updatedLiquidity = ALMLPWrapperEntity.liquidity;

--- a/src/EventHandlers/CLFactory.ts
+++ b/src/EventHandlers/CLFactory.ts
@@ -72,8 +72,8 @@ CLFactory.PoolCreated.handler(async ({ event, context }) => {
     return;
   }
 
-  // For new pool creation, set the entity directly (updateLiquidityPoolAggregator is for updates, not creation)
-  context.LiquidityPoolAggregator.set(result.liquidityPoolAggregator);
+  // For new pool creation, set the entity directly (updatePool is for updates, not creation)
+  context.Pool.set(result.liquidityPoolAggregator);
 
   await flushPendingRootPoolMappingAndVotes(
     context,

--- a/src/EventHandlers/CLFactory/CLFactoryPoolCreatedLogic.ts
+++ b/src/EventHandlers/CLFactory/CLFactoryPoolCreatedLogic.ts
@@ -2,22 +2,22 @@ import type {
   CLFactory_PoolCreated_event,
   CLGaugeConfig,
   FeeToTickSpacingMapping,
-  LiquidityPoolAggregator,
   Token,
   handlerContext,
 } from "generated";
-import { createLiquidityPoolAggregatorEntity } from "../../Aggregators/LiquidityPoolAggregator";
+import { createPoolEntity } from "../../Aggregators/Pool";
 import {
   RootPoolLeafPoolId,
   nfpmForCLPool,
   rootPoolMatchingHash,
 } from "../../Constants";
 import type { TokenEntityMapping } from "../../CustomTypes";
+import type { Pool } from "../../EntityTypes";
 import { createTokenEntity } from "../../PriceOracle";
 import { flushPendingVotesAndDistributionsForRootPool } from "../Voter/CrossChainPendingResolution";
 
 export interface CLFactoryPoolCreatedResult {
-  liquidityPoolAggregator: LiquidityPoolAggregator;
+  liquidityPoolAggregator: Pool;
 }
 
 /**
@@ -30,7 +30,7 @@ export interface CLPoolPendingInitializeInput {
 }
 
 /**
- * Builds the LiquidityPoolAggregator for a freshly-created CL pool. Token
+ * Builds the Pool for a freshly-created CL pool. Token
  * entities are created on demand if the caller did not pre-resolve them.
  *
  * If `pendingInitialize` is provided (Slipstream same-tx ordering, where
@@ -49,7 +49,7 @@ export interface CLPoolPendingInitializeInput {
  * @param pendingInitialize - Optional opening price buffered by CLPool.Initialize
  * @returns The constructed aggregator, or `null` when the bytecode gate (#677)
  *   confirmed either token side is a non-contract — caller should skip
- *   `context.LiquidityPoolAggregator.set` and any root-pool flush so no
+ *   `context.Pool.set` and any root-pool flush so no
  *   dangling token references are persisted.
  */
 export async function processCLFactoryPoolCreated(
@@ -87,7 +87,7 @@ export async function processCLFactoryPoolCreated(
           );
           if (created === null) {
             context.log.warn(
-              `[CLFactory.PoolCreated] Skipping LiquidityPoolAggregator for pool ${event.params.pool} on chain ${event.chainId} — non-contract token side`,
+              `[CLFactory.PoolCreated] Skipping Pool for pool ${event.params.pool} on chain ${event.chainId} — non-contract token side`,
             );
             return null;
           }
@@ -104,7 +104,7 @@ export async function processCLFactoryPoolCreated(
     }
 
     // Create the liquidity pool aggregator
-    const baseAggregator = createLiquidityPoolAggregatorEntity({
+    const baseAggregator = createPoolEntity({
       poolAddress: event.params.pool,
       chainId: event.chainId,
       isCL: true,

--- a/src/EventHandlers/CLGaugeFactory/CLGaugeFactorySharedLogic.ts
+++ b/src/EventHandlers/CLGaugeFactory/CLGaugeFactorySharedLogic.ts
@@ -108,7 +108,7 @@ export async function applySetPenaltyRate(
 }
 
 /**
- * Apply a per-gauge emission cap to the matching LiquidityPoolAggregator.
+ * Apply a per-gauge emission cap to the matching Pool.
  * Shared by CLGaugeFactoryV2 and CLGaugeFactoryV3.
  * @param gauge - Gauge address from the event payload
  * @param newEmissionCap - New emissions cap for the gauge's pool
@@ -124,7 +124,7 @@ export async function applySetEmissionCap(
   factoryLogPrefix: string,
   context: handlerContext,
 ): Promise<void> {
-  const poolEntityList = await context.LiquidityPoolAggregator.getWhere({
+  const poolEntityList = await context.Pool.getWhere({
     gaugeAddress: { _eq: gauge },
   });
 
@@ -141,7 +141,7 @@ export async function applySetEmissionCap(
 
   const poolEntity = poolEntityList[0];
 
-  context.LiquidityPoolAggregator.set({
+  context.Pool.set({
     ...poolEntity,
     gaugeEmissionsCap: newEmissionCap,
     lastUpdatedTimestamp: new Date(blockTimestampSeconds * 1000),

--- a/src/EventHandlers/CLGaugeFactory/CLGaugeFactoryV3.ts
+++ b/src/EventHandlers/CLGaugeFactory/CLGaugeFactoryV3.ts
@@ -37,7 +37,7 @@ CLGaugeFactoryV3.SetDefaultMinStakeTime.handler(async ({ event, context }) => {
 
 CLGaugeFactoryV3.SetPoolMinStakeTime.handler(async ({ event, context }) => {
   const poolId = PoolId(event.chainId, event.params._pool);
-  const pool = await context.LiquidityPoolAggregator.get(poolId);
+  const pool = await context.Pool.get(poolId);
 
   if (!pool) {
     context.log.error(
@@ -46,7 +46,7 @@ CLGaugeFactoryV3.SetPoolMinStakeTime.handler(async ({ event, context }) => {
     return;
   }
 
-  context.LiquidityPoolAggregator.set({
+  context.Pool.set({
     ...pool,
     minStakeTime: event.params._minStakeTime,
     lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),

--- a/src/EventHandlers/CLPool.ts
+++ b/src/EventHandlers/CLPool.ts
@@ -1,9 +1,6 @@
 import { CLPool } from "generated";
-import {
-  loadPoolData,
-  updateLiquidityPoolAggregator,
-} from "../Aggregators/LiquidityPoolAggregator";
 import { createOUSDTSwapEntity } from "../Aggregators/OUSDTSwaps";
+import { loadPoolData, updatePool } from "../Aggregators/Pool";
 import {
   loadOrCreateUserData,
   updateUserStatsPerPool,
@@ -63,7 +60,7 @@ CLPool.Burn.handler(async ({ event, context }) => {
   );
   const timestamp = new Date(event.block.timestamp * 1000);
 
-  await updateLiquidityPoolAggregator(
+  await updatePool(
     result.liquidityPoolDiff,
     liquidityPoolAggregator,
     timestamp,
@@ -116,7 +113,7 @@ CLPool.Collect.handler(async ({ event, context }) => {
 
   // Update pool and user entities
   await Promise.all([
-    updateLiquidityPoolAggregator(
+    updatePool(
       poolDiff,
       liquidityPoolAggregator,
       timestamp,
@@ -173,7 +170,7 @@ CLPool.CollectFees.handler(async ({ event, context }) => {
 
   // Update pool and user entities
   await Promise.all([
-    updateLiquidityPoolAggregator(
+    updatePool(
       poolDiff,
       liquidityPoolAggregator,
       timestamp,
@@ -220,7 +217,7 @@ CLPool.Flash.handler(async ({ event, context }) => {
 
   // Update pool and user entities (only update user if there's volume)
   await Promise.all([
-    updateLiquidityPoolAggregator(
+    updatePool(
       poolDiff,
       liquidityPoolAggregator,
       timestamp,
@@ -262,7 +259,7 @@ CLPool.IncreaseObservationCardinalityNext.handler(
       lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
     };
 
-    await updateLiquidityPoolAggregator(
+    await updatePool(
       cardinalityDiff,
       liquidityPoolAggregator,
       new Date(event.block.timestamp * 1000),
@@ -315,7 +312,7 @@ CLPool.Mint.handler(async ({ event, context }) => {
   );
   const timestamp = new Date(event.block.timestamp * 1000);
 
-  await updateLiquidityPoolAggregator(
+  await updatePool(
     result.liquidityPoolDiff,
     liquidityPoolAggregator,
     timestamp,
@@ -380,7 +377,7 @@ CLPool.SetFeeProtocol.handler(async ({ event, context }) => {
     lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
   };
 
-  await updateLiquidityPoolAggregator(
+  await updatePool(
     feeProtocolDiff,
     liquidityPoolAggregator,
     new Date(event.block.timestamp * 1000),
@@ -431,7 +428,7 @@ CLPool.Swap.handler(async ({ event, context }) => {
 
   // Update pool and user entities
   await Promise.all([
-    updateLiquidityPoolAggregator(
+    updatePool(
       poolDiff,
       liquidityPoolAggregator,
       timestamp,

--- a/src/EventHandlers/CLPool/CLPoolBurnLogic.ts
+++ b/src/EventHandlers/CLPool/CLPoolBurnLogic.ts
@@ -1,15 +1,11 @@
-import type {
-  CLPool_Burn_event,
-  LiquidityPoolAggregator,
-  Token,
-  handlerContext,
-} from "generated";
-import type { LiquidityPoolAggregatorDiff } from "../../Aggregators/LiquidityPoolAggregator";
+import type { CLPool_Burn_event, Token, handlerContext } from "generated";
+import type { PoolDiff } from "../../Aggregators/Pool";
 import { CLPositionPendingPrincipalId } from "../../Constants";
+import type { Pool } from "../../EntityTypes";
 import { calculateTotalUSD } from "../../Helpers";
 
 export interface CLPoolBurnResult {
-  liquidityPoolDiff: Partial<LiquidityPoolAggregatorDiff>;
+  liquidityPoolDiff: Partial<PoolDiff>;
 }
 
 /**
@@ -33,7 +29,7 @@ export interface CLPoolBurnResult {
  */
 export async function processCLPoolBurn(
   event: CLPool_Burn_event,
-  liquidityPoolAggregator: LiquidityPoolAggregator,
+  liquidityPoolAggregator: Pool,
   token0Instance: Token,
   token1Instance: Token,
   context: handlerContext,
@@ -61,7 +57,7 @@ export async function processCLPoolBurn(
     event.params.tickLower <= currentTick &&
     currentTick < event.params.tickUpper;
 
-  const liquidityPoolDiff: Partial<LiquidityPoolAggregatorDiff> = {
+  const liquidityPoolDiff: Partial<PoolDiff> = {
     incrementalReserve0: -event.params.amount0,
     incrementalReserve1: -event.params.amount1,
     currentTotalLiquidityUSD: currentTotalLiquidityUSD,

--- a/src/EventHandlers/CLPool/CLPoolCollectFeesLogic.ts
+++ b/src/EventHandlers/CLPool/CLPoolCollectFeesLogic.ts
@@ -1,10 +1,10 @@
 import type { CLPool_CollectFees_event, Token } from "generated";
-import type { LiquidityPoolAggregatorDiff } from "../../Aggregators/LiquidityPoolAggregator";
+import type { PoolDiff } from "../../Aggregators/Pool";
 import type { UserStatsPerPoolDiff } from "../../Aggregators/UserStatsPerPool";
 import { calculateTotalUSD, calculateWhitelistedFeesUSD } from "../../Helpers";
 
 export interface CLPoolCollectFeesResult {
-  liquidityPoolDiff: Partial<LiquidityPoolAggregatorDiff>;
+  liquidityPoolDiff: Partial<PoolDiff>;
   userDiff: Partial<UserStatsPerPoolDiff>;
 }
 
@@ -14,7 +14,7 @@ export function processCLPoolCollectFees(
   token1Instance: Token | undefined,
 ): CLPoolCollectFeesResult {
   // Calculate the increment values (not new totals)
-  // updateLiquidityPoolAggregator expects increments and will add them to current values
+  // updatePool expects increments and will add them to current values
   const stakedFeesIncrementUSD = calculateTotalUSD(
     event.params.amount0,
     event.params.amount1,
@@ -33,7 +33,7 @@ export function processCLPoolCollectFees(
   // Gauge fees accumulate in gaugeFees.token0/token1 during swaps but are excluded from
   // reserves at swap time. When the gauge collects them, no reserve change is needed.
   // Therefore, CollectFees events should NOT affect reserves — only track fees collected.
-  // Return increments (not new totals) since updateLiquidityPoolAggregator will add them to current values
+  // Return increments (not new totals) since updatePool will add them to current values
   const liquidityPoolDiff = {
     incrementalTotalStakedFeesCollected0: event.params.amount0,
     incrementalTotalStakedFeesCollected1: event.params.amount1,

--- a/src/EventHandlers/CLPool/CLPoolCollectLogic.ts
+++ b/src/EventHandlers/CLPool/CLPoolCollectLogic.ts
@@ -4,13 +4,13 @@ import type {
   Token,
   handlerContext,
 } from "generated";
-import type { LiquidityPoolAggregatorDiff } from "../../Aggregators/LiquidityPoolAggregator";
+import type { PoolDiff } from "../../Aggregators/Pool";
 import type { UserStatsPerPoolDiff } from "../../Aggregators/UserStatsPerPool";
 import { CLPositionPendingPrincipalId } from "../../Constants";
 import { calculateTotalUSD, calculateWhitelistedFeesUSD } from "../../Helpers";
 
 export interface CLPoolCollectResult {
-  liquidityPoolDiff: Partial<LiquidityPoolAggregatorDiff>;
+  liquidityPoolDiff: Partial<PoolDiff>;
   userLiquidityDiff: Partial<UserStatsPerPoolDiff>;
 }
 

--- a/src/EventHandlers/CLPool/CLPoolFlashLogic.ts
+++ b/src/EventHandlers/CLPool/CLPoolFlashLogic.ts
@@ -1,10 +1,10 @@
 import type { CLPool_Flash_event, Token } from "generated";
-import type { LiquidityPoolAggregatorDiff } from "../../Aggregators/LiquidityPoolAggregator";
+import type { PoolDiff } from "../../Aggregators/Pool";
 import type { UserStatsPerPoolDiff } from "../../Aggregators/UserStatsPerPool";
 import { calculateTotalUSD } from "../../Helpers";
 
 export interface CLPoolFlashResult {
-  liquidityPoolDiff: Partial<LiquidityPoolAggregatorDiff>;
+  liquidityPoolDiff: Partial<PoolDiff>;
   userFlashLoanDiff: Partial<UserStatsPerPoolDiff>;
 }
 

--- a/src/EventHandlers/CLPool/CLPoolMintLogic.ts
+++ b/src/EventHandlers/CLPool/CLPoolMintLogic.ts
@@ -1,13 +1,10 @@
-import type {
-  CLPool_Mint_event,
-  LiquidityPoolAggregator,
-  Token,
-} from "generated";
-import type { LiquidityPoolAggregatorDiff } from "../../Aggregators/LiquidityPoolAggregator";
+import type { CLPool_Mint_event, Token } from "generated";
+import type { PoolDiff } from "../../Aggregators/Pool";
+import type { Pool } from "../../EntityTypes";
 import { calculateTotalUSD } from "../../Helpers";
 
 export interface CLPoolMintResult {
-  liquidityPoolDiff: Partial<LiquidityPoolAggregatorDiff>;
+  liquidityPoolDiff: Partial<PoolDiff>;
 }
 
 /**
@@ -28,7 +25,7 @@ export interface CLPoolMintResult {
  */
 export function processCLPoolMint(
   event: CLPool_Mint_event,
-  liquidityPoolAggregator: LiquidityPoolAggregator,
+  liquidityPoolAggregator: Pool,
   token0Instance: Token,
   token1Instance: Token,
 ): CLPoolMintResult {
@@ -49,7 +46,7 @@ export function processCLPoolMint(
     event.params.tickLower <= currentTick &&
     currentTick < event.params.tickUpper;
 
-  const liquidityPoolDiff: Partial<LiquidityPoolAggregatorDiff> = {
+  const liquidityPoolDiff: Partial<PoolDiff> = {
     incrementalReserve0: event.params.amount0,
     incrementalReserve1: event.params.amount1,
     currentTotalLiquidityUSD: currentTotalLiquidityUSD,

--- a/src/EventHandlers/CLPool/CLPoolSwapLogic.ts
+++ b/src/EventHandlers/CLPool/CLPoolSwapLogic.ts
@@ -1,13 +1,9 @@
-import type {
-  CLPool_Swap_event,
-  LiquidityPoolAggregator,
-  Token,
-  handlerContext,
-} from "generated";
+import type { CLPool_Swap_event, Token, handlerContext } from "generated";
 import { processTickCrossingsForStaked } from "../../Aggregators/CLStakedLiquidity";
-import type { LiquidityPoolAggregatorDiff } from "../../Aggregators/LiquidityPoolAggregator";
+import type { PoolDiff } from "../../Aggregators/Pool";
 import type { UserStatsPerPoolDiff } from "../../Aggregators/UserStatsPerPool";
 import { CL_FEE_SCALE } from "../../Constants";
+import type { Pool } from "../../EntityTypes";
 import {
   calculateTokenAmountUSD,
   calculateTotalUSD,
@@ -17,7 +13,7 @@ import {
 import { abs } from "../../Maths";
 
 export interface CLPoolSwapResult {
-  liquidityPoolDiff: Partial<LiquidityPoolAggregatorDiff>;
+  liquidityPoolDiff: Partial<PoolDiff>;
   userSwapDiff: Partial<UserStatsPerPoolDiff>;
 }
 
@@ -102,7 +98,7 @@ export function calculateSwapVolume(
  */
 export function calculateSwapFees(
   event: CLPool_Swap_event,
-  liquidityPoolAggregator: LiquidityPoolAggregator,
+  liquidityPoolAggregator: Pool,
   token0Instance: Token | undefined,
   token1Instance: Token | undefined,
   context: handlerContext,
@@ -176,7 +172,7 @@ export function calculateSwapFees(
  */
 function calculateSwapVolumeAndFees(
   event: CLPool_Swap_event,
-  liquidityPoolAggregator: LiquidityPoolAggregator,
+  liquidityPoolAggregator: Pool,
   token0Instance: Token | undefined,
   token1Instance: Token | undefined,
   context: handlerContext,
@@ -224,7 +220,7 @@ function calculateSwapVolumeAndFees(
  */
 export function calculateSwapLiquidityChanges(
   event: CLPool_Swap_event,
-  liquidityPoolAggregator: LiquidityPoolAggregator,
+  liquidityPoolAggregator: Pool,
   token0Instance: Token | undefined,
   token1Instance: Token | undefined,
   clFeeRate: bigint,
@@ -261,7 +257,7 @@ export function calculateSwapLiquidityChanges(
 
 export async function processCLPoolSwap(
   event: CLPool_Swap_event,
-  liquidityPoolAggregator: LiquidityPoolAggregator,
+  liquidityPoolAggregator: Pool,
   token0Instance: Token | undefined,
   token1Instance: Token | undefined,
   context: handlerContext,

--- a/src/EventHandlers/Gauges/GaugeSharedLogic.ts
+++ b/src/EventHandlers/Gauges/GaugeSharedLogic.ts
@@ -1,14 +1,14 @@
-import type { LiquidityPoolAggregator, handlerContext } from "generated";
+import type { handlerContext } from "generated";
 import {
   applyStakedPositionToEdges,
   isPositionInRange,
 } from "../../Aggregators/CLStakedLiquidity";
-import type { PoolData } from "../../Aggregators/LiquidityPoolAggregator";
+import type { PoolData } from "../../Aggregators/Pool";
 import {
   findPoolByGaugeAddress,
   loadPoolData,
-  updateLiquidityPoolAggregator,
-} from "../../Aggregators/LiquidityPoolAggregator";
+  updatePool,
+} from "../../Aggregators/Pool";
 import {
   loadOrCreateUserData,
   updateUserStatsPerPool,
@@ -18,6 +18,7 @@ import {
   NonFungiblePositionId,
   TokenId,
 } from "../../Constants";
+import type { Pool } from "../../EntityTypes";
 import {
   calculatePositionAmountsFromLiquidity,
   calculateTotalUSD,
@@ -49,7 +50,7 @@ export interface GaugeEventData {
  */
 async function computeCLStakedReservesOnGaugeEvent(
   data: GaugeEventData,
-  liquidityPoolAggregator: LiquidityPoolAggregator,
+  liquidityPoolAggregator: Pool,
   poolData: PoolData,
   context: handlerContext,
   direction: 1n | -1n,
@@ -160,7 +161,7 @@ async function computeCLStakedReservesOnGaugeEvent(
  */
 function computeNonCLStakedUSDIfAvailable(
   stakeAmount: bigint,
-  liquidityPoolAggregator: LiquidityPoolAggregator,
+  liquidityPoolAggregator: Pool,
   poolData: PoolData,
   context: handlerContext,
 ): bigint | undefined {
@@ -213,7 +214,7 @@ export async function findPoolOrSkipRootGauge(
   chainId: number,
   context: handlerContext,
   handlerName: string,
-): Promise<{ pool: LiquidityPoolAggregator } | null> {
+): Promise<{ pool: Pool } | null> {
   const pool = await findPoolByGaugeAddress(gaugeAddress, chainId, context);
   if (pool) {
     return { pool };
@@ -233,7 +234,7 @@ export async function findPoolOrSkipRootGauge(
  */
 function computeNonCLPoolStakedUSD(
   newPoolStake: bigint,
-  liquidityPoolAggregator: LiquidityPoolAggregator,
+  liquidityPoolAggregator: Pool,
   poolData: PoolData,
   context: handlerContext,
 ): bigint | undefined {
@@ -359,7 +360,7 @@ export async function processGaugeDeposit(
   };
 
   await Promise.all([
-    updateLiquidityPoolAggregator(
+    updatePool(
       poolDiff,
       liquidityPoolAggregator,
       timestamp,
@@ -479,7 +480,7 @@ export async function processGaugeWithdraw(
   };
 
   await Promise.all([
-    updateLiquidityPoolAggregator(
+    updatePool(
       poolDiff,
       liquidityPoolAggregator,
       timestamp,
@@ -575,7 +576,7 @@ export async function processGaugeClaimRewards(
 
   // Update pool and user entities in parallel
   await Promise.all([
-    updateLiquidityPoolAggregator(
+    updatePool(
       poolDiff,
       liquidityPoolAggregator,
       timestamp,

--- a/src/EventHandlers/NFPM/NFPMCommonLogic.ts
+++ b/src/EventHandlers/NFPM/NFPMCommonLogic.ts
@@ -3,8 +3,8 @@ import {
   applyStakedPositionToEdges,
   isPositionInRange,
 } from "../../Aggregators/CLStakedLiquidity";
-import type { PoolData } from "../../Aggregators/LiquidityPoolAggregator";
-import { updateLiquidityPoolAggregator } from "../../Aggregators/LiquidityPoolAggregator";
+import type { PoolData } from "../../Aggregators/Pool";
+import { updatePool } from "../../Aggregators/Pool";
 import {
   loadOrCreateUserData,
   updateUserStatsPerPool,
@@ -143,7 +143,7 @@ export async function updateStakedPositionLiquidity(
     // the edge-list update so the swap path has correct state once a price is
     // established, but skip the amount math that would otherwise produce
     // garbage from sqrtPriceX96=0.
-    await updateLiquidityPoolAggregator(
+    await updatePool(
       { stakedTickEdges, stakedTickEdgeNets, hasStakes },
       liquidityPoolAggregator,
       timestamp,
@@ -184,7 +184,7 @@ export async function updateStakedPositionLiquidity(
     hasStakes,
   };
 
-  await updateLiquidityPoolAggregator(
+  await updatePool(
     stakedDiff,
     liquidityPoolAggregator,
     timestamp,

--- a/src/EventHandlers/NFPM/NFPMDecreaseLiquidityLogic.ts
+++ b/src/EventHandlers/NFPM/NFPMDecreaseLiquidityLogic.ts
@@ -1,9 +1,9 @@
 import type { NFPM_DecreaseLiquidity_event, handlerContext } from "generated";
-import { loadPoolData } from "../../Aggregators/LiquidityPoolAggregator";
 import {
   type NonFungiblePositionDiff,
   updateNonFungiblePosition,
 } from "../../Aggregators/NonFungiblePosition";
+import { loadPoolData } from "../../Aggregators/Pool";
 import { NonFungiblePositionId } from "../../Constants";
 import {
   LiquidityChangeType,

--- a/src/EventHandlers/NFPM/NFPMIncreaseLiquidityLogic.ts
+++ b/src/EventHandlers/NFPM/NFPMIncreaseLiquidityLogic.ts
@@ -4,11 +4,11 @@ import type {
   NonFungiblePosition,
   handlerContext,
 } from "generated";
-import { loadPoolData } from "../../Aggregators/LiquidityPoolAggregator";
 import {
   type NonFungiblePositionDiff,
   updateNonFungiblePosition,
 } from "../../Aggregators/NonFungiblePosition";
+import { loadPoolData } from "../../Aggregators/Pool";
 import { NonFungiblePositionId, TxCLPoolMintRegistryId } from "../../Constants";
 import {
   LiquidityChangeType,

--- a/src/EventHandlers/NFPM/NFPMTransferLogic.ts
+++ b/src/EventHandlers/NFPM/NFPMTransferLogic.ts
@@ -4,11 +4,8 @@ import type {
   NonFungiblePosition,
   handlerContext,
 } from "generated";
-import {
-  type PoolData,
-  loadPoolData,
-} from "../../Aggregators/LiquidityPoolAggregator";
 import { updateNonFungiblePosition } from "../../Aggregators/NonFungiblePosition";
+import { type PoolData, loadPoolData } from "../../Aggregators/Pool";
 import {
   NonFungiblePositionId,
   PoolId,
@@ -284,7 +281,7 @@ export async function handleRegularTransfer(
 
   // TODO: Refactor loadPoolData() to support partial results so handlers that only
   // need pool-level fields (like gaugeAddress) do not need a separate pool lookup.
-  const poolEntity = await context.LiquidityPoolAggregator.get(
+  const poolEntity = await context.Pool.get(
     PoolId(event.chainId, position.pool),
   );
 

--- a/src/EventHandlers/Pool.ts
+++ b/src/EventHandlers/Pool.ts
@@ -1,10 +1,7 @@
 import { Pool } from "generated";
 
-import {
-  loadPoolData,
-  updateLiquidityPoolAggregator,
-} from "../Aggregators/LiquidityPoolAggregator";
 import { createOUSDTSwapEntity } from "../Aggregators/OUSDTSwaps";
+import { loadPoolData, updatePool } from "../Aggregators/Pool";
 import {
   loadOrCreateUserData,
   updateUserStatsPerPool,
@@ -115,7 +112,7 @@ Pool.Fees.handler(async ({ event, context }) => {
   // Update pool and user entities in parallel
   await Promise.all([
     liquidityPoolDiff
-      ? updateLiquidityPoolAggregator(
+      ? updatePool(
           liquidityPoolDiff,
           liquidityPoolAggregator,
           timestamp,
@@ -165,7 +162,7 @@ Pool.Swap.handler(async ({ event, context }) => {
 
   // Update pool and user entities in parallel
   await Promise.all([
-    updateLiquidityPoolAggregator(
+    updatePool(
       liquidityPoolDiff,
       liquidityPoolAggregator,
       timestamp,
@@ -229,7 +226,7 @@ Pool.Sync.handler(async ({ event, context }) => {
 
   // Apply liquidity pool updates
   if (liquidityPoolDiff) {
-    await updateLiquidityPoolAggregator(
+    await updatePool(
       liquidityPoolDiff,
       liquidityPoolAggregator,
       liquidityPoolDiff.lastUpdatedTimestamp as Date,
@@ -306,7 +303,7 @@ Pool.Claim.handler(async ({ event, context }) => {
   const timestamp = result.poolDiff.lastUpdatedTimestamp as Date;
 
   await Promise.all([
-    updateLiquidityPoolAggregator(
+    updatePool(
       result.poolDiff,
       liquidityPoolAggregator,
       timestamp,

--- a/src/EventHandlers/Pool/PoolBurnAndMintLogic.ts
+++ b/src/EventHandlers/Pool/PoolBurnAndMintLogic.ts
@@ -5,10 +5,7 @@ import type {
   Token,
   handlerContext,
 } from "generated";
-import {
-  type PoolData,
-  updateLiquidityPoolAggregator,
-} from "../../Aggregators/LiquidityPoolAggregator";
+import { type PoolData, updatePool } from "../../Aggregators/Pool";
 import {
   loadOrCreateUserData,
   updateUserStatsPerPool,
@@ -294,7 +291,7 @@ export async function processPoolLiquidityEvent(
     lastUpdatedTimestamp: timestamp,
   };
 
-  await updateLiquidityPoolAggregator(
+  await updatePool(
     poolDiff,
     liquidityPoolAggregator,
     timestamp,

--- a/src/EventHandlers/Pool/PoolClaimLogic.ts
+++ b/src/EventHandlers/Pool/PoolClaimLogic.ts
@@ -1,10 +1,10 @@
 import type { Pool_Claim_event, Token } from "generated";
-import type { LiquidityPoolAggregatorDiff } from "../../Aggregators/LiquidityPoolAggregator";
+import type { PoolDiff } from "../../Aggregators/Pool";
 import type { UserStatsPerPoolDiff } from "../../Aggregators/UserStatsPerPool";
 import { calculateTotalUSD } from "../../Helpers";
 
 export interface PoolClaimResult {
-  poolDiff: Partial<LiquidityPoolAggregatorDiff>;
+  poolDiff: Partial<PoolDiff>;
   userDiff: Partial<UserStatsPerPoolDiff>;
 }
 

--- a/src/EventHandlers/Pool/PoolFeesLogic.ts
+++ b/src/EventHandlers/Pool/PoolFeesLogic.ts
@@ -1,10 +1,10 @@
 import type { Pool_Fees_event, Token } from "generated";
-import type { LiquidityPoolAggregatorDiff } from "../../Aggregators/LiquidityPoolAggregator";
+import type { PoolDiff } from "../../Aggregators/Pool";
 import type { UserStatsPerPoolDiff } from "../../Aggregators/UserStatsPerPool";
 import { calculateTotalUSD, calculateWhitelistedFeesUSD } from "../../Helpers";
 
 export interface PoolFeesResult {
-  liquidityPoolDiff?: Partial<LiquidityPoolAggregatorDiff>;
+  liquidityPoolDiff?: Partial<PoolDiff>;
   userDiff?: Partial<UserStatsPerPoolDiff>;
 }
 

--- a/src/EventHandlers/Pool/PoolSwapLogic.ts
+++ b/src/EventHandlers/Pool/PoolSwapLogic.ts
@@ -1,5 +1,5 @@
 import type { Pool_Swap_event, Token } from "generated";
-import type { LiquidityPoolAggregatorDiff } from "../../Aggregators/LiquidityPoolAggregator";
+import type { PoolDiff } from "../../Aggregators/Pool";
 import type { UserStatsPerPoolDiff } from "../../Aggregators/UserStatsPerPool";
 import {
   calculateTokenAmountUSD,
@@ -7,7 +7,7 @@ import {
 } from "../../Helpers";
 
 export interface PoolSwapResult {
-  liquidityPoolDiff: Partial<LiquidityPoolAggregatorDiff>;
+  liquidityPoolDiff: Partial<PoolDiff>;
   userSwapDiff: Partial<UserStatsPerPoolDiff>;
 }
 

--- a/src/EventHandlers/Pool/PoolSyncLogic.ts
+++ b/src/EventHandlers/Pool/PoolSyncLogic.ts
@@ -1,13 +1,10 @@
-import type {
-  LiquidityPoolAggregator,
-  Pool_Sync_event,
-  Token,
-} from "generated";
-import type { LiquidityPoolAggregatorDiff } from "../../Aggregators/LiquidityPoolAggregator";
+import type { Pool_Sync_event, Token } from "generated";
+import type { PoolDiff } from "../../Aggregators/Pool";
+import type { Pool } from "../../EntityTypes";
 import { calculateTotalUSD } from "../../Helpers";
 
 export interface PoolSyncResult {
-  liquidityPoolDiff: Partial<LiquidityPoolAggregatorDiff>;
+  liquidityPoolDiff: Partial<PoolDiff>;
 }
 
 /**
@@ -22,7 +19,7 @@ export interface PoolSyncResult {
  */
 export function processPoolSync(
   event: Pool_Sync_event,
-  liquidityPoolAggregator: LiquidityPoolAggregator,
+  liquidityPoolAggregator: Pool,
   token0Instance: Token | undefined,
   token1Instance: Token | undefined,
 ): PoolSyncResult {

--- a/src/EventHandlers/Pool/PoolTransferLogic.ts
+++ b/src/EventHandlers/Pool/PoolTransferLogic.ts
@@ -1,9 +1,5 @@
-import type {
-  LiquidityPoolAggregator,
-  Pool_Transfer_event,
-  handlerContext,
-} from "generated";
-import { updateLiquidityPoolAggregator } from "../../Aggregators/LiquidityPoolAggregator";
+import type { Pool_Transfer_event, handlerContext } from "generated";
+import { updatePool } from "../../Aggregators/Pool";
 import {
   loadOrCreateUserData,
   updateUserStatsPerPool,
@@ -13,6 +9,7 @@ import {
   TxPoolTransferRegistryId,
   ZERO_ADDRESS,
 } from "../../Constants";
+import type { Pool } from "../../EntityTypes";
 
 /**
  * Update pool totalLPTokenSupply based on mint/burn transfers
@@ -29,7 +26,7 @@ export async function updatePoolTotalSupply(
   isMint: boolean,
   isBurn: boolean,
   value: bigint,
-  liquidityPoolAggregator: LiquidityPoolAggregator,
+  liquidityPoolAggregator: Pool,
   timestamp: Date,
   context: handlerContext,
   eventChainId: number,
@@ -48,7 +45,7 @@ export async function updatePoolTotalSupply(
   };
 
   if (incrementalTotalLPSupply !== 0n) {
-    await updateLiquidityPoolAggregator(
+    await updatePool(
       poolDiff,
       liquidityPoolAggregator,
       timestamp,
@@ -242,7 +239,7 @@ export async function storeTransferForMatching(
  */
 export async function processPoolTransfer(
   event: Pool_Transfer_event,
-  liquidityPoolAggregator: LiquidityPoolAggregator,
+  liquidityPoolAggregator: Pool,
   poolAddress: string,
   chainId: number,
   context: handlerContext,

--- a/src/EventHandlers/PoolFactory.ts
+++ b/src/EventHandlers/PoolFactory.ts
@@ -1,9 +1,6 @@
 import { PoolFactory } from "generated";
-import type { LiquidityPoolAggregator, Token } from "generated";
-import {
-  createLiquidityPoolAggregatorEntity,
-  updateLiquidityPoolAggregator,
-} from "../Aggregators/LiquidityPoolAggregator";
+import type { Token } from "generated";
+import { createPoolEntity, updatePool } from "../Aggregators/Pool";
 import {
   DEFAULT_SAMM_FEE_BPS,
   DEFAULT_VAMM_FEE_BPS,
@@ -13,6 +10,7 @@ import {
   TokenId,
 } from "../Constants";
 import { getRootPoolAddress } from "../Effects/RootPool";
+import type { Pool } from "../EntityTypes";
 import { createTokenEntity } from "../PriceOracle";
 import type { TokenEntityMapping } from "./../CustomTypes";
 import { flushPendingVotesAndDistributionsForRootPool } from "./Voter/CrossChainPendingResolution";
@@ -66,7 +64,7 @@ PoolFactory.PoolCreated.handler(async ({ event, context }) => {
       const created = createdTokens[i];
       if (created === null) {
         context.log.warn(
-          `[PoolFactory.PoolCreated] Skipping LiquidityPoolAggregator for pool ${event.params.pool} on chain ${event.chainId} — non-contract token side`,
+          `[PoolFactory.PoolCreated] Skipping Pool for pool ${event.params.pool} on chain ${event.chainId} — non-contract token side`,
         );
         return;
       }
@@ -85,7 +83,7 @@ PoolFactory.PoolCreated.handler(async ({ event, context }) => {
 
   const fee = event.params.stable ? DEFAULT_SAMM_FEE_BPS : DEFAULT_VAMM_FEE_BPS;
 
-  const pool = createLiquidityPoolAggregatorEntity({
+  const pool = createPoolEntity({
     poolAddress: event.params.pool,
     chainId: event.chainId,
     isCL: false,
@@ -100,8 +98,8 @@ PoolFactory.PoolCreated.handler(async ({ event, context }) => {
     currentFee: fee,
   });
 
-  // For new pool creation, set the entity directly (updateLiquidityPoolAggregator is for updates, not creation)
-  context.LiquidityPoolAggregator.set(pool);
+  // For new pool creation, set the entity directly (updatePool is for updates, not creation)
+  context.Pool.set(pool);
 
   // For non-Optimism and non-Base pools, set the RootPool_LeafPool entity
   // Mapping RootPool (on optimism) to Pool (on superchain)
@@ -151,19 +149,19 @@ PoolFactory.PoolCreated.handler(async ({ event, context }) => {
 
 PoolFactory.SetCustomFee.handler(async ({ event, context }) => {
   const poolId = PoolId(event.chainId, event.params.pool);
-  const poolEntity = await context.LiquidityPoolAggregator.get(poolId);
+  const poolEntity = await context.Pool.get(poolId);
 
   if (!poolEntity) {
     context.log.warn(`Pool ${poolId} not found for SetCustomFee event`);
     return;
   }
 
-  const diff: Partial<LiquidityPoolAggregator> = {
+  const diff: Partial<Pool> = {
     baseFee: BigInt(event.params.fee),
     currentFee: BigInt(event.params.fee), // When custom fee is set, both baseFee and currentFee are updated
   };
 
-  await updateLiquidityPoolAggregator(
+  await updatePool(
     diff,
     poolEntity,
     new Date(event.block.timestamp * 1000),

--- a/src/EventHandlers/PoolLauncher/CLPoolLauncher.ts
+++ b/src/EventHandlers/PoolLauncher/CLPoolLauncher.ts
@@ -2,7 +2,7 @@ import { CLPoolLauncher } from "generated";
 import type { PoolLauncherPool } from "generated";
 import { PoolId } from "../../Constants";
 import {
-  linkLiquidityPoolAggregatorToPoolLauncher,
+  linkPoolToPoolLauncher,
   processPoolLauncherPool,
 } from "./PoolLauncherLogic";
 
@@ -27,13 +27,8 @@ CLPoolLauncher.Launch.handler(async ({ event, context }) => {
     context,
   );
 
-  // Link existing LiquidityPoolAggregator to PoolLauncherPool
-  await linkLiquidityPoolAggregatorToPoolLauncher(
-    poolAddress,
-    event.chainId,
-    context,
-    "CL",
-  );
+  // Link existing Pool to PoolLauncherPool
+  await linkPoolToPoolLauncher(poolAddress, event.chainId, context, "CL");
 });
 
 CLPoolLauncher.Migrate.handler(async ({ event, context }) => {
@@ -73,13 +68,8 @@ CLPoolLauncher.Migrate.handler(async ({ event, context }) => {
       context,
     );
 
-    // Link existing LiquidityPoolAggregator to PoolLauncherPool for migrated pool
-    await linkLiquidityPoolAggregatorToPoolLauncher(
-      newPoolAddress,
-      event.chainId,
-      context,
-      "CL",
-    );
+    // Link existing Pool to PoolLauncherPool for migrated pool
+    await linkPoolToPoolLauncher(newPoolAddress, event.chainId, context, "CL");
   } else {
     context.log.warn(
       `PoolLauncherPool not found for migration: ${underlyingPool}`,

--- a/src/EventHandlers/PoolLauncher/PoolLauncherLogic.ts
+++ b/src/EventHandlers/PoolLauncher/PoolLauncherLogic.ts
@@ -1,9 +1,6 @@
-import type {
-  LiquidityPoolAggregator,
-  PoolLauncherPool,
-  handlerContext,
-} from "generated";
+import type { PoolLauncherPool, handlerContext } from "generated";
 import { PoolId } from "../../Constants";
+import type { Pool } from "../../EntityTypes";
 
 // Helper function to create or update PoolLauncherPool entity
 export async function processPoolLauncherPool(
@@ -52,31 +49,30 @@ export async function processPoolLauncherPool(
   return poolLauncherPool;
 }
 
-// Helper function to link existing LiquidityPoolAggregator to PoolLauncherPool
-export async function linkLiquidityPoolAggregatorToPoolLauncher(
+// Helper function to link existing Pool to PoolLauncherPool
+export async function linkPoolToPoolLauncher(
   poolAddress: string,
   chainId: number,
   context: handlerContext,
   factoryType: "CL" | "V2",
 ): Promise<void> {
-  // Load the existing LiquidityPoolAggregator (created by CLFactory or V2Factory)
+  // Load the existing Pool (created by CLFactory or V2Factory)
   const poolId = PoolId(chainId, poolAddress);
-  const existingLiquidityPoolAggregator =
-    await context.LiquidityPoolAggregator.get(poolId);
+  const existingPool = await context.Pool.get(poolId);
 
-  if (!existingLiquidityPoolAggregator) {
+  if (!existingPool) {
     context.log.warn(
-      `LiquidityPoolAggregator not found for pool ${poolId} - it should have been created by ${factoryType}Factory`,
+      `Pool not found for pool ${poolId} - it should have been created by ${factoryType}Factory`,
     );
     return;
   }
 
-  // Update the existing LiquidityPoolAggregator to link it to PoolLauncherPool
-  const updatedLiquidityPoolAggregator: LiquidityPoolAggregator = {
-    ...existingLiquidityPoolAggregator,
+  // Update the existing Pool to link it to PoolLauncherPool
+  const updatedPool: Pool = {
+    ...existingPool,
     poolLauncherPoolId: poolId,
     lastUpdatedTimestamp: new Date(),
   };
 
-  context.LiquidityPoolAggregator.set(updatedLiquidityPoolAggregator);
+  context.Pool.set(updatedPool);
 }

--- a/src/EventHandlers/PoolLauncher/V2PoolLauncher.ts
+++ b/src/EventHandlers/PoolLauncher/V2PoolLauncher.ts
@@ -2,7 +2,7 @@ import { V2PoolLauncher } from "generated";
 import type { PoolLauncherPool } from "generated";
 import { PoolId } from "../../Constants";
 import {
-  linkLiquidityPoolAggregatorToPoolLauncher,
+  linkPoolToPoolLauncher,
   processPoolLauncherPool,
 } from "./PoolLauncherLogic";
 
@@ -27,13 +27,8 @@ V2PoolLauncher.Launch.handler(async ({ event, context }) => {
     context,
   );
 
-  // Link existing LiquidityPoolAggregator to PoolLauncherPool
-  await linkLiquidityPoolAggregatorToPoolLauncher(
-    poolAddress,
-    event.chainId,
-    context,
-    "V2",
-  );
+  // Link existing Pool to PoolLauncherPool
+  await linkPoolToPoolLauncher(poolAddress, event.chainId, context, "V2");
 });
 
 V2PoolLauncher.Migrate.handler(async ({ event, context }) => {
@@ -73,13 +68,8 @@ V2PoolLauncher.Migrate.handler(async ({ event, context }) => {
       context,
     );
 
-    // Link existing LiquidityPoolAggregator to PoolLauncherPool for migrated pool
-    await linkLiquidityPoolAggregatorToPoolLauncher(
-      newPoolAddress,
-      event.chainId,
-      context,
-      "V2",
-    );
+    // Link existing Pool to PoolLauncherPool for migrated pool
+    await linkPoolToPoolLauncher(newPoolAddress, event.chainId, context, "V2");
   } else {
     context.log.warn(
       `PoolLauncherPool not found for migration: ${underlyingPool}`,

--- a/src/EventHandlers/Redistributor/Redistributor.ts
+++ b/src/EventHandlers/Redistributor/Redistributor.ts
@@ -1,20 +1,17 @@
 import { Redistributor, type handlerContext } from "generated";
-import {
-  type LiquidityPoolAggregatorDiff,
-  updateLiquidityPoolAggregator,
-} from "../../Aggregators/LiquidityPoolAggregator";
+import { type PoolDiff, updatePool } from "../../Aggregators/Pool";
 import { applyRedistributorConfigUpdate } from "./RedistributorConfigSharedLogic";
 
 type RedistributorCounterDelta = Partial<
   Pick<
-    LiquidityPoolAggregatorDiff,
+    PoolDiff,
     | "incrementalTotalEmissionsRedistributed"
     | "incrementalTotalEmissionsForfeited"
   >
 >;
 
 /**
- * Resolve the `LiquidityPoolAggregator` whose `gaugeAddress` matches the event's
+ * Resolve the `Pool` whose `gaugeAddress` matches the event's
  * gauge and apply a cumulative delta to one of the redistributor counters.
  *
  * Log-and-drop when no pool matches: Redistributor and the Voter/Gauge factories
@@ -39,7 +36,7 @@ async function applyRedistributorCounterDelta(
   blockNumber: number,
   context: handlerContext,
 ): Promise<void> {
-  const poolEntityList = await context.LiquidityPoolAggregator.getWhere({
+  const poolEntityList = await context.Pool.getWhere({
     gaugeAddress: { _eq: gauge },
   });
 
@@ -58,7 +55,7 @@ async function applyRedistributorCounterDelta(
 
   const poolEntity = poolEntityList[0];
 
-  await updateLiquidityPoolAggregator(
+  await updatePool(
     delta,
     poolEntity,
     new Date(blockTimestampSeconds * 1000),

--- a/src/EventHandlers/RootCLPoolFactory.ts
+++ b/src/EventHandlers/RootCLPoolFactory.ts
@@ -18,7 +18,7 @@ RootCLPoolFactory.RootPoolCreated.handler(async ({ event, context }) => {
 
   const hash = rootPoolMatchingHash(leafChainId, token0, token1, tickSpacing);
 
-  const pools = await context.LiquidityPoolAggregator.getWhere({
+  const pools = await context.Pool.getWhere({
     rootPoolMatchingHash: { _eq: hash },
   });
 
@@ -34,14 +34,14 @@ RootCLPoolFactory.RootPoolCreated.handler(async ({ event, context }) => {
       rootPoolMatchingHash: hash,
     });
     context.log.warn(
-      `RootPoolCreated: no LiquidityPoolAggregator found for hash ${hash}. PendingRootPoolMapping stored for later reconciliation.`,
+      `RootPoolCreated: no Pool found for hash ${hash}. PendingRootPoolMapping stored for later reconciliation.`,
     );
     return;
   }
 
   if (pools.length !== 1) {
     context.log.error(
-      `Expected exactly one matching LiquidityPoolAggregator for RootPoolCreated: token0=${token0}, token1=${token1}, chainId=${leafChainId}, tickSpacing=${tickSpacing}`,
+      `Expected exactly one matching Pool for RootPoolCreated: token0=${token0}, token1=${token1}, chainId=${leafChainId}, tickSpacing=${tickSpacing}`,
     );
     return;
   }

--- a/src/EventHandlers/SwapFeeModule/CustomSwapFeeModule.ts
+++ b/src/EventHandlers/SwapFeeModule/CustomSwapFeeModule.ts
@@ -1,26 +1,24 @@
 import { CustomSwapFeeModule } from "generated";
-import type {
-  DynamicFeeGlobalConfig,
-  LiquidityPoolAggregator,
-} from "generated";
-import { updateLiquidityPoolAggregator } from "../../Aggregators/LiquidityPoolAggregator";
+import type { DynamicFeeGlobalConfig } from "generated";
+import { updatePool } from "../../Aggregators/Pool";
 import { PoolId } from "../../Constants";
+import type { Pool } from "../../EntityTypes";
 
 CustomSwapFeeModule.SetCustomFee.handler(async ({ event, context }) => {
   const poolId = PoolId(event.chainId, event.params.pool);
-  const pool = await context.LiquidityPoolAggregator.get(poolId);
+  const pool = await context.Pool.get(poolId);
 
   if (!pool) {
     context.log.warn(`Pool ${poolId} not found for SetCustomFee event`);
     return;
   }
 
-  const diff: Partial<LiquidityPoolAggregator> = {
+  const diff: Partial<Pool> = {
     baseFee: BigInt(event.params.fee),
     currentFee: BigInt(event.params.fee),
   };
 
-  await updateLiquidityPoolAggregator(
+  await updatePool(
     diff,
     pool,
     new Date(event.block.timestamp * 1000),

--- a/src/EventHandlers/SwapFeeModule/DynamicSwapFeeModule.ts
+++ b/src/EventHandlers/SwapFeeModule/DynamicSwapFeeModule.ts
@@ -1,25 +1,23 @@
 import { DynamicSwapFeeModule } from "generated";
-import type {
-  DynamicFeeGlobalConfig,
-  LiquidityPoolAggregator,
-} from "generated";
-import { updateLiquidityPoolAggregator } from "../../Aggregators/LiquidityPoolAggregator";
+import type { DynamicFeeGlobalConfig } from "generated";
+import { updatePool } from "../../Aggregators/Pool";
 import { PoolId } from "../../Constants";
+import type { Pool } from "../../EntityTypes";
 
 DynamicSwapFeeModule.CustomFeeSet.handler(async ({ event, context }) => {
   const poolId = PoolId(event.chainId, event.params.pool);
-  const pool = await context.LiquidityPoolAggregator.get(poolId);
+  const pool = await context.Pool.get(poolId);
 
   if (!pool) {
     context.log.warn(`Pool ${poolId} not found for CustomFeeSet event`);
     return;
   }
 
-  const diff: Partial<LiquidityPoolAggregator> = {
+  const diff: Partial<Pool> = {
     baseFee: BigInt(event.params.fee),
   };
 
-  await updateLiquidityPoolAggregator(
+  await updatePool(
     diff,
     pool,
     new Date(event.block.timestamp * 1000),
@@ -45,18 +43,18 @@ DynamicSwapFeeModule.SecondsAgoSet.handler(async ({ event, context }) => {
 
 DynamicSwapFeeModule.ScalingFactorSet.handler(async ({ event, context }) => {
   const poolId = PoolId(event.chainId, event.params.pool);
-  const pool = await context.LiquidityPoolAggregator.get(poolId);
+  const pool = await context.Pool.get(poolId);
 
   if (!pool) {
     context.log.warn(`Pool ${poolId} not found for ScalingFactorSet event`);
     return;
   }
 
-  const diff: Partial<LiquidityPoolAggregator> = {
+  const diff: Partial<Pool> = {
     scalingFactor: BigInt(event.params.scalingFactor),
   };
 
-  await updateLiquidityPoolAggregator(
+  await updatePool(
     diff,
     pool,
     new Date(event.block.timestamp * 1000),
@@ -68,18 +66,18 @@ DynamicSwapFeeModule.ScalingFactorSet.handler(async ({ event, context }) => {
 
 DynamicSwapFeeModule.FeeCapSet.handler(async ({ event, context }) => {
   const poolId = PoolId(event.chainId, event.params.pool);
-  const pool = await context.LiquidityPoolAggregator.get(poolId);
+  const pool = await context.Pool.get(poolId);
 
   if (!pool) {
     context.log.warn(`Pool ${poolId} not found for FeeCapSet event`);
     return;
   }
 
-  const diff: Partial<LiquidityPoolAggregator> = {
+  const diff: Partial<Pool> = {
     feeCap: BigInt(event.params.feeCap),
   };
 
-  await updateLiquidityPoolAggregator(
+  await updatePool(
     diff,
     pool,
     new Date(event.block.timestamp * 1000),

--- a/src/EventHandlers/SwapFeeModule/UnstakedFeeModuleSharedLogic.ts
+++ b/src/EventHandlers/SwapFeeModule/UnstakedFeeModuleSharedLogic.ts
@@ -1,8 +1,5 @@
 import type { handlerContext } from "generated";
-import {
-  type LiquidityPoolAggregatorDiff,
-  updateLiquidityPoolAggregator,
-} from "../../Aggregators/LiquidityPoolAggregator";
+import { type PoolDiff, updatePool } from "../../Aggregators/Pool";
 import { PoolId } from "../../Constants";
 
 export interface UnstakedFeeEventData {
@@ -35,18 +32,18 @@ export async function applyUnstakedFee(
   context: handlerContext,
 ): Promise<void> {
   const poolId = PoolId(data.chainId, data.poolAddress);
-  const pool = await context.LiquidityPoolAggregator.get(poolId);
+  const pool = await context.Pool.get(poolId);
 
   if (!pool) {
     context.log.warn(`Pool ${poolId} not found for ${data.logContext} event`);
     return;
   }
 
-  const diff: Partial<LiquidityPoolAggregatorDiff> = {
+  const diff: Partial<PoolDiff> = {
     unstakedFee: data.fee,
   };
 
-  await updateLiquidityPoolAggregator(
+  await updatePool(
     diff,
     pool,
     new Date(data.blockTimestamp * 1000),

--- a/src/EventHandlers/Voter/CrossChainPendingResolution.ts
+++ b/src/EventHandlers/Voter/CrossChainPendingResolution.ts
@@ -16,8 +16,8 @@ import type {
 import {
   type PoolData,
   loadPoolData,
-  updateLiquidityPoolAggregator,
-} from "../../Aggregators/LiquidityPoolAggregator";
+  updatePool,
+} from "../../Aggregators/Pool";
 import {
   loadOrCreateUserData,
   updateUserStatsPerPool,
@@ -76,7 +76,7 @@ export async function getPendingVotesByRootPool(
 }
 
 /**
- * Applies a single pending vote to the leaf pool: updates LiquidityPoolAggregator,
+ * Applies a single pending vote to the leaf pool: updates Pool,
  * UserStatsPerPool, and VeNFTPoolVote. Uses incremental pool update (current total + delta)
  * since we don't have the event's totalWeight.
  * @param context - The handler context
@@ -141,7 +141,7 @@ export async function processPendingVote(
   ]);
 
   await Promise.all([
-    updateLiquidityPoolAggregator(
+    updatePool(
       poolVoteDiff,
       leafPool,
       timestamp,
@@ -251,7 +251,7 @@ export async function processAllPendingVotesForRootPool(
 
   for (const pendingVote of pendingVotes) {
     // Reload leaf pool data each iteration: processPendingVote updates the pool (e.g. veNFTamountStaked)
-    // via updateLiquidityPoolAggregator, so the next vote must see the updated state to compute
+    // via updatePool, so the next vote must see the updated state to compute
     // the correct cumulative totalWeight.
     const currentLeafPoolData = await loadPoolData(
       leafPoolAddress,
@@ -300,7 +300,7 @@ export async function getPendingDistributionsByRootPool(
 
 /**
  * Applies a single pending distribution to the leaf pool: loads reward token, computes values,
- * builds LP diff (without gaugeAddress for cross-chain), and updates the LiquidityPoolAggregator.
+ * builds LP diff (without gaugeAddress for cross-chain), and updates the Pool.
  * @param context - The handler context
  * @param pending - The pending distribution to process
  * @param leafPoolAddress - The address of the leaf pool
@@ -365,7 +365,7 @@ export async function processPendingDistribution(
   const timestampMs = blockTimestamp * 1000;
   const poolDiff = buildPoolDiffFromDistribute(result, timestampMs, undefined);
 
-  await updateLiquidityPoolAggregator(
+  await updatePool(
     poolDiff,
     currentLiquidityPool,
     new Date(timestampMs),

--- a/src/EventHandlers/Voter/SuperchainLeafVoter.ts
+++ b/src/EventHandlers/Voter/SuperchainLeafVoter.ts
@@ -1,10 +1,7 @@
 import { SuperchainLeafVoter } from "generated";
 
 import type { Token } from "generated";
-import {
-  findPoolByGaugeAddress,
-  updateLiquidityPoolAggregator,
-} from "../../Aggregators/LiquidityPoolAggregator";
+import { findPoolByGaugeAddress, updatePool } from "../../Aggregators/Pool";
 import {
   PoolId,
   SUPERCHAIN_LEAF_VOTER_CLPOOLS_FACTORY_LIST,
@@ -32,7 +29,7 @@ SuperchainLeafVoter.GaugeCreated.handler(async ({ event, context }) => {
   const poolId = PoolId(event.chainId, event.params.pool);
   const gaugeAddress = event.params.gauge;
 
-  const poolEntity = await context.LiquidityPoolAggregator.get(poolId);
+  const poolEntity = await context.Pool.get(poolId);
 
   if (poolEntity) {
     const poolUpdateDiff = {
@@ -43,7 +40,7 @@ SuperchainLeafVoter.GaugeCreated.handler(async ({ event, context }) => {
       lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
     };
 
-    await updateLiquidityPoolAggregator(
+    await updatePool(
       poolUpdateDiff,
       poolEntity,
       new Date(event.block.timestamp * 1000),
@@ -69,7 +66,7 @@ SuperchainLeafVoter.GaugeKilled.handler(async ({ event, context }) => {
       lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
     };
 
-    await updateLiquidityPoolAggregator(
+    await updatePool(
       poolUpdateDiff,
       poolEntity,
       new Date(event.block.timestamp * 1000),
@@ -94,7 +91,7 @@ SuperchainLeafVoter.GaugeRevived.handler(async ({ event, context }) => {
       lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
     };
 
-    await updateLiquidityPoolAggregator(
+    await updatePool(
       poolUpdateDiff,
       poolEntity,
       new Date(event.block.timestamp * 1000),

--- a/src/EventHandlers/Voter/Voter.ts
+++ b/src/EventHandlers/Voter/Voter.ts
@@ -5,8 +5,8 @@ import {
   findPoolByGaugeAddress,
   isMissingRootPoolMapping,
   loadPoolDataOrRootCLPool,
-  updateLiquidityPoolAggregator,
-} from "../../Aggregators/LiquidityPoolAggregator";
+  updatePool,
+} from "../../Aggregators/Pool";
 import {
   loadOrCreateUserData,
   updateUserStatsPerPool,
@@ -54,7 +54,7 @@ Voter.GaugeCreated.handler(async ({ event, context }) => {
   const poolId = PoolId(event.chainId, event.params.pool);
   const gaugeAddress = event.params.gauge;
 
-  const poolEntity = await context.LiquidityPoolAggregator.get(poolId);
+  const poolEntity = await context.Pool.get(poolId);
 
   if (poolEntity) {
     const poolUpdateDiff = {
@@ -65,7 +65,7 @@ Voter.GaugeCreated.handler(async ({ event, context }) => {
       lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
     };
 
-    await updateLiquidityPoolAggregator(
+    await updatePool(
       poolUpdateDiff,
       poolEntity,
       new Date(event.block.timestamp * 1000),
@@ -74,7 +74,7 @@ Voter.GaugeCreated.handler(async ({ event, context }) => {
       event.block.number,
     );
   } else {
-    // RootPool case: no LiquidityPoolAggregator on this chain
+    // RootPool case: no Pool on this chain
     // Store root gauge → root pool for DistributeReward cross-chain resolution
     const id = RootGaugeRootPoolId(event.chainId, event.params.gauge);
     context.RootGauge_RootPool.set({
@@ -164,7 +164,7 @@ Voter.Voted.handler(async ({ event, context }) => {
     );
 
   await Promise.all([
-    updateLiquidityPoolAggregator(
+    updatePool(
       poolVoteDiff,
       liquidityPoolAggregator,
       timestamp,
@@ -261,7 +261,7 @@ Voter.Abstained.handler(async ({ event, context }) => {
   ]);
 
   await Promise.all([
-    updateLiquidityPoolAggregator(
+    updatePool(
       poolVoteDiff,
       liquidityPoolAggregator,
       timestamp,
@@ -294,8 +294,7 @@ Voter.DistributeReward.handler(async ({ event, context }) => {
         context,
       );
       if (poolEntity) {
-        const pool =
-          (await context.LiquidityPoolAggregator.get(poolEntity.id)) ?? null;
+        const pool = (await context.Pool.get(poolEntity.id)) ?? null;
         return pool ? { pool, isCrossChain: false } : null;
       }
       return resolveLeafPoolForRootGauge(
@@ -377,7 +376,7 @@ Voter.DistributeReward.handler(async ({ event, context }) => {
     isCrossChainDistribution ? undefined : event.params.gauge,
   );
 
-  await updateLiquidityPoolAggregator(
+  await updatePool(
     poolDiff,
     currentLiquidityPool,
     new Date(timestampMs),
@@ -476,7 +475,7 @@ Voter.GaugeKilled.handler(async ({ event, context }) => {
       lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
     };
 
-    await updateLiquidityPoolAggregator(
+    await updatePool(
       poolUpdateDiff,
       poolEntity,
       new Date(event.block.timestamp * 1000),
@@ -501,7 +500,7 @@ Voter.GaugeRevived.handler(async ({ event, context }) => {
       lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
     };
 
-    await updateLiquidityPoolAggregator(
+    await updatePool(
       poolUpdateDiff,
       poolEntity,
       new Date(event.block.timestamp * 1000),

--- a/src/EventHandlers/Voter/VoterCommonLogic.ts
+++ b/src/EventHandlers/Voter/VoterCommonLogic.ts
@@ -1,14 +1,9 @@
-import type {
-  LiquidityPoolAggregator,
-  Token,
-  VeNFTState,
-  handlerContext,
-} from "generated";
+import type { Token, VeNFTState, handlerContext } from "generated";
 import {
-  type LiquidityPoolAggregatorDiff,
+  type PoolDiff,
   loadPoolData,
-  updateLiquidityPoolAggregator,
-} from "../../Aggregators/LiquidityPoolAggregator";
+  updatePool,
+} from "../../Aggregators/Pool";
 import type { UserStatsPerPoolDiff } from "../../Aggregators/UserStatsPerPool";
 import type { VeNFTPoolVoteDiff } from "../../Aggregators/VeNFTPoolVote";
 import {
@@ -17,6 +12,7 @@ import {
   isKnownSinkRootPool,
 } from "../../Constants";
 import { getTokensDeposited } from "../../Effects/Index";
+import type { Pool } from "../../EntityTypes";
 import {
   calculateTokenAmountUSD,
   normalizeTokenAmountTo1e18,
@@ -99,8 +95,8 @@ export function buildPoolDiffFromDistribute(
   result: VoterCommonResult,
   timestampMs: number,
   gaugeAddress?: string,
-): Partial<LiquidityPoolAggregatorDiff> {
-  const diff: Partial<LiquidityPoolAggregatorDiff> = {
+): Partial<PoolDiff> {
+  const diff: Partial<PoolDiff> = {
     totalVotesDeposited: result.tokensDeposited,
     totalVotesDepositedUSD: result.normalizedVotesDepositedAmountUsd,
     incrementalTotalEmissions: result.normalizedEmissionsAmount,
@@ -117,7 +113,7 @@ export function buildPoolDiffFromDistribute(
 /**
  * Resolves a root gauge (RootGauge/RootCLGauge on OP) to the corresponding leaf pool via
  * RootGauge_RootPool and RootPool_LeafPool. Used when DistributeReward fires for a gauge
- * that has no local LiquidityPoolAggregator (the real pool is on a leaf chain).
+ * that has no local Pool (the real pool is on a leaf chain).
  * @param context - The handler context
  * @param chainId - The chain ID
  * @param gaugeAddress - The address of the root gauge
@@ -127,7 +123,7 @@ export async function resolveLeafPoolForRootGauge(
   context: handlerContext,
   chainId: number,
   gaugeAddress: string,
-): Promise<{ pool: LiquidityPoolAggregator; isCrossChain: true } | null> {
+): Promise<{ pool: Pool; isCrossChain: true } | null> {
   const rootGaugeMapping = await context.RootGauge_RootPool.get(
     RootGaugeRootPoolId(chainId, gaugeAddress),
   );
@@ -174,7 +170,7 @@ export async function resolveLeafPoolForRootGauge(
 
 /**
  * Computes diffs for pool (absolute total), user stats and VeNFTPoolVote (incremental delta).
- * @param totalWeight - New total veNFT staked in pool (absolute; used for LiquidityPoolAggregator)
+ * @param totalWeight - New total veNFT staked in pool (absolute; used for Pool)
  * @param weight - Delta for this vote (used for UserStatsPerPool and VeNFTPoolVote)
  * @param veNFTState - The VeNFTState for the token
  * @param timestamp - The timestamp of the event
@@ -188,7 +184,7 @@ export function computeVoterRelatedEntitiesDiff(
   timestamp: Date,
   eventType: VoterEventType,
 ): {
-  poolVoteDiff: Partial<LiquidityPoolAggregatorDiff>;
+  poolVoteDiff: Partial<PoolDiff>;
   userStatsPerPoolDiff: Partial<UserStatsPerPoolDiff>;
   veNFTPoolVoteDiff: Partial<VeNFTPoolVoteDiff>;
 } {

--- a/src/EventHandlers/VotingReward/BribesVotingReward.ts
+++ b/src/EventHandlers/VotingReward/BribesVotingReward.ts
@@ -1,8 +1,5 @@
 import { BribesVotingReward } from "generated";
-import {
-  PoolAddressField,
-  updateLiquidityPoolAggregator,
-} from "../../Aggregators/LiquidityPoolAggregator";
+import { PoolAddressField, updatePool } from "../../Aggregators/Pool";
 import { updateUserStatsPerPool } from "../../Aggregators/UserStatsPerPool";
 import {
   loadVotingRewardData,
@@ -39,7 +36,7 @@ BribesVotingReward.ClaimRewards.handler(async ({ event, context }) => {
 
   await Promise.all([
     result.poolDiff
-      ? updateLiquidityPoolAggregator(
+      ? updatePool(
           result.poolDiff,
           loadedData.poolData.liquidityPoolAggregator,
           new Date(data.timestamp * 1000),

--- a/src/EventHandlers/VotingReward/FeesVotingReward.ts
+++ b/src/EventHandlers/VotingReward/FeesVotingReward.ts
@@ -1,8 +1,5 @@
 import { FeesVotingReward } from "generated";
-import {
-  PoolAddressField,
-  updateLiquidityPoolAggregator,
-} from "../../Aggregators/LiquidityPoolAggregator";
+import { PoolAddressField, updatePool } from "../../Aggregators/Pool";
 import { updateUserStatsPerPool } from "../../Aggregators/UserStatsPerPool";
 import {
   loadVotingRewardData,
@@ -39,7 +36,7 @@ FeesVotingReward.ClaimRewards.handler(async ({ event, context }) => {
 
   await Promise.all([
     result.poolDiff
-      ? updateLiquidityPoolAggregator(
+      ? updatePool(
           result.poolDiff,
           loadedData.poolData.liquidityPoolAggregator,
           new Date(data.timestamp * 1000),

--- a/src/EventHandlers/VotingReward/SuperchainIncentiveVotingReward.ts
+++ b/src/EventHandlers/VotingReward/SuperchainIncentiveVotingReward.ts
@@ -1,8 +1,5 @@
 import { SuperchainIncentiveVotingReward } from "generated";
-import {
-  PoolAddressField,
-  updateLiquidityPoolAggregator,
-} from "../../Aggregators/LiquidityPoolAggregator";
+import { PoolAddressField, updatePool } from "../../Aggregators/Pool";
 import { updateUserStatsPerPool } from "../../Aggregators/UserStatsPerPool";
 import {
   loadVotingRewardData,
@@ -43,7 +40,7 @@ SuperchainIncentiveVotingReward.ClaimRewards.handler(
 
     await Promise.all([
       result.poolDiff
-        ? updateLiquidityPoolAggregator(
+        ? updatePool(
             result.poolDiff,
             loadedData.poolData.liquidityPoolAggregator,
             new Date(data.timestamp * 1000),

--- a/src/EventHandlers/VotingReward/VotingRewardSharedLogic.ts
+++ b/src/EventHandlers/VotingReward/VotingRewardSharedLogic.ts
@@ -1,15 +1,10 @@
-import type {
-  LiquidityPoolAggregator,
-  Token,
-  UserStatsPerPool,
-  handlerContext,
-} from "generated";
+import type { Token, UserStatsPerPool, handlerContext } from "generated";
 import {
-  type LiquidityPoolAggregatorDiff,
   PoolAddressField,
+  type PoolDiff,
   findPoolByField,
   loadPoolData,
-} from "../../Aggregators/LiquidityPoolAggregator";
+} from "../../Aggregators/Pool";
 import {
   type UserStatsPerPoolDiff,
   loadOrCreateUserData,
@@ -21,6 +16,7 @@ import {
   hasContractBytecode,
   roundBlockToInterval,
 } from "../../Effects/Index";
+import type { Pool } from "../../EntityTypes";
 import { calculateTokenAmountUSD } from "../../Helpers";
 import { refreshTokenPrice } from "../../PriceOracle";
 
@@ -38,7 +34,7 @@ export interface VotingRewardClaimRewardsData extends VotingRewardEventData {
 }
 
 export interface VotingRewardClaimRewardsResult {
-  poolDiff: Partial<LiquidityPoolAggregatorDiff>;
+  poolDiff: Partial<PoolDiff>;
   userDiff: Partial<UserStatsPerPoolDiff>;
 }
 
@@ -198,8 +194,8 @@ export async function loadVotingRewardData(
   handlerName: string,
   field: PoolAddressField,
 ): Promise<{
-  pool?: LiquidityPoolAggregator;
-  poolData?: { liquidityPoolAggregator: LiquidityPoolAggregator };
+  pool?: Pool;
+  poolData?: { liquidityPoolAggregator: Pool };
   userData: UserStatsPerPool;
 } | null> {
   const votingRewardAddress = data.votingRewardAddress;

--- a/src/Helpers.ts
+++ b/src/Helpers.ts
@@ -3,9 +3,10 @@ import {
   TickMath,
   maxLiquidityForAmounts,
 } from "@uniswap/v3-sdk";
-import type { LiquidityPoolAggregator, Token, handlerContext } from "generated";
+import type { Token, handlerContext } from "generated";
 import JSBI from "jsbi";
 import { TEN_TO_THE_18_BI } from "./Constants";
+import type { Pool } from "./EntityTypes";
 import { multiplyBase1e18 } from "./Maths";
 
 /**
@@ -329,9 +330,9 @@ export function concentratedLiquidityToUSD(
  */
 export function computeNonCLStakedUSD(
   stakeAmount: bigint,
-  poolEntity: LiquidityPoolAggregator,
+  poolEntity: Pool,
   poolData: {
-    liquidityPoolAggregator: LiquidityPoolAggregator;
+    liquidityPoolAggregator: Pool;
     token0Instance?: Token;
     token1Instance?: Token;
   },

--- a/src/Snapshots/Index.ts
+++ b/src/Snapshots/Index.ts
@@ -6,9 +6,9 @@ export {
   type SnapshotForPersist,
 } from "./Shared";
 export {
-  createLiquidityPoolAggregatorSnapshot,
-  setLiquidityPoolAggregatorSnapshot,
-} from "./LiquidityPoolAggregatorSnapshot";
+  createPoolSnapshot,
+  setPoolSnapshot,
+} from "./PoolSnapshot";
 export {
   createUserStatsPerPoolSnapshot,
   setUserStatsPerPoolSnapshot,

--- a/src/Snapshots/PoolSnapshot.ts
+++ b/src/Snapshots/PoolSnapshot.ts
@@ -1,10 +1,7 @@
-import type {
-  LiquidityPoolAggregator,
-  LiquidityPoolAggregatorSnapshot,
-  handlerContext,
-} from "generated";
+import type { handlerContext } from "generated";
 
-import { LiquidityPoolAggregatorSnapshotId } from "../Constants";
+import { PoolSnapshotId } from "../Constants";
+import type { Pool, PoolSnapshot } from "../EntityTypes";
 import {
   type SnapshotForPersist,
   SnapshotType,
@@ -13,18 +10,18 @@ import {
 } from "./Shared";
 
 /**
- * Creates an epoch-aligned snapshot of LiquidityPoolAggregator (no persistence).
- * @param entity - LiquidityPoolAggregator to snapshot
+ * Creates an epoch-aligned snapshot of Pool (no persistence).
+ * @param entity - Pool to snapshot
  * @param timestamp - Timestamp used to compute snapshot epoch
- * @returns Epoch-aligned LiquidityPoolAggregatorSnapshot
+ * @returns Epoch-aligned PoolSnapshot
  */
-export function createLiquidityPoolAggregatorSnapshot(
-  entity: LiquidityPoolAggregator,
+export function createPoolSnapshot(
+  entity: Pool,
   timestamp: Date,
-): LiquidityPoolAggregatorSnapshot {
+): PoolSnapshot {
   const epoch = getSnapshotEpoch(timestamp);
 
-  const snapshotId = LiquidityPoolAggregatorSnapshotId(
+  const snapshotId = PoolSnapshotId(
     entity.chainId,
     entity.poolAddress,
     epoch.getTime(),
@@ -109,20 +106,20 @@ export function createLiquidityPoolAggregatorSnapshot(
 }
 
 /**
- * Creates and persists an epoch-aligned snapshot of a LiquidityPoolAggregator.
- * @param entity - LiquidityPoolAggregator to snapshot
+ * Creates and persists an epoch-aligned snapshot of a Pool.
+ * @param entity - Pool to snapshot
  * @param timestamp - Timestamp used to compute snapshot epoch
  * @param context - Handler context
  * @returns void
  */
-export function setLiquidityPoolAggregatorSnapshot(
-  entity: LiquidityPoolAggregator,
+export function setPoolSnapshot(
+  entity: Pool,
   timestamp: Date,
   context: handlerContext,
 ): void {
   const snapshotForPersist: SnapshotForPersist = {
-    type: SnapshotType.LiquidityPoolAggregator,
-    snapshot: createLiquidityPoolAggregatorSnapshot(entity, timestamp),
+    type: SnapshotType.Pool,
+    snapshot: createPoolSnapshot(entity, timestamp),
   };
   persistSnapshot(snapshotForPersist, context);
 }

--- a/src/Snapshots/Shared.ts
+++ b/src/Snapshots/Shared.ts
@@ -1,6 +1,5 @@
 import type {
   ALM_LP_WrapperSnapshot,
-  LiquidityPoolAggregatorSnapshot,
   NonFungiblePositionSnapshot,
   TokenPriceSnapshot,
   UserStatsPerPoolSnapshot,
@@ -10,9 +9,10 @@ import type {
 } from "generated";
 
 import { SNAPSHOT_INTERVAL_IN_MS } from "../Constants";
+import type { PoolSnapshot } from "../EntityTypes";
 
 export enum SnapshotType {
-  LiquidityPoolAggregator = "LiquidityPoolAggregator",
+  Pool = "Pool",
   UserStatsPerPool = "UserStatsPerPool",
   NonFungiblePosition = "NonFungiblePosition",
   ALMLPWrapper = "ALMLPWrapper",
@@ -28,8 +28,8 @@ export enum SnapshotType {
  */
 export type SnapshotForPersist =
   | {
-      type: SnapshotType.LiquidityPoolAggregator;
-      snapshot: LiquidityPoolAggregatorSnapshot;
+      type: SnapshotType.Pool;
+      snapshot: PoolSnapshot;
     }
   | { type: SnapshotType.UserStatsPerPool; snapshot: UserStatsPerPoolSnapshot }
   | {
@@ -84,8 +84,8 @@ export function persistSnapshot(
   context: handlerContext,
 ): void {
   switch (item.type) {
-    case SnapshotType.LiquidityPoolAggregator:
-      context.LiquidityPoolAggregatorSnapshot.set(item.snapshot);
+    case SnapshotType.Pool:
+      context.PoolSnapshot.set(item.snapshot);
       break;
     case SnapshotType.UserStatsPerPool:
       context.UserStatsPerPoolSnapshot.set(item.snapshot);

--- a/test/Aggregators/CLStakedLiquidityEdgeSanity.test.ts
+++ b/test/Aggregators/CLStakedLiquidityEdgeSanity.test.ts
@@ -15,7 +15,7 @@ import { sqrtAt } from "./common";
 /**
  * Co-located sanity test for #649: replacing `processTickCrossingsForStaked`
  * fan-out with the sparse stakedTickEdges / stakedTickEdgeNets list on
- * LiquidityPoolAggregator.
+ * Pool.
  *
  * Two assertions:
  *   (a) The edge list stays sorted + monotone under arbitrary gauge
@@ -28,7 +28,7 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
   const {
     mockToken0Data,
     mockToken1Data,
-    createMockLiquidityPoolAggregator,
+    createMockPool,
     createMockNonFungiblePosition,
     defaultNfpmAddress,
   } = setupCommon();
@@ -43,13 +43,13 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
   it("(a) stakedTickEdges stays sorted + monotone across 150 interleaved gauge Deposit/Withdraw events", async () => {
     let mockDb = MockDb.createMockDb();
 
-    const liquidityPool = createMockLiquidityPoolAggregator({
+    const liquidityPool = createMockPool({
       isCL: true,
       gaugeAddress,
       hasStakes: false,
     });
 
-    mockDb = mockDb.entities.LiquidityPoolAggregator.set(liquidityPool);
+    mockDb = mockDb.entities.Pool.set(liquidityPool);
     mockDb = mockDb.entities.Token.set(mockToken0Data as Token);
     mockDb = mockDb.entities.Token.set(mockToken1Data as Token);
 
@@ -124,7 +124,7 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
     expect(events.length).toBeGreaterThanOrEqual(150);
 
     const resultDb = await mockDb.processEvents(events);
-    const updated = resultDb.entities.LiquidityPoolAggregator.get(
+    const updated = resultDb.entities.Pool.get(
       PoolId(chainId, liquidityPool.poolAddress),
     );
 

--- a/test/Aggregators/Pool.test.ts
+++ b/test/Aggregators/Pool.test.ts
@@ -1,20 +1,21 @@
-import type { LiquidityPoolAggregator, Token, handlerContext } from "generated";
+import type { Token, handlerContext } from "generated";
 import {
   loadPoolData,
   loadPoolDataOrRootCLPool,
   updateDynamicFeePools,
-  updateLiquidityPoolAggregator,
-} from "../../src/Aggregators/LiquidityPoolAggregator";
+  updatePool,
+} from "../../src/Aggregators/Pool";
 import {
   type CHAIN_CONSTANTS,
-  LiquidityPoolAggregatorSnapshotId,
   PoolId,
+  PoolSnapshotId,
   RootPoolLeafPoolId,
   toChecksumAddress,
 } from "../../src/Constants";
 import { getSwapFee } from "../../src/Effects/SwapFee";
+import type { Pool } from "../../src/EntityTypes";
 import * as PriceOracle from "../../src/PriceOracle";
-import { setLiquidityPoolAggregatorSnapshot } from "../../src/Snapshots/LiquidityPoolAggregatorSnapshot";
+import { setPoolSnapshot } from "../../src/Snapshots/PoolSnapshot";
 import { getSnapshotEpoch } from "../../src/Snapshots/Shared";
 import { setupCommon } from "../EventHandlers/Pool/common";
 
@@ -22,16 +23,16 @@ import { setupCommon } from "../EventHandlers/Pool/common";
 type ReadContractMethod =
   (typeof CHAIN_CONSTANTS)[10]["eth_client"]["readContract"];
 
-describe("LiquidityPoolAggregator Functions", () => {
+describe("Pool Functions", () => {
   let mockContext: Partial<handlerContext>;
-  let liquidityPoolAggregator: Partial<LiquidityPoolAggregator>;
+  let liquidityPoolAggregator: Partial<Pool>;
   let timestamp: Date;
   const blockNumber = 131536921;
-  const { createMockLiquidityPoolAggregator } = setupCommon();
+  const { createMockPool } = setupCommon();
 
   beforeEach(() => {
     mockContext = {
-      LiquidityPoolAggregatorSnapshot: {
+      PoolSnapshot: {
         set: vi.fn(),
         get: vi.fn(),
         getOrThrow: vi.fn(),
@@ -39,7 +40,7 @@ describe("LiquidityPoolAggregator Functions", () => {
         deleteUnsafe: vi.fn(),
         getWhere: vi.fn().mockResolvedValue([]),
       },
-      LiquidityPoolAggregator: {
+      Pool: {
         set: vi.fn(),
         get: vi.fn(),
         getOrThrow: vi.fn(),
@@ -100,7 +101,7 @@ describe("LiquidityPoolAggregator Functions", () => {
         return {};
       }),
     };
-    liquidityPoolAggregator = createMockLiquidityPoolAggregator({
+    liquidityPoolAggregator = createMockPool({
       id: toChecksumAddress("0x1234567890123456789012345678901234567890"),
       name: "Test Pool",
       token0_id: "token0",
@@ -151,7 +152,7 @@ describe("LiquidityPoolAggregator Functions", () => {
   describe("updateDynamicFeePools", () => {
     it("should update the pool with current dynamic fee", async () => {
       const updatedPool = await updateDynamicFeePools(
-        liquidityPoolAggregator as LiquidityPoolAggregator,
+        liquidityPoolAggregator as Pool,
         mockContext as handlerContext,
         10,
         blockNumber,
@@ -165,7 +166,7 @@ describe("LiquidityPoolAggregator Functions", () => {
       const poolNoFactory = {
         ...liquidityPoolAggregator,
         factoryAddress: "",
-      } as LiquidityPoolAggregator;
+      } as Pool;
 
       const updatedPool = await updateDynamicFeePools(
         poolNoFactory,
@@ -191,7 +192,7 @@ describe("LiquidityPoolAggregator Functions", () => {
 
       // Should complete without throwing and skip update
       await updateDynamicFeePools(
-        liquidityPoolAggregator as LiquidityPoolAggregator,
+        liquidityPoolAggregator as Pool,
         mockContext as handlerContext,
         10,
         blockNumber,
@@ -220,7 +221,7 @@ describe("LiquidityPoolAggregator Functions", () => {
       const effectMock = vi.mocked(mockContext.effect ?? fallbackEffect);
 
       const updatedPool = await updateDynamicFeePools(
-        liquidityPoolAggregator as LiquidityPoolAggregator,
+        liquidityPoolAggregator as Pool,
         mockContext as handlerContext,
         8453,
         blockNumber,
@@ -233,17 +234,15 @@ describe("LiquidityPoolAggregator Functions", () => {
 
   describe("Snapshot Creation", () => {
     beforeEach(() => {
-      setLiquidityPoolAggregatorSnapshot(
-        liquidityPoolAggregator as LiquidityPoolAggregator,
+      setPoolSnapshot(
+        liquidityPoolAggregator as Pool,
         timestamp,
         mockContext as handlerContext,
       );
     });
 
     it("should create a snapshot of the liquidity pool aggregator", () => {
-      const mockSet = vi.mocked(
-        mockContext.LiquidityPoolAggregatorSnapshot?.set,
-      );
+      const mockSet = vi.mocked(mockContext.PoolSnapshot?.set);
       expect(mockSet).toHaveBeenCalledTimes(1);
       const snapshot = mockSet?.mock.calls[0]?.[0];
       expect(snapshot).toBeDefined();
@@ -253,7 +252,7 @@ describe("LiquidityPoolAggregator Functions", () => {
         throw new Error("test setup: chainId and poolAddress must be set");
       }
       expect(snapshot?.id).toBe(
-        LiquidityPoolAggregatorSnapshotId(
+        PoolSnapshotId(
           chainId,
           poolAddress,
           getSnapshotEpoch(timestamp).getTime(),
@@ -263,14 +262,14 @@ describe("LiquidityPoolAggregator Functions", () => {
     });
   });
 
-  describe("updateLiquidityPoolAggregator", () => {
+  describe("updatePool", () => {
     it("should overwrite totalLiquidityUSD when currentTotalLiquidityUSD is provided", async () => {
-      await updateLiquidityPoolAggregator(
+      await updatePool(
         {
           currentTotalLiquidityUSD: 777n,
         },
         {
-          ...(liquidityPoolAggregator as LiquidityPoolAggregator),
+          ...(liquidityPoolAggregator as Pool),
           totalLiquidityUSD: 100n,
         },
         timestamp,
@@ -279,19 +278,19 @@ describe("LiquidityPoolAggregator Functions", () => {
         blockNumber,
       );
 
-      const poolStore = mockContext.LiquidityPoolAggregator;
+      const poolStore = mockContext.Pool;
       if (!poolStore) {
-        throw new Error("test setup: LiquidityPoolAggregator store must exist");
+        throw new Error("test setup: Pool store must exist");
       }
       const setCalls = vi.mocked(poolStore.set).mock.calls;
       expect(setCalls.at(-1)?.[0]?.totalLiquidityUSD).toBe(777n);
     });
 
     it("should preserve totalLiquidityUSD when no overwrite is provided", async () => {
-      await updateLiquidityPoolAggregator(
+      await updatePool(
         {},
         {
-          ...(liquidityPoolAggregator as LiquidityPoolAggregator),
+          ...(liquidityPoolAggregator as Pool),
           totalLiquidityUSD: 100n,
         },
         timestamp,
@@ -300,9 +299,9 @@ describe("LiquidityPoolAggregator Functions", () => {
         blockNumber,
       );
 
-      const poolStore = mockContext.LiquidityPoolAggregator;
+      const poolStore = mockContext.Pool;
       if (!poolStore) {
-        throw new Error("test setup: LiquidityPoolAggregator store must exist");
+        throw new Error("test setup: Pool store must exist");
       }
       const setCalls = vi.mocked(poolStore.set).mock.calls;
       expect(setCalls.at(-1)?.[0]?.totalLiquidityUSD).toBe(100n);
@@ -314,10 +313,10 @@ describe("LiquidityPoolAggregator Functions", () => {
     // without waiting for the next swap.
     describe("liquidityInRange (issue #703)", () => {
       it("applies incrementalLiquidityInRange on top of current value", async () => {
-        await updateLiquidityPoolAggregator(
+        await updatePool(
           { incrementalLiquidityInRange: 1_000_000n },
           {
-            ...(liquidityPoolAggregator as LiquidityPoolAggregator),
+            ...(liquidityPoolAggregator as Pool),
             liquidityInRange: 5_000_000n,
           },
           timestamp,
@@ -326,25 +325,23 @@ describe("LiquidityPoolAggregator Functions", () => {
           blockNumber,
         );
 
-        const poolStore = mockContext.LiquidityPoolAggregator;
+        const poolStore = mockContext.Pool;
         if (!poolStore) {
-          throw new Error(
-            "test setup: LiquidityPoolAggregator store must exist",
-          );
+          throw new Error("test setup: Pool store must exist");
         }
         const setCalls = vi.mocked(poolStore.set).mock.calls;
-        const updated = setCalls.at(-1)?.[0] as LiquidityPoolAggregator;
+        const updated = setCalls.at(-1)?.[0] as Pool;
         expect(updated.liquidityInRange).toBe(6_000_000n);
       });
 
       it("absolute liquidityInRange (Swap authoritative reset) wins over incrementalLiquidityInRange", async () => {
-        await updateLiquidityPoolAggregator(
+        await updatePool(
           {
             liquidityInRange: 42n,
             incrementalLiquidityInRange: 1_000_000n,
           },
           {
-            ...(liquidityPoolAggregator as LiquidityPoolAggregator),
+            ...(liquidityPoolAggregator as Pool),
             liquidityInRange: 5_000_000n,
           },
           timestamp,
@@ -353,22 +350,20 @@ describe("LiquidityPoolAggregator Functions", () => {
           blockNumber,
         );
 
-        const poolStore = mockContext.LiquidityPoolAggregator;
+        const poolStore = mockContext.Pool;
         if (!poolStore) {
-          throw new Error(
-            "test setup: LiquidityPoolAggregator store must exist",
-          );
+          throw new Error("test setup: Pool store must exist");
         }
         const setCalls = vi.mocked(poolStore.set).mock.calls;
-        const updated = setCalls.at(-1)?.[0] as LiquidityPoolAggregator;
+        const updated = setCalls.at(-1)?.[0] as Pool;
         expect(updated.liquidityInRange).toBe(42n);
       });
 
       it("preserves current liquidityInRange when diff supplies neither field", async () => {
-        await updateLiquidityPoolAggregator(
+        await updatePool(
           {},
           {
-            ...(liquidityPoolAggregator as LiquidityPoolAggregator),
+            ...(liquidityPoolAggregator as Pool),
             liquidityInRange: 5_000_000n,
           },
           timestamp,
@@ -377,22 +372,20 @@ describe("LiquidityPoolAggregator Functions", () => {
           blockNumber,
         );
 
-        const poolStore = mockContext.LiquidityPoolAggregator;
+        const poolStore = mockContext.Pool;
         if (!poolStore) {
-          throw new Error(
-            "test setup: LiquidityPoolAggregator store must exist",
-          );
+          throw new Error("test setup: Pool store must exist");
         }
         const setCalls = vi.mocked(poolStore.set).mock.calls;
-        const updated = setCalls.at(-1)?.[0] as LiquidityPoolAggregator;
+        const updated = setCalls.at(-1)?.[0] as Pool;
         expect(updated.liquidityInRange).toBe(5_000_000n);
       });
 
       it("decrements via negative incrementalLiquidityInRange (Burn semantics)", async () => {
-        await updateLiquidityPoolAggregator(
+        await updatePool(
           { incrementalLiquidityInRange: -700_000n },
           {
-            ...(liquidityPoolAggregator as LiquidityPoolAggregator),
+            ...(liquidityPoolAggregator as Pool),
             liquidityInRange: 5_000_000n,
           },
           timestamp,
@@ -401,14 +394,12 @@ describe("LiquidityPoolAggregator Functions", () => {
           blockNumber,
         );
 
-        const poolStore = mockContext.LiquidityPoolAggregator;
+        const poolStore = mockContext.Pool;
         if (!poolStore) {
-          throw new Error(
-            "test setup: LiquidityPoolAggregator store must exist",
-          );
+          throw new Error("test setup: Pool store must exist");
         }
         const setCalls = vi.mocked(poolStore.set).mock.calls;
-        const updated = setCalls.at(-1)?.[0] as LiquidityPoolAggregator;
+        const updated = setCalls.at(-1)?.[0] as Pool;
         expect(updated.liquidityInRange).toBe(4_300_000n);
       });
     });
@@ -417,17 +408,17 @@ describe("LiquidityPoolAggregator Functions", () => {
       // Simulates the NFPMCommonLogic path where the edge list becomes empty
       // after a full unstake: the producer passes `hasStakes: undefined` (see
       // src/EventHandlers/NFPM/NFPMCommonLogic.ts:147, `stakedTickEdges.length > 0 ? true : undefined`).
-      // The monotonic-latch merge at LiquidityPoolAggregator.ts:390
+      // The monotonic-latch merge at Pool.ts:390
       // (`current.hasStakes || (diff.hasStakes ?? false)`) must keep the
       // prior `true` value regardless of the empty edge list.
-      await updateLiquidityPoolAggregator(
+      await updatePool(
         {
           hasStakes: undefined,
           stakedTickEdges: [],
           stakedTickEdgeNets: [],
         },
         {
-          ...(liquidityPoolAggregator as LiquidityPoolAggregator),
+          ...(liquidityPoolAggregator as Pool),
           hasStakes: true,
           stakedTickEdges: [100n, 200n],
           stakedTickEdgeNets: [500n, -500n],
@@ -438,12 +429,12 @@ describe("LiquidityPoolAggregator Functions", () => {
         blockNumber,
       );
 
-      const poolStore = mockContext.LiquidityPoolAggregator;
+      const poolStore = mockContext.Pool;
       if (!poolStore) {
-        throw new Error("test setup: LiquidityPoolAggregator store must exist");
+        throw new Error("test setup: Pool store must exist");
       }
       const setCalls = vi.mocked(poolStore.set).mock.calls;
-      const updated = setCalls.at(-1)?.[0] as LiquidityPoolAggregator;
+      const updated = setCalls.at(-1)?.[0] as Pool;
       expect(updated.hasStakes).toBe(true);
       // Edge arrays should still be replaced (empty) since the diff provides them.
       expect(updated.stakedTickEdges).toEqual([]);
@@ -473,10 +464,10 @@ describe("LiquidityPoolAggregator Functions", () => {
         new Date(timestamp.getTime() - 2 * 60 * 60 * 1000);
 
       it("warns at snapshot epoch when stakedReserve0 is negative", async () => {
-        await updateLiquidityPoolAggregator(
+        await updatePool(
           { incrementalStakedReserve0: -100n },
           {
-            ...(liquidityPoolAggregator as LiquidityPoolAggregator),
+            ...(liquidityPoolAggregator as Pool),
             isCL: true,
             stakedReserve0: 50n,
             stakedReserve1: 1000n,
@@ -493,10 +484,10 @@ describe("LiquidityPoolAggregator Functions", () => {
       });
 
       it("warns at snapshot epoch when stakedReserve1 is negative", async () => {
-        await updateLiquidityPoolAggregator(
+        await updatePool(
           { incrementalStakedReserve1: -100n },
           {
-            ...(liquidityPoolAggregator as LiquidityPoolAggregator),
+            ...(liquidityPoolAggregator as Pool),
             isCL: true,
             stakedReserve0: 1000n,
             stakedReserve1: 50n,
@@ -513,13 +504,13 @@ describe("LiquidityPoolAggregator Functions", () => {
       });
 
       it("does not warn when staked reserves stay non-negative after the diff", async () => {
-        await updateLiquidityPoolAggregator(
+        await updatePool(
           {
             incrementalStakedReserve0: -50n,
             incrementalStakedReserve1: -50n,
           },
           {
-            ...(liquidityPoolAggregator as LiquidityPoolAggregator),
+            ...(liquidityPoolAggregator as Pool),
             isCL: true,
             stakedReserve0: 100n,
             stakedReserve1: 100n,
@@ -536,13 +527,13 @@ describe("LiquidityPoolAggregator Functions", () => {
       });
 
       it("warns again at the next snapshot epoch while staked reserves remain negative", async () => {
-        await updateLiquidityPoolAggregator(
+        await updatePool(
           {
             incrementalStakedReserve0: -10n,
             incrementalStakedReserve1: -10n,
           },
           {
-            ...(liquidityPoolAggregator as LiquidityPoolAggregator),
+            ...(liquidityPoolAggregator as Pool),
             isCL: true,
             stakedReserve0: -100n,
             stakedReserve1: -100n,
@@ -560,13 +551,13 @@ describe("LiquidityPoolAggregator Functions", () => {
       });
 
       it("does not warn when reserves are negative but inside the same snapshot epoch (rate-limit gate)", async () => {
-        await updateLiquidityPoolAggregator(
+        await updatePool(
           {
             incrementalStakedReserve0: -10n,
             incrementalStakedReserve1: -10n,
           },
           {
-            ...(liquidityPoolAggregator as LiquidityPoolAggregator),
+            ...(liquidityPoolAggregator as Pool),
             isCL: true,
             stakedReserve0: -100n,
             stakedReserve1: -100n,
@@ -598,16 +589,16 @@ describe("LiquidityPoolAggregator Functions", () => {
         );
       };
 
-      const lastSet = (): LiquidityPoolAggregator => {
-        const setMock = vi.mocked(mockContext.LiquidityPoolAggregator?.set);
-        return setMock?.mock.lastCall?.[0] as LiquidityPoolAggregator;
+      const lastSet = (): Pool => {
+        const setMock = vi.mocked(mockContext.Pool?.set);
+        return setMock?.mock.lastCall?.[0] as Pool;
       };
 
       it("clamps reserve0 to 0n and logs guard when delta would drive it negative", async () => {
-        await updateLiquidityPoolAggregator(
+        await updatePool(
           { incrementalReserve0: -100n },
           {
-            ...(liquidityPoolAggregator as LiquidityPoolAggregator),
+            ...(liquidityPoolAggregator as Pool),
             reserve0: 50n,
             reserve1: 1000n,
             lastSnapshotTimestamp: sameEpochAsTimestamp(),
@@ -633,15 +624,15 @@ describe("LiquidityPoolAggregator Functions", () => {
         // parameter — those agree in practice (a reserve diff comes from the
         // pool's own chain) and the pool's chainId is what Hasura consumers query.
         expect(msg).toContain(
-          `chainId=${(liquidityPoolAggregator as LiquidityPoolAggregator).chainId}`,
+          `chainId=${(liquidityPoolAggregator as Pool).chainId}`,
         );
       });
 
       it("clamps reserve1 to 0n and logs guard when delta would drive it negative", async () => {
-        await updateLiquidityPoolAggregator(
+        await updatePool(
           { incrementalReserve1: -100n },
           {
-            ...(liquidityPoolAggregator as LiquidityPoolAggregator),
+            ...(liquidityPoolAggregator as Pool),
             reserve0: 1000n,
             reserve1: 50n,
             lastSnapshotTimestamp: sameEpochAsTimestamp(),
@@ -662,10 +653,10 @@ describe("LiquidityPoolAggregator Functions", () => {
       });
 
       it("does not clamp or log when reserves stay non-negative", async () => {
-        await updateLiquidityPoolAggregator(
+        await updatePool(
           { incrementalReserve0: -50n, incrementalReserve1: -50n },
           {
-            ...(liquidityPoolAggregator as LiquidityPoolAggregator),
+            ...(liquidityPoolAggregator as Pool),
             reserve0: 100n,
             reserve1: 100n,
             lastSnapshotTimestamp: sameEpochAsTimestamp(),
@@ -683,10 +674,10 @@ describe("LiquidityPoolAggregator Functions", () => {
       });
 
       it("clamps both reserves independently and logs once per field", async () => {
-        await updateLiquidityPoolAggregator(
+        await updatePool(
           { incrementalReserve0: -200n, incrementalReserve1: -200n },
           {
-            ...(liquidityPoolAggregator as LiquidityPoolAggregator),
+            ...(liquidityPoolAggregator as Pool),
             reserve0: 100n,
             reserve1: 100n,
             lastSnapshotTimestamp: sameEpochAsTimestamp(),
@@ -707,10 +698,10 @@ describe("LiquidityPoolAggregator Functions", () => {
       // clamp fires on every update that would underflow, not only at hour
       // boundaries, so a Burn-larger-than-Mint mid-epoch still gets caught.
       it("clamps mid-epoch (no snapshot boundary required)", async () => {
-        await updateLiquidityPoolAggregator(
+        await updatePool(
           { incrementalReserve0: -500n },
           {
-            ...(liquidityPoolAggregator as LiquidityPoolAggregator),
+            ...(liquidityPoolAggregator as Pool),
             reserve0: 100n,
             reserve1: 100n,
             // lastSnapshotTimestamp === timestamp → no snapshot this call.
@@ -735,14 +726,14 @@ describe("LiquidityPoolAggregator Functions", () => {
         // currentTotalLiquidityUSD comes from the producer (Burn handler) and
         // is passed through unchanged; the aggregator does not recompute it
         // from reserves. We assert the diff value lands on the entity.
-        await updateLiquidityPoolAggregator(
+        await updatePool(
           {
             incrementalReserve0: -1000n,
             incrementalReserve1: -1000n,
             currentTotalLiquidityUSD: 0n,
           },
           {
-            ...(liquidityPoolAggregator as LiquidityPoolAggregator),
+            ...(liquidityPoolAggregator as Pool),
             isCL: true,
             reserve0: 100n,
             reserve1: 100n,
@@ -788,9 +779,9 @@ describe("LiquidityPoolAggregator Functions", () => {
         totalVotesDepositedUSD: 3000n,
         incrementalTotalEmissions: 4000n,
       };
-      await updateLiquidityPoolAggregator(
+      await updatePool(
         diff,
-        liquidityPoolAggregator as LiquidityPoolAggregator,
+        liquidityPoolAggregator as Pool,
         timestamp,
         mockContext as handlerContext,
         10,
@@ -799,9 +790,8 @@ describe("LiquidityPoolAggregator Functions", () => {
     });
 
     it("should update the liquidity pool aggregator", () => {
-      const mockSet = vi.mocked(mockContext.LiquidityPoolAggregator?.set);
-      const updatedAggregator = mockSet?.mock
-        .calls[0]?.[0] as LiquidityPoolAggregator;
+      const mockSet = vi.mocked(mockContext.Pool?.set);
+      const updatedAggregator = mockSet?.mock.calls[0]?.[0] as Pool;
       expect(updatedAggregator.totalVolume0).toBe(diff.incrementalTotalVolume0);
       expect(updatedAggregator.totalVolume1).toBe(diff.incrementalTotalVolume1);
       expect(updatedAggregator.numberOfSwaps).toBe(
@@ -832,18 +822,16 @@ describe("LiquidityPoolAggregator Functions", () => {
       const effectSpy = vi.mocked(mockContext.effect);
       effectSpy.mockClear();
 
-      await updateLiquidityPoolAggregator(
+      await updatePool(
         diff,
-        liquidityPoolWithOldSnapshot as LiquidityPoolAggregator,
+        liquidityPoolWithOldSnapshot as Pool,
         currentTimestamp,
         mockContext as handlerContext,
         10,
         blockNumber,
       );
 
-      const mockSet = vi.mocked(
-        mockContext.LiquidityPoolAggregatorSnapshot?.set,
-      );
+      const mockSet = vi.mocked(mockContext.PoolSnapshot?.set);
       const snapshot = mockSet?.mock.calls[0]?.[0];
       expect(snapshot).toBeDefined();
 
@@ -872,18 +860,16 @@ describe("LiquidityPoolAggregator Functions", () => {
       const effectSpy = vi.mocked(mockContext.effect);
       effectSpy.mockClear();
 
-      await updateLiquidityPoolAggregator(
+      await updatePool(
         diff,
-        clPoolWithOldSnapshot as LiquidityPoolAggregator,
+        clPoolWithOldSnapshot as Pool,
         currentTimestamp,
         mockContext as handlerContext,
         10,
         blockNumber,
       );
 
-      const mockSet = vi.mocked(
-        mockContext.LiquidityPoolAggregatorSnapshot?.set,
-      );
+      const mockSet = vi.mocked(mockContext.PoolSnapshot?.set);
       const snapshot = mockSet?.mock.calls[0]?.[0];
       expect(snapshot).toBeDefined();
 
@@ -905,7 +891,7 @@ describe("LiquidityPoolAggregator Functions", () => {
         "0x1234567890123456789012345678901234567890",
       );
 
-      const clPool = createMockLiquidityPoolAggregator({
+      const clPool = createMockPool({
         poolAddress: poolAddr,
         chainId: 10,
         isCL: true,
@@ -960,8 +946,8 @@ describe("LiquidityPoolAggregator Functions", () => {
       const setMock = vi.fn();
       const ctx = {
         ...mockContext,
-        LiquidityPoolAggregator: {
-          ...mockContext.LiquidityPoolAggregator,
+        Pool: {
+          ...mockContext.Pool,
           set: setMock,
         },
         Token: {
@@ -974,17 +960,9 @@ describe("LiquidityPoolAggregator Functions", () => {
         },
       } as unknown as handlerContext;
 
-      await updateLiquidityPoolAggregator(
-        diff,
-        clPool,
-        currentTimestamp,
-        ctx,
-        10,
-        blockNumber,
-      );
+      await updatePool(diff, clPool, currentTimestamp, ctx, 10, blockNumber);
 
-      const updatedAggregator = setMock.mock
-        .calls[0]?.[0] as LiquidityPoolAggregator;
+      const updatedAggregator = setMock.mock.calls[0]?.[0] as Pool;
 
       // Should have computed staked USD from stakedReserve0/stakedReserve1 (not the stale 100n)
       expect(updatedAggregator.currentLiquidityStakedUSD).toBeGreaterThan(0n);
@@ -995,7 +973,7 @@ describe("LiquidityPoolAggregator Functions", () => {
       const oldTimestamp = new Date(Date.now() - 2 * 60 * 60 * 1000);
       const currentTimestamp = new Date();
 
-      const clPool = createMockLiquidityPoolAggregator({
+      const clPool = createMockPool({
         chainId: 10,
         isCL: true,
         lastSnapshotTimestamp: oldTimestamp,
@@ -1013,14 +991,7 @@ describe("LiquidityPoolAggregator Functions", () => {
         },
       } as unknown as handlerContext;
 
-      await updateLiquidityPoolAggregator(
-        diff,
-        clPool,
-        currentTimestamp,
-        ctx,
-        10,
-        blockNumber,
-      );
+      await updatePool(diff, clPool, currentTimestamp, ctx, 10, blockNumber);
 
       // getWhere should NOT have been called (skipped because staked == 0)
       expect(ctx.NonFungiblePosition.getWhere).not.toHaveBeenCalled();
@@ -1030,7 +1001,7 @@ describe("LiquidityPoolAggregator Functions", () => {
       const oldTimestamp = new Date(Date.now() - 2 * 60 * 60 * 1000);
       const currentTimestamp = new Date();
 
-      const clPool = createMockLiquidityPoolAggregator({
+      const clPool = createMockPool({
         chainId: 10,
         isCL: true,
         lastSnapshotTimestamp: oldTimestamp,
@@ -1044,8 +1015,8 @@ describe("LiquidityPoolAggregator Functions", () => {
       const setMock = vi.fn();
       const ctx = {
         ...mockContext,
-        LiquidityPoolAggregator: {
-          ...mockContext.LiquidityPoolAggregator,
+        Pool: {
+          ...mockContext.Pool,
           set: setMock,
         },
         NonFungiblePosition: {
@@ -1053,17 +1024,9 @@ describe("LiquidityPoolAggregator Functions", () => {
         },
       } as unknown as handlerContext;
 
-      await updateLiquidityPoolAggregator(
-        diff,
-        clPool,
-        currentTimestamp,
-        ctx,
-        10,
-        blockNumber,
-      );
+      await updatePool(diff, clPool, currentTimestamp, ctx, 10, blockNumber);
 
-      const updatedAggregator = setMock.mock
-        .calls[0]?.[0] as LiquidityPoolAggregator;
+      const updatedAggregator = setMock.mock.calls[0]?.[0] as Pool;
 
       // Stale USD should be cleared to 0
       expect(updatedAggregator.currentLiquidityStakedUSD).toBe(0n);
@@ -1075,7 +1038,7 @@ describe("LiquidityPoolAggregator Functions", () => {
       const oldTimestamp = new Date(Date.now() - 2 * 60 * 60 * 1000);
       const currentTimestamp = new Date();
 
-      const v2Pool = createMockLiquidityPoolAggregator({
+      const v2Pool = createMockPool({
         chainId: 10,
         isCL: false,
         lastSnapshotTimestamp: oldTimestamp,
@@ -1086,8 +1049,8 @@ describe("LiquidityPoolAggregator Functions", () => {
       const setMock = vi.fn();
       const ctx = {
         ...mockContext,
-        LiquidityPoolAggregator: {
-          ...mockContext.LiquidityPoolAggregator,
+        Pool: {
+          ...mockContext.Pool,
           set: setMock,
         },
         NonFungiblePosition: {
@@ -1095,21 +1058,13 @@ describe("LiquidityPoolAggregator Functions", () => {
         },
       } as unknown as handlerContext;
 
-      await updateLiquidityPoolAggregator(
-        diff,
-        v2Pool,
-        currentTimestamp,
-        ctx,
-        10,
-        blockNumber,
-      );
+      await updatePool(diff, v2Pool, currentTimestamp, ctx, 10, blockNumber);
 
       // getWhere should NOT have been called (non-CL pool)
       expect(ctx.NonFungiblePosition.getWhere).not.toHaveBeenCalled();
 
       // Staked USD should be preserved
-      const updatedAggregator = setMock.mock
-        .calls[0]?.[0] as LiquidityPoolAggregator;
+      const updatedAggregator = setMock.mock.calls[0]?.[0] as Pool;
       expect(updatedAggregator.currentLiquidityStakedUSD).toBe(100n);
     });
   });
@@ -1125,16 +1080,16 @@ describe("LiquidityPoolAggregator Functions", () => {
       new Date(timestamp.getTime() - 2 * 60 * 60 * 1000);
 
     it("warns at snapshot epoch when totalFeesGeneratedUSD exceeds 5% of totalVolumeUSD", async () => {
-      const pool = createMockLiquidityPoolAggregator({
+      const pool = createMockPool({
         totalVolumeUSD: 1_000n * 10n ** 18n,
         totalFeesGeneratedUSD: 0n,
         lastSnapshotTimestamp: previousEpoch(),
         lastUpdatedTimestamp: previousEpoch(),
       });
 
-      await updateLiquidityPoolAggregator(
+      await updatePool(
         { incrementalTotalFeesGeneratedUSD: 60n * 10n ** 18n },
-        pool as LiquidityPoolAggregator,
+        pool as Pool,
         timestamp,
         mockContext as handlerContext,
         10,
@@ -1150,16 +1105,16 @@ describe("LiquidityPoolAggregator Functions", () => {
     });
 
     it("does not warn when fees are below the 5% threshold", async () => {
-      const pool = createMockLiquidityPoolAggregator({
+      const pool = createMockPool({
         totalVolumeUSD: 1_000n * 10n ** 18n,
         totalFeesGeneratedUSD: 0n,
         lastSnapshotTimestamp: previousEpoch(),
         lastUpdatedTimestamp: previousEpoch(),
       });
 
-      await updateLiquidityPoolAggregator(
+      await updatePool(
         { incrementalTotalFeesGeneratedUSD: 10n * 10n ** 18n },
-        pool as LiquidityPoolAggregator,
+        pool as Pool,
         timestamp,
         mockContext as handlerContext,
         10,
@@ -1175,16 +1130,16 @@ describe("LiquidityPoolAggregator Functions", () => {
     });
 
     it("does not warn when totalVolumeUSD is zero (avoid div-by-zero noise)", async () => {
-      const pool = createMockLiquidityPoolAggregator({
+      const pool = createMockPool({
         totalVolumeUSD: 0n,
         totalFeesGeneratedUSD: 0n,
         lastSnapshotTimestamp: previousEpoch(),
         lastUpdatedTimestamp: previousEpoch(),
       });
 
-      await updateLiquidityPoolAggregator(
+      await updatePool(
         { incrementalTotalFeesGeneratedUSD: 10n * 10n ** 18n },
-        pool as LiquidityPoolAggregator,
+        pool as Pool,
         timestamp,
         mockContext as handlerContext,
         10,
@@ -1200,16 +1155,16 @@ describe("LiquidityPoolAggregator Functions", () => {
     });
 
     it("does not warn when divergent but inside the same snapshot epoch (rate-limit gate)", async () => {
-      const pool = createMockLiquidityPoolAggregator({
+      const pool = createMockPool({
         totalVolumeUSD: 1_000n * 10n ** 18n,
         totalFeesGeneratedUSD: 100n * 10n ** 18n,
         lastSnapshotTimestamp: timestamp,
         lastUpdatedTimestamp: timestamp,
       });
 
-      await updateLiquidityPoolAggregator(
+      await updatePool(
         { incrementalTotalFeesGeneratedUSD: 1n * 10n ** 18n },
-        pool as LiquidityPoolAggregator,
+        pool as Pool,
         timestamp,
         mockContext as handlerContext,
         10,
@@ -1262,11 +1217,9 @@ describe("LiquidityPoolAggregator Functions", () => {
         isWhitelisted: false,
       } as Token;
 
-      const mockLiquidityPoolGet = vi.mocked(
-        mockContext.LiquidityPoolAggregator?.get,
-      );
+      const mockLiquidityPoolGet = vi.mocked(mockContext.Pool?.get);
       mockLiquidityPoolGet?.mockResolvedValue(
-        liquidityPoolAggregator as unknown as LiquidityPoolAggregator,
+        liquidityPoolAggregator as unknown as Pool,
       );
 
       const mockTokenGet = vi.mocked(mockContext.Token?.get);
@@ -1621,9 +1574,7 @@ describe("LiquidityPoolAggregator Functions", () => {
     });
 
     it("should return null when pool is not found", async () => {
-      const mockLiquidityPoolGet = vi.mocked(
-        mockContext.LiquidityPoolAggregator?.get,
-      );
+      const mockLiquidityPoolGet = vi.mocked(mockContext.Pool?.get);
       mockLiquidityPoolGet?.mockResolvedValue(undefined);
 
       const result = await loadPoolData(
@@ -1696,7 +1647,7 @@ describe("LiquidityPoolAggregator Functions", () => {
     });
 
     it("should return pool data directly when pool exists", async () => {
-      const rootPool = createMockLiquidityPoolAggregator({
+      const rootPool = createMockPool({
         id: rootPoolId,
         chainId: chainId,
         token0_id: "token0",
@@ -1705,9 +1656,7 @@ describe("LiquidityPoolAggregator Functions", () => {
         token1_address: token1.address,
       });
 
-      const mockLiquidityPoolGet = vi.mocked(
-        mockContext.LiquidityPoolAggregator?.get,
-      );
+      const mockLiquidityPoolGet = vi.mocked(mockContext.Pool?.get);
       mockLiquidityPoolGet?.mockImplementation((address: string) => {
         if (address === rootPoolId) return Promise.resolve(rootPool);
         return Promise.resolve(undefined);
@@ -1746,7 +1695,7 @@ describe("LiquidityPoolAggregator Functions", () => {
     it("should load leaf pool data when root pool is not found but RootPool_LeafPool exists", async () => {
       const leafChainId = 252;
       const leafPoolId = PoolId(leafChainId, leafPoolAddress);
-      const leafPool = createMockLiquidityPoolAggregator({
+      const leafPool = createMockPool({
         id: leafPoolId,
         chainId: leafChainId,
         token0_id: "token0",
@@ -1768,9 +1717,7 @@ describe("LiquidityPoolAggregator Functions", () => {
         leafPoolAddress: leafPoolAddress,
       };
 
-      const mockLiquidityPoolGet = vi.mocked(
-        mockContext.LiquidityPoolAggregator?.get,
-      );
+      const mockLiquidityPoolGet = vi.mocked(mockContext.Pool?.get);
       mockLiquidityPoolGet?.mockImplementation((address: string) => {
         if (address === rootPoolId) return Promise.resolve(undefined);
         if (address === leafPoolId) return Promise.resolve(leafPool);
@@ -1819,7 +1766,7 @@ describe("LiquidityPoolAggregator Functions", () => {
         errorMessages?.some(
           (msg) =>
             typeof msg === "string" &&
-            msg.includes(`LiquidityPoolAggregator ${rootPoolId} not found`),
+            msg.includes(`Pool ${rootPoolId} not found`),
         ),
       ).toBe(false);
     });
@@ -1827,7 +1774,7 @@ describe("LiquidityPoolAggregator Functions", () => {
     it("should not forward blockNumber/blockTimestamp to leaf chain loadPoolData (cross-chain fix)", async () => {
       const leafChainId = 252;
       const leafPoolId = PoolId(leafChainId, leafPoolAddress);
-      const leafPool = createMockLiquidityPoolAggregator({
+      const leafPool = createMockPool({
         id: leafPoolId,
         chainId: leafChainId,
         token0_id: "token0",
@@ -1849,9 +1796,7 @@ describe("LiquidityPoolAggregator Functions", () => {
         leafPoolAddress: leafPoolAddress,
       };
 
-      const mockLiquidityPoolGet = vi.mocked(
-        mockContext.LiquidityPoolAggregator?.get,
-      );
+      const mockLiquidityPoolGet = vi.mocked(mockContext.Pool?.get);
       mockLiquidityPoolGet?.mockImplementation((address: string) => {
         if (address === leafPoolId) return Promise.resolve(leafPool);
         return Promise.resolve(undefined);
@@ -1891,9 +1836,7 @@ describe("LiquidityPoolAggregator Functions", () => {
     });
 
     it("should return MAPPING_NOT_FOUND when root pool not found and no RootPool_LeafPool exists", async () => {
-      const mockLiquidityPoolGet = vi.mocked(
-        mockContext.LiquidityPoolAggregator?.get,
-      );
+      const mockLiquidityPoolGet = vi.mocked(mockContext.Pool?.get);
       mockLiquidityPoolGet?.mockResolvedValue(undefined);
 
       const mockRootPoolLeafPoolGetWhere = vi.mocked(
@@ -1923,9 +1866,7 @@ describe("LiquidityPoolAggregator Functions", () => {
         errorMessages?.some(
           (msg) =>
             typeof msg === "string" &&
-            msg.includes(
-              `LiquidityPoolAggregator ${rootPoolId} not found on chain ${chainId}`,
-            ),
+            msg.includes(`Pool ${rootPoolId} not found on chain ${chainId}`),
         ),
       ).toBe(true);
     });
@@ -1959,9 +1900,7 @@ describe("LiquidityPoolAggregator Functions", () => {
         ),
       };
 
-      const mockLiquidityPoolGet = vi.mocked(
-        mockContext.LiquidityPoolAggregator?.get,
-      );
+      const mockLiquidityPoolGet = vi.mocked(mockContext.Pool?.get);
       mockLiquidityPoolGet?.mockResolvedValue(undefined);
 
       const mockRootPoolLeafPoolGetWhere = vi.mocked(
@@ -2011,9 +1950,7 @@ describe("LiquidityPoolAggregator Functions", () => {
         leafPoolAddress: leafPoolAddress,
       };
 
-      const mockLiquidityPoolGet = vi.mocked(
-        mockContext.LiquidityPoolAggregator?.get,
-      );
+      const mockLiquidityPoolGet = vi.mocked(mockContext.Pool?.get);
       mockLiquidityPoolGet?.mockResolvedValue(undefined);
 
       const mockRootPoolLeafPoolGetWhere = vi.mocked(
@@ -2054,9 +1991,7 @@ describe("LiquidityPoolAggregator Functions", () => {
       const mockRootPoolLeafPoolGetWhere = vi.mocked(
         mockContext.RootPool_LeafPool?.getWhere,
       );
-      const mockLiquidityPoolGet = vi.mocked(
-        mockContext.LiquidityPoolAggregator?.get,
-      );
+      const mockLiquidityPoolGet = vi.mocked(mockContext.Pool?.get);
       const mockErrorLog = vi.mocked(mockContext.log?.error);
       const mockWarnLog = vi.mocked(mockContext.log?.warn);
 

--- a/test/Aggregators/UserStatsPerPoolCLSnapshotUSD.test.ts
+++ b/test/Aggregators/UserStatsPerPoolCLSnapshotUSD.test.ts
@@ -53,7 +53,7 @@ describe("UserStatsPerPool CL snapshot USD via direct gets", () => {
     isCL?: boolean;
   }) {
     const isCL = opts.isCL ?? true;
-    const poolEntity = common.createMockLiquidityPoolAggregator({
+    const poolEntity = common.createMockPool({
       poolAddress: mockPoolAddress,
       chainId: mockChainId,
       isCL,
@@ -85,7 +85,7 @@ describe("UserStatsPerPool CL snapshot USD via direct gets", () => {
     return common.createMockContext({
       UserStatsPerPool: { set: async () => {} },
       UserStatsPerPoolSnapshot: { set: vi.fn() },
-      LiquidityPoolAggregator: {
+      Pool: {
         get: async (id: string) => (id === poolId ? poolEntity : undefined),
       },
       Token: {

--- a/test/Aggregators/Users.test.ts
+++ b/test/Aggregators/Users.test.ts
@@ -497,7 +497,7 @@ describe("UserStatsPerPool Aggregator", () => {
       const {
         createMockUserStatsPerPool,
         createMockNonFungiblePosition,
-        createMockLiquidityPoolAggregator,
+        createMockPool,
       } = setupCommon();
       const oldTimestamp = new Date(Date.now() - 2 * 60 * 60 * 1000);
       const currentTimestamp = new Date();
@@ -516,7 +516,7 @@ describe("UserStatsPerPool Aggregator", () => {
         lastSnapshotTimestamp: oldTimestamp, // Triggers snapshot
       });
 
-      const mockLPA = createMockLiquidityPoolAggregator({
+      const mockLPA = createMockPool({
         poolAddress: poolAddr,
         chainId: mockChainId,
         isCL: true,
@@ -579,7 +579,7 @@ describe("UserStatsPerPool Aggregator", () => {
             savedUserStats = entity;
           },
         },
-        LiquidityPoolAggregator: {
+        Pool: {
           get: vi.fn().mockResolvedValue(mockLPA),
         },
         Token: {
@@ -634,7 +634,7 @@ describe("UserStatsPerPool Aggregator", () => {
 
       const snapshotCtx = {
         ...mockContext,
-        LiquidityPoolAggregator: {
+        Pool: {
           get: vi.fn(),
         },
         NonFungiblePosition: {
@@ -650,7 +650,7 @@ describe("UserStatsPerPool Aggregator", () => {
       );
 
       // LPA should not be loaded (skipped because staked == 0)
-      expect(snapshotCtx.LiquidityPoolAggregator.get).not.toHaveBeenCalled();
+      expect(snapshotCtx.Pool.get).not.toHaveBeenCalled();
     });
 
     it("should zero CL staked USD at snapshot time when staked liquidity is 0 but USD is stale", async () => {
@@ -676,7 +676,7 @@ describe("UserStatsPerPool Aggregator", () => {
             savedUserStats = entity;
           },
         },
-        LiquidityPoolAggregator: {
+        Pool: {
           get: vi.fn(),
         },
         NonFungiblePosition: {
@@ -694,12 +694,11 @@ describe("UserStatsPerPool Aggregator", () => {
       // Stale USD should be cleared to 0
       expect(savedUserStats?.currentLiquidityStakedUSD).toBe(0n);
       // LPA should not be loaded (no need when stake is 0)
-      expect(snapshotCtx.LiquidityPoolAggregator.get).not.toHaveBeenCalled();
+      expect(snapshotCtx.Pool.get).not.toHaveBeenCalled();
     });
 
     it("should compute staked USD at snapshot time for non-CL pool user", async () => {
-      const { createMockUserStatsPerPool, createMockLiquidityPoolAggregator } =
-        setupCommon();
+      const { createMockUserStatsPerPool, createMockPool } = setupCommon();
       const oldTimestamp = new Date(Date.now() - 2 * 60 * 60 * 1000);
       const currentTimestamp = new Date();
 
@@ -712,7 +711,7 @@ describe("UserStatsPerPool Aggregator", () => {
         lastSnapshotTimestamp: oldTimestamp,
       });
 
-      const nonCLPool = createMockLiquidityPoolAggregator({
+      const nonCLPool = createMockPool({
         poolAddress: mockPoolAddress,
         chainId: mockChainId,
         isCL: false,
@@ -720,7 +719,7 @@ describe("UserStatsPerPool Aggregator", () => {
 
       const snapshotCtx = {
         ...mockContext,
-        LiquidityPoolAggregator: {
+        Pool: {
           get: vi.fn().mockResolvedValue(nonCLPool),
         },
         Token: {
@@ -748,7 +747,7 @@ describe("UserStatsPerPool Aggregator", () => {
     it("should compute correct non-CL staked USD from reserves and token prices at snapshot", async () => {
       const {
         createMockUserStatsPerPool,
-        createMockLiquidityPoolAggregator,
+        createMockPool,
         mockToken0Data,
         mockToken1Data,
       } = setupCommon();
@@ -764,7 +763,7 @@ describe("UserStatsPerPool Aggregator", () => {
         lastSnapshotTimestamp: oldTimestamp,
       });
 
-      const nonCLPool = createMockLiquidityPoolAggregator({
+      const nonCLPool = createMockPool({
         poolAddress: mockPoolAddress,
         chainId: mockChainId,
         isCL: false,
@@ -786,7 +785,7 @@ describe("UserStatsPerPool Aggregator", () => {
 
       const snapshotCtx = {
         ...mockContext,
-        LiquidityPoolAggregator: {
+        Pool: {
           get: vi.fn().mockResolvedValue(nonCLPool),
         },
         Token: {
@@ -828,7 +827,7 @@ describe("UserStatsPerPool Aggregator", () => {
 
       const snapshotCtx = {
         ...mockContext,
-        LiquidityPoolAggregator: {
+        Pool: {
           get: vi.fn().mockResolvedValue(undefined), // LPA not found
         },
         NonFungiblePosition: {
@@ -850,8 +849,7 @@ describe("UserStatsPerPool Aggregator", () => {
     });
 
     it("should NOT compute staked USD at snapshot time when CL pool has sqrtPriceX96 == 0", async () => {
-      const { createMockUserStatsPerPool, createMockLiquidityPoolAggregator } =
-        setupCommon();
+      const { createMockUserStatsPerPool, createMockPool } = setupCommon();
       const oldTimestamp = new Date(Date.now() - 2 * 60 * 60 * 1000);
       const currentTimestamp = new Date();
 
@@ -864,7 +862,7 @@ describe("UserStatsPerPool Aggregator", () => {
         lastSnapshotTimestamp: oldTimestamp,
       });
 
-      const clPoolNoPrice = createMockLiquidityPoolAggregator({
+      const clPoolNoPrice = createMockPool({
         poolAddress: mockPoolAddress,
         chainId: mockChainId,
         isCL: true,
@@ -873,7 +871,7 @@ describe("UserStatsPerPool Aggregator", () => {
 
       const snapshotCtx = {
         ...mockContext,
-        LiquidityPoolAggregator: {
+        Pool: {
           get: vi.fn().mockResolvedValue(clPoolNoPrice),
         },
         Token: {

--- a/test/EventHandlers/ALM/DeployFactoryV1.test.ts
+++ b/test/EventHandlers/ALM/DeployFactoryV1.test.ts
@@ -8,10 +8,7 @@ import {
   NonFungiblePositionId,
   toChecksumAddress,
 } from "../../../src/Constants";
-import {
-  extendMockDbWithGetWhere,
-  setupLiquidityPoolAggregator,
-} from "../../testHelpers";
+import { extendMockDbWithGetWhere, setupPool } from "../../testHelpers";
 import { setupCommon } from "../Pool/common";
 
 describe("ALMDeployFactoryV1 StrategyCreated Event", () => {
@@ -84,11 +81,7 @@ describe("ALMDeployFactoryV1 StrategyCreated Event", () => {
       };
 
       mockDb = mockDb.entities.NonFungiblePosition.set(mockNFPM);
-      mockDb = setupLiquidityPoolAggregator(
-        mockDb,
-        mockLiquidityPoolData,
-        poolAddress,
-      );
+      mockDb = setupPool(mockDb, mockLiquidityPoolData, poolAddress);
 
       // Track entities for getWhere query
       const storedNFPMs = [mockNFPM];
@@ -307,11 +300,7 @@ describe("ALMDeployFactoryV1 StrategyCreated Event", () => {
 
       mockDb = mockDb.entities.NonFungiblePosition.set(matchingNFPM);
       mockDb = mockDb.entities.NonFungiblePosition.set(nonMatchingNFPM);
-      mockDb = setupLiquidityPoolAggregator(
-        mockDb,
-        mockLiquidityPoolData,
-        poolAddress,
-      );
+      mockDb = setupPool(mockDb, mockLiquidityPoolData, poolAddress);
 
       const storedNFPMs = [matchingNFPM, nonMatchingNFPM];
 
@@ -402,11 +391,7 @@ describe("ALMDeployFactoryV1 StrategyCreated Event", () => {
 
       mockDb = mockDb.entities.NonFungiblePosition.set(matchingNFPM1);
       mockDb = mockDb.entities.NonFungiblePosition.set(matchingNFPM2);
-      mockDb = setupLiquidityPoolAggregator(
-        mockDb,
-        mockLiquidityPoolData,
-        poolAddress,
-      );
+      mockDb = setupPool(mockDb, mockLiquidityPoolData, poolAddress);
 
       const storedNFPMs = [matchingNFPM1, matchingNFPM2];
 

--- a/test/EventHandlers/ALM/DeployFactoryV2.test.ts
+++ b/test/EventHandlers/ALM/DeployFactoryV2.test.ts
@@ -8,10 +8,7 @@ import {
   NonFungiblePositionId,
   toChecksumAddress,
 } from "../../../src/Constants";
-import {
-  extendMockDbWithGetWhere,
-  setupLiquidityPoolAggregator,
-} from "../../testHelpers";
+import { extendMockDbWithGetWhere, setupPool } from "../../testHelpers";
 import { setupCommon } from "../Pool/common";
 
 describe("ALMDeployFactoryV2 StrategyCreated Event", () => {
@@ -76,11 +73,7 @@ describe("ALMDeployFactoryV2 StrategyCreated Event", () => {
       };
 
       mockDb = mockDb.entities.NonFungiblePosition.set(mockNFPM);
-      mockDb = setupLiquidityPoolAggregator(
-        mockDb,
-        mockLiquidityPoolData,
-        poolAddress,
-      );
+      mockDb = setupPool(mockDb, mockLiquidityPoolData, poolAddress);
 
       // Pre-populate with TotalSupplyLimitUpdated event
       const totalSupplyEventId = ALMLPWrapperId(chainId, lpWrapperAddress);
@@ -342,11 +335,7 @@ describe("ALMDeployFactoryV2 StrategyCreated Event", () => {
       mockDb = mockDb.entities.NonFungiblePosition.set(matchingNFPM);
       mockDb = mockDb.entities.NonFungiblePosition.set(nonMatchingNFPM1);
       mockDb = mockDb.entities.NonFungiblePosition.set(nonMatchingNFPM2);
-      mockDb = setupLiquidityPoolAggregator(
-        mockDb,
-        mockLiquidityPoolData,
-        poolAddress,
-      );
+      mockDb = setupPool(mockDb, mockLiquidityPoolData, poolAddress);
 
       // Pre-populate with TotalSupplyLimitUpdated event
       const totalSupplyEventId = ALMLPWrapperId(chainId, lpWrapperAddress);
@@ -758,11 +747,7 @@ describe("ALMDeployFactoryV2 StrategyCreated Event", () => {
 
       mockDb = mockDb.entities.NonFungiblePosition.set(matchingNFPM1);
       mockDb = mockDb.entities.NonFungiblePosition.set(matchingNFPM2);
-      mockDb = setupLiquidityPoolAggregator(
-        mockDb,
-        mockLiquidityPoolData,
-        poolAddress,
-      );
+      mockDb = setupPool(mockDb, mockLiquidityPoolData, poolAddress);
 
       // Pre-populate with TotalSupplyLimitUpdated event
       const totalSupplyEventId = ALMLPWrapperId(chainId, lpWrapperAddress);

--- a/test/EventHandlers/ALM/LPWrapperLogic.test.ts
+++ b/test/EventHandlers/ALM/LPWrapperLogic.test.ts
@@ -63,17 +63,17 @@ describe("LPWrapperLogic", () => {
   const mockSqrtPriceX96 = 79228162514264337593543950336n; // sqrt(1) * 2^96
 
   let mockContext: handlerContext;
-  let mockLiquidityPoolAggregator: Mock;
+  let mockPool: Mock;
 
   beforeEach(() => {
-    mockLiquidityPoolAggregator = vi.fn().mockResolvedValue({
+    mockPool = vi.fn().mockResolvedValue({
       sqrtPriceX96: mockSqrtPriceX96,
       isCL: true,
     });
 
     mockContext = {
-      LiquidityPoolAggregator: {
-        get: mockLiquidityPoolAggregator,
+      Pool: {
+        get: mockPool,
       },
       log: {
         warn: vi.fn(),
@@ -196,8 +196,8 @@ describe("LPWrapperLogic", () => {
       // Result should be a calculated liquidity value (not the original)
       expect(result).not.toBe(wrapper.liquidity);
       expect(typeof result).toBe("bigint");
-      expect(mockLiquidityPoolAggregator).toHaveBeenCalledTimes(1);
-      expect(mockLiquidityPoolAggregator).toHaveBeenCalledWith(poolId);
+      expect(mockPool).toHaveBeenCalledTimes(1);
+      expect(mockPool).toHaveBeenCalledWith(poolId);
     });
 
     it("should return current liquidity if pool entity is not found", async () => {
@@ -212,7 +212,7 @@ describe("LPWrapperLogic", () => {
       const updatedAmount1 = 300n * 10n ** 6n;
 
       // Mock pool entity not found
-      mockLiquidityPoolAggregator.mockResolvedValue(null);
+      mockPool.mockResolvedValue(null);
 
       const result = await calculateLiquidityFromAmounts(
         wrapper,
@@ -228,7 +228,7 @@ describe("LPWrapperLogic", () => {
       // Should return current liquidity
       expect(result).toBe(wrapper.liquidity);
       expect(vi.mocked(mockContext.log.error)).toHaveBeenCalledTimes(1);
-      expect(mockLiquidityPoolAggregator).toHaveBeenCalledTimes(1);
+      expect(mockPool).toHaveBeenCalledTimes(1);
     });
 
     it("should return current liquidity if pool entity fetch throws error", async () => {
@@ -243,9 +243,7 @@ describe("LPWrapperLogic", () => {
       const updatedAmount1 = 300n * 10n ** 6n;
 
       // Mock pool entity fetch throws error
-      mockLiquidityPoolAggregator.mockRejectedValue(
-        new Error("Failed to fetch"),
-      );
+      mockPool.mockRejectedValue(new Error("Failed to fetch"));
 
       const result = await calculateLiquidityFromAmounts(
         wrapper,
@@ -275,7 +273,7 @@ describe("LPWrapperLogic", () => {
       const updatedAmount1 = 300n * 10n ** 6n;
 
       // Mock pool with undefined sqrtPriceX96
-      mockLiquidityPoolAggregator.mockResolvedValue({
+      mockPool.mockResolvedValue({
         sqrtPriceX96: undefined,
         isCL: true,
       });
@@ -311,7 +309,7 @@ describe("LPWrapperLogic", () => {
       const updatedAmount1 = 300n * 10n ** 6n;
 
       // Mock pool with sqrtPriceX96 = 0
-      mockLiquidityPoolAggregator.mockResolvedValue({
+      mockPool.mockResolvedValue({
         sqrtPriceX96: 0n,
         isCL: true,
       });
@@ -344,9 +342,7 @@ describe("LPWrapperLogic", () => {
       const updatedAmount1 = 300n * 10n ** 6n;
 
       // Throw unexpected error when fetching pool entity
-      mockLiquidityPoolAggregator.mockRejectedValue(
-        new Error("Unexpected error"),
-      );
+      mockPool.mockRejectedValue(new Error("Unexpected error"));
 
       const result = await calculateLiquidityFromAmounts(
         wrapper,
@@ -379,7 +375,7 @@ describe("LPWrapperLogic", () => {
       const updatedAmount1 = 300n * 10n ** 6n;
 
       // Mock pool entity fetch to throw error
-      mockLiquidityPoolAggregator.mockRejectedValue(new Error("Failed"));
+      mockPool.mockRejectedValue(new Error("Failed"));
 
       await calculateLiquidityFromAmounts(
         wrapper,
@@ -484,7 +480,7 @@ describe("LPWrapperLogic", () => {
         },
         UserStatsPerPoolSnapshot: { set: vi.fn() },
         ALM_LP_WrapperSnapshot: { set: vi.fn() },
-        LiquidityPoolAggregator: {
+        Pool: {
           get: vi.fn((poolAddr) => {
             if (poolAddr === poolId) {
               return Promise.resolve(mockPool);
@@ -626,7 +622,7 @@ describe("LPWrapperLogic", () => {
         },
         UserStatsPerPoolSnapshot: { set: vi.fn() },
         ALM_LP_WrapperSnapshot: { set: vi.fn() },
-        LiquidityPoolAggregator: {
+        Pool: {
           get: vi.fn((poolAddr) => {
             if (poolAddr === poolId) {
               return Promise.resolve(mockPool);
@@ -1280,7 +1276,7 @@ describe("LPWrapperLogic", () => {
         },
         UserStatsPerPoolSnapshot: { set: vi.fn() },
         ALM_LP_WrapperSnapshot: { set: vi.fn() },
-        LiquidityPoolAggregator: {
+        Pool: {
           get: vi.fn((poolAddr) => {
             if (poolAddr === poolId) {
               return Promise.resolve(mockPool);

--- a/test/EventHandlers/ALM/LPWrapperV1.test.ts
+++ b/test/EventHandlers/ALM/LPWrapperV1.test.ts
@@ -149,7 +149,7 @@ describe("ALMLPWrapperV1 Events", () => {
       expect(wrapper?.lpAmount).toBe(
         mockALMLPWrapperData.lpAmount + 1000n * TEN_TO_THE_18_BI,
       ); // 2000 + 1000 = 3000
-      // No LiquidityPoolAggregator in mockDb → sqrtPriceX96 undefined → liquidity unchanged
+      // No Pool in mockDb → sqrtPriceX96 undefined → liquidity unchanged
       expect(wrapper?.liquidity).toBe(mockALMLPWrapperData.liquidity);
       expect(wrapper?.lastUpdatedTimestamp).toEqual(new Date(1000000 * 1000));
     });
@@ -335,7 +335,7 @@ describe("ALMLPWrapperV1 Events", () => {
       const wrapper = result.entities.ALM_LP_Wrapper.get(wrapperId);
 
       expect(wrapper).toBeDefined();
-      // No LiquidityPoolAggregator in mockDb → sqrtPriceX96 undefined → liquidity unchanged
+      // No Pool in mockDb → sqrtPriceX96 undefined → liquidity unchanged
       expect(wrapper?.liquidity).toBe(mockALMLPWrapperData.liquidity);
       // lpAmount is decremented (aggregation from events)
       expect(wrapper?.lpAmount).toBe(1500n * TEN_TO_THE_18_BI); // 2000 - 500

--- a/test/EventHandlers/CLFactory.test.ts
+++ b/test/EventHandlers/CLFactory.test.ts
@@ -1,4 +1,4 @@
-import type { CLGaugeConfig, LiquidityPoolAggregator, Token } from "generated";
+import type { CLGaugeConfig, Token } from "generated";
 import type { MockInstance } from "vitest";
 import {
   CLFactory,
@@ -21,6 +21,7 @@ import {
   toChecksumAddress,
 } from "../../src/Constants";
 import { getTokensDeposited } from "../../src/Effects/Voter";
+import type { Pool } from "../../src/EntityTypes";
 import * as CLFactoryPoolCreatedLogic from "../../src/EventHandlers/CLFactory/CLFactoryPoolCreatedLogic";
 import * as PriceOracle from "../../src/PriceOracle";
 import { setupCommon } from "./Pool/common";
@@ -133,7 +134,7 @@ describe("CLFactory Events", () => {
               currentFee: mapping?.fee,
               lastUpdatedTimestamp: new Date(1000000 * 1000),
               veNFTamountStaked: 0n,
-            } as LiquidityPoolAggregator,
+            } as Pool,
           };
         },
       );
@@ -206,9 +207,7 @@ describe("CLFactory Events", () => {
     });
 
     it("should set the liquidity pool aggregator entity", () => {
-      const pool = resultDB.entities.LiquidityPoolAggregator.get(
-        PoolId(chainId, poolAddress),
-      );
+      const pool = resultDB.entities.Pool.get(PoolId(chainId, poolAddress));
       expect(pool).toBeDefined();
       expect(pool?.id).toBe(PoolId(chainId, poolAddress));
       expect(pool?.chainId).toBe(chainId);
@@ -234,9 +233,7 @@ describe("CLFactory Events", () => {
       const result = await preloadMockDb.processEvents([mockEvent]);
 
       // Verify that the handler ran (pool should be created if mapping exists)
-      const pool = result.entities.LiquidityPoolAggregator.get(
-        PoolId(chainId, poolAddress),
-      );
+      const pool = result.entities.Pool.get(PoolId(chainId, poolAddress));
 
       // Since we verified the mapping exists, the handler should have run and created the pool
       expect(pool).toBeDefined();
@@ -264,9 +261,7 @@ describe("CLFactory Events", () => {
     });
 
     it("should set baseFee and currentFee from FeeToTickSpacingMapping when mapping exists", () => {
-      const pool = resultDB.entities.LiquidityPoolAggregator.get(
-        PoolId(chainId, poolAddress),
-      );
+      const pool = resultDB.entities.Pool.get(PoolId(chainId, poolAddress));
       expect(pool?.baseFee).toBe(500n);
       expect(pool?.currentFee).toBe(500n);
     });
@@ -279,9 +274,7 @@ describe("CLFactory Events", () => {
 
       const result = await mockDbWithoutMapping.processEvents([mockEvent]);
 
-      const pool = result.entities.LiquidityPoolAggregator.get(
-        PoolId(chainId, poolAddress),
-      );
+      const pool = result.entities.Pool.get(PoolId(chainId, poolAddress));
       // When mapping doesn't exist, handler returns early and no pool is created
       expect(pool).toBeUndefined();
     });
@@ -336,9 +329,8 @@ describe("CLFactory Events", () => {
       });
 
       it("should flush pending votes when PendingVote and VeNFTState exist", async () => {
-        const { createMockLiquidityPoolAggregator, createMockVeNFTState } =
-          setupCommon();
-        const fullPool = createMockLiquidityPoolAggregator({
+        const { createMockPool, createMockVeNFTState } = setupCommon();
+        const fullPool = createMockPool({
           id: PoolId(chainId, poolAddress),
           chainId,
           token0_id: TokenId(chainId, token0Address),
@@ -422,9 +414,7 @@ describe("CLFactory Events", () => {
         );
         expect(processedPendingVote).toBeUndefined();
 
-        const leafPool = result.entities.LiquidityPoolAggregator.get(
-          PoolId(chainId, poolAddress),
-        );
+        const leafPool = result.entities.Pool.get(PoolId(chainId, poolAddress));
         expect(leafPool?.veNFTamountStaked).toBe(voteWeight);
       });
     });
@@ -560,8 +550,7 @@ describe("CLFactory Events", () => {
       }
 
       it("should flush PendingRootPoolMapping and PendingVote when processing RootPoolCreated, Voted, then CLFactory.PoolCreated (two processEvents: root chain 10, leaf chain 252)", async () => {
-        const { createMockLiquidityPoolAggregator, createMockVeNFTState } =
-          setupCommon();
+        const { createMockPool, createMockVeNFTState } = setupCommon();
         const voteTokenId = 1n;
         const voteWeight = 100n;
         const ownerAddress = toChecksumAddress(
@@ -582,7 +571,7 @@ describe("CLFactory Events", () => {
         });
 
         {
-          const fullPool = createMockLiquidityPoolAggregator({
+          const fullPool = createMockPool({
             id: PoolId(leafChainId, leafPoolAddress),
             chainId: leafChainId,
             token0_id: TokenId(leafChainId, token0Address),
@@ -656,7 +645,7 @@ describe("CLFactory Events", () => {
           );
           expect(processedPendingVote).toBeUndefined();
 
-          const leafPool = result.entities.LiquidityPoolAggregator.get(
+          const leafPool = result.entities.Pool.get(
             PoolId(leafChainId, leafPoolAddress),
           );
           expect(leafPool).toBeDefined();
@@ -672,8 +661,7 @@ describe("CLFactory Events", () => {
         const leafGaugeAddress = toChecksumAddress(
           "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
         );
-        const { createMockLiquidityPoolAggregator, createMockToken } =
-          setupCommon();
+        const { createMockPool, createMockToken } = setupCommon();
         const distAmount = 1000n * 10n ** 18n;
         const tokensDepositedMock = 500n * 10n ** 18n;
 
@@ -712,7 +700,7 @@ describe("CLFactory Events", () => {
         });
 
         {
-          const fullPool = createMockLiquidityPoolAggregator({
+          const fullPool = createMockPool({
             id: PoolId(leafChainId, leafPoolAddress),
             chainId: leafChainId,
             token0_id: TokenId(leafChainId, token0Address),
@@ -834,7 +822,7 @@ describe("CLFactory Events", () => {
             result.entities.PendingDistribution.get(pendingDistId),
           ).toBeUndefined();
 
-          const leafPool = result.entities.LiquidityPoolAggregator.get(
+          const leafPool = result.entities.Pool.get(
             PoolId(leafChainId, leafPoolAddress),
           );
           expect(leafPool).toBeDefined();
@@ -849,8 +837,7 @@ describe("CLFactory Events", () => {
         const rootPoolAddress = toChecksumAddress(
           "0xC4Cbb0ba3c902Fb4b49B3844230354d45C779F74",
         );
-        const { createMockLiquidityPoolAggregator, createMockVeNFTState } =
-          setupCommon();
+        const { createMockPool, createMockVeNFTState } = setupCommon();
         const voteWeight1 = 100n;
         const voteWeight2 = 200n;
         const tokenId1 = 1n;
@@ -863,7 +850,7 @@ describe("CLFactory Events", () => {
           "0x3333333333333333333333333333333333333333",
         );
 
-        const fullPool = createMockLiquidityPoolAggregator({
+        const fullPool = createMockPool({
           id: PoolId(chainId, poolAddress),
           chainId,
           token0_id: TokenId(chainId, token0Address),
@@ -950,9 +937,7 @@ describe("CLFactory Events", () => {
         );
         expect(rootPoolLeafPool).toBeDefined();
 
-        const leafPool = result.entities.LiquidityPoolAggregator.get(
-          PoolId(chainId, poolAddress),
-        );
+        const leafPool = result.entities.Pool.get(PoolId(chainId, poolAddress));
         expect(leafPool).toBeDefined();
         expect(leafPool?.veNFTamountStaked).toBe(voteWeight1 + voteWeight2);
       });
@@ -1215,9 +1200,7 @@ describe("CLFactory.PoolCreated ↔ CLPoolPendingInitialize buffer", () => {
 
     const resultDB = await mockDb.processEvents([event]);
 
-    const pool = resultDB.entities.LiquidityPoolAggregator.get(
-      PoolId(chainId, poolAddress),
-    );
+    const pool = resultDB.entities.Pool.get(PoolId(chainId, poolAddress));
     expect(pool).toBeDefined();
     if (!pool) return;
     expect(pool.sqrtPriceX96).toBe(sqrtPriceX96);
@@ -1282,9 +1265,7 @@ describe("CLFactory.PoolCreated ↔ CLPoolPendingInitialize buffer", () => {
 
     const resultDB = await mockDb.processEvents([event]);
 
-    const pool = resultDB.entities.LiquidityPoolAggregator.get(
-      PoolId(chainId, poolAddress),
-    );
+    const pool = resultDB.entities.Pool.get(PoolId(chainId, poolAddress));
     expect(pool).toBeDefined();
     if (!pool) return;
     expect(pool.sqrtPriceX96).toBe(0n);

--- a/test/EventHandlers/CLGaugeFactory/CLGaugeFactoryV2.test.ts
+++ b/test/EventHandlers/CLGaugeFactory/CLGaugeFactoryV2.test.ts
@@ -3,11 +3,10 @@ import {
   MockDb,
 } from "../../../generated/src/TestHelpers.gen";
 import { toChecksumAddress } from "../../../src/Constants";
-import { type MockLiquidityPoolAggregator, setupCommon } from "../Pool/common";
+import { type MockPool, setupCommon } from "../Pool/common";
 
 describe("CLGaugeFactoryV2 Event Handlers", () => {
-  const { mockLiquidityPoolData, createMockLiquidityPoolAggregator } =
-    setupCommon();
+  const { mockLiquidityPoolData, createMockPool } = setupCommon();
   const chainId = 10;
   const mockGaugeFactoryAddress = toChecksumAddress(
     "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -170,17 +169,17 @@ describe("CLGaugeFactoryV2 Event Handlers", () => {
   });
 
   describe("SetEmissionCap Event Handler", () => {
-    let mockPoolWithGauge: MockLiquidityPoolAggregator;
+    let mockPoolWithGauge: MockPool;
     let mockDbWithGetWhere: typeof mockDb;
 
     beforeEach(() => {
       // Create a pool entity with a gauge address
-      mockPoolWithGauge = createMockLiquidityPoolAggregator({
+      mockPoolWithGauge = createMockPool({
         gaugeAddress: mockGaugeAddress,
         gaugeEmissionsCap: 0n, // Initial value
       });
 
-      mockDb = mockDb.entities.LiquidityPoolAggregator.set(mockPoolWithGauge);
+      mockDb = mockDb.entities.Pool.set(mockPoolWithGauge);
 
       // Set up mockDb with getWhere support for gaugeAddress filtering
       const storedPools = [mockPoolWithGauge];
@@ -189,8 +188,8 @@ describe("CLGaugeFactoryV2 Event Handlers", () => {
         ...mockDb,
         entities: {
           ...mockDb.entities,
-          LiquidityPoolAggregator: {
-            ...mockDb.entities.LiquidityPoolAggregator,
+          Pool: {
+            ...mockDb.entities.Pool,
             getWhere: {
               gaugeAddress: {
                 eq: async (gaugeAddr: string) => {
@@ -226,9 +225,7 @@ describe("CLGaugeFactoryV2 Event Handlers", () => {
 
       const result = await mockDbWithGetWhere.processEvents([mockEvent]);
 
-      const updatedPool = result.entities.LiquidityPoolAggregator.get(
-        mockLiquidityPoolData.id,
-      );
+      const updatedPool = result.entities.Pool.get(mockLiquidityPoolData.id);
 
       expect(updatedPool).toBeDefined();
 
@@ -264,11 +261,9 @@ describe("CLGaugeFactoryV2 Event Handlers", () => {
 
       // Update mockDb with the result entities
       mockDb = MockDb.createMockDb();
-      const pool1 = result1.entities.LiquidityPoolAggregator.get(
-        mockLiquidityPoolData.id,
-      );
+      const pool1 = result1.entities.Pool.get(mockLiquidityPoolData.id);
       if (pool1) {
-        mockDb = mockDb.entities.LiquidityPoolAggregator.set(pool1);
+        mockDb = mockDb.entities.Pool.set(pool1);
       }
 
       // Second update with different cap
@@ -290,9 +285,7 @@ describe("CLGaugeFactoryV2 Event Handlers", () => {
 
       const result2 = await mockDb.processEvents([mockEvent2]);
 
-      const updatedPool = result2.entities.LiquidityPoolAggregator.get(
-        mockLiquidityPoolData.id,
-      );
+      const updatedPool = result2.entities.Pool.get(mockLiquidityPoolData.id);
 
       expect(updatedPool).toBeDefined();
       if (!updatedPool) return;
@@ -313,8 +306,8 @@ describe("CLGaugeFactoryV2 Event Handlers", () => {
         ...mockDb,
         entities: {
           ...mockDb.entities,
-          LiquidityPoolAggregator: {
-            ...mockDb.entities.LiquidityPoolAggregator,
+          Pool: {
+            ...mockDb.entities.Pool,
             getWhere: {
               gaugeAddress: {
                 eq: async (_gaugeAddr: string) => {
@@ -344,9 +337,7 @@ describe("CLGaugeFactoryV2 Event Handlers", () => {
       const result = await mockDbWithEmptyGetWhere.processEvents([mockEvent]);
 
       // Pool should not be updated
-      const pool = result.entities.LiquidityPoolAggregator.get(
-        mockLiquidityPoolData.id,
-      );
+      const pool = result.entities.Pool.get(mockLiquidityPoolData.id);
 
       expect(pool).toBeDefined();
       if (!pool) return;
@@ -373,9 +364,7 @@ describe("CLGaugeFactoryV2 Event Handlers", () => {
 
       const result = await mockDbWithGetWhere.processEvents([mockEvent]);
 
-      const updatedPool = result.entities.LiquidityPoolAggregator.get(
-        mockLiquidityPoolData.id,
-      );
+      const updatedPool = result.entities.Pool.get(mockLiquidityPoolData.id);
 
       expect(updatedPool).toBeDefined();
       if (!updatedPool) return;

--- a/test/EventHandlers/CLGaugeFactory/CLGaugeFactoryV3.test.ts
+++ b/test/EventHandlers/CLGaugeFactory/CLGaugeFactoryV3.test.ts
@@ -5,11 +5,10 @@ import {
   MockDb,
 } from "../../../generated/src/TestHelpers.gen";
 import { PoolId, toChecksumAddress } from "../../../src/Constants";
-import { type MockLiquidityPoolAggregator, setupCommon } from "../Pool/common";
+import { type MockPool, setupCommon } from "../Pool/common";
 
 describe("CLGaugeFactoryV3 Event Handlers", () => {
-  const { mockLiquidityPoolData, createMockLiquidityPoolAggregator } =
-    setupCommon();
+  const { mockLiquidityPoolData, createMockPool } = setupCommon();
   const chainId = 8453; // Base — where V3 is deployed
   const v2FactoryAddress = toChecksumAddress(
     "0xB630227a79707D517320b6c0f885806389dFcbB3",
@@ -108,16 +107,16 @@ describe("CLGaugeFactoryV3 Event Handlers", () => {
   });
 
   describe("SetEmissionCap", () => {
-    let mockPoolWithGauge: MockLiquidityPoolAggregator;
+    let mockPoolWithGauge: MockPool;
     let mockDbWithGetWhere: typeof mockDb;
 
     beforeEach(() => {
-      mockPoolWithGauge = createMockLiquidityPoolAggregator({
+      mockPoolWithGauge = createMockPool({
         gaugeAddress: mockGaugeAddress,
         gaugeEmissionsCap: 0n,
       });
 
-      mockDb = mockDb.entities.LiquidityPoolAggregator.set(mockPoolWithGauge);
+      mockDb = mockDb.entities.Pool.set(mockPoolWithGauge);
 
       const storedPools = [mockPoolWithGauge];
 
@@ -125,8 +124,8 @@ describe("CLGaugeFactoryV3 Event Handlers", () => {
         ...mockDb,
         entities: {
           ...mockDb.entities,
-          LiquidityPoolAggregator: {
-            ...mockDb.entities.LiquidityPoolAggregator,
+          Pool: {
+            ...mockDb.entities.Pool,
             getWhere: {
               gaugeAddress: {
                 eq: async (gaugeAddr: string) =>
@@ -143,7 +142,7 @@ describe("CLGaugeFactoryV3 Event Handlers", () => {
       } as typeof mockDb;
     });
 
-    it("updates LiquidityPoolAggregator.gaugeEmissionsCap by gauge address", async () => {
+    it("updates Pool.gaugeEmissionsCap by gauge address", async () => {
       const event = CLGaugeFactoryV3.SetEmissionCap.createMockEvent({
         _gauge: mockGaugeAddress,
         _newEmissionCap: mockEmissionCap,
@@ -161,9 +160,7 @@ describe("CLGaugeFactoryV3 Event Handlers", () => {
 
       const result = await mockDbWithGetWhere.processEvents([event]);
 
-      const pool = result.entities.LiquidityPoolAggregator.get(
-        mockLiquidityPoolData.id,
-      );
+      const pool = result.entities.Pool.get(mockLiquidityPoolData.id);
       expect(pool).toBeDefined();
       if (!pool) return;
       expect(pool.gaugeEmissionsCap).toBe(mockEmissionCap);
@@ -176,8 +173,8 @@ describe("CLGaugeFactoryV3 Event Handlers", () => {
         ...mockDb,
         entities: {
           ...mockDb.entities,
-          LiquidityPoolAggregator: {
-            ...mockDb.entities.LiquidityPoolAggregator,
+          Pool: {
+            ...mockDb.entities.Pool,
             getWhere: {
               gaugeAddress: {
                 eq: async (_: string) => [],
@@ -204,9 +201,7 @@ describe("CLGaugeFactoryV3 Event Handlers", () => {
 
       const result = await emptyDb.processEvents([event]);
 
-      const pool = result.entities.LiquidityPoolAggregator.get(
-        mockLiquidityPoolData.id,
-      );
+      const pool = result.entities.Pool.get(mockLiquidityPoolData.id);
       expect(pool).toBeDefined();
       if (!pool) return;
       expect(pool.gaugeEmissionsCap).toBe(0n);
@@ -283,14 +278,14 @@ describe("CLGaugeFactoryV3 Event Handlers", () => {
     );
     const poolOnBaseId = PoolId(chainId, poolAddress);
 
-    it("sets minStakeTime on the matching LiquidityPoolAggregator", async () => {
-      const existingPool = createMockLiquidityPoolAggregator({
+    it("sets minStakeTime on the matching Pool", async () => {
+      const existingPool = createMockPool({
         id: poolOnBaseId,
         chainId,
         poolAddress: poolAddress as `0x${string}`,
         minStakeTime: 0n,
       });
-      const seeded = mockDb.entities.LiquidityPoolAggregator.set(existingPool);
+      const seeded = mockDb.entities.Pool.set(existingPool);
 
       const event = CLGaugeFactoryV3.SetPoolMinStakeTime.createMockEvent({
         _pool: poolAddress,
@@ -309,7 +304,7 @@ describe("CLGaugeFactoryV3 Event Handlers", () => {
 
       const result = await seeded.processEvents([event]);
 
-      const pool = result.entities.LiquidityPoolAggregator.get(poolOnBaseId);
+      const pool = result.entities.Pool.get(poolOnBaseId);
       expect(pool).toBeDefined();
       if (!pool) return;
       expect(pool.minStakeTime).toBe(3_600n);
@@ -335,7 +330,7 @@ describe("CLGaugeFactoryV3 Event Handlers", () => {
       const result = await mockDb.processEvents([event]);
 
       // Verify no pool entity was created for the missing pool — handler short-circuits.
-      const missingPool = result.entities.LiquidityPoolAggregator.get(
+      const missingPool = result.entities.Pool.get(
         PoolId(
           chainId,
           toChecksumAddress("0xdddddddddddddddddddddddddddddddddddddddd"),

--- a/test/EventHandlers/CLPool.test.ts
+++ b/test/EventHandlers/CLPool.test.ts
@@ -14,13 +14,13 @@ import * as CLPoolCollectLogic from "../../src/EventHandlers/CLPool/CLPoolCollec
 import * as CLPoolFlashLogic from "../../src/EventHandlers/CLPool/CLPoolFlashLogic";
 import * as CLPoolMintLogic from "../../src/EventHandlers/CLPool/CLPoolMintLogic";
 import * as CLPoolSwapLogic from "../../src/EventHandlers/CLPool/CLPoolSwapLogic";
-import { type MockLiquidityPoolAggregator, setupCommon } from "./Pool/common";
+import { type MockPool, setupCommon } from "./Pool/common";
 
 describe("CLPool Events", () => {
   const {
     mockToken0Data,
     mockToken1Data,
-    createMockLiquidityPoolAggregator,
+    createMockPool,
     createMockUserStatsPerPool,
   } = setupCommon();
   const chainId = 10;
@@ -32,14 +32,14 @@ describe("CLPool Events", () => {
   );
 
   let mockDb: ReturnType<typeof MockDb.createMockDb>;
-  let liquidityPool: MockLiquidityPoolAggregator;
+  let liquidityPool: MockPool;
   let userStats: ReturnType<typeof createMockUserStatsPerPool>;
 
   beforeEach(() => {
     mockDb = MockDb.createMockDb();
 
     // Set up liquidity pool
-    liquidityPool = createMockLiquidityPoolAggregator({
+    liquidityPool = createMockPool({
       isCL: true,
     });
 
@@ -53,7 +53,7 @@ describe("CLPool Events", () => {
     });
 
     // Set up entities in mock DB
-    mockDb = mockDb.entities.LiquidityPoolAggregator.set(liquidityPool);
+    mockDb = mockDb.entities.Pool.set(liquidityPool);
     mockDb = mockDb.entities.UserStatsPerPool.set(userStats);
     mockDb = mockDb.entities.Token.set(mockToken0Data as Token);
     mockDb = mockDb.entities.Token.set(mockToken1Data as Token);
@@ -117,9 +117,7 @@ describe("CLPool Events", () => {
 
       expect(processSpy).toHaveBeenCalled();
       expect(processSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
-      const updatedPool = resultDB.entities.LiquidityPoolAggregator.get(
-        liquidityPool.id,
-      );
+      const updatedPool = resultDB.entities.Pool.get(liquidityPool.id);
       expect(updatedPool).toBeDefined();
 
       // Verify pool cumulative totals are updated correctly from incremental values
@@ -164,7 +162,7 @@ describe("CLPool Events", () => {
       };
 
       let ousdtDb = MockDb.createMockDb();
-      ousdtDb = ousdtDb.entities.LiquidityPoolAggregator.set(ousdtPool);
+      ousdtDb = ousdtDb.entities.Pool.set(ousdtPool);
       ousdtDb = ousdtDb.entities.Token.set(ousdtToken);
       ousdtDb = ousdtDb.entities.Token.set(mockToken1Data as Token);
       ousdtDb = ousdtDb.entities.UserStatsPerPool.set(userStats);
@@ -191,7 +189,7 @@ describe("CLPool Events", () => {
       };
 
       let ousdtDb2 = MockDb.createMockDb();
-      ousdtDb2 = ousdtDb2.entities.LiquidityPoolAggregator.set(ousdtToken1Pool);
+      ousdtDb2 = ousdtDb2.entities.Pool.set(ousdtToken1Pool);
       ousdtDb2 = ousdtDb2.entities.Token.set(mockToken0Data as Token);
       ousdtDb2 = ousdtDb2.entities.Token.set(ousdtToken);
       ousdtDb2 = ousdtDb2.entities.UserStatsPerPool.set(userStats);
@@ -249,7 +247,7 @@ describe("CLPool Events", () => {
       };
 
       let ousdtDb = MockDb.createMockDb();
-      ousdtDb = ousdtDb.entities.LiquidityPoolAggregator.set(ousdtPool);
+      ousdtDb = ousdtDb.entities.Pool.set(ousdtPool);
       ousdtDb = ousdtDb.entities.Token.set(ousdtToken);
       ousdtDb = ousdtDb.entities.Token.set(mockToken1Data as Token);
       ousdtDb = ousdtDb.entities.UserStatsPerPool.set(userStats);
@@ -368,9 +366,7 @@ describe("CLPool Events", () => {
 
       // Should not throw, handler should return early
       expect(processSpy).not.toHaveBeenCalled();
-      const updatedPool = emptyDb.entities.LiquidityPoolAggregator.get(
-        liquidityPool.id,
-      );
+      const updatedPool = emptyDb.entities.Pool.get(liquidityPool.id);
       expect(updatedPool).toBeUndefined();
     });
   });
@@ -418,9 +414,7 @@ describe("CLPool Events", () => {
 
       expect(processSpy).toHaveBeenCalled();
       expect(processSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
-      const updatedPool = resultDB.entities.LiquidityPoolAggregator.get(
-        liquidityPool.id,
-      );
+      const updatedPool = resultDB.entities.Pool.get(liquidityPool.id);
       expect(updatedPool).toBeDefined();
     });
 
@@ -430,9 +424,7 @@ describe("CLPool Events", () => {
 
       // Should not throw, handler should return early
       expect(processSpy).not.toHaveBeenCalled();
-      const updatedPool = emptyDb.entities.LiquidityPoolAggregator.get(
-        liquidityPool.id,
-      );
+      const updatedPool = emptyDb.entities.Pool.get(liquidityPool.id);
       expect(updatedPool).toBeUndefined();
     });
   });
@@ -488,9 +480,7 @@ describe("CLPool Events", () => {
 
       expect(processSpy).toHaveBeenCalled();
       expect(processSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
-      const updatedPool = resultDB.entities.LiquidityPoolAggregator.get(
-        liquidityPool.id,
-      );
+      const updatedPool = resultDB.entities.Pool.get(liquidityPool.id);
       expect(updatedPool).toBeDefined();
     });
 
@@ -500,9 +490,7 @@ describe("CLPool Events", () => {
 
       // Should not throw, handler should return early
       expect(processSpy).not.toHaveBeenCalled();
-      const updatedPool = emptyDb.entities.LiquidityPoolAggregator.get(
-        liquidityPool.id,
-      );
+      const updatedPool = emptyDb.entities.Pool.get(liquidityPool.id);
       expect(updatedPool).toBeUndefined();
     });
   });
@@ -556,9 +544,7 @@ describe("CLPool Events", () => {
 
       expect(processSpy).toHaveBeenCalled();
       expect(processSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
-      const updatedPool = resultDB.entities.LiquidityPoolAggregator.get(
-        liquidityPool.id,
-      );
+      const updatedPool = resultDB.entities.Pool.get(liquidityPool.id);
       expect(updatedPool).toBeDefined();
     });
 
@@ -568,9 +554,7 @@ describe("CLPool Events", () => {
 
       // Should not throw, handler should return early
       expect(processSpy).not.toHaveBeenCalled();
-      const updatedPool = emptyDb.entities.LiquidityPoolAggregator.get(
-        liquidityPool.id,
-      );
+      const updatedPool = emptyDb.entities.Pool.get(liquidityPool.id);
       expect(updatedPool).toBeUndefined();
     });
 
@@ -617,9 +601,7 @@ describe("CLPool Events", () => {
       expect(updatedToken1).toBeDefined();
 
       // Verify pool was updated
-      const updatedPool = resultDB.entities.LiquidityPoolAggregator.get(
-        liquidityPool.id,
-      );
+      const updatedPool = resultDB.entities.Pool.get(liquidityPool.id);
       expect(updatedPool).toBeDefined();
       // Verify staked and unstaked fees are tracked separately
       expect(updatedPool?.totalStakedFeesCollectedUSD).toBeDefined();
@@ -683,9 +665,7 @@ describe("CLPool Events", () => {
 
       expect(processSpy).toHaveBeenCalled();
       expect(processSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
-      const updatedPool = resultDB.entities.LiquidityPoolAggregator.get(
-        liquidityPool.id,
-      );
+      const updatedPool = resultDB.entities.Pool.get(liquidityPool.id);
       expect(updatedPool).toBeDefined();
     });
 
@@ -695,9 +675,7 @@ describe("CLPool Events", () => {
 
       // Should not throw, handler should return early
       expect(processSpy).not.toHaveBeenCalled();
-      const updatedPool = emptyDb.entities.LiquidityPoolAggregator.get(
-        liquidityPool.id,
-      );
+      const updatedPool = emptyDb.entities.Pool.get(liquidityPool.id);
       expect(updatedPool).toBeUndefined();
     });
 
@@ -775,9 +753,7 @@ describe("CLPool Events", () => {
     it("should update observation cardinality", async () => {
       const resultDB = await mockDb.processEvents([mockEvent]);
 
-      const updatedPool = resultDB.entities.LiquidityPoolAggregator.get(
-        liquidityPool.id,
-      );
+      const updatedPool = resultDB.entities.Pool.get(liquidityPool.id);
       expect(updatedPool).toBeDefined();
       expect(updatedPool?.observationCardinalityNext).toBe(100n);
     });
@@ -787,9 +763,7 @@ describe("CLPool Events", () => {
       await emptyDb.processEvents([mockEvent]);
 
       // Should not throw, handler should return early
-      const updatedPool = emptyDb.entities.LiquidityPoolAggregator.get(
-        liquidityPool.id,
-      );
+      const updatedPool = emptyDb.entities.Pool.get(liquidityPool.id);
       expect(updatedPool).toBeUndefined();
     });
   });
@@ -819,9 +793,7 @@ describe("CLPool Events", () => {
     it("should update fee protocol settings", async () => {
       const resultDB = await mockDb.processEvents([mockEvent]);
 
-      const updatedPool = resultDB.entities.LiquidityPoolAggregator.get(
-        liquidityPool.id,
-      );
+      const updatedPool = resultDB.entities.Pool.get(liquidityPool.id);
       expect(updatedPool).toBeDefined();
       expect(updatedPool?.feeProtocol0).toBe(10n);
       expect(updatedPool?.feeProtocol1).toBe(20n);
@@ -832,9 +804,7 @@ describe("CLPool Events", () => {
       await emptyDb.processEvents([mockEvent]);
 
       // Should not throw, handler should return early
-      const updatedPool = emptyDb.entities.LiquidityPoolAggregator.get(
-        liquidityPool.id,
-      );
+      const updatedPool = emptyDb.entities.Pool.get(liquidityPool.id);
       expect(updatedPool).toBeUndefined();
     });
   });
@@ -868,9 +838,7 @@ describe("CLPool Events", () => {
       const resultDB = await MockDb.createMockDb().processEvents([mockEvent]);
 
       // No phantom aggregator created — Initialize lacks token0/token1/tickSpacing.
-      expect(
-        resultDB.entities.LiquidityPoolAggregator.get(PoolId(chainId, pool)),
-      ).toBeUndefined();
+      expect(resultDB.entities.Pool.get(PoolId(chainId, pool))).toBeUndefined();
 
       const pending = resultDB.entities.CLPoolPendingInitialize.get(
         PoolId(chainId, pool),

--- a/test/EventHandlers/CLPool/CLPoolBurnLogic.test.ts
+++ b/test/EventHandlers/CLPool/CLPoolBurnLogic.test.ts
@@ -1,11 +1,11 @@
 import type {
   CLPool_Burn_event,
   CLPositionPendingPrincipal,
-  LiquidityPoolAggregator,
   Token,
   handlerContext,
 } from "generated";
 import { toChecksumAddress } from "../../../src/Constants";
+import type { Pool } from "../../../src/EntityTypes";
 import { processCLPoolBurn } from "../../../src/EventHandlers/CLPool/CLPoolBurnLogic";
 import { calculateTotalUSD } from "../../../src/Helpers";
 import { setupCommon } from "../Pool/common";
@@ -56,7 +56,7 @@ describe("CLPoolBurnLogic", () => {
     lastUpdatedTimestamp: new Date(1000000 * 1000),
   };
 
-  const mockLiquidityPoolAggregator: LiquidityPoolAggregator = {
+  const mockPool: Pool = {
     ...mockLiquidityPoolData,
     reserve0: 1000000n,
     reserve1: 3000000000000000000n,
@@ -80,7 +80,7 @@ describe("CLPoolBurnLogic", () => {
       const ctx = createMockContext();
       const result = await processCLPoolBurn(
         mockEvent,
-        mockLiquidityPoolAggregator,
+        mockPool,
         mockToken0,
         mockToken1,
         ctx,
@@ -95,13 +95,7 @@ describe("CLPoolBurnLogic", () => {
 
     it("should track burned principal in CLPositionPendingPrincipal", async () => {
       const ctx = createMockContext();
-      await processCLPoolBurn(
-        mockEvent,
-        mockLiquidityPoolAggregator,
-        mockToken0,
-        mockToken1,
-        ctx,
-      );
+      await processCLPoolBurn(mockEvent, mockPool, mockToken0, mockToken1, ctx);
 
       // Should have called set with burn amounts
       const setCall = vi.mocked(ctx.CLPositionPendingPrincipal.set).mock
@@ -117,13 +111,7 @@ describe("CLPoolBurnLogic", () => {
         pendingPrincipal1: 200000n,
       };
       const ctx = createMockContext(existingTracker);
-      await processCLPoolBurn(
-        mockEvent,
-        mockLiquidityPoolAggregator,
-        mockToken0,
-        mockToken1,
-        ctx,
-      );
+      await processCLPoolBurn(mockEvent, mockPool, mockToken0, mockToken1, ctx);
 
       const setCall = vi.mocked(ctx.CLPositionPendingPrincipal.set).mock
         .lastCall?.[0] as CLPositionPendingPrincipal;
@@ -133,8 +121,8 @@ describe("CLPoolBurnLogic", () => {
 
     it("should decrement liquidityInRange when tickLower <= aggregator.tick < tickUpper (in-range)", async () => {
       // mockEvent uses tickLower=-1000n, tickUpper=1000n; default aggregator.tick=0n is in range.
-      const inRangeAggregator: LiquidityPoolAggregator = {
-        ...mockLiquidityPoolAggregator,
+      const inRangeAggregator: Pool = {
+        ...mockPool,
         tick: 0n,
         liquidityInRange: 5_000_000n,
       };
@@ -156,8 +144,8 @@ describe("CLPoolBurnLogic", () => {
     });
 
     it("should not touch liquidityInRange on burn when out of range (tick below tickLower)", async () => {
-      const belowAggregator: LiquidityPoolAggregator = {
-        ...mockLiquidityPoolAggregator,
+      const belowAggregator: Pool = {
+        ...mockPool,
         tick: -5000n,
       };
       const ctx = createMockContext();
@@ -177,8 +165,8 @@ describe("CLPoolBurnLogic", () => {
     });
 
     it("should not touch liquidityInRange on burn when tick at tickUpper (exclusive)", async () => {
-      const atUpperAggregator: LiquidityPoolAggregator = {
-        ...mockLiquidityPoolAggregator,
+      const atUpperAggregator: Pool = {
+        ...mockPool,
         tick: 1000n,
       };
       const ctx = createMockContext();
@@ -204,7 +192,7 @@ describe("CLPoolBurnLogic", () => {
       const ctx = createMockContext();
       const result = await processCLPoolBurn(
         mockEvent,
-        mockLiquidityPoolAggregator,
+        mockPool,
         tokenWithDifferentDecimals,
         mockToken1,
         ctx,
@@ -214,8 +202,8 @@ describe("CLPoolBurnLogic", () => {
         incrementalReserve0: -mockEvent.params.amount0,
         incrementalReserve1: -mockEvent.params.amount1,
         currentTotalLiquidityUSD: calculateTotalUSD(
-          mockLiquidityPoolAggregator.reserve0 - mockEvent.params.amount0,
-          mockLiquidityPoolAggregator.reserve1 - mockEvent.params.amount1,
+          mockPool.reserve0 - mockEvent.params.amount0,
+          mockPool.reserve1 - mockEvent.params.amount1,
           tokenWithDifferentDecimals,
           mockToken1,
         ),

--- a/test/EventHandlers/CLPool/CLPoolCollectFeesLogic.test.ts
+++ b/test/EventHandlers/CLPool/CLPoolCollectFeesLogic.test.ts
@@ -1,9 +1,6 @@
-import type {
-  CLPool_CollectFees_event,
-  LiquidityPoolAggregator,
-  Token,
-} from "generated";
+import type { CLPool_CollectFees_event, Token } from "generated";
 import { toChecksumAddress } from "../../../src/Constants";
+import type { Pool } from "../../../src/EntityTypes";
 import { processCLPoolCollectFees } from "../../../src/EventHandlers/CLPool/CLPoolCollectFeesLogic";
 import { setupCommon } from "../Pool/common";
 
@@ -32,7 +29,7 @@ describe("CLPoolCollectFeesLogic", () => {
     },
   } as CLPool_CollectFees_event;
 
-  const mockLiquidityPoolAggregator: LiquidityPoolAggregator = {
+  const mockPool: Pool = {
     ...mockLiquidityPoolData,
     id: toChecksumAddress("0x1234567890123456789012345678901234567890"),
     token0_id: mockToken0Data.id,
@@ -469,20 +466,20 @@ describe("CLPoolCollectFeesLogic", () => {
         5000000000000000000n, // Increment: $5.00
       );
 
-      // Simulate what updateLiquidityPoolAggregator does: add diff to current
+      // Simulate what updatePool does: add diff to current
       // After first event: 0 + 1 = 1 token0, 0 + 2 = 2 token1, 0 + 5 = 5 USD
-      const aggregatorAfterFirst: LiquidityPoolAggregator = {
-        ...mockLiquidityPoolAggregator,
+      const aggregatorAfterFirst: Pool = {
+        ...mockPool,
         totalStakedFeesCollected0:
-          mockLiquidityPoolAggregator.totalStakedFeesCollected0 +
+          mockPool.totalStakedFeesCollected0 +
           (result1.liquidityPoolDiff.incrementalTotalStakedFeesCollected0 ??
             0n), // 0 + 1 = 1
         totalStakedFeesCollected1:
-          mockLiquidityPoolAggregator.totalStakedFeesCollected1 +
+          mockPool.totalStakedFeesCollected1 +
           (result1.liquidityPoolDiff.incrementalTotalStakedFeesCollected1 ??
             0n), // 0 + 2 = 2
         totalStakedFeesCollectedUSD:
-          mockLiquidityPoolAggregator.totalStakedFeesCollectedUSD +
+          mockPool.totalStakedFeesCollectedUSD +
           (result1.liquidityPoolDiff.incrementalTotalStakedFeesCollectedUSD ??
             0n), // 0 + 5 = 5
       };
@@ -495,7 +492,7 @@ describe("CLPoolCollectFeesLogic", () => {
       );
 
       // Second event should return the same increments (not accumulated totals)
-      // The diff contains increments that updateLiquidityPoolAggregator will add
+      // The diff contains increments that updatePool will add
       expect(
         result2.liquidityPoolDiff.incrementalTotalStakedFeesCollected0,
       ).toBe(
@@ -512,7 +509,7 @@ describe("CLPoolCollectFeesLogic", () => {
         5000000000000000000n, // Increment: $5.00 (same as first event)
       );
 
-      // Verify that if we simulate updateLiquidityPoolAggregator adding the diff:
+      // Verify that if we simulate updatePool adding the diff:
       // After second event: 1 + 1 = 2 token0, 2 + 2 = 4 token1, 5 + 5 = 10 USD
       const finalTotal0 =
         aggregatorAfterFirst.totalStakedFeesCollected0 +

--- a/test/EventHandlers/CLPool/CLPoolMint.test.ts
+++ b/test/EventHandlers/CLPool/CLPoolMint.test.ts
@@ -18,9 +18,7 @@ describe("CLPool Mint Event Handler", () => {
     mockDb = MockDb.createMockDb();
 
     // Set up mock database with required entities
-    const updatedDB1 = mockDb.entities.LiquidityPoolAggregator.set(
-      mockLiquidityPoolData,
-    );
+    const updatedDB1 = mockDb.entities.Pool.set(mockLiquidityPoolData);
     const updatedDB2 = updatedDB1.entities.Token.set(mockToken0Data);
     mockDb = updatedDB2.entities.Token.set(mockToken1Data);
   });

--- a/test/EventHandlers/CLPool/CLPoolMintLogic.test.ts
+++ b/test/EventHandlers/CLPool/CLPoolMintLogic.test.ts
@@ -1,6 +1,7 @@
-import type { LiquidityPoolAggregator, Token } from "generated";
+import type { Token } from "generated";
 import { CLPool } from "../../../generated/src/TestHelpers.gen";
 import { toChecksumAddress } from "../../../src/Constants";
+import type { Pool } from "../../../src/EntityTypes";
 import { processCLPoolMint } from "../../../src/EventHandlers/CLPool/CLPoolMintLogic";
 import { setupCommon } from "../Pool/common";
 
@@ -54,18 +55,18 @@ describe("CLPoolMintLogic", () => {
     lastUpdatedTimestamp: new Date(1000000 * 1000),
   };
 
-  const mockLiquidityPoolAggregator = {
+  const mockPool = {
     ...mockLiquidityPoolData,
     reserve0: 1000000000000000000n,
     reserve1: 2000000000000000000n,
     totalLiquidityUSD: 5000000000000000000n,
-  } as LiquidityPoolAggregator;
+  } as Pool;
 
   describe("processCLPoolMint", () => {
     it("should process mint event successfully with valid data", () => {
       const result = processCLPoolMint(
         mockEvent,
-        mockLiquidityPoolAggregator,
+        mockPool,
         mockToken0,
         mockToken1,
       );
@@ -87,7 +88,7 @@ describe("CLPoolMintLogic", () => {
     it("should calculate correct liquidity values for mint event", () => {
       const result = processCLPoolMint(
         mockEvent,
-        mockLiquidityPoolAggregator,
+        mockPool,
         mockToken0,
         mockToken1,
       );
@@ -112,7 +113,7 @@ describe("CLPoolMintLogic", () => {
 
       const result = processCLPoolMint(
         mockEvent,
-        mockLiquidityPoolAggregator,
+        mockPool,
         tokenWithDifferentDecimals,
         mockToken1,
       );
@@ -139,7 +140,7 @@ describe("CLPoolMintLogic", () => {
 
       const result = processCLPoolMint(
         eventWithZeroAmounts,
-        mockLiquidityPoolAggregator,
+        mockPool,
         mockToken0,
         mockToken1,
       );
@@ -155,10 +156,10 @@ describe("CLPoolMintLogic", () => {
       // mockEvent uses tickLower=100000, tickUpper=200000.
       // Place aggregator.tick mid-range so the position contributes its full L.
       const inRangeAggregator = {
-        ...mockLiquidityPoolAggregator,
+        ...mockPool,
         tick: 150000n,
         liquidityInRange: 7_000_000_000n,
-      } as LiquidityPoolAggregator;
+      } as Pool;
 
       const result = processCLPoolMint(
         mockEvent,
@@ -176,10 +177,10 @@ describe("CLPoolMintLogic", () => {
     });
 
     it("should not touch liquidityInRange when position is out of range (tick below tickLower)", () => {
-      // Default mockLiquidityPoolAggregator.tick = 0n, tickLower = 100000n → below.
+      // Default mockPool.tick = 0n, tickLower = 100000n → below.
       const result = processCLPoolMint(
         mockEvent,
-        mockLiquidityPoolAggregator,
+        mockPool,
         mockToken0,
         mockToken1,
       );
@@ -193,9 +194,9 @@ describe("CLPoolMintLogic", () => {
     it("should not touch liquidityInRange when position is out of range (tick at or above tickUpper)", () => {
       // tickUpper is exclusive: tick === tickUpper means out-of-range above.
       const aboveAggregator = {
-        ...mockLiquidityPoolAggregator,
+        ...mockPool,
         tick: 200000n,
-      } as LiquidityPoolAggregator;
+      } as Pool;
 
       const result = processCLPoolMint(
         mockEvent,
@@ -211,9 +212,9 @@ describe("CLPoolMintLogic", () => {
 
     it("should include the boundary at tickLower (inclusive)", () => {
       const atLowerAggregator = {
-        ...mockLiquidityPoolAggregator,
+        ...mockPool,
         tick: 100000n,
-      } as LiquidityPoolAggregator;
+      } as Pool;
 
       const result = processCLPoolMint(
         mockEvent,

--- a/test/EventHandlers/CLPool/CLPoolSwapLogic.test.ts
+++ b/test/EventHandlers/CLPool/CLPoolSwapLogic.test.ts
@@ -1,10 +1,6 @@
-import type {
-  CLPool_Swap_event,
-  LiquidityPoolAggregator,
-  Token,
-  handlerContext,
-} from "generated";
+import type { CLPool_Swap_event, Token, handlerContext } from "generated";
 import { TEN_TO_THE_18_BI, toChecksumAddress } from "../../../src/Constants";
+import type { Pool } from "../../../src/EntityTypes";
 import {
   calculateSwapFees,
   calculateSwapLiquidityChanges,
@@ -53,7 +49,7 @@ describe("CLPoolSwapLogic", () => {
     },
   } as CLPool_Swap_event;
 
-  const mockLiquidityPoolAggregator: LiquidityPoolAggregator = {
+  const mockPool: Pool = {
     ...mockLiquidityPoolData,
     id: POOL_ID,
     token0_id: mockToken0Data.id,
@@ -226,7 +222,7 @@ describe("CLPoolSwapLogic", () => {
     it("should calculate fees correctly with currentFee", () => {
       const result = calculateSwapFees(
         mockEvent,
-        mockLiquidityPoolAggregator,
+        mockPool,
         mockToken0,
         mockToken1,
         mockContext,
@@ -243,10 +239,10 @@ describe("CLPoolSwapLogic", () => {
 
     it("should fallback to baseFee when currentFee is undefined", () => {
       const poolWithBaseFee = {
-        ...mockLiquidityPoolAggregator,
+        ...mockPool,
         currentFee: undefined,
         baseFee: CL_FEE_100,
-      } as unknown as LiquidityPoolAggregator;
+      } as unknown as Pool;
 
       const result = calculateSwapFees(
         mockEvent,
@@ -265,10 +261,10 @@ describe("CLPoolSwapLogic", () => {
 
     it("should return zero fees when both currentFee and baseFee are undefined", () => {
       const poolWithoutFee = {
-        ...mockLiquidityPoolAggregator,
+        ...mockPool,
         currentFee: undefined,
         baseFee: undefined,
-      } as unknown as LiquidityPoolAggregator;
+      } as unknown as Pool;
 
       const result = calculateSwapFees(
         mockEvent,
@@ -299,7 +295,7 @@ describe("CLPoolSwapLogic", () => {
 
       const result = calculateSwapFees(
         mockEvent,
-        mockLiquidityPoolAggregator,
+        mockPool,
         tokenWith6Decimals,
         mockToken1,
         mockContext,
@@ -315,7 +311,7 @@ describe("CLPoolSwapLogic", () => {
     it("should calculate USD fees using token0 price when available", () => {
       const result = calculateSwapFees(
         mockEvent,
-        mockLiquidityPoolAggregator,
+        mockPool,
         mockToken0,
         mockToken1,
         mockContext,
@@ -333,7 +329,7 @@ describe("CLPoolSwapLogic", () => {
 
       const result = calculateSwapFees(
         mockEvent,
-        mockLiquidityPoolAggregator,
+        mockPool,
         token0WithZeroPrice,
         mockToken1,
         mockContext,
@@ -356,7 +352,7 @@ describe("CLPoolSwapLogic", () => {
 
       const result = calculateSwapFees(
         mockEvent,
-        mockLiquidityPoolAggregator,
+        mockPool,
         token0WithZeroPrice,
         token1WithoutPrice,
         mockContext,
@@ -370,17 +366,17 @@ describe("CLPoolSwapLogic", () => {
     it("should exclude fees from the input token and leave output unchanged", () => {
       const result = calculateSwapLiquidityChanges(
         mockEvent,
-        mockLiquidityPoolAggregator,
+        mockPool,
         mockToken0,
         mockToken1,
         CL_FEE_30,
       );
       const fee0 = (1n * TEN_TO_THE_18_BI * CL_FEE_30) / 1000000n;
       expect(result.newReserve0).toBe(
-        mockLiquidityPoolAggregator.reserve0 + 1n * TEN_TO_THE_18_BI - fee0,
+        mockPool.reserve0 + 1n * TEN_TO_THE_18_BI - fee0,
       );
       expect(result.newReserve1).toBe(
-        mockLiquidityPoolAggregator.reserve1 - 2n * TEN_TO_THE_18_BI,
+        mockPool.reserve1 - 2n * TEN_TO_THE_18_BI,
       );
     });
 
@@ -395,16 +391,16 @@ describe("CLPoolSwapLogic", () => {
       };
       const result = calculateSwapLiquidityChanges(
         eventWithNegativeAmounts,
-        mockLiquidityPoolAggregator,
+        mockPool,
         mockToken0,
         mockToken1,
         CL_FEE_30,
       );
       expect(result.newReserve0).toBe(
-        mockLiquidityPoolAggregator.reserve0 - 5n * TEN_TO_THE_18_BI,
+        mockPool.reserve0 - 5n * TEN_TO_THE_18_BI,
       );
       expect(result.newReserve1).toBe(
-        mockLiquidityPoolAggregator.reserve1 - 3n * TEN_TO_THE_18_BI,
+        mockPool.reserve1 - 3n * TEN_TO_THE_18_BI,
       );
     });
 
@@ -419,7 +415,7 @@ describe("CLPoolSwapLogic", () => {
       };
       const result = calculateSwapLiquidityChanges(
         eventWithPositiveAmounts,
-        mockLiquidityPoolAggregator,
+        mockPool,
         mockToken0,
         mockToken1,
         CL_FEE_30,
@@ -427,26 +423,26 @@ describe("CLPoolSwapLogic", () => {
       const fee0 = (5n * TEN_TO_THE_18_BI * CL_FEE_30) / 1000000n;
       const fee1 = (3n * TEN_TO_THE_18_BI * CL_FEE_30) / 1000000n;
       expect(result.newReserve0).toBe(
-        mockLiquidityPoolAggregator.reserve0 + 5n * TEN_TO_THE_18_BI - fee0,
+        mockPool.reserve0 + 5n * TEN_TO_THE_18_BI - fee0,
       );
       expect(result.newReserve1).toBe(
-        mockLiquidityPoolAggregator.reserve1 + 3n * TEN_TO_THE_18_BI - fee1,
+        mockPool.reserve1 + 3n * TEN_TO_THE_18_BI - fee1,
       );
     });
 
     it("should not deduct fees when fee rate is zero", () => {
       const result = calculateSwapLiquidityChanges(
         mockEvent,
-        mockLiquidityPoolAggregator,
+        mockPool,
         undefined,
         undefined,
         0n,
       );
       expect(result.newReserve0).toBe(
-        mockLiquidityPoolAggregator.reserve0 + mockEvent.params.amount0,
+        mockPool.reserve0 + mockEvent.params.amount0,
       );
       expect(result.newReserve1).toBe(
-        mockLiquidityPoolAggregator.reserve1 + mockEvent.params.amount1,
+        mockPool.reserve1 + mockEvent.params.amount1,
       );
     });
   });
@@ -455,7 +451,7 @@ describe("CLPoolSwapLogic", () => {
     it("should process swap event and calculate correct volumes and fees", async () => {
       const result = await processCLPoolSwap(
         mockEvent,
-        mockLiquidityPoolAggregator,
+        mockPool,
         mockToken0,
         mockToken1,
         mockContext,
@@ -501,7 +497,7 @@ describe("CLPoolSwapLogic", () => {
 
       const result = await processCLPoolSwap(
         eventWithZeroAmounts,
-        mockLiquidityPoolAggregator,
+        mockPool,
         mockToken0,
         mockToken1,
         mockContext,
@@ -518,18 +514,14 @@ describe("CLPoolSwapLogic", () => {
     it("should handle undefined tokens with fallback to pool prices", async () => {
       const result = await processCLPoolSwap(
         mockEvent,
-        mockLiquidityPoolAggregator,
+        mockPool,
         undefined,
         undefined,
         mockContext,
       );
 
-      expect(result.liquidityPoolDiff.token0Price).toBe(
-        mockLiquidityPoolAggregator.token0Price,
-      );
-      expect(result.liquidityPoolDiff.token1Price).toBe(
-        mockLiquidityPoolAggregator.token1Price,
-      );
+      expect(result.liquidityPoolDiff.token0Price).toBe(mockPool.token0Price);
+      expect(result.liquidityPoolDiff.token1Price).toBe(mockPool.token1Price);
     });
 
     it("should exclude fees from reserve increments (input side only)", async () => {
@@ -544,7 +536,7 @@ describe("CLPoolSwapLogic", () => {
 
       const result = await processCLPoolSwap(
         eventWithPositiveAmounts,
-        mockLiquidityPoolAggregator,
+        mockPool,
         mockToken0,
         mockToken1,
         mockContext,
@@ -566,7 +558,7 @@ describe("CLPoolSwapLogic", () => {
 
       const result = await processCLPoolSwap(
         mockEvent,
-        mockLiquidityPoolAggregator,
+        mockPool,
         whitelistedToken0,
         whitelistedToken1,
         mockContext,
@@ -589,7 +581,7 @@ describe("CLPoolSwapLogic", () => {
 
       const result = await processCLPoolSwap(
         mockEvent,
-        mockLiquidityPoolAggregator,
+        mockPool,
         token0WithNewPrice,
         token1WithNewPrice,
         mockContext,
@@ -602,7 +594,7 @@ describe("CLPoolSwapLogic", () => {
     it("should set correct timestamps", async () => {
       const result = await processCLPoolSwap(
         mockEvent,
-        mockLiquidityPoolAggregator,
+        mockPool,
         mockToken0,
         mockToken1,
         mockContext,
@@ -619,7 +611,7 @@ describe("CLPoolSwapLogic", () => {
     it("should set liquidityInRange from event params", async () => {
       const result = await processCLPoolSwap(
         mockEvent,
-        mockLiquidityPoolAggregator,
+        mockPool,
         mockToken0,
         mockToken1,
         mockContext,
@@ -632,7 +624,7 @@ describe("CLPoolSwapLogic", () => {
 
     it("should compute staked reserve deltas proportionally", async () => {
       const poolWithStaked = {
-        ...mockLiquidityPoolAggregator,
+        ...mockPool,
         tick: 500n, // Different from event tick (1000n) to trigger tick crossing
         tickSpacing: 200n,
         stakedLiquidityInRange: 200n,
@@ -656,7 +648,7 @@ describe("CLPoolSwapLogic", () => {
 
     it("should return zero staked deltas when no staked liquidity", async () => {
       const poolNoStaked = {
-        ...mockLiquidityPoolAggregator,
+        ...mockPool,
         stakedLiquidityInRange: 0n,
       };
 
@@ -675,7 +667,7 @@ describe("CLPoolSwapLogic", () => {
 
     it("should skip tick crossings when tick unchanged", async () => {
       const poolSameTick = {
-        ...mockLiquidityPoolAggregator,
+        ...mockPool,
         tick: mockEvent.params.tick, // Same tick → no crossing
         tickSpacing: 200n,
         stakedLiquidityInRange: 500n,
@@ -703,7 +695,7 @@ describe("CLPoolSwapLogic", () => {
       "keeps fee USD within 1%% of volume USD at fee tier %s",
       async (fee) => {
         const pool = {
-          ...mockLiquidityPoolAggregator,
+          ...mockPool,
           currentFee: fee,
           baseFee: fee,
         };

--- a/test/EventHandlers/Gauges/GaugeSharedLogic.test.ts
+++ b/test/EventHandlers/Gauges/GaugeSharedLogic.test.ts
@@ -17,11 +17,10 @@ import {
   processGaugeDeposit,
   processGaugeWithdraw,
 } from "../../../src/EventHandlers/Gauges/GaugeSharedLogic";
-import { type MockLiquidityPoolAggregator, setupCommon } from "../Pool/common";
+import { type MockPool, setupCommon } from "../Pool/common";
 
 describe("GaugeSharedLogic", () => {
-  const { mockToken0Data, mockToken1Data, createMockLiquidityPoolAggregator } =
-    setupCommon();
+  const { mockToken0Data, mockToken1Data, createMockPool } = setupCommon();
   const mockChainId = 8453;
   const mockPoolAddress = toChecksumAddress(
     "0x1111111111111111111111111111111111111111",
@@ -60,7 +59,7 @@ describe("GaugeSharedLogic", () => {
     isWhitelisted: true,
   };
 
-  let mockLiquidityPoolAggregator: MockLiquidityPoolAggregator;
+  let mockPool: MockPool;
   let mockUserStatsPerPool: ReturnType<
     ReturnType<typeof setupCommon>["createMockUserStatsPerPool"]
   >;
@@ -99,7 +98,7 @@ describe("GaugeSharedLogic", () => {
       },
     };
 
-    mockLiquidityPoolAggregator = createMockLiquidityPoolAggregator({
+    mockPool = createMockPool({
       poolAddress: mockPoolAddress,
       chainId: mockChainId,
       name: "USDC/USDT",
@@ -151,9 +150,7 @@ describe("GaugeSharedLogic", () => {
     };
 
     mockDb = MockDb.createMockDb();
-    updatedDB = mockDb.entities.LiquidityPoolAggregator.set(
-      mockLiquidityPoolAggregator,
-    );
+    updatedDB = mockDb.entities.Pool.set(mockPool);
     updatedDB = updatedDB.entities.Token.set(mockToken0);
     updatedDB = updatedDB.entities.Token.set(mockToken1);
     updatedDB = updatedDB.entities.Token.set(mockRewardToken);
@@ -161,19 +158,17 @@ describe("GaugeSharedLogic", () => {
 
     // Create a proper mock context
     mockContext = {
-      LiquidityPoolAggregator: {
-        get: (id: string) => updatedDB.entities.LiquidityPoolAggregator.get(id),
+      Pool: {
+        get: (id: string) => updatedDB.entities.Pool.get(id),
         // biome-ignore lint/suspicious/noExplicitAny: Mock entity for testing
         set: (entity: any) => {
-          updatedDB = updatedDB.entities.LiquidityPoolAggregator.set(entity);
+          updatedDB = updatedDB.entities.Pool.set(entity);
           return updatedDB;
         },
         // biome-ignore lint/suspicious/noExplicitAny: Mock entity for testing
         getWhere: async (params: any) => {
           if (params.gaugeAddress?._eq) {
-            const pool = updatedDB.entities.LiquidityPoolAggregator.get(
-              mockLiquidityPoolAggregator.id,
-            );
+            const pool = updatedDB.entities.Pool.get(mockPool.id);
             return pool && pool.gaugeAddress === params.gaugeAddress._eq
               ? [pool]
               : [];
@@ -266,9 +261,7 @@ describe("GaugeSharedLogic", () => {
 
       await processGaugeDeposit(depositData, mockContext, "TestGaugeDeposit");
 
-      const updatedPool = updatedDB.entities.LiquidityPoolAggregator.get(
-        mockLiquidityPoolAggregator.id,
-      );
+      const updatedPool = updatedDB.entities.Pool.get(mockPool.id);
       const updatedUser = updatedDB.entities.UserStatsPerPool.get(
         mockUserStatsPerPool.id,
       );
@@ -295,8 +288,8 @@ describe("GaugeSharedLogic", () => {
     });
 
     it("should preserve existing pool staked USD when non-CL valuation is unavailable", async () => {
-      mockLiquidityPoolAggregator = {
-        ...mockLiquidityPoolAggregator,
+      mockPool = {
+        ...mockPool,
         currentLiquidityStakedUSD: 777000000000000000000n,
         totalLPTokenSupply: 0n,
       };
@@ -305,9 +298,7 @@ describe("GaugeSharedLogic", () => {
         currentLiquidityStakedUSD: 333000000000000000000n,
       };
 
-      updatedDB = updatedDB.entities.LiquidityPoolAggregator.set(
-        mockLiquidityPoolAggregator,
-      );
+      updatedDB = updatedDB.entities.Pool.set(mockPool);
       updatedDB = updatedDB.entities.UserStatsPerPool.set(mockUserStatsPerPool);
 
       const depositData: GaugeEventData = {
@@ -321,9 +312,7 @@ describe("GaugeSharedLogic", () => {
 
       await processGaugeDeposit(depositData, mockContext, "TestGaugeDeposit");
 
-      const updatedPool = updatedDB.entities.LiquidityPoolAggregator.get(
-        mockLiquidityPoolAggregator.id,
-      );
+      const updatedPool = updatedDB.entities.Pool.get(mockPool.id);
       const updatedUser = updatedDB.entities.UserStatsPerPool.get(
         mockUserStatsPerPool.id,
       );
@@ -367,9 +356,7 @@ describe("GaugeSharedLogic", () => {
         "TestGaugeWithdraw",
       );
 
-      const updatedPool = updatedDB.entities.LiquidityPoolAggregator.get(
-        mockLiquidityPoolAggregator.id,
-      );
+      const updatedPool = updatedDB.entities.Pool.get(mockPool.id);
       const updatedUser = updatedDB.entities.UserStatsPerPool.get(
         mockUserStatsPerPool.id,
       );
@@ -416,9 +403,7 @@ describe("GaugeSharedLogic", () => {
         "TestGaugeWithdraw",
       );
 
-      const updatedPool = updatedDB.entities.LiquidityPoolAggregator.get(
-        mockLiquidityPoolAggregator.id,
-      );
+      const updatedPool = updatedDB.entities.Pool.get(mockPool.id);
       const updatedUser = updatedDB.entities.UserStatsPerPool.get(
         mockUserStatsPerPool.id,
       );
@@ -458,9 +443,7 @@ describe("GaugeSharedLogic", () => {
         mockContext,
         "TestGaugeWithdraw",
       );
-      const updatedPool = updatedDB.entities.LiquidityPoolAggregator.get(
-        mockLiquidityPoolAggregator.id,
-      );
+      const updatedPool = updatedDB.entities.Pool.get(mockPool.id);
       const updatedUser = updatedDB.entities.UserStatsPerPool.get(
         mockUserStatsPerPool.id,
       );
@@ -495,9 +478,7 @@ describe("GaugeSharedLogic", () => {
         "TestGaugeClaimRewards",
       );
 
-      const updatedPool = updatedDB.entities.LiquidityPoolAggregator.get(
-        mockLiquidityPoolAggregator.id,
-      );
+      const updatedPool = updatedDB.entities.Pool.get(mockPool.id);
       const updatedUser = updatedDB.entities.UserStatsPerPool.get(
         mockUserStatsPerPool.id,
       );
@@ -573,7 +554,7 @@ describe("GaugeSharedLogic", () => {
         "TestHandler",
       );
       expect(result).not.toBeNull();
-      expect(result?.pool.id).toBe(mockLiquidityPoolAggregator.id);
+      expect(result?.pool.id).toBe(mockPool.id);
       expect(result?.pool.poolAddress).toBe(mockPoolAddress);
     });
 
@@ -681,9 +662,7 @@ describe("GaugeSharedLogic", () => {
       );
 
       expect(logErrorSpy).not.toHaveBeenCalled();
-      const updatedPool = updatedDB.entities.LiquidityPoolAggregator.get(
-        mockLiquidityPoolAggregator.id,
-      );
+      const updatedPool = updatedDB.entities.Pool.get(mockPool.id);
       expect(updatedPool?.numberOfGaugeDeposits).toBe(0n);
     });
 
@@ -709,9 +688,7 @@ describe("GaugeSharedLogic", () => {
       );
 
       expect(logErrorSpy).not.toHaveBeenCalled();
-      const updatedPool = updatedDB.entities.LiquidityPoolAggregator.get(
-        mockLiquidityPoolAggregator.id,
-      );
+      const updatedPool = updatedDB.entities.Pool.get(mockPool.id);
       expect(updatedPool?.numberOfGaugeWithdrawals).toBe(0n);
     });
 
@@ -737,9 +714,7 @@ describe("GaugeSharedLogic", () => {
       );
 
       expect(logErrorSpy).not.toHaveBeenCalled();
-      const updatedPool = updatedDB.entities.LiquidityPoolAggregator.get(
-        mockLiquidityPoolAggregator.id,
-      );
+      const updatedPool = updatedDB.entities.Pool.get(mockPool.id);
       expect(updatedPool?.numberOfGaugeRewardClaims).toBe(0n);
     });
   });
@@ -761,9 +736,7 @@ describe("GaugeSharedLogic", () => {
       await processGaugeDeposit(depositData, mockContext, "TestGaugeDeposit");
 
       // Pool and user should remain unchanged
-      const updatedPool = updatedDB.entities.LiquidityPoolAggregator.get(
-        mockLiquidityPoolAggregator.id,
-      );
+      const updatedPool = updatedDB.entities.Pool.get(mockPool.id);
       const updatedUser = updatedDB.entities.UserStatsPerPool.get(
         mockUserStatsPerPool.id,
       );
@@ -776,8 +749,8 @@ describe("GaugeSharedLogic", () => {
       // Create a context that returns null for pool data
       const mockContextWithNullPool = {
         ...mockContext,
-        LiquidityPoolAggregator: {
-          ...mockContext.LiquidityPoolAggregator,
+        Pool: {
+          ...mockContext.Pool,
           get: () => Promise.resolve(undefined), // Return null to simulate missing pool
         },
       };
@@ -799,9 +772,7 @@ describe("GaugeSharedLogic", () => {
       );
 
       // Pool and user should remain unchanged
-      const updatedPool = updatedDB.entities.LiquidityPoolAggregator.get(
-        mockLiquidityPoolAggregator.id,
-      );
+      const updatedPool = updatedDB.entities.Pool.get(mockPool.id);
       const updatedUser = updatedDB.entities.UserStatsPerPool.get(
         mockUserStatsPerPool.id,
       );
@@ -814,8 +785,8 @@ describe("GaugeSharedLogic", () => {
       // Create a context that returns null for pool data
       const mockContextWithNullPool = {
         ...mockContext,
-        LiquidityPoolAggregator: {
-          ...mockContext.LiquidityPoolAggregator,
+        Pool: {
+          ...mockContext.Pool,
           get: () => Promise.resolve(undefined), // Return null to simulate missing pool
         },
       };
@@ -837,9 +808,7 @@ describe("GaugeSharedLogic", () => {
       );
 
       // Pool and user should remain unchanged
-      const updatedPool = updatedDB.entities.LiquidityPoolAggregator.get(
-        mockLiquidityPoolAggregator.id,
-      );
+      const updatedPool = updatedDB.entities.Pool.get(mockPool.id);
       const updatedUser = updatedDB.entities.UserStatsPerPool.get(
         mockUserStatsPerPool.id,
       );
@@ -852,8 +821,8 @@ describe("GaugeSharedLogic", () => {
       // Create a context that returns null for pool data
       const mockContextWithNullPool = {
         ...mockContext,
-        LiquidityPoolAggregator: {
-          ...mockContext.LiquidityPoolAggregator,
+        Pool: {
+          ...mockContext.Pool,
           get: () => Promise.resolve(undefined), // Return null to simulate missing pool
         },
       };
@@ -875,9 +844,7 @@ describe("GaugeSharedLogic", () => {
       );
 
       // Pool and user should remain unchanged
-      const updatedPool = updatedDB.entities.LiquidityPoolAggregator.get(
-        mockLiquidityPoolAggregator.id,
-      );
+      const updatedPool = updatedDB.entities.Pool.get(mockPool.id);
       const updatedUser = updatedDB.entities.UserStatsPerPool.get(
         mockUserStatsPerPool.id,
       );
@@ -919,9 +886,7 @@ describe("GaugeSharedLogic", () => {
       );
 
       // Pool and user should remain unchanged
-      const updatedPool = updatedDB.entities.LiquidityPoolAggregator.get(
-        mockLiquidityPoolAggregator.id,
-      );
+      const updatedPool = updatedDB.entities.Pool.get(mockPool.id);
       const updatedUser = updatedDB.entities.UserStatsPerPool.get(
         mockUserStatsPerPool.id,
       );
@@ -936,19 +901,16 @@ describe("GaugeSharedLogic", () => {
       TickMath.getSqrtRatioAtTick(0).toString(),
     );
 
-    let clPool: MockLiquidityPoolAggregator;
+    let clPool: MockPool;
     let clMockContext: typeof mockContext;
 
     const mockTokenId1 = 42n;
     const mockTokenId2 = 99n;
 
     beforeEach(() => {
-      const {
-        createMockLiquidityPoolAggregator,
-        createMockNonFungiblePosition,
-      } = setupCommon();
+      const { createMockPool, createMockNonFungiblePosition } = setupCommon();
 
-      clPool = createMockLiquidityPoolAggregator({
+      clPool = createMockPool({
         poolAddress: mockPoolAddress,
         chainId: mockChainId,
         isCL: true,
@@ -992,18 +954,16 @@ describe("GaugeSharedLogic", () => {
         [pos2.id, pos2],
       ]);
 
-      updatedDB = updatedDB.entities.LiquidityPoolAggregator.set(clPool);
+      updatedDB = updatedDB.entities.Pool.set(clPool);
 
       clMockContext = {
         ...mockContext,
-        LiquidityPoolAggregator: {
-          ...mockContext.LiquidityPoolAggregator,
+        Pool: {
+          ...mockContext.Pool,
           // biome-ignore lint/suspicious/noExplicitAny: Mock entity for testing
           getWhere: async (params: any) => {
             if (params.gaugeAddress?._eq) {
-              const pool = updatedDB.entities.LiquidityPoolAggregator.get(
-                clPool.id,
-              );
+              const pool = updatedDB.entities.Pool.get(clPool.id);
               return pool && pool.gaugeAddress === params.gaugeAddress._eq
                 ? [pool]
                 : [];
@@ -1015,7 +975,7 @@ describe("GaugeSharedLogic", () => {
           get: async (id: string) => positionMap.get(id),
           getWhere: async () => [],
         },
-        LiquidityPoolAggregatorSnapshot: {
+        PoolSnapshot: {
           set: () => {},
         },
       };
@@ -1043,9 +1003,7 @@ describe("GaugeSharedLogic", () => {
 
     it("should set hasStakes=true on first CL deposit", async () => {
       // Before any deposit, the pool was created with hasStakes=false
-      const initialPool = updatedDB.entities.LiquidityPoolAggregator.get(
-        clPool.id,
-      );
+      const initialPool = updatedDB.entities.Pool.get(clPool.id);
       expect(initialPool?.hasStakes).toBe(false);
 
       await processGaugeDeposit(
@@ -1062,9 +1020,7 @@ describe("GaugeSharedLogic", () => {
         "CLGauge.Deposit",
       );
 
-      const updatedPool = updatedDB.entities.LiquidityPoolAggregator.get(
-        clPool.id,
-      );
+      const updatedPool = updatedDB.entities.Pool.get(clPool.id);
       expect(updatedPool?.hasStakes).toBe(true);
     });
 

--- a/test/EventHandlers/NFPM/NFPM.test.ts
+++ b/test/EventHandlers/NFPM/NFPM.test.ts
@@ -16,7 +16,7 @@ describe("NFPM Events", () => {
     mockToken0Data,
     mockToken1Data,
     mockLiquidityPoolData,
-    createMockLiquidityPoolAggregator,
+    createMockPool,
   } = setupCommon();
 
   let mockDb: ReturnType<typeof MockDb.createMockDb>;
@@ -57,7 +57,7 @@ describe("NFPM Events", () => {
     });
     mockDb = mockDb.entities.Token.set(mockToken0Data);
     mockDb = mockDb.entities.Token.set(mockToken1Data);
-    mockDb = mockDb.entities.LiquidityPoolAggregator.set(mockLiquidityPoolData);
+    mockDb = mockDb.entities.Pool.set(mockLiquidityPoolData);
   });
 
   afterEach(() => {
@@ -675,16 +675,14 @@ describe("NFPM Events", () => {
         id: TokenId(chainIdBase, token1Address),
         chainId: chainIdBase,
       };
-      const mockLiquidityPoolAggregatorBase = createMockLiquidityPoolAggregator(
-        {
-          chainId: chainIdBase,
-          poolAddress: poolAddressBase,
-          token0_id: mockToken0DataBase.id,
-          token1_id: mockToken1DataBase.id,
-          token0_address: token0Address,
-          token1_address: token1Address,
-        },
-      );
+      const mockPoolBase = createMockPool({
+        chainId: chainIdBase,
+        poolAddress: poolAddressBase,
+        token0_id: mockToken0DataBase.id,
+        token1_id: mockToken1DataBase.id,
+        token0_address: token0Address,
+        token1_address: token1Address,
+      });
       // Setup mockDb with both positions (same tokenId, different chains)
       const mockDbCrossChain = MockDb.createMockDb();
       const dbWithBasePosition =
@@ -698,10 +696,7 @@ describe("NFPM Events", () => {
       )
         .entities.Token.set(mockToken0DataBase)
         .entities.Token.set(mockToken1DataBase);
-      const finalDb =
-        dbWithBothChainsTokens.entities.LiquidityPoolAggregator.set(
-          mockLiquidityPoolAggregatorBase,
-        );
+      const finalDb = dbWithBothChainsTokens.entities.Pool.set(mockPoolBase);
 
       // Setup getWhere to return both positions when querying by tokenId
       const storedPositions = [positionBase, positionLisk];

--- a/test/EventHandlers/NFPM/NFPMCommonLogic.test.ts
+++ b/test/EventHandlers/NFPM/NFPMCommonLogic.test.ts
@@ -5,10 +5,7 @@ import {
   applyStakedPositionToEdges,
   isPositionInRange,
 } from "../../../src/Aggregators/CLStakedLiquidity";
-import {
-  type PoolData,
-  updateLiquidityPoolAggregator,
-} from "../../../src/Aggregators/LiquidityPoolAggregator";
+import { type PoolData, updatePool } from "../../../src/Aggregators/Pool";
 import {
   loadOrCreateUserData,
   updateUserStatsPerPool,
@@ -29,7 +26,7 @@ import {
 import { defaultNfpmAddress, setupCommon } from "../Pool/common";
 
 vi.mock("../../../src/Aggregators/CLStakedLiquidity");
-vi.mock("../../../src/Aggregators/LiquidityPoolAggregator");
+vi.mock("../../../src/Aggregators/Pool");
 vi.mock("../../../src/Aggregators/UserStatsPerPool");
 vi.mock("../../../src/Helpers");
 
@@ -287,8 +284,8 @@ describe("NFPMCommonLogic", () => {
 
     beforeEach(() => {
       vi.mocked(isPositionInRange).mockReset();
-      vi.mocked(updateLiquidityPoolAggregator).mockReset();
-      vi.mocked(updateLiquidityPoolAggregator).mockResolvedValue(undefined);
+      vi.mocked(updatePool).mockReset();
+      vi.mocked(updatePool).mockResolvedValue(undefined);
       vi.mocked(calculatePositionAmountsFromLiquidity).mockReset();
       vi.mocked(calculatePositionAmountsFromLiquidity).mockReturnValue({
         amount0: 100n,
@@ -345,7 +342,7 @@ describe("NFPMCommonLogic", () => {
         -200n,
         200n,
       );
-      expect(updateLiquidityPoolAggregator).toHaveBeenCalledWith(
+      expect(updatePool).toHaveBeenCalledWith(
         {
           stakedLiquidityInRange: 6000n, // 1000 + 5000
           incrementalStakedReserve0: 100n, // direction=+1 * 100
@@ -382,7 +379,7 @@ describe("NFPMCommonLogic", () => {
         -200n,
         200n,
       );
-      expect(updateLiquidityPoolAggregator).toHaveBeenCalledWith(
+      expect(updatePool).toHaveBeenCalledWith(
         {
           stakedLiquidityInRange: -2000n, // 1000 + (-3000)
           incrementalStakedReserve0: -100n, // direction=-1 * 100
@@ -418,7 +415,7 @@ describe("NFPMCommonLogic", () => {
         -200n,
         200n,
       );
-      expect(updateLiquidityPoolAggregator).toHaveBeenCalledWith(
+      expect(updatePool).toHaveBeenCalledWith(
         {
           stakedLiquidityInRange: undefined, // not in range, so unchanged
           incrementalStakedReserve0: 100n,
@@ -459,7 +456,7 @@ describe("NFPMCommonLogic", () => {
       // Reserve math is skipped (no sqrtPriceX96 to split into token0/token1),
       // but we still persist the edge-list update so the swap path has correct
       // state once the pool is initialized.
-      expect(updateLiquidityPoolAggregator).toHaveBeenCalledWith(
+      expect(updatePool).toHaveBeenCalledWith(
         {
           stakedTickEdges: [-200n, 200n],
           stakedTickEdgeNets: [5000n, -5000n],

--- a/test/EventHandlers/NFPM/NFPMDecreaseLiquidityLogic.test.ts
+++ b/test/EventHandlers/NFPM/NFPMDecreaseLiquidityLogic.test.ts
@@ -1,9 +1,6 @@
 import type { NonFungiblePosition, handlerContext } from "generated";
 import { MockDb, NFPM } from "../../../generated/src/TestHelpers.gen";
-import {
-  type PoolData,
-  loadPoolData,
-} from "../../../src/Aggregators/LiquidityPoolAggregator";
+import { type PoolData, loadPoolData } from "../../../src/Aggregators/Pool";
 import {
   NonFungiblePositionId,
   NonFungiblePositionSnapshotId,
@@ -20,10 +17,8 @@ import {
 import { getSnapshotEpoch } from "../../../src/Snapshots/Shared";
 import { defaultNfpmAddress } from "../Pool/common";
 
-vi.mock("../../../src/Aggregators/LiquidityPoolAggregator", async () => ({
-  ...(await vi.importActual(
-    "../../../src/Aggregators/LiquidityPoolAggregator",
-  )),
+vi.mock("../../../src/Aggregators/Pool", async () => ({
+  ...(await vi.importActual("../../../src/Aggregators/Pool")),
   loadPoolData: vi.fn(),
 }));
 
@@ -112,7 +107,7 @@ describe("NFPMDecreaseLiquidityLogic", () => {
 
     mockContext = {
       ...mockDb,
-      LiquidityPoolAggregator: {
+      Pool: {
         get: vi.fn().mockResolvedValue(undefined),
       },
       UserStatsPerPool: {

--- a/test/EventHandlers/NFPM/NFPMIncreaseLiquidityLogic.test.ts
+++ b/test/EventHandlers/NFPM/NFPMIncreaseLiquidityLogic.test.ts
@@ -4,10 +4,7 @@ import type {
   handlerContext,
 } from "generated";
 import { MockDb, NFPM } from "../../../generated/src/TestHelpers.gen";
-import {
-  type PoolData,
-  loadPoolData,
-} from "../../../src/Aggregators/LiquidityPoolAggregator";
+import { type PoolData, loadPoolData } from "../../../src/Aggregators/Pool";
 import {
   CLPoolMintEventId,
   NonFungiblePositionId,
@@ -23,10 +20,8 @@ import {
 } from "../../../src/EventHandlers/NFPM/NFPMIncreaseLiquidityLogic";
 import { defaultNfpmAddress } from "../Pool/common";
 
-vi.mock("../../../src/Aggregators/LiquidityPoolAggregator", async () => ({
-  ...(await vi.importActual(
-    "../../../src/Aggregators/LiquidityPoolAggregator",
-  )),
+vi.mock("../../../src/Aggregators/Pool", async () => ({
+  ...(await vi.importActual("../../../src/Aggregators/Pool")),
   loadPoolData: vi.fn(),
 }));
 
@@ -129,7 +124,7 @@ describe("NFPMIncreaseLiquidityLogic", () => {
 
     return {
       ...currentDb,
-      LiquidityPoolAggregator: {
+      Pool: {
         get: vi.fn().mockResolvedValue(undefined),
       },
       UserStatsPerPool: {

--- a/test/EventHandlers/NFPM/NFPMTransferLogic.test.ts
+++ b/test/EventHandlers/NFPM/NFPMTransferLogic.test.ts
@@ -5,8 +5,8 @@ import type {
   handlerContext,
 } from "generated";
 import { MockDb, NFPM } from "../../../generated/src/TestHelpers.gen";
-import { loadPoolData } from "../../../src/Aggregators/LiquidityPoolAggregator";
-import type { PoolData } from "../../../src/Aggregators/LiquidityPoolAggregator";
+import { loadPoolData } from "../../../src/Aggregators/Pool";
+import type { PoolData } from "../../../src/Aggregators/Pool";
 import {
   CLPoolMintEventId,
   NonFungiblePositionId,
@@ -27,10 +27,8 @@ import {
 } from "../../../src/EventHandlers/NFPM/NFPMTransferLogic";
 import { defaultNfpmAddress } from "../Pool/common";
 
-vi.mock("../../../src/Aggregators/LiquidityPoolAggregator", async () => ({
-  ...(await vi.importActual(
-    "../../../src/Aggregators/LiquidityPoolAggregator",
-  )),
+vi.mock("../../../src/Aggregators/Pool", async () => ({
+  ...(await vi.importActual("../../../src/Aggregators/Pool")),
   loadPoolData: vi.fn(),
 }));
 
@@ -256,7 +254,7 @@ describe("NFPMTransferLogic", () => {
 
     return {
       ...currentDb,
-      LiquidityPoolAggregator: {
+      Pool: {
         get: vi.fn().mockImplementation((id: string) => {
           if (id !== PoolId(chainId, poolAddress)) {
             return Promise.resolve(undefined);

--- a/test/EventHandlers/Pool/Burn.test.ts
+++ b/test/EventHandlers/Pool/Burn.test.ts
@@ -12,7 +12,7 @@ describe("Pool Burn Event", () => {
     commonData = setupCommon();
 
     // Set up mock database with common data
-    const updatedDB1 = mockDb.entities.LiquidityPoolAggregator.set(
+    const updatedDB1 = mockDb.entities.Pool.set(
       commonData.mockLiquidityPoolData,
     );
     const updatedDB2 = updatedDB1.entities.Token.set(commonData.mockToken0Data);
@@ -41,7 +41,7 @@ describe("Pool Burn Event", () => {
     const result = await mockDb.processEvents([mockEvent]);
 
     // Verify that the liquidity pool aggregator was updated
-    const updatedAggregator = result.entities.LiquidityPoolAggregator.get(
+    const updatedAggregator = result.entities.Pool.get(
       commonData.mockLiquidityPoolData.id,
     );
     expect(updatedAggregator).toBeDefined();
@@ -69,7 +69,7 @@ describe("Pool Burn Event", () => {
       const updatedDB2 = updatedDB1.entities.Token.set(
         commonData.mockToken1Data,
       );
-      // Note: We intentionally don't set the LiquidityPoolAggregator
+      // Note: We intentionally don't set the Pool
 
       const mockEvent = Pool.Burn.createMockEvent({
         sender: toChecksumAddress("0x1111111111111111111111111111111111111111"),
@@ -92,7 +92,7 @@ describe("Pool Burn Event", () => {
       const postEventDB = await updatedDB2.processEvents([mockEvent]);
 
       // Pool should not exist
-      const pool = postEventDB.entities.LiquidityPoolAggregator.get(
+      const pool = postEventDB.entities.Pool.get(
         commonData.mockLiquidityPoolData.id,
       );
       expect(pool).toBeUndefined();

--- a/test/EventHandlers/Pool/Claim.test.ts
+++ b/test/EventHandlers/Pool/Claim.test.ts
@@ -1,17 +1,16 @@
-import type { LiquidityPoolAggregator, Token } from "generated";
+import type { Token } from "generated";
 import type { MockInstance } from "vitest";
 import { MockDb, Pool } from "../../../generated/src/TestHelpers.gen";
 import { toChecksumAddress } from "../../../src/Constants";
+import type { Pool as PoolEntity } from "../../../src/EntityTypes";
 import * as PriceOracle from "../../../src/PriceOracle";
-import { type MockLiquidityPoolAggregator, setupCommon } from "./common";
+import { type MockPool, setupCommon } from "./common";
 
 describe("Pool Claim Event", () => {
   let mockToken0Data: Token;
   let mockToken1Data: Token;
-  let mockLiquidityPoolData: MockLiquidityPoolAggregator;
-  let createMockLiquidityPoolAggregator: ReturnType<
-    typeof setupCommon
-  >["createMockLiquidityPoolAggregator"];
+  let mockLiquidityPoolData: MockPool;
+  let createMockPool: ReturnType<typeof setupCommon>["createMockPool"];
   let mockDb: ReturnType<typeof MockDb.createMockDb>;
   let mockPriceOracle: MockInstance;
 
@@ -23,12 +22,12 @@ describe("Pool Claim Event", () => {
     const {
       mockToken0Data: token0,
       mockToken1Data: token1,
-      createMockLiquidityPoolAggregator: builder,
+      createMockPool: builder,
     } = setupCommon();
     mockToken0Data = token0;
     mockToken1Data = token1;
-    createMockLiquidityPoolAggregator = builder;
-    mockLiquidityPoolData = createMockLiquidityPoolAggregator({
+    createMockPool = builder;
+    mockLiquidityPoolData = createMockPool({
       gaugeAddress: gaugeAddress,
     });
 
@@ -68,12 +67,10 @@ describe("Pool Claim Event", () => {
       };
 
       let postEventDB: ReturnType<typeof MockDb.createMockDb>;
-      let updatedPool: LiquidityPoolAggregator | undefined;
+      let updatedPool: PoolEntity | undefined;
 
       beforeEach(async () => {
-        const updatedDB1 = mockDb.entities.LiquidityPoolAggregator.set(
-          mockLiquidityPoolData,
-        );
+        const updatedDB1 = mockDb.entities.Pool.set(mockLiquidityPoolData);
         const updatedDB2 = updatedDB1.entities.Token.set(
           mockToken0Data as Token,
         );
@@ -84,9 +81,7 @@ describe("Pool Claim Event", () => {
         const mockEvent = Pool.Claim.createMockEvent(eventData);
 
         postEventDB = await updatedDB3.processEvents([mockEvent]);
-        updatedPool = postEventDB.entities.LiquidityPoolAggregator.get(
-          mockLiquidityPoolData.id,
-        );
+        updatedPool = postEventDB.entities.Pool.get(mockLiquidityPoolData.id);
       });
 
       it("should update staked fees collected amounts", () => {
@@ -168,12 +163,10 @@ describe("Pool Claim Event", () => {
       };
 
       let postEventDB: ReturnType<typeof MockDb.createMockDb>;
-      let updatedPool: LiquidityPoolAggregator | undefined;
+      let updatedPool: PoolEntity | undefined;
 
       beforeEach(async () => {
-        const updatedDB1 = mockDb.entities.LiquidityPoolAggregator.set(
-          mockLiquidityPoolData,
-        );
+        const updatedDB1 = mockDb.entities.Pool.set(mockLiquidityPoolData);
         const updatedDB2 = updatedDB1.entities.Token.set(
           mockToken0Data as Token,
         );
@@ -184,9 +177,7 @@ describe("Pool Claim Event", () => {
         const mockEvent = Pool.Claim.createMockEvent(eventData);
 
         postEventDB = await updatedDB3.processEvents([mockEvent]);
-        updatedPool = postEventDB.entities.LiquidityPoolAggregator.get(
-          mockLiquidityPoolData.id,
-        );
+        updatedPool = postEventDB.entities.Pool.get(mockLiquidityPoolData.id);
       });
 
       it("should update unstaked fees collected amounts", () => {
@@ -250,9 +241,7 @@ describe("Pool Claim Event", () => {
           },
         };
 
-        const updatedDB1 = mockDb.entities.LiquidityPoolAggregator.set(
-          mockLiquidityPoolData,
-        );
+        const updatedDB1 = mockDb.entities.Pool.set(mockLiquidityPoolData);
         const updatedDB2 = updatedDB1.entities.Token.set(
           mockToken0Data as Token,
         );
@@ -263,7 +252,7 @@ describe("Pool Claim Event", () => {
         const mockEvent = Pool.Claim.createMockEvent(eventData);
 
         const postEventDB = await updatedDB3.processEvents([mockEvent]);
-        const updatedPool = postEventDB.entities.LiquidityPoolAggregator.get(
+        const updatedPool = postEventDB.entities.Pool.get(
           mockLiquidityPoolData.id,
         );
 
@@ -285,7 +274,7 @@ describe("Pool Claim Event", () => {
       });
 
       it("should handle case when gauge address is undefined", async () => {
-        const poolWithoutGauge = createMockLiquidityPoolAggregator({
+        const poolWithoutGauge = createMockPool({
           gaugeAddress: undefined,
         });
 
@@ -310,8 +299,7 @@ describe("Pool Claim Event", () => {
           },
         };
 
-        const updatedDB1 =
-          mockDb.entities.LiquidityPoolAggregator.set(poolWithoutGauge);
+        const updatedDB1 = mockDb.entities.Pool.set(poolWithoutGauge);
         const updatedDB2 = updatedDB1.entities.Token.set(
           mockToken0Data as Token,
         );
@@ -322,7 +310,7 @@ describe("Pool Claim Event", () => {
         const mockEvent = Pool.Claim.createMockEvent(eventData);
 
         const postEventDB = await updatedDB3.processEvents([mockEvent]);
-        const updatedPool = postEventDB.entities.LiquidityPoolAggregator.get(
+        const updatedPool = postEventDB.entities.Pool.get(
           mockLiquidityPoolData.id,
         );
 
@@ -364,7 +352,7 @@ describe("Pool Claim Event", () => {
 
       const postEventDB = await mockDb.processEvents([mockEvent]);
 
-      const pool = postEventDB.entities.LiquidityPoolAggregator.get(
+      const pool = postEventDB.entities.Pool.get(
         toChecksumAddress(eventData.mockEventData.srcAddress),
       );
 

--- a/test/EventHandlers/Pool/Fees.test.ts
+++ b/test/EventHandlers/Pool/Fees.test.ts
@@ -1,10 +1,7 @@
-import type {
-  LiquidityPoolAggregator,
-  Token,
-  UserStatsPerPool,
-} from "generated";
+import type { Token, UserStatsPerPool } from "generated";
 import { MockDb, Pool } from "../../../generated/src/TestHelpers.gen";
 import { UserStatsPerPoolId, toChecksumAddress } from "../../../src/Constants";
+import type { Pool as PoolEntity } from "../../../src/EntityTypes";
 import * as PoolFeesLogic from "../../../src/EventHandlers/Pool/PoolFeesLogic";
 import { setupCommon } from "./common";
 
@@ -40,16 +37,14 @@ describe("Pool Fees Event", () => {
 
   expectations.totalFeesUSDWhitelisted = expectations.totalFeesGeneratedUSD;
 
-  let updatedPool: LiquidityPoolAggregator | undefined;
+  let updatedPool: PoolEntity | undefined;
   let createdUserStats: UserStatsPerPool | undefined;
 
   beforeEach(async () => {
     mockDb = MockDb.createMockDb();
     updatedDB = mockDb.entities.Token.set(mockToken0Data as Token);
     updatedDB = updatedDB.entities.Token.set(mockToken1Data as Token);
-    updatedDB = updatedDB.entities.LiquidityPoolAggregator.set(
-      mockLiquidityPoolData,
-    );
+    updatedDB = updatedDB.entities.Pool.set(mockLiquidityPoolData);
 
     const mockEvent = Pool.Fees.createMockEvent({
       amount0: expectations.amount0In,
@@ -68,7 +63,7 @@ describe("Pool Fees Event", () => {
 
     const result = await updatedDB.processEvents([mockEvent]);
 
-    updatedPool = result.entities.LiquidityPoolAggregator.get(poolId);
+    updatedPool = result.entities.Pool.get(poolId);
     createdUserStats = result.entities.UserStatsPerPool.get(
       UserStatsPerPoolId(
         10,
@@ -78,12 +73,12 @@ describe("Pool Fees Event", () => {
     );
   });
 
-  it("should update LiquidityPoolAggregator", async () => {
+  it("should update Pool", async () => {
     expect(updatedPool).toBeDefined();
     expect(updatedPool?.lastUpdatedTimestamp).toEqual(new Date(1000000 * 1000));
   });
 
-  it("should update LiquidityPoolAggregator nominal fees", async () => {
+  it("should update Pool nominal fees", async () => {
     // For regular pools, fees are tracked as unstaked fees
     expect(updatedPool?.totalFeesGenerated0).toBe(
       mockLiquidityPoolData.totalFeesGenerated0 + expectations.amount0In,
@@ -93,13 +88,13 @@ describe("Pool Fees Event", () => {
     );
   });
 
-  it("should update LiquidityPoolAggregator total fees in USD", async () => {
+  it("should update Pool total fees in USD", async () => {
     expect(updatedPool?.totalFeesGeneratedUSD).toBe(
       expectations.totalFeesGeneratedUSD,
     );
   });
 
-  it("should update LiquidityPoolAggregator total fees in USD whitelisted", async () => {
+  it("should update Pool total fees in USD whitelisted", async () => {
     expect(updatedPool?.totalFeesUSDWhitelisted).toBe(
       expectations.totalFeesUSDWhitelisted,
     );
@@ -228,7 +223,7 @@ describe("Pool Fees Event", () => {
         mockToken0Data as Token,
       );
       const updatedDB2 = updatedDB1.entities.Token.set(mockToken1Data as Token);
-      // Note: We intentionally don't set the LiquidityPoolAggregator
+      // Note: We intentionally don't set the Pool
 
       const mockEvent = Pool.Fees.createMockEvent({
         amount0: 3n * 10n ** 18n,
@@ -248,7 +243,7 @@ describe("Pool Fees Event", () => {
       const postEventDB = await updatedDB2.processEvents([mockEvent]);
 
       // Pool should not exist
-      const pool = postEventDB.entities.LiquidityPoolAggregator.get(poolId);
+      const pool = postEventDB.entities.Pool.get(poolId);
       expect(pool).toBeUndefined();
 
       // User stats will still be created because loadOrCreateUserData is called in parallel
@@ -281,9 +276,7 @@ describe("Pool Fees Event", () => {
       const freshMockDb = MockDb.createMockDb();
       const testDB = freshMockDb.entities.Token.set(mockToken0Data as Token);
       const testDB2 = testDB.entities.Token.set(mockToken1Data as Token);
-      const testDB3 = testDB2.entities.LiquidityPoolAggregator.set(
-        mockLiquidityPoolData,
-      );
+      const testDB3 = testDB2.entities.Pool.set(mockLiquidityPoolData);
 
       // Mock processPoolFees to return undefined liquidityPoolDiff
       processSpy = vi.spyOn(PoolFeesLogic, "processPoolFees").mockReturnValue({
@@ -314,7 +307,7 @@ describe("Pool Fees Event", () => {
       const result = await testDB3.processEvents([mockEvent]);
 
       // Pool should not be updated since liquidityPoolDiff is undefined
-      const pool = result.entities.LiquidityPoolAggregator.get(poolId);
+      const pool = result.entities.Pool.get(poolId);
       expect(pool?.totalFeesGenerated0).toBe(
         mockLiquidityPoolData.totalFeesGenerated0,
       );
@@ -336,9 +329,7 @@ describe("Pool Fees Event", () => {
       const freshMockDb = MockDb.createMockDb();
       const testDB = freshMockDb.entities.Token.set(mockToken0Data as Token);
       const testDB2 = testDB.entities.Token.set(mockToken1Data as Token);
-      const testDB3 = testDB2.entities.LiquidityPoolAggregator.set(
-        mockLiquidityPoolData,
-      );
+      const testDB3 = testDB2.entities.Pool.set(mockLiquidityPoolData);
 
       // Mock processPoolFees to return undefined userDiff
       const processSpy = vi
@@ -372,7 +363,7 @@ describe("Pool Fees Event", () => {
       const result = await testDB3.processEvents([mockEvent]);
 
       // Pool should still be updated
-      const pool = result.entities.LiquidityPoolAggregator.get(poolId);
+      const pool = result.entities.Pool.get(poolId);
       expect(pool?.totalFeesGenerated0).toBe(
         mockLiquidityPoolData.totalFeesGenerated0 + 3n * 10n ** 18n,
       );

--- a/test/EventHandlers/Pool/Mint.test.ts
+++ b/test/EventHandlers/Pool/Mint.test.ts
@@ -12,7 +12,7 @@ describe("Pool Mint Event", () => {
     commonData = setupCommon();
 
     // Set up mock database with common data
-    const updatedDB1 = mockDb.entities.LiquidityPoolAggregator.set(
+    const updatedDB1 = mockDb.entities.Pool.set(
       commonData.mockLiquidityPoolData,
     );
     const updatedDB2 = updatedDB1.entities.Token.set(commonData.mockToken0Data);
@@ -40,7 +40,7 @@ describe("Pool Mint Event", () => {
     const result = await mockDb.processEvents([mockEvent]);
 
     // Verify that the liquidity pool aggregator was updated
-    const updatedAggregator = result.entities.LiquidityPoolAggregator.get(
+    const updatedAggregator = result.entities.Pool.get(
       commonData.mockLiquidityPoolData.id,
     );
     expect(updatedAggregator).toBeDefined();
@@ -68,7 +68,7 @@ describe("Pool Mint Event", () => {
       const updatedDB2 = updatedDB1.entities.Token.set(
         commonData.mockToken1Data,
       );
-      // Note: We intentionally don't set the LiquidityPoolAggregator
+      // Note: We intentionally don't set the Pool
 
       const mockEvent = Pool.Mint.createMockEvent({
         sender: toChecksumAddress("0x1111111111111111111111111111111111111111"),
@@ -90,7 +90,7 @@ describe("Pool Mint Event", () => {
       const postEventDB = await updatedDB2.processEvents([mockEvent]);
 
       // Pool should not exist
-      const pool = postEventDB.entities.LiquidityPoolAggregator.get(
+      const pool = postEventDB.entities.Pool.get(
         commonData.mockLiquidityPoolData.id,
       );
       expect(pool).toBeUndefined();

--- a/test/EventHandlers/Pool/PoolBurnAndMintLogic.test.ts
+++ b/test/EventHandlers/Pool/PoolBurnAndMintLogic.test.ts
@@ -119,7 +119,7 @@ describe("PoolBurnAndMintLogic", () => {
           if (idx >= 0) mockRegistries.splice(idx, 1);
         }),
       },
-      LiquidityPoolAggregator: {
+      Pool: {
         get: vi.fn(),
         set: vi.fn(),
       },

--- a/test/EventHandlers/Pool/PoolSyncLogic.test.ts
+++ b/test/EventHandlers/Pool/PoolSyncLogic.test.ts
@@ -1,10 +1,6 @@
-import type {
-  LiquidityPoolAggregator,
-  Pool_Sync_event,
-  Token,
-  handlerContext,
-} from "generated";
+import type { Pool_Sync_event, Token, handlerContext } from "generated";
 import { toChecksumAddress } from "../../../src/Constants";
+import type { Pool } from "../../../src/EntityTypes";
 import { processPoolSync } from "../../../src/EventHandlers/Pool/PoolSyncLogic";
 import { setupCommon } from "./common";
 
@@ -29,7 +25,7 @@ describe("PoolSyncLogic", () => {
     },
   };
 
-  const mockLiquidityPoolAggregator = {
+  const mockPool = {
     ...mockLiquidityPoolData,
     reserve0: 500n,
     reserve1: 1000n,
@@ -54,7 +50,7 @@ describe("PoolSyncLogic", () => {
     ),
     gaugeIsAlive: true,
     lastUpdatedTimestamp: new Date(1000000 * 1000),
-  } as LiquidityPoolAggregator;
+  } as Pool;
 
   const mockToken0 = {
     id: toChecksumAddress("0x2222222222222222222222222222222222222222"),
@@ -92,7 +88,7 @@ describe("PoolSyncLogic", () => {
     it("should create entity and calculate sync updates for successful sync", () => {
       const result = processPoolSync(
         mockEvent,
-        mockLiquidityPoolAggregator,
+        mockPool,
         mockToken0,
         mockToken1,
       );
@@ -113,7 +109,7 @@ describe("PoolSyncLogic", () => {
     it("should calculate total liquidity USD correctly with both tokens", () => {
       const result = processPoolSync(
         mockEvent,
-        mockLiquidityPoolAggregator,
+        mockPool,
         mockToken0,
         mockToken1,
       );
@@ -126,7 +122,7 @@ describe("PoolSyncLogic", () => {
     it("should calculate total liquidity USD correctly with only token0", () => {
       const result = processPoolSync(
         mockEvent,
-        mockLiquidityPoolAggregator,
+        mockPool,
         mockToken0,
         undefined,
       );
@@ -139,7 +135,7 @@ describe("PoolSyncLogic", () => {
     it("should calculate total liquidity USD correctly with only token1", () => {
       const result = processPoolSync(
         mockEvent,
-        mockLiquidityPoolAggregator,
+        mockPool,
         undefined,
         mockToken1,
       );
@@ -148,12 +144,7 @@ describe("PoolSyncLogic", () => {
     });
 
     it("should leave totalLiquidityUSD unchanged when no tokens are available", () => {
-      const result = processPoolSync(
-        mockEvent,
-        mockLiquidityPoolAggregator,
-        undefined,
-        undefined,
-      );
+      const result = processPoolSync(mockEvent, mockPool, undefined, undefined);
 
       // No tokens available: keep existing values (no change)
       expect(result.liquidityPoolDiff.currentTotalLiquidityUSD).toBeUndefined();
@@ -167,7 +158,7 @@ describe("PoolSyncLogic", () => {
 
       const result = processPoolSync(
         mockEvent,
-        mockLiquidityPoolAggregator,
+        mockPool,
         mockToken0WithDifferentDecimals,
         mockToken1,
       );
@@ -188,7 +179,7 @@ describe("PoolSyncLogic", () => {
 
       const result = processPoolSync(
         mockEventWithZeroAmounts,
-        mockLiquidityPoolAggregator,
+        mockPool,
         mockToken0,
         mockToken1,
       );
@@ -201,19 +192,14 @@ describe("PoolSyncLogic", () => {
     });
 
     it("should handle missing token instances gracefully", () => {
-      const result = processPoolSync(
-        mockEvent,
-        mockLiquidityPoolAggregator,
-        undefined,
-        undefined,
-      );
+      const result = processPoolSync(mockEvent, mockPool, undefined, undefined);
 
       expect(result.liquidityPoolDiff).toBeDefined();
 
       // Should use existing prices from aggregator
       expect(result.liquidityPoolDiff).toMatchObject({
-        token0Price: mockLiquidityPoolAggregator.token0Price,
-        token1Price: mockLiquidityPoolAggregator.token1Price,
+        token0Price: mockPool.token0Price,
+        token1Price: mockPool.token1Price,
       });
     });
 
@@ -230,7 +216,7 @@ describe("PoolSyncLogic", () => {
 
       const result = processPoolSync(
         mockEvent,
-        mockLiquidityPoolAggregator,
+        mockPool,
         mockToken0WithNewPrice,
         mockToken1WithNewPrice,
       );

--- a/test/EventHandlers/Pool/PoolTransferLogic.test.ts
+++ b/test/EventHandlers/Pool/PoolTransferLogic.test.ts
@@ -1,11 +1,10 @@
 import type {
-  LiquidityPoolAggregator,
   Pool_Transfer_event,
   UserStatsPerPool,
   handlerContext,
 } from "generated";
 import type { MockInstance } from "vitest";
-import * as LiquidityPoolAggregatorModule from "../../../src/Aggregators/LiquidityPoolAggregator";
+import * as PoolModule from "../../../src/Aggregators/Pool";
 import * as UserStatsPerPoolModule from "../../../src/Aggregators/UserStatsPerPool";
 import {
   PoolTransferInTxId,
@@ -13,6 +12,7 @@ import {
   ZERO_ADDRESS,
   toChecksumAddress,
 } from "../../../src/Constants";
+import type { Pool } from "../../../src/EntityTypes";
 import {
   processPoolTransfer,
   storeTransferForMatching,
@@ -44,13 +44,13 @@ describe("PoolTransferLogic", () => {
 
   // Shared mock context
   let mockContext: handlerContext;
-  let mockLiquidityPoolAggregator: LiquidityPoolAggregator;
-  let updateLiquidityPoolAggregatorSpy: MockInstance;
+  let mockPool: Pool;
+  let updatePoolSpy: MockInstance;
   let updateUserStatsPerPoolSpy: MockInstance;
   let loadOrCreateUserDataSpy: MockInstance;
 
   beforeEach(() => {
-    mockLiquidityPoolAggregator = {
+    mockPool = {
       ...mockLiquidityPoolData,
       totalLPTokenSupply: 1000n * 10n ** 18n,
     };
@@ -61,7 +61,7 @@ describe("PoolTransferLogic", () => {
         warn: vi.fn(),
         info: vi.fn(),
       },
-      LiquidityPoolAggregator: {
+      Pool: {
         get: vi.fn(),
         set: vi.fn(),
       },
@@ -81,8 +81,8 @@ describe("PoolTransferLogic", () => {
     } as unknown as handlerContext;
 
     // Set up spies with mocks
-    updateLiquidityPoolAggregatorSpy = vi
-      .spyOn(LiquidityPoolAggregatorModule, "updateLiquidityPoolAggregator")
+    updatePoolSpy = vi
+      .spyOn(PoolModule, "updatePool")
       .mockResolvedValue(undefined);
 
     loadOrCreateUserDataSpy = vi
@@ -131,18 +131,18 @@ describe("PoolTransferLogic", () => {
         true, // isMint
         false, // isBurn
         LP_VALUE,
-        mockLiquidityPoolAggregator,
+        mockPool,
         TIMESTAMP_DATE,
         mockContext,
         CHAIN_ID,
         BLOCK_NUMBER,
       );
 
-      expect(updateLiquidityPoolAggregatorSpy).toHaveBeenCalledWith(
+      expect(updatePoolSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           incrementalTotalLPSupply: LP_VALUE,
         }),
-        mockLiquidityPoolAggregator,
+        mockPool,
         TIMESTAMP_DATE,
         mockContext,
         CHAIN_ID,
@@ -155,18 +155,18 @@ describe("PoolTransferLogic", () => {
         false, // isMint
         true, // isBurn
         LP_VALUE,
-        mockLiquidityPoolAggregator,
+        mockPool,
         TIMESTAMP_DATE,
         mockContext,
         CHAIN_ID,
         BLOCK_NUMBER,
       );
 
-      expect(updateLiquidityPoolAggregatorSpy).toHaveBeenCalledWith(
+      expect(updatePoolSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           incrementalTotalLPSupply: -LP_VALUE,
         }),
-        mockLiquidityPoolAggregator,
+        mockPool,
         TIMESTAMP_DATE,
         mockContext,
         CHAIN_ID,
@@ -179,14 +179,14 @@ describe("PoolTransferLogic", () => {
         false, // isMint
         false, // isBurn
         LP_VALUE,
-        mockLiquidityPoolAggregator,
+        mockPool,
         TIMESTAMP_DATE,
         mockContext,
         CHAIN_ID,
         BLOCK_NUMBER,
       );
 
-      expect(updateLiquidityPoolAggregatorSpy).not.toHaveBeenCalled();
+      expect(updatePoolSpy).not.toHaveBeenCalled();
     });
   });
 
@@ -420,14 +420,14 @@ describe("PoolTransferLogic", () => {
 
       await processPoolTransfer(
         event,
-        mockLiquidityPoolAggregator,
+        mockPool,
         POOL_ADDRESS,
         CHAIN_ID,
         mockContext,
         TIMESTAMP_DATE,
       );
 
-      expect(updateLiquidityPoolAggregatorSpy).toHaveBeenCalled();
+      expect(updatePoolSpy).toHaveBeenCalled();
       expect(updateUserStatsPerPoolSpy).toHaveBeenCalled();
       expect(mockContext.PoolTransferInTx.set).toHaveBeenCalled();
     });
@@ -445,14 +445,14 @@ describe("PoolTransferLogic", () => {
 
       await processPoolTransfer(
         event,
-        mockLiquidityPoolAggregator,
+        mockPool,
         POOL_ADDRESS,
         CHAIN_ID,
         mockContext,
         TIMESTAMP_DATE,
       );
 
-      expect(updateLiquidityPoolAggregatorSpy).toHaveBeenCalled();
+      expect(updatePoolSpy).toHaveBeenCalled();
       expect(updateUserStatsPerPoolSpy).toHaveBeenCalled();
       expect(mockContext.PoolTransferInTx.set).toHaveBeenCalled();
     });
@@ -466,7 +466,7 @@ describe("PoolTransferLogic", () => {
 
       await processPoolTransfer(
         event,
-        mockLiquidityPoolAggregator,
+        mockPool,
         POOL_ADDRESS,
         CHAIN_ID,
         mockContext,

--- a/test/EventHandlers/Pool/Swap.test.ts
+++ b/test/EventHandlers/Pool/Swap.test.ts
@@ -1,4 +1,4 @@
-import type { LiquidityPoolAggregator, Token } from "generated";
+import type { Token } from "generated";
 import type { MockInstance } from "vitest";
 import { MockDb, Pool } from "../../../generated/src/TestHelpers.gen";
 import {
@@ -9,6 +9,7 @@ import {
   UserStatsPerPoolId,
   toChecksumAddress,
 } from "../../../src/Constants";
+import type { Pool as PoolEntity } from "../../../src/EntityTypes";
 import * as PriceOracle from "../../../src/PriceOracle";
 import { setupCommon } from "./common";
 
@@ -120,10 +121,10 @@ describe("Pool Swap Event", () => {
 
   describe("when both tokens exist", () => {
     let postEventDB: ReturnType<typeof MockDb.createMockDb>;
-    let updatedPool: LiquidityPoolAggregator | undefined;
+    let updatedPool: PoolEntity | undefined;
 
     beforeEach(async () => {
-      const updatedDB1 = mockDb.entities.LiquidityPoolAggregator.set({
+      const updatedDB1 = mockDb.entities.Pool.set({
         ...mockLiquidityPoolData,
         stakedTickEdges: [...mockLiquidityPoolData.stakedTickEdges],
         stakedTickEdgeNets: [...mockLiquidityPoolData.stakedTickEdgeNets],
@@ -134,7 +135,7 @@ describe("Pool Swap Event", () => {
       const mockEvent = Pool.Swap.createMockEvent(eventData);
 
       postEventDB = await updatedDB3.processEvents([mockEvent]);
-      updatedPool = postEventDB.entities.LiquidityPoolAggregator.get(
+      updatedPool = postEventDB.entities.Pool.get(
         PoolId(
           eventData.mockEventData.chainId,
           eventData.mockEventData.srcAddress,
@@ -198,14 +199,14 @@ describe("Pool Swap Event", () => {
       // Create a mockDb without the pool
       const updatedDB1 = mockDb.entities.Token.set(mockToken0Data as Token);
       const updatedDB2 = updatedDB1.entities.Token.set(mockToken1Data as Token);
-      // Note: We intentionally don't set the LiquidityPoolAggregator
+      // Note: We intentionally don't set the Pool
 
       const mockEvent = Pool.Swap.createMockEvent(eventData);
 
       const postEventDB = await updatedDB2.processEvents([mockEvent]);
 
       // Pool should not exist
-      const pool = postEventDB.entities.LiquidityPoolAggregator.get(
+      const pool = postEventDB.entities.Pool.get(
         PoolId(
           eventData.mockEventData.chainId,
           eventData.mockEventData.srcAddress,
@@ -246,8 +247,7 @@ describe("Pool Swap Event", () => {
         stakedTickEdgeNets: [...mockLiquidityPoolData.stakedTickEdgeNets],
       };
 
-      const updatedDB1 =
-        mockDb.entities.LiquidityPoolAggregator.set(poolWithOusdt);
+      const updatedDB1 = mockDb.entities.Pool.set(poolWithOusdt);
       const updatedDB2 = updatedDB1.entities.Token.set(ousdtToken as Token);
       const updatedDB3 = updatedDB2.entities.Token.set(mockToken1Data as Token);
 
@@ -282,8 +282,7 @@ describe("Pool Swap Event", () => {
         stakedTickEdgeNets: [...mockLiquidityPoolData.stakedTickEdgeNets],
       };
 
-      const updatedDB1 =
-        mockDb.entities.LiquidityPoolAggregator.set(poolWithOusdt);
+      const updatedDB1 = mockDb.entities.Pool.set(poolWithOusdt);
       const updatedDB2 = updatedDB1.entities.Token.set(mockToken0Data as Token);
       const updatedDB3 = updatedDB2.entities.Token.set(ousdtToken as Token);
 
@@ -307,7 +306,7 @@ describe("Pool Swap Event", () => {
     });
 
     it("should not create OUSDTSwap entity when neither token is OUSDT", async () => {
-      const updatedDB1 = mockDb.entities.LiquidityPoolAggregator.set({
+      const updatedDB1 = mockDb.entities.Pool.set({
         ...mockLiquidityPoolData,
         stakedTickEdges: [...mockLiquidityPoolData.stakedTickEdges],
         stakedTickEdgeNets: [...mockLiquidityPoolData.stakedTickEdgeNets],

--- a/test/EventHandlers/Pool/Sync.test.ts
+++ b/test/EventHandlers/Pool/Sync.test.ts
@@ -5,7 +5,7 @@ import {
   TEN_TO_THE_18_BI,
   toChecksumAddress,
 } from "../../../src/Constants";
-import { setupLiquidityPoolAggregator } from "../../testHelpers";
+import { setupPool } from "../../testHelpers";
 import { setupCommon } from "./common";
 
 describe("Pool Sync Event", () => {
@@ -83,7 +83,7 @@ describe("Pool Sync Event", () => {
     let postEventDB: ReturnType<typeof MockDb.createMockDb>;
 
     beforeEach(async () => {
-      const updatedDB1 = setupLiquidityPoolAggregator(
+      const updatedDB1 = setupPool(
         mockDb,
         mockLiquidityPoolData,
         eventData.mockEventData.srcAddress,
@@ -96,7 +96,7 @@ describe("Pool Sync Event", () => {
       postEventDB = await updatedDB3.processEvents([mockEvent]);
     });
     it("should update reserves and usd liquidity", async () => {
-      const updatedPool = postEventDB.entities.LiquidityPoolAggregator.get(
+      const updatedPool = postEventDB.entities.Pool.get(
         PoolId(
           eventData.mockEventData.chainId,
           eventData.mockEventData.srcAddress,
@@ -116,14 +116,14 @@ describe("Pool Sync Event", () => {
       // Create a mockDb without the pool
       const updatedDB1 = mockDb.entities.Token.set(mockToken0Data);
       const updatedDB2 = updatedDB1.entities.Token.set(mockToken1Data);
-      // Note: We intentionally don't set the LiquidityPoolAggregator
+      // Note: We intentionally don't set the Pool
 
       const mockEvent = Pool.Sync.createMockEvent(eventData);
 
       const postEventDB = await updatedDB2.processEvents([mockEvent]);
 
       // Pool should not exist
-      const pool = postEventDB.entities.LiquidityPoolAggregator.get(
+      const pool = postEventDB.entities.Pool.get(
         PoolId(
           eventData.mockEventData.chainId,
           eventData.mockEventData.srcAddress,

--- a/test/EventHandlers/Pool/Transfer.test.ts
+++ b/test/EventHandlers/Pool/Transfer.test.ts
@@ -17,7 +17,7 @@ describe("Pool Transfer Event", () => {
     poolAddress = commonData.mockLiquidityPoolData.poolAddress;
 
     // Set up mock database with common data
-    const updatedDB1 = mockDb.entities.LiquidityPoolAggregator.set(
+    const updatedDB1 = mockDb.entities.Pool.set(
       commonData.mockLiquidityPoolData,
     );
     const updatedDB2 = updatedDB1.entities.Token.set(commonData.mockToken0Data);
@@ -49,7 +49,7 @@ describe("Pool Transfer Event", () => {
     const result = await mockDb.processEvents([mockEvent]);
 
     // Verify pool aggregator was updated with new totalLPTokenSupply
-    const updatedAggregator = result.entities.LiquidityPoolAggregator.get(
+    const updatedAggregator = result.entities.Pool.get(
       commonData.mockLiquidityPoolData.id,
     );
     expect(updatedAggregator).toBeDefined();
@@ -83,8 +83,7 @@ describe("Pool Transfer Event", () => {
       ...commonData.mockLiquidityPoolData,
       totalLPTokenSupply: INITIAL_SUPPLY,
     };
-    const updatedDB1 =
-      mockDb.entities.LiquidityPoolAggregator.set(poolWithSupply);
+    const updatedDB1 = mockDb.entities.Pool.set(poolWithSupply);
     mockDb = updatedDB1;
 
     const mockEvent = Pool.Transfer.createMockEvent({
@@ -106,7 +105,7 @@ describe("Pool Transfer Event", () => {
     const result = await mockDb.processEvents([mockEvent]);
 
     // Verify pool aggregator was updated with reduced totalLPTokenSupply
-    const updatedAggregator = result.entities.LiquidityPoolAggregator.get(
+    const updatedAggregator = result.entities.Pool.get(
       commonData.mockLiquidityPoolData.id,
     );
     expect(updatedAggregator).toBeDefined();
@@ -158,7 +157,7 @@ describe("Pool Transfer Event", () => {
     const result = await mockDb.processEvents([mockEvent]);
 
     // Verify pool aggregator totalLPTokenSupply was NOT changed (regular transfer)
-    const updatedAggregator = result.entities.LiquidityPoolAggregator.get(
+    const updatedAggregator = result.entities.Pool.get(
       commonData.mockLiquidityPoolData.id,
     );
     expect(updatedAggregator).toBeDefined();
@@ -194,7 +193,7 @@ describe("Pool Transfer Event", () => {
       const updatedDB2 = updatedDB1.entities.Token.set(
         commonData.mockToken1Data,
       );
-      // Note: We intentionally don't set the LiquidityPoolAggregator
+      // Note: We intentionally don't set the Pool
 
       const mockEvent = Pool.Transfer.createMockEvent({
         from: toChecksumAddress("0x1111111111111111111111111111111111111111"),
@@ -215,7 +214,7 @@ describe("Pool Transfer Event", () => {
       const postEventDB = await updatedDB2.processEvents([mockEvent]);
 
       // Pool should not exist
-      const pool = postEventDB.entities.LiquidityPoolAggregator.get(
+      const pool = postEventDB.entities.Pool.get(
         commonData.mockLiquidityPoolData.id,
       );
       expect(pool).toBeUndefined();

--- a/test/EventHandlers/Pool/common.ts
+++ b/test/EventHandlers/Pool/common.ts
@@ -1,7 +1,6 @@
 import { TickMath } from "@uniswap/v3-sdk";
 import type {
   ALM_LP_Wrapper,
-  LiquidityPoolAggregator,
   NonFungiblePosition,
   Token,
   UserStatsPerPool,
@@ -21,6 +20,7 @@ import {
   VeNFTPoolVoteId,
   toChecksumAddress,
 } from "../../../src/Constants";
+import type { Pool } from "../../../src/EntityTypes";
 import { calculateTokenAmountUSD } from "../../../src/Helpers";
 
 // Canonical NFPM used for mock NonFungiblePosition fixtures (Optimism-old NFPM).
@@ -32,19 +32,19 @@ export const defaultNfpmAddress = toChecksumAddress(
 );
 
 /**
- * Shared alias for the mock `LiquidityPoolAggregator` shape returned by
- * `setupCommon().createMockLiquidityPoolAggregator(...)`.
+ * Shared alias for the mock `Pool` shape returned by
+ * `setupCommon().createMockPool(...)`.
  *
  * Why the alias exists: envio codegen emits TWO slightly different array-field
  * types for the same entity — `readonly bigint[]` in `envio.d.ts` vs mutable
- * `bigint[]` in `Indexer.gen.ts`. `createMockLiquidityPoolAggregator` deliberately
+ * `bigint[]` in `Indexer.gen.ts`. `createMockPool` deliberately
  * returns an inferred (untyped) shape with mutable arrays so it satisfies both.
- * Annotating a test variable as `LiquidityPoolAggregator` directly conflicts
+ * Annotating a test variable as `Pool` directly conflicts
  * with `MockDb.set()`'s expected mutable shape. Tests should use this alias
  * instead of duplicating the `ReturnType<...>` incantation per file.
  */
-export type MockLiquidityPoolAggregator = ReturnType<
-  ReturnType<typeof setupCommon>["createMockLiquidityPoolAggregator"]
+export type MockPool = ReturnType<
+  ReturnType<typeof setupCommon>["createMockPool"]
 >;
 
 export function setupCommon() {
@@ -86,7 +86,7 @@ export function setupCommon() {
     lastSuccessfulPriceTimestamp: new Date(),
   };
 
-  // Not annotated as LiquidityPoolAggregator to avoid readonly bigint[] vs bigint[] mismatch
+  // Not annotated as Pool to avoid readonly bigint[] vs bigint[] mismatch
   // between envio.d.ts (readonly bigint[]) and Indexer.gen.ts (bigint[]) for stakedTickEdges /
   // stakedTickEdgeNets array fields. Same workaround as mockUserStatsPerPoolData.
   const mockLiquidityPoolData = {
@@ -411,17 +411,15 @@ export function setupCommon() {
   }
 
   /**
-   * Creates a mock LiquidityPoolAggregator entity with customizable fields.
+   * Creates a mock Pool entity with customizable fields.
    * All fields default to values from mockLiquidityPoolData, allowing tests to override only what they need.
    *
-   * @param overrides - Partial LiquidityPoolAggregator to override default values
-   * @returns A complete LiquidityPoolAggregator entity (untyped return to let TS
+   * @param overrides - Partial Pool to override default values
+   * @returns A complete Pool entity (untyped return to let TS
    *   infer mutable bigint[] for stakedTickEdges / stakedTickEdgeNets — same
    *   readonly-vs-mutable workaround as createMockUserStatsPerPool).
    */
-  function createMockLiquidityPoolAggregator(
-    overrides: Partial<LiquidityPoolAggregator> = {},
-  ) {
+  function createMockPool(overrides: Partial<Pool> = {}) {
     // Calculate id if poolAddress or chainId are provided
     const chainId = overrides.chainId ?? CHAIN_ID;
     const poolAddress = toChecksumAddress(
@@ -534,7 +532,7 @@ export function setupCommon() {
     defaultNfpmAddress,
     createMockToken,
     createMockUserStatsPerPool,
-    createMockLiquidityPoolAggregator,
+    createMockPool,
     createMockVeNFTState,
     createMockVeNFTPoolVote,
     createMockNonFungiblePosition,

--- a/test/EventHandlers/PoolFactory.test.ts
+++ b/test/EventHandlers/PoolFactory.test.ts
@@ -1,4 +1,4 @@
-import type { LiquidityPoolAggregator, Token } from "generated";
+import type { Token } from "generated";
 import type { PublicClient } from "viem";
 import type { MockInstance } from "vitest";
 import { MockDb, PoolFactory } from "../../generated/src/TestHelpers.gen";
@@ -11,6 +11,7 @@ import {
   toChecksumAddress,
 } from "../../src/Constants";
 import * as HelpersModule from "../../src/Effects/Helpers";
+import type { Pool } from "../../src/EntityTypes";
 import * as CrossChainPendingResolution from "../../src/EventHandlers/Voter/CrossChainPendingResolution";
 import * as PriceOracle from "../../src/PriceOracle";
 import { mutateChainConstants } from "../testHelpers";
@@ -21,7 +22,7 @@ describe("PoolFactory Events", () => {
     mockToken0Data,
     mockToken1Data,
     mockLiquidityPoolData,
-    createMockLiquidityPoolAggregator,
+    createMockPool,
   } = setupCommon();
   const poolAddress = mockLiquidityPoolData.poolAddress;
   // Real Optimism contracts (WETH, USDC.e) so the #677 hasContractBytecode
@@ -52,7 +53,7 @@ describe("PoolFactory Events", () => {
   }
 
   describe("PoolCreated event", () => {
-    let createdPool: LiquidityPoolAggregator | undefined;
+    let createdPool: Pool | undefined;
     let chainConstantsCleanup: (() => void) | undefined;
 
     const fraxtalChainId = 252;
@@ -81,9 +82,7 @@ describe("PoolFactory Events", () => {
         },
       });
       const result = await mockDb.processEvents([mockEvent]);
-      createdPool = result.entities.LiquidityPoolAggregator.get(
-        PoolId(chainId, poolAddress),
-      );
+      createdPool = result.entities.Pool.get(PoolId(chainId, poolAddress));
     });
 
     afterEach(() => {
@@ -103,7 +102,7 @@ describe("PoolFactory Events", () => {
     });
 
     // Issue #677 follow-up: when createTokenEntity returns null (bytecode
-    // gate confirmed the address is a non-contract), no LiquidityPoolAggregator
+    // gate confirmed the address is a non-contract), no Pool
     // is created so we don't persist a pool pointing at a token row that was
     // deliberately not written. Uses a placeholder address for token0 that
     // has no on-chain bytecode on Optimism.
@@ -113,7 +112,7 @@ describe("PoolFactory Events", () => {
     // (gate returns hasCode:true → token row created → assertion flips). Live
     // probe in the previous PR session confirmed the gate's correctness against
     // real RPCs; re-enable once effects are mockable under processEvents.
-    it.skip("should skip LiquidityPoolAggregator when token has no bytecode", async () => {
+    it.skip("should skip Pool when token has no bytecode", async () => {
       const noBytecodeToken = toChecksumAddress(
         "0x1111111111111111111111111111111111111111",
       );
@@ -133,9 +132,7 @@ describe("PoolFactory Events", () => {
         },
       });
       const result = await mockDb.processEvents([mockEvent]);
-      const pool = result.entities.LiquidityPoolAggregator.get(
-        PoolId(chainId, poolAddress),
-      );
+      const pool = result.entities.Pool.get(PoolId(chainId, poolAddress));
       expect(pool).toBeUndefined();
     });
 
@@ -162,9 +159,7 @@ describe("PoolFactory Events", () => {
         },
       });
       const result = await mockDb.processEvents([mockEvent]);
-      const pool = result.entities.LiquidityPoolAggregator.get(
-        PoolId(chainId, poolAddress),
-      );
+      const pool = result.entities.Pool.get(PoolId(chainId, poolAddress));
       expect(pool).toBeDefined();
     });
 
@@ -207,9 +202,7 @@ describe("PoolFactory Events", () => {
       });
       resetMockPriceOracle();
       const result = await mockDb.processEvents([mockEvent]);
-      const pool = result.entities.LiquidityPoolAggregator.get(
-        PoolId(chainId, poolAddress),
-      );
+      const pool = result.entities.Pool.get(PoolId(chainId, poolAddress));
       expect(pool?.factoryAddress).toBe(mockEvent.srcAddress);
     });
 
@@ -238,9 +231,7 @@ describe("PoolFactory Events", () => {
         },
       });
       const result = await mockDb.processEvents([mockEvent]);
-      const stablePool = result.entities.LiquidityPoolAggregator.get(
-        PoolId(chainId, poolAddress),
-      );
+      const stablePool = result.entities.Pool.get(PoolId(chainId, poolAddress));
 
       // Stable pools should use DEFAULT_SAMM_FEE_BPS
       expect(stablePool?.baseFee).toBe(DEFAULT_SAMM_FEE_BPS);
@@ -402,7 +393,7 @@ describe("PoolFactory Events", () => {
       const result = await mockDb.processEvents([mockEvent]);
 
       // Should still create the pool even if root pool address fetch fails
-      const createdPool = result.entities.LiquidityPoolAggregator.get(
+      const createdPool = result.entities.Pool.get(
         PoolId(fraxtalChainId, poolAddress),
       );
       expect(createdPool).toBeDefined();
@@ -452,7 +443,7 @@ describe("PoolFactory Events", () => {
       const result = await mockDb.processEvents([mockEvent]);
 
       // Should still create the pool
-      const createdPool = result.entities.LiquidityPoolAggregator.get(
+      const createdPool = result.entities.Pool.get(
         PoolId(fraxtalChainId, poolAddress),
       );
       expect(createdPool).toBeDefined();
@@ -525,15 +516,15 @@ describe("PoolFactory Events", () => {
   });
 
   describe("SetCustomFee event", () => {
-    it("should update the LiquidityPoolAggregator", async () => {
+    it("should update the Pool", async () => {
       // Setup - create a pool entity first
       let mockDb = MockDb.createMockDb();
-      const existingPool = createMockLiquidityPoolAggregator({
+      const existingPool = createMockPool({
         baseFee: undefined,
         currentFee: undefined,
         lastUpdatedTimestamp: new Date(900000 * 1000),
       });
-      mockDb = mockDb.entities.LiquidityPoolAggregator.set(existingPool);
+      mockDb = mockDb.entities.Pool.set(existingPool);
 
       const customFee = 500n; // 0.05% fee (500 basis points)
       const blockTimestamp = 2000000;
@@ -554,8 +545,8 @@ describe("PoolFactory Events", () => {
       // Execute
       const result = await mockDb.processEvents([mockEvent]);
 
-      // Assert - check LiquidityPoolAggregator was updated
-      const updatedPool = result.entities.LiquidityPoolAggregator.get(
+      // Assert - check Pool was updated
+      const updatedPool = result.entities.Pool.get(
         PoolId(chainId, poolAddress),
       );
       expect(updatedPool).toBeDefined();
@@ -575,12 +566,12 @@ describe("PoolFactory Events", () => {
       // Setup - create a pool entity with existing fees
       let mockDb = MockDb.createMockDb();
       const existingFee = 300n;
-      const existingPool = createMockLiquidityPoolAggregator({
+      const existingPool = createMockPool({
         baseFee: existingFee,
         currentFee: existingFee,
         lastUpdatedTimestamp: new Date(900000 * 1000),
       });
-      mockDb = mockDb.entities.LiquidityPoolAggregator.set(existingPool);
+      mockDb = mockDb.entities.Pool.set(existingPool);
 
       const newFee = 750n;
       const blockTimestamp = 2000000;
@@ -602,7 +593,7 @@ describe("PoolFactory Events", () => {
       const result = await mockDb.processEvents([mockEvent]);
 
       // Assert - check fees were updated
-      const updatedPool = result.entities.LiquidityPoolAggregator.get(
+      const updatedPool = result.entities.Pool.get(
         PoolId(chainId, poolAddress),
       );
       expect(updatedPool).toBeDefined();
@@ -637,10 +628,8 @@ describe("PoolFactory Events", () => {
       // Execute
       const result = await mockDb.processEvents([mockEvent]);
 
-      // Assert - LiquidityPoolAggregator should not be updated
-      const pool = result.entities.LiquidityPoolAggregator.get(
-        PoolId(10, nonExistentPoolAddress),
-      );
+      // Assert - Pool should not be updated
+      const pool = result.entities.Pool.get(PoolId(10, nonExistentPoolAddress));
       expect(pool).toBeUndefined();
     });
   });

--- a/test/EventHandlers/PoolLauncher/CLPoolLauncher.test.ts
+++ b/test/EventHandlers/PoolLauncher/CLPoolLauncher.test.ts
@@ -1,11 +1,10 @@
 import type { PoolLauncherPool, Token } from "generated";
 import { CLPoolLauncher, MockDb } from "generated/src/TestHelpers.gen";
 import { PoolId, TokenId, toChecksumAddress } from "../../../src/Constants";
-import { type MockLiquidityPoolAggregator, setupCommon } from "../Pool/common";
+import { type MockPool, setupCommon } from "../Pool/common";
 
 describe("CLPoolLauncher Events", () => {
-  const { createMockLiquidityPoolAggregator, mockToken0Data, mockToken1Data } =
-    setupCommon();
+  const { createMockPool, mockToken0Data, mockToken1Data } = setupCommon();
 
   const mockChainId = 10;
   const mockPoolAddress = toChecksumAddress(
@@ -57,11 +56,11 @@ describe("CLPoolLauncher Events", () => {
     isWhitelisted: true,
   };
 
-  let mockLiquidityPoolAggregator: MockLiquidityPoolAggregator;
+  let mockPool: MockPool;
   let mockDb: ReturnType<typeof MockDb.createMockDb>;
 
   beforeEach(() => {
-    mockLiquidityPoolAggregator = createMockLiquidityPoolAggregator({
+    mockPool = createMockPool({
       poolAddress: mockPoolAddress,
       chainId: mockChainId,
     });
@@ -69,13 +68,11 @@ describe("CLPoolLauncher Events", () => {
     mockDb = MockDb.createMockDb();
     mockDb = mockDb.entities.Token.set(mockToken0);
     mockDb = mockDb.entities.Token.set(mockToken1);
-    mockDb = mockDb.entities.LiquidityPoolAggregator.set(
-      mockLiquidityPoolAggregator,
-    );
+    mockDb = mockDb.entities.Pool.set(mockPool);
   });
 
   describe("CLPoolLauncher.Launch", () => {
-    it("should create a new PoolLauncherPool and link to LiquidityPoolAggregator", async () => {
+    it("should create a new PoolLauncherPool and link to Pool", async () => {
       const mockEvent = CLPoolLauncher.Launch.createMockEvent({
         pool: mockPoolAddress,
         sender: mockCreator,
@@ -109,11 +106,10 @@ describe("CLPoolLauncher Events", () => {
       expect(poolLauncherPool?.pairToken).toBe(mockPairToken);
       expect(poolLauncherPool?.isEmerging).toBe(false);
 
-      // Check that LiquidityPoolAggregator was linked
-      const liquidityPoolAggregator =
-        result.entities.LiquidityPoolAggregator.get(
-          PoolId(mockChainId, mockPoolAddress),
-        );
+      // Check that Pool was linked
+      const liquidityPoolAggregator = result.entities.Pool.get(
+        PoolId(mockChainId, mockPoolAddress),
+      );
       expect(liquidityPoolAggregator).toBeDefined();
       expect(liquidityPoolAggregator?.poolLauncherPoolId).toBe(
         PoolId(mockChainId, mockPoolAddress),

--- a/test/EventHandlers/PoolLauncher/PoolLauncherLogic.test.ts
+++ b/test/EventHandlers/PoolLauncher/PoolLauncherLogic.test.ts
@@ -1,18 +1,15 @@
-import type {
-  LiquidityPoolAggregator,
-  PoolLauncherPool,
-  handlerContext,
-} from "generated";
+import type { PoolLauncherPool, handlerContext } from "generated";
 import { MockDb } from "../../../generated/src/TestHelpers.gen";
 import { PoolId, toChecksumAddress } from "../../../src/Constants";
+import type { Pool } from "../../../src/EntityTypes";
 import {
-  linkLiquidityPoolAggregatorToPoolLauncher,
+  linkPoolToPoolLauncher,
   processPoolLauncherPool,
 } from "../../../src/EventHandlers/PoolLauncher/PoolLauncherLogic";
 import { setupCommon } from "../Pool/common";
 
 describe("PoolLauncherLogic", () => {
-  const { createMockLiquidityPoolAggregator } = setupCommon();
+  const { createMockPool } = setupCommon();
 
   let mockContext: handlerContext;
   let mockDb: ReturnType<typeof MockDb.createMockDb>;
@@ -26,13 +23,13 @@ describe("PoolLauncherLogic", () => {
           mockDb = mockDb.entities.PoolLauncherPool.set(entity);
         },
       },
-      LiquidityPoolAggregator: {
-        get: (id: string) => mockDb.entities.LiquidityPoolAggregator.get(id),
-        set: (entity: LiquidityPoolAggregator) => {
+      Pool: {
+        get: (id: string) => mockDb.entities.Pool.get(id),
+        set: (entity: Pool) => {
           // Copy readonly bigint[] fields into mutable bigint[] to satisfy
           // MockDb.set() — envio.d.ts types these as readonly but Indexer.gen.ts
-          // expects mutable. Same workaround as createMockLiquidityPoolAggregator.
-          mockDb = mockDb.entities.LiquidityPoolAggregator.set({
+          // expects mutable. Same workaround as createMockPool.
+          mockDb = mockDb.entities.Pool.set({
             ...entity,
             stakedTickEdges: [...entity.stakedTickEdges],
             stakedTickEdgeNets: [...entity.stakedTickEdgeNets],
@@ -250,39 +247,31 @@ describe("PoolLauncherLogic", () => {
     });
   });
 
-  describe("linkLiquidityPoolAggregatorToPoolLauncher", () => {
+  describe("linkPoolToPoolLauncher", () => {
     const poolAddress = toChecksumAddress(
       "0x1234567890123456789012345678901234567890",
     );
     const chainId = 8453;
 
     describe("with CL factory", () => {
-      it("should successfully link existing LiquidityPoolAggregator to PoolLauncherPool", async () => {
-        // Create an existing LiquidityPoolAggregator (as if created by CLFactory)
-        const existingLiquidityPoolAggregator =
-          createMockLiquidityPoolAggregator({
-            poolAddress: poolAddress,
-            chainId: chainId,
-            name: "TEST/USDC",
-            reserve0: 1000000n,
-            reserve1: 2000000n,
-            totalLiquidityUSD: 3000000n,
-            isCL: true,
-          });
+      it("should successfully link existing Pool to PoolLauncherPool", async () => {
+        // Create an existing Pool (as if created by CLFactory)
+        const existingPool = createMockPool({
+          poolAddress: poolAddress,
+          chainId: chainId,
+          name: "TEST/USDC",
+          reserve0: 1000000n,
+          reserve1: 2000000n,
+          totalLiquidityUSD: 3000000n,
+          isCL: true,
+        });
 
-        mockDb = mockDb.entities.LiquidityPoolAggregator.set(
-          existingLiquidityPoolAggregator,
-        );
+        mockDb = mockDb.entities.Pool.set(existingPool);
 
-        await linkLiquidityPoolAggregatorToPoolLauncher(
-          poolAddress,
-          chainId,
-          mockContext,
-          "CL",
-        );
+        await linkPoolToPoolLauncher(poolAddress, chainId, mockContext, "CL");
 
         // Assert
-        const updatedEntity = mockDb.entities.LiquidityPoolAggregator.get(
+        const updatedEntity = mockDb.entities.Pool.get(
           PoolId(chainId, poolAddress),
         );
         expect(updatedEntity).toBeDefined();
@@ -302,7 +291,7 @@ describe("PoolLauncherLogic", () => {
         expect(updatedEntity?.gaugeIsAlive).toBe(true);
       });
 
-      it("should handle case where LiquidityPoolAggregator does not exist", async () => {
+      it("should handle case where Pool does not exist", async () => {
         let warnCalled = false;
         const mockContextWithWarn = {
           ...mockContext,
@@ -310,9 +299,7 @@ describe("PoolLauncherLogic", () => {
             ...mockContext.log,
             warn: (message: string) => {
               warnCalled = true;
-              expect(message).toContain(
-                "LiquidityPoolAggregator not found for pool",
-              );
+              expect(message).toContain("Pool not found for pool");
               expect(message).toContain(
                 "it should have been created by CLFactory",
               );
@@ -320,7 +307,7 @@ describe("PoolLauncherLogic", () => {
           },
         };
 
-        await linkLiquidityPoolAggregatorToPoolLauncher(
+        await linkPoolToPoolLauncher(
           poolAddress,
           chainId,
           mockContextWithWarn,
@@ -331,39 +318,29 @@ describe("PoolLauncherLogic", () => {
         expect(warnCalled).toBe(true);
 
         // Verify no entity was created or updated
-        const entity = mockDb.entities.LiquidityPoolAggregator.get(
-          PoolId(chainId, poolAddress),
-        );
+        const entity = mockDb.entities.Pool.get(PoolId(chainId, poolAddress));
         expect(entity).toBeUndefined();
       });
     });
 
     describe("with V2 factory", () => {
-      it("should successfully link existing LiquidityPoolAggregator to PoolLauncherPool", async () => {
-        // Create an existing LiquidityPoolAggregator (as if created by V2Factory)
-        const existingLiquidityPoolAggregator =
-          createMockLiquidityPoolAggregator({
-            poolAddress: poolAddress,
-            chainId: chainId,
-            name: "TEST/USDC",
-            reserve0: 1000000n,
-            reserve1: 2000000n,
-            totalLiquidityUSD: 3000000n,
-          });
+      it("should successfully link existing Pool to PoolLauncherPool", async () => {
+        // Create an existing Pool (as if created by V2Factory)
+        const existingPool = createMockPool({
+          poolAddress: poolAddress,
+          chainId: chainId,
+          name: "TEST/USDC",
+          reserve0: 1000000n,
+          reserve1: 2000000n,
+          totalLiquidityUSD: 3000000n,
+        });
 
-        mockDb = mockDb.entities.LiquidityPoolAggregator.set(
-          existingLiquidityPoolAggregator,
-        );
+        mockDb = mockDb.entities.Pool.set(existingPool);
 
-        await linkLiquidityPoolAggregatorToPoolLauncher(
-          poolAddress,
-          chainId,
-          mockContext,
-          "V2",
-        );
+        await linkPoolToPoolLauncher(poolAddress, chainId, mockContext, "V2");
 
         // Assert
-        const updatedEntity = mockDb.entities.LiquidityPoolAggregator.get(
+        const updatedEntity = mockDb.entities.Pool.get(
           PoolId(chainId, poolAddress),
         );
         expect(updatedEntity).toBeDefined();
@@ -383,7 +360,7 @@ describe("PoolLauncherLogic", () => {
         expect(updatedEntity?.gaugeIsAlive).toBe(true);
       });
 
-      it("should handle case where LiquidityPoolAggregator does not exist", async () => {
+      it("should handle case where Pool does not exist", async () => {
         let warnCalled = false;
         const mockContextWithWarn = {
           ...mockContext,
@@ -391,15 +368,13 @@ describe("PoolLauncherLogic", () => {
             ...mockContext.log,
             warn: (message: string) => {
               warnCalled = true;
-              expect(message).toContain(
-                "LiquidityPoolAggregator not found for pool",
-              );
+              expect(message).toContain("Pool not found for pool");
               expect(message).toContain("V2Factory");
             },
           },
         };
 
-        await linkLiquidityPoolAggregatorToPoolLauncher(
+        await linkPoolToPoolLauncher(
           poolAddress,
           chainId,
           mockContextWithWarn,
@@ -410,36 +385,23 @@ describe("PoolLauncherLogic", () => {
         expect(warnCalled).toBe(true);
 
         // Verify no entity was created or updated
-        const entity = mockDb.entities.LiquidityPoolAggregator.get(
-          PoolId(chainId, poolAddress),
-        );
+        const entity = mockDb.entities.Pool.get(PoolId(chainId, poolAddress));
         expect(entity).toBeUndefined();
       });
     });
 
     it("should handle different chain IDs correctly", async () => {
-      const existingLiquidityPoolAggregator = createMockLiquidityPoolAggregator(
-        {
-          poolAddress: poolAddress,
-          chainId: 10,
-        },
-      );
+      const existingPool = createMockPool({
+        poolAddress: poolAddress,
+        chainId: 10,
+      });
 
-      mockDb = mockDb.entities.LiquidityPoolAggregator.set(
-        existingLiquidityPoolAggregator,
-      );
+      mockDb = mockDb.entities.Pool.set(existingPool);
 
-      await linkLiquidityPoolAggregatorToPoolLauncher(
-        poolAddress,
-        10,
-        mockContext,
-        "CL",
-      );
+      await linkPoolToPoolLauncher(poolAddress, 10, mockContext, "CL");
 
       // Assert
-      const updatedEntity = mockDb.entities.LiquidityPoolAggregator.get(
-        PoolId(10, poolAddress),
-      );
+      const updatedEntity = mockDb.entities.Pool.get(PoolId(10, poolAddress));
       expect(updatedEntity).toBeDefined();
       expect(updatedEntity?.poolLauncherPoolId).toBe(PoolId(10, poolAddress));
     });

--- a/test/EventHandlers/PoolLauncher/V2PoolLauncher.test.ts
+++ b/test/EventHandlers/PoolLauncher/V2PoolLauncher.test.ts
@@ -1,11 +1,10 @@
 import type { PoolLauncherPool, Token } from "generated";
 import { MockDb, V2PoolLauncher } from "generated/src/TestHelpers.gen";
 import { PoolId, TokenId, toChecksumAddress } from "../../../src/Constants";
-import { type MockLiquidityPoolAggregator, setupCommon } from "../Pool/common";
+import { type MockPool, setupCommon } from "../Pool/common";
 
 describe("V2PoolLauncher Events", () => {
-  const { createMockLiquidityPoolAggregator, mockToken0Data, mockToken1Data } =
-    setupCommon();
+  const { createMockPool, mockToken0Data, mockToken1Data } = setupCommon();
   const mockChainId = 10;
   const mockPoolAddress = toChecksumAddress(
     "0x1111111111111111111111111111111111111111",
@@ -56,11 +55,11 @@ describe("V2PoolLauncher Events", () => {
     isWhitelisted: true,
   };
 
-  let mockLiquidityPoolAggregator: MockLiquidityPoolAggregator;
+  let mockPool: MockPool;
   let mockDb: ReturnType<typeof MockDb.createMockDb>;
 
   beforeEach(() => {
-    mockLiquidityPoolAggregator = createMockLiquidityPoolAggregator({
+    mockPool = createMockPool({
       poolAddress: mockPoolAddress,
       chainId: mockChainId,
     });
@@ -68,13 +67,11 @@ describe("V2PoolLauncher Events", () => {
     mockDb = MockDb.createMockDb();
     mockDb = mockDb.entities.Token.set(mockToken0);
     mockDb = mockDb.entities.Token.set(mockToken1);
-    mockDb = mockDb.entities.LiquidityPoolAggregator.set(
-      mockLiquidityPoolAggregator,
-    );
+    mockDb = mockDb.entities.Pool.set(mockPool);
   });
 
   describe("V2PoolLauncher.Launch", () => {
-    it("should create a new PoolLauncherPool and link to LiquidityPoolAggregator", async () => {
+    it("should create a new PoolLauncherPool and link to Pool", async () => {
       const mockEvent = V2PoolLauncher.Launch.createMockEvent({
         pool: mockPoolAddress,
         sender: mockCreator,
@@ -108,11 +105,10 @@ describe("V2PoolLauncher Events", () => {
       expect(poolLauncherPool?.pairToken).toBe(mockPairToken);
       expect(poolLauncherPool?.isEmerging).toBe(false);
 
-      // Check that LiquidityPoolAggregator was linked
-      const liquidityPoolAggregator =
-        result.entities.LiquidityPoolAggregator.get(
-          PoolId(mockChainId, mockPoolAddress),
-        );
+      // Check that Pool was linked
+      const liquidityPoolAggregator = result.entities.Pool.get(
+        PoolId(mockChainId, mockPoolAddress),
+      );
       expect(liquidityPoolAggregator).toBeDefined();
       expect(liquidityPoolAggregator?.poolLauncherPoolId).toBe(
         PoolId(mockChainId, mockPoolAddress),

--- a/test/EventHandlers/Redistributor/Redistributor.test.ts
+++ b/test/EventHandlers/Redistributor/Redistributor.test.ts
@@ -1,10 +1,10 @@
 import { MockDb, Redistributor } from "../../../generated/src/TestHelpers.gen";
 import { toChecksumAddress } from "../../../src/Constants";
-import { type MockLiquidityPoolAggregator, setupCommon } from "../Pool/common";
+import { type MockPool, setupCommon } from "../Pool/common";
 import { makeRedistributorMockEventData } from "./common";
 
 describe("Redistributor Event Handlers", () => {
-  const { createMockLiquidityPoolAggregator } = setupCommon();
+  const { createMockPool } = setupCommon();
   const chainId = 8453; // Base
   const redistributorAddress = toChecksumAddress(
     "0xEe5b3C7b333e2870B746b3B2b168EF0958e55e15",
@@ -43,8 +43,8 @@ describe("Redistributor Event Handlers", () => {
   const seedPool = (
     existingForfeited = 0n,
     existingRedistributed = 0n,
-  ): MockLiquidityPoolAggregator =>
-    createMockLiquidityPoolAggregator({
+  ): MockPool =>
+    createMockPool({
       chainId,
       gaugeAddress,
       totalEmissionsForfeited: existingForfeited,
@@ -54,8 +54,7 @@ describe("Redistributor Event Handlers", () => {
   describe("Deposited event", () => {
     it("increments totalEmissionsForfeited on the gauge's pool", async () => {
       const pool = seedPool(10n);
-      const populatedDb =
-        MockDb.createMockDb().entities.LiquidityPoolAggregator.set(pool);
+      const populatedDb = MockDb.createMockDb().entities.Pool.set(pool);
       const amount = 1_234_567_890_000_000_000n;
 
       const mockEvent = Redistributor.Deposited.createMockEvent({
@@ -72,7 +71,7 @@ describe("Redistributor Event Handlers", () => {
       });
 
       const result = await populatedDb.processEvents([mockEvent]);
-      const updatedPool = result.entities.LiquidityPoolAggregator.get(pool.id);
+      const updatedPool = result.entities.Pool.get(pool.id);
 
       expect(updatedPool?.totalEmissionsForfeited).toBe(10n + amount);
       expect(updatedPool?.totalEmissionsRedistributed).toBe(0n);
@@ -81,8 +80,7 @@ describe("Redistributor Event Handlers", () => {
 
     it("no-ops when the gauge does not match any pool", async () => {
       const pool = seedPool();
-      const populatedDb =
-        MockDb.createMockDb().entities.LiquidityPoolAggregator.set(pool);
+      const populatedDb = MockDb.createMockDb().entities.Pool.set(pool);
 
       const mockEvent = Redistributor.Deposited.createMockEvent({
         gauge: unknownGaugeAddress,
@@ -98,24 +96,19 @@ describe("Redistributor Event Handlers", () => {
       });
 
       const result = await populatedDb.processEvents([mockEvent]);
-      const unchangedPool = result.entities.LiquidityPoolAggregator.get(
-        pool.id,
-      );
+      const unchangedPool = result.entities.Pool.get(pool.id);
 
       expect(unchangedPool?.totalEmissionsForfeited).toBe(0n);
       expect(unchangedPool?.totalEmissionsRedistributed).toBe(0n);
       // Guard against the handler synthesising a pool entity on gauge miss.
-      expect(
-        Array.from(result.entities.LiquidityPoolAggregator.getAll()).length,
-      ).toBe(1);
+      expect(Array.from(result.entities.Pool.getAll()).length).toBe(1);
     });
   });
 
   describe("Redistributed event", () => {
     it("increments totalEmissionsRedistributed on the gauge's pool", async () => {
       const pool = seedPool(0n, 3n);
-      const populatedDb =
-        MockDb.createMockDb().entities.LiquidityPoolAggregator.set(pool);
+      const populatedDb = MockDb.createMockDb().entities.Pool.set(pool);
       const amount = 42_000_000_000_000_000_000n;
 
       const mockEvent = Redistributor.Redistributed.createMockEvent({
@@ -132,7 +125,7 @@ describe("Redistributor Event Handlers", () => {
       });
 
       const result = await populatedDb.processEvents([mockEvent]);
-      const updatedPool = result.entities.LiquidityPoolAggregator.get(pool.id);
+      const updatedPool = result.entities.Pool.get(pool.id);
 
       expect(updatedPool?.totalEmissionsRedistributed).toBe(3n + amount);
       expect(updatedPool?.totalEmissionsForfeited).toBe(0n);
@@ -141,8 +134,7 @@ describe("Redistributor Event Handlers", () => {
 
     it("accumulates across multiple Redistributed events in the same tx", async () => {
       const pool = seedPool();
-      const populatedDb =
-        MockDb.createMockDb().entities.LiquidityPoolAggregator.set(pool);
+      const populatedDb = MockDb.createMockDb().entities.Pool.set(pool);
 
       const firstEvent = Redistributor.Redistributed.createMockEvent({
         sender: senderAddress,
@@ -170,7 +162,7 @@ describe("Redistributor Event Handlers", () => {
       });
 
       const result = await populatedDb.processEvents([firstEvent, secondEvent]);
-      const updatedPool = result.entities.LiquidityPoolAggregator.get(pool.id);
+      const updatedPool = result.entities.Pool.get(pool.id);
 
       expect(updatedPool?.totalEmissionsRedistributed).toBe(3n);
     });

--- a/test/EventHandlers/RootCLPoolFactory.test.ts
+++ b/test/EventHandlers/RootCLPoolFactory.test.ts
@@ -12,7 +12,7 @@ import {
   toChecksumAddress,
 } from "../../src/Constants";
 import { flushPendingVotesAndDistributionsForRootPool } from "../../src/EventHandlers/Voter/CrossChainPendingResolution";
-import { type MockLiquidityPoolAggregator, setupCommon } from "./Pool/common";
+import { type MockPool, setupCommon } from "./Pool/common";
 
 vi.mock(
   "../../src/EventHandlers/Voter/CrossChainPendingResolution",
@@ -73,13 +73,13 @@ describe("RootCLPoolFactory Events", () => {
 
     describe("when matching pool exists on leaf chain", () => {
       let resultDB: ReturnType<typeof MockDb.createMockDb>;
-      let mockLiquidityPool: MockLiquidityPoolAggregator;
+      let mockLiquidityPool: MockPool;
 
       beforeEach(async () => {
-        const { createMockLiquidityPoolAggregator } = setupCommon();
+        const { createMockPool } = setupCommon();
 
         // Create a pool on the leaf chain with matching token addresses and tickSpacing
-        mockLiquidityPool = createMockLiquidityPoolAggregator({
+        mockLiquidityPool = createMockPool({
           id: PoolId(leafChainId, leafPoolAddress),
           poolAddress: leafPoolAddress,
           chainId: leafChainId,
@@ -97,7 +97,7 @@ describe("RootCLPoolFactory Events", () => {
           ),
         });
 
-        mockDb = mockDb.entities.LiquidityPoolAggregator.set(mockLiquidityPool);
+        mockDb = mockDb.entities.Pool.set(mockLiquidityPool);
 
         resultDB = await mockDb.processEvents([mockEvent]);
       });
@@ -142,7 +142,7 @@ describe("RootCLPoolFactory Events", () => {
 
       beforeEach(async () => {
         const {
-          createMockLiquidityPoolAggregator,
+          createMockPool,
           createMockVeNFTState,
           mockToken0Data,
           mockToken1Data,
@@ -158,7 +158,7 @@ describe("RootCLPoolFactory Events", () => {
           id: TokenId(leafChainId, mockToken1Data.address),
           chainId: leafChainId,
         };
-        const mockLiquidityPool = createMockLiquidityPoolAggregator({
+        const mockLiquidityPool = createMockPool({
           id: PoolId(leafChainId, leafPoolAddress),
           poolAddress: leafPoolAddress,
           chainId: leafChainId,
@@ -194,7 +194,7 @@ describe("RootCLPoolFactory Events", () => {
           transactionHash: "0xhash",
         };
 
-        mockDb = mockDb.entities.LiquidityPoolAggregator.set(mockLiquidityPool);
+        mockDb = mockDb.entities.Pool.set(mockLiquidityPool);
         mockDb = mockDb.entities.Token.set(leafToken0);
         mockDb = mockDb.entities.Token.set(leafToken1);
         mockDb = mockDb.entities.VeNFTState.set(veNFTState);
@@ -219,7 +219,7 @@ describe("RootCLPoolFactory Events", () => {
         );
         expect(processedPendingVote).toBeUndefined();
 
-        const leafPool = resultDB.entities.LiquidityPoolAggregator.get(
+        const leafPool = resultDB.entities.Pool.get(
           PoolId(leafChainId, leafPoolAddress),
         );
         expect(leafPool?.veNFTamountStaked).toBe(voteWeight);
@@ -277,14 +277,14 @@ describe("RootCLPoolFactory Events", () => {
 
     describe("when multiple matching pools exist", () => {
       let resultDB: ReturnType<typeof MockDb.createMockDb>;
-      let mockLiquidityPool1: MockLiquidityPoolAggregator;
-      let mockLiquidityPool2: MockLiquidityPoolAggregator;
+      let mockLiquidityPool1: MockPool;
+      let mockLiquidityPool2: MockPool;
 
       beforeEach(async () => {
-        const { createMockLiquidityPoolAggregator } = setupCommon();
+        const { createMockPool } = setupCommon();
 
         // Create two pools with the same rootPoolMatchingHash
-        mockLiquidityPool1 = createMockLiquidityPoolAggregator({
+        mockLiquidityPool1 = createMockPool({
           id: PoolId(leafChainId, leafPoolAddress),
           poolAddress: leafPoolAddress,
           chainId: leafChainId,
@@ -303,7 +303,7 @@ describe("RootCLPoolFactory Events", () => {
         });
 
         // Different pool address
-        mockLiquidityPool2 = createMockLiquidityPoolAggregator({
+        mockLiquidityPool2 = createMockPool({
           id: PoolId(
             leafChainId,
             toChecksumAddress("0xFc00000000000000000000000000000000000001"),
@@ -326,10 +326,8 @@ describe("RootCLPoolFactory Events", () => {
           ),
         });
 
-        mockDb =
-          mockDb.entities.LiquidityPoolAggregator.set(mockLiquidityPool1);
-        mockDb =
-          mockDb.entities.LiquidityPoolAggregator.set(mockLiquidityPool2);
+        mockDb = mockDb.entities.Pool.set(mockLiquidityPool1);
+        mockDb = mockDb.entities.Pool.set(mockLiquidityPool2);
 
         resultDB = await mockDb.processEvents([mockEvent]);
       });

--- a/test/EventHandlers/SwapFeeModule/CustomSwapFeeModule.test.ts
+++ b/test/EventHandlers/SwapFeeModule/CustomSwapFeeModule.test.ts
@@ -6,13 +6,13 @@ import { toChecksumAddress } from "../../../src/Constants";
 import { setupCommon } from "../Pool/common";
 
 describe("CustomSwapFeeModule Events", () => {
-  const { createMockLiquidityPoolAggregator } = setupCommon();
+  const { createMockPool } = setupCommon();
   const moduleAddress = toChecksumAddress(
     "0xbcAE2d4b4E8E34a4100e69E9C73af8214a89572e",
   );
   const chainId = 42220; // Celo
 
-  const mockLiquidityPoolAggregator = createMockLiquidityPoolAggregator({
+  const mockPool = createMockPool({
     chainId: chainId,
   });
 
@@ -23,12 +23,10 @@ describe("CustomSwapFeeModule Events", () => {
       const fee = 300n;
 
       // Pre-populate pool in the mock database
-      const populatedDb = mockDb.entities.LiquidityPoolAggregator.set(
-        mockLiquidityPoolAggregator,
-      );
+      const populatedDb = mockDb.entities.Pool.set(mockPool);
 
       const mockEvent = CustomSwapFeeModule.SetCustomFee.createMockEvent({
-        pool: mockLiquidityPoolAggregator.poolAddress as `0x${string}`,
+        pool: mockPool.poolAddress as `0x${string}`,
         fee: fee,
         mockEventData: {
           block: {
@@ -59,12 +57,10 @@ describe("CustomSwapFeeModule Events", () => {
       const fee = 400n;
 
       // Pre-populate pool in the mock database
-      const populatedDb = mockDb.entities.LiquidityPoolAggregator.set(
-        mockLiquidityPoolAggregator,
-      );
+      const populatedDb = mockDb.entities.Pool.set(mockPool);
 
       const mockEvent = CustomSwapFeeModule.SetCustomFee.createMockEvent({
-        pool: mockLiquidityPoolAggregator.poolAddress as `0x${string}`,
+        pool: mockPool.poolAddress as `0x${string}`,
         fee: fee,
         mockEventData: {
           block: {
@@ -82,9 +78,7 @@ describe("CustomSwapFeeModule Events", () => {
       const result = await populatedDb.processEvents([mockEvent]);
 
       // Assert: Check that pool's baseFee was updated
-      const updatedPool = result.entities.LiquidityPoolAggregator.get(
-        mockLiquidityPoolAggregator.id,
-      );
+      const updatedPool = result.entities.Pool.get(mockPool.id);
       expect(updatedPool).toBeDefined();
       expect(updatedPool?.baseFee).toBe(fee);
       expect(updatedPool?.currentFee).toBe(fee);

--- a/test/EventHandlers/SwapFeeModule/CustomUnstakedFeeModule.test.ts
+++ b/test/EventHandlers/SwapFeeModule/CustomUnstakedFeeModule.test.ts
@@ -66,9 +66,8 @@ describe("CustomUnstakedFeeModule Events", () => {
     it.each(chainCases)(
       "should set unstakedFee on $name",
       async ({ chainId, srcAddress, fee }) => {
-        const pool = common.createMockLiquidityPoolAggregator({ chainId });
-        const populatedDb =
-          MockDb.createMockDb().entities.LiquidityPoolAggregator.set(pool);
+        const pool = common.createMockPool({ chainId });
+        const populatedDb = MockDb.createMockDb().entities.Pool.set(pool);
 
         const event = createSetCustomFeeEvent({
           poolAddress: pool.poolAddress,
@@ -79,9 +78,7 @@ describe("CustomUnstakedFeeModule Events", () => {
 
         const result = await populatedDb.processEvents([event]);
 
-        const updatedPool = result.entities.LiquidityPoolAggregator.get(
-          pool.id,
-        );
+        const updatedPool = result.entities.Pool.get(pool.id);
         expect(updatedPool).toBeDefined();
         expect(updatedPool?.unstakedFee).toBe(fee);
         // baseFee and currentFee must be orthogonal and untouched.
@@ -95,9 +92,8 @@ describe("CustomUnstakedFeeModule Events", () => {
     const chainId = 8453;
 
     it("should store the raw ZERO_FEE_INDICATOR sentinel (420) without normalization", async () => {
-      const pool = common.createMockLiquidityPoolAggregator({ chainId });
-      const populatedDb =
-        MockDb.createMockDb().entities.LiquidityPoolAggregator.set(pool);
+      const pool = common.createMockPool({ chainId });
+      const populatedDb = MockDb.createMockDb().entities.Pool.set(pool);
 
       const event = createSetCustomFeeEvent({
         poolAddress: pool.poolAddress,
@@ -108,12 +104,12 @@ describe("CustomUnstakedFeeModule Events", () => {
 
       const result = await populatedDb.processEvents([event]);
 
-      const updatedPool = result.entities.LiquidityPoolAggregator.get(pool.id);
+      const updatedPool = result.entities.Pool.get(pool.id);
       expect(updatedPool?.unstakedFee).toBe(420n);
     });
 
     it("should no-op (not throw) when the pool aggregator does not exist", async () => {
-      const pool = common.createMockLiquidityPoolAggregator({ chainId });
+      const pool = common.createMockPool({ chainId });
       const mockDb = MockDb.createMockDb();
 
       const event = createSetCustomFeeEvent({
@@ -125,7 +121,7 @@ describe("CustomUnstakedFeeModule Events", () => {
 
       const result = await mockDb.processEvents([event]);
 
-      const updatedPool = result.entities.LiquidityPoolAggregator.get(pool.id);
+      const updatedPool = result.entities.Pool.get(pool.id);
       expect(updatedPool).toBeUndefined();
     });
   });

--- a/test/EventHandlers/SwapFeeModule/DynamicSwapFeeModule.test.ts
+++ b/test/EventHandlers/SwapFeeModule/DynamicSwapFeeModule.test.ts
@@ -57,9 +57,7 @@ describe("DynamicSwapFeeModule Events", () => {
       // Pre-populate tokens and pool in the mock database
       mockDb = mockDb.entities.Token.set(mockToken0Data);
       mockDb = mockDb.entities.Token.set(mockToken1Data);
-      mockDb = mockDb.entities.LiquidityPoolAggregator.set(
-        mockLiquidityPoolData,
-      );
+      mockDb = mockDb.entities.Pool.set(mockLiquidityPoolData);
 
       // Execute - Update baseFee
       let result = await mockDb.processEvents([
@@ -79,9 +77,7 @@ describe("DynamicSwapFeeModule Events", () => {
         }),
       ]);
 
-      let updatedPool = result.entities.LiquidityPoolAggregator.get(
-        mockLiquidityPoolData.id,
-      );
+      let updatedPool = result.entities.Pool.get(mockLiquidityPoolData.id);
 
       expect(updatedPool).toBeDefined();
       expect(updatedPool?.baseFee).toBe(baseFee);
@@ -109,9 +105,7 @@ describe("DynamicSwapFeeModule Events", () => {
         }),
       ]);
 
-      updatedPool = result.entities.LiquidityPoolAggregator.get(
-        mockLiquidityPoolData.id,
-      );
+      updatedPool = result.entities.Pool.get(mockLiquidityPoolData.id);
 
       expect(updatedPool).toBeDefined();
       // baseFee should be preserved from the previous event
@@ -140,9 +134,7 @@ describe("DynamicSwapFeeModule Events", () => {
         }),
       ]);
 
-      updatedPool = result.entities.LiquidityPoolAggregator.get(
-        mockLiquidityPoolData.id,
-      );
+      updatedPool = result.entities.Pool.get(mockLiquidityPoolData.id);
       expect(updatedPool).toBeDefined();
       // baseFee and scalingFactor should be preserved from previous events
       expect(updatedPool?.baseFee).toBe(baseFee);

--- a/test/EventHandlers/SwapFeeModule/UnstakedFeeModule.test.ts
+++ b/test/EventHandlers/SwapFeeModule/UnstakedFeeModule.test.ts
@@ -71,11 +71,10 @@ describe("UnstakedFeeModule Events", () => {
     it.each(feeCases)(
       "should store $label on the pool",
       async ({ fee, srcAddress }) => {
-        const pool = common.createMockLiquidityPoolAggregator({
+        const pool = common.createMockPool({
           chainId: CHAIN_ID_BASE,
         });
-        const populatedDb =
-          MockDb.createMockDb().entities.LiquidityPoolAggregator.set(pool);
+        const populatedDb = MockDb.createMockDb().entities.Pool.set(pool);
 
         const event = createCustomFeeSetEvent({
           poolAddress: pool.poolAddress,
@@ -85,9 +84,7 @@ describe("UnstakedFeeModule Events", () => {
 
         const result = await populatedDb.processEvents([event]);
 
-        const updatedPool = result.entities.LiquidityPoolAggregator.get(
-          pool.id,
-        );
+        const updatedPool = result.entities.Pool.get(pool.id);
         expect(updatedPool).toBeDefined();
         expect(updatedPool?.unstakedFee).toBe(fee);
         // baseFee and currentFee must be orthogonal and untouched.
@@ -97,7 +94,7 @@ describe("UnstakedFeeModule Events", () => {
     );
 
     it("should no-op (not throw) when the pool aggregator does not exist", async () => {
-      const pool = common.createMockLiquidityPoolAggregator({
+      const pool = common.createMockPool({
         chainId: CHAIN_ID_BASE,
       });
       const mockDb = MockDb.createMockDb();
@@ -110,18 +107,18 @@ describe("UnstakedFeeModule Events", () => {
 
       const result = await mockDb.processEvents([event]);
 
-      const updatedPool = result.entities.LiquidityPoolAggregator.get(pool.id);
+      const updatedPool = result.entities.Pool.get(pool.id);
       expect(updatedPool).toBeUndefined();
     });
   });
 
   describe("Last-writer-wins across module deployments", () => {
     it("applies the most-recent event regardless of which module (Custom vs plain) fired it", async () => {
-      const pool = common.createMockLiquidityPoolAggregator({
+      const pool = common.createMockPool({
         chainId: CHAIN_ID_BASE,
       });
       let mockDb = MockDb.createMockDb();
-      mockDb = mockDb.entities.LiquidityPoolAggregator.set(pool);
+      mockDb = mockDb.entities.Pool.set(pool);
 
       // First: Initial CustomUnstakedFeeModule fires SetCustomFee with 300.
       const initialEvent = CustomUnstakedFeeModule.SetCustomFee.createMockEvent(
@@ -155,7 +152,7 @@ describe("UnstakedFeeModule Events", () => {
       });
       const result = await mockDb.processEvents([laterEvent]);
 
-      const updatedPool = result.entities.LiquidityPoolAggregator.get(pool.id);
+      const updatedPool = result.entities.Pool.get(pool.id);
       expect(updatedPool?.unstakedFee).toBe(700n);
     });
   });

--- a/test/EventHandlers/Voter/CrossChainPendingResolution.test.ts
+++ b/test/EventHandlers/Voter/CrossChainPendingResolution.test.ts
@@ -1,5 +1,4 @@
 import type {
-  LiquidityPoolAggregator,
   PendingDistribution,
   PendingVote,
   RootPool_LeafPool,
@@ -8,8 +7,8 @@ import type {
   VeNFTState,
   handlerContext,
 } from "generated";
-import type { PoolData } from "../../../src/Aggregators/LiquidityPoolAggregator";
-import * as LiquidityPoolAggregatorModule from "../../../src/Aggregators/LiquidityPoolAggregator";
+import type { PoolData } from "../../../src/Aggregators/Pool";
+import * as PoolModule from "../../../src/Aggregators/Pool";
 import * as UserStatsPerPoolModule from "../../../src/Aggregators/UserStatsPerPool";
 import * as VeNFTPoolVoteModule from "../../../src/Aggregators/VeNFTPoolVote";
 import * as VeNFTStateModule from "../../../src/Aggregators/VeNFTState";
@@ -23,6 +22,7 @@ import {
   VeNFTId,
   toChecksumAddress,
 } from "../../../src/Constants";
+import type { Pool } from "../../../src/EntityTypes";
 import {
   deleteProcessedPendingDistribution,
   deleteProcessedPendingVote,
@@ -101,7 +101,7 @@ describe("CrossChainPendingResolution", () => {
     common: ReturnType<typeof setupCommon>,
     overrides?: {
       pendingVoteOverrides?: Partial<PendingVote>;
-      leafPoolOverrides?: Partial<LiquidityPoolAggregator>;
+      leafPoolOverrides?: Partial<Pool>;
     },
   ): {
     pendingVote: PendingVote;
@@ -114,7 +114,7 @@ describe("CrossChainPendingResolution", () => {
     updateUserSpy: ReturnType<typeof vi.spyOn>;
     updateVoteSpy: ReturnType<typeof vi.spyOn>;
   } {
-    const leafPool = common.createMockLiquidityPoolAggregator({
+    const leafPool = common.createMockPool({
       id: PoolId(leafChainId, leafPoolAddress),
       chainId: leafChainId,
       poolAddress: leafPoolAddress,
@@ -154,7 +154,7 @@ describe("CrossChainPendingResolution", () => {
       mockUserStats,
     );
     const updatePoolSpy = vi
-      .spyOn(LiquidityPoolAggregatorModule, "updateLiquidityPoolAggregator")
+      .spyOn(PoolModule, "updatePool")
       .mockResolvedValue(undefined);
     const updateUserSpy = vi
       .spyOn(UserStatsPerPoolModule, "updateUserStatsPerPool")
@@ -165,7 +165,7 @@ describe("CrossChainPendingResolution", () => {
 
     const context = {
       VeNFTState: { get: vi.fn() },
-      LiquidityPoolAggregator: { set: vi.fn() },
+      Pool: { set: vi.fn() },
     } as unknown as handlerContext;
 
     return {
@@ -292,12 +292,8 @@ describe("CrossChainPendingResolution", () => {
 
   describe("processPendingVote", () => {
     it("should skip when VeNFTState is missing", async () => {
-      const {
-        createMockLiquidityPoolAggregator,
-        mockToken0Data,
-        mockToken1Data,
-      } = common;
-      const leafPool = createMockLiquidityPoolAggregator({
+      const { createMockPool, mockToken0Data, mockToken1Data } = common;
+      const leafPool = createMockPool({
         id: PoolId(leafChainId, leafPoolAddress),
         chainId: leafChainId,
         poolAddress: leafPoolAddress,
@@ -348,7 +344,7 @@ describe("CrossChainPendingResolution", () => {
       expect(updateUserSpy).toHaveBeenCalledTimes(1);
       expect(updateVoteSpy).toHaveBeenCalledTimes(1);
 
-      // Cross-chain fix: updateLiquidityPoolAggregator must receive pendingVote.chainId
+      // Cross-chain fix: updatePool must receive pendingVote.chainId
       // (root chain, not leafChainId) so the updateDynamicFeePools guard detects
       // the chain mismatch and skips the fee query (which would use root block on leaf RPC).
       const [, , , , eventChainIdArg, blockNumberArg] =
@@ -522,7 +518,7 @@ describe("CrossChainPendingResolution", () => {
       const liquidityPoolGet = vi.fn().mockResolvedValue(undefined);
       const context = {
         RootPool_LeafPool: { getWhere: rootPoolLeafPoolGetWhere },
-        LiquidityPoolAggregator: { get: liquidityPoolGet },
+        Pool: { get: liquidityPoolGet },
         Token: { get: vi.fn().mockResolvedValue(undefined) },
         log: {
           error: vi.fn(),
@@ -533,11 +529,7 @@ describe("CrossChainPendingResolution", () => {
     });
 
     it("should break loop when loadPoolData returns null during iteration", async () => {
-      const {
-        createMockLiquidityPoolAggregator,
-        mockToken0Data,
-        mockToken1Data,
-      } = common;
+      const { createMockPool, mockToken0Data, mockToken1Data } = common;
       const mapping: RootPool_LeafPool = {
         id: RootPoolLeafPoolId(
           rootChainId,
@@ -550,7 +542,7 @@ describe("CrossChainPendingResolution", () => {
         leafChainId,
         leafPoolAddress,
       };
-      const leafPool = createMockLiquidityPoolAggregator({
+      const leafPool = createMockPool({
         id: PoolId(leafChainId, leafPoolAddress),
         chainId: leafChainId,
         poolAddress: leafPoolAddress,
@@ -569,7 +561,7 @@ describe("CrossChainPendingResolution", () => {
       ]);
       let loadPoolDataCallCount = 0;
       const loadPoolDataSpy = vi
-        .spyOn(LiquidityPoolAggregatorModule, "loadPoolData")
+        .spyOn(PoolModule, "loadPoolData")
         .mockImplementation(async () => {
           loadPoolDataCallCount++;
           return loadPoolDataCallCount === 1 ? leafPoolData : null;
@@ -578,7 +570,7 @@ describe("CrossChainPendingResolution", () => {
       const context = {
         RootPool_LeafPool: { getWhere: rootPoolLeafPoolGetWhere },
         PendingVote: { getWhere: pendingVoteGetWhere, deleteUnsafe },
-        LiquidityPoolAggregator: { get: vi.fn().mockResolvedValue(leafPool) },
+        Pool: { get: vi.fn().mockResolvedValue(leafPool) },
         Token: {
           get: vi
             .fn()
@@ -598,11 +590,7 @@ describe("CrossChainPendingResolution", () => {
     });
 
     it("should not delete pending vote when VeNFTState is missing so it can be retried later", async () => {
-      const {
-        createMockLiquidityPoolAggregator,
-        mockToken0Data,
-        mockToken1Data,
-      } = common;
+      const { createMockPool, mockToken0Data, mockToken1Data } = common;
       const mapping: RootPool_LeafPool = {
         id: RootPoolLeafPoolId(
           rootChainId,
@@ -615,7 +603,7 @@ describe("CrossChainPendingResolution", () => {
         leafChainId,
         leafPoolAddress,
       };
-      const leafPool = createMockLiquidityPoolAggregator({
+      const leafPool = createMockPool({
         id: PoolId(leafChainId, leafPoolAddress),
         chainId: leafChainId,
         poolAddress: leafPoolAddress,
@@ -632,14 +620,12 @@ describe("CrossChainPendingResolution", () => {
       const rootPoolLeafPoolGetWhere = vi.fn().mockResolvedValue([mapping]);
       const pendingVoteGetWhere = vi.fn().mockResolvedValue([pendingVote]);
       const deleteUnsafe = vi.fn();
-      vi.spyOn(LiquidityPoolAggregatorModule, "loadPoolData").mockResolvedValue(
-        leafPoolData,
-      );
+      vi.spyOn(PoolModule, "loadPoolData").mockResolvedValue(leafPoolData);
       vi.spyOn(VeNFTStateModule, "loadVeNFTState").mockResolvedValue(undefined);
       const context = {
         RootPool_LeafPool: { getWhere: rootPoolLeafPoolGetWhere },
         PendingVote: { getWhere: pendingVoteGetWhere, deleteUnsafe },
-        LiquidityPoolAggregator: { get: vi.fn().mockResolvedValue(leafPool) },
+        Pool: { get: vi.fn().mockResolvedValue(leafPool) },
         Token: {
           get: vi
             .fn()
@@ -658,11 +644,7 @@ describe("CrossChainPendingResolution", () => {
     });
 
     it("should continue processing remaining pending votes and log error when processPendingVote throws for one vote", async () => {
-      const {
-        createMockLiquidityPoolAggregator,
-        mockToken0Data,
-        mockToken1Data,
-      } = common;
+      const { createMockPool, mockToken0Data, mockToken1Data } = common;
       const mockVeNFTState = common.createMockVeNFTState({
         id: VeNFTId(rootChainId, tokenId),
         chainId: rootChainId,
@@ -690,7 +672,7 @@ describe("CrossChainPendingResolution", () => {
         leafChainId,
         leafPoolAddress,
       };
-      const leafPool = createMockLiquidityPoolAggregator({
+      const leafPool = createMockPool({
         id: PoolId(leafChainId, leafPoolAddress),
         chainId: leafChainId,
         poolAddress: leafPoolAddress,
@@ -711,9 +693,7 @@ describe("CrossChainPendingResolution", () => {
       const pendingVoteGetWhere = vi
         .fn()
         .mockResolvedValue([pendingVote1, pendingVote2]);
-      vi.spyOn(LiquidityPoolAggregatorModule, "loadPoolData").mockResolvedValue(
-        leafPoolData,
-      );
+      vi.spyOn(PoolModule, "loadPoolData").mockResolvedValue(leafPoolData);
       const processError = new Error("processPendingVote failed");
       vi.spyOn(VeNFTStateModule, "loadVeNFTState")
         .mockRejectedValueOnce(processError)
@@ -726,10 +706,7 @@ describe("CrossChainPendingResolution", () => {
         UserStatsPerPoolModule,
         "loadOrCreateUserData",
       ).mockResolvedValue(mockUserStats);
-      vi.spyOn(
-        LiquidityPoolAggregatorModule,
-        "updateLiquidityPoolAggregator",
-      ).mockResolvedValue(undefined);
+      vi.spyOn(PoolModule, "updatePool").mockResolvedValue(undefined);
       vi.spyOn(
         UserStatsPerPoolModule,
         "updateUserStatsPerPool",
@@ -742,7 +719,7 @@ describe("CrossChainPendingResolution", () => {
       const context = {
         RootPool_LeafPool: { getWhere: rootPoolLeafPoolGetWhere },
         PendingVote: { getWhere: pendingVoteGetWhere, deleteUnsafe },
-        LiquidityPoolAggregator: {
+        Pool: {
           get: vi.fn().mockResolvedValue(leafPool),
           set: vi.fn(),
         },
@@ -779,11 +756,7 @@ describe("CrossChainPendingResolution", () => {
     });
 
     it("should continue loop and log error when deleteProcessedPendingVote throws after successful process", async () => {
-      const {
-        createMockLiquidityPoolAggregator,
-        mockToken0Data,
-        mockToken1Data,
-      } = common;
+      const { createMockPool, mockToken0Data, mockToken1Data } = common;
       const mockVeNFTState = common.createMockVeNFTState({
         id: VeNFTId(rootChainId, tokenId),
         chainId: rootChainId,
@@ -811,7 +784,7 @@ describe("CrossChainPendingResolution", () => {
         leafChainId,
         leafPoolAddress,
       };
-      const leafPool = createMockLiquidityPoolAggregator({
+      const leafPool = createMockPool({
         id: PoolId(leafChainId, leafPoolAddress),
         chainId: leafChainId,
         poolAddress: leafPoolAddress,
@@ -831,9 +804,7 @@ describe("CrossChainPendingResolution", () => {
       const deleteUnsafe = vi.fn().mockImplementationOnce(() => {
         throw deleteError;
       });
-      vi.spyOn(LiquidityPoolAggregatorModule, "loadPoolData").mockResolvedValue(
-        leafPoolData,
-      );
+      vi.spyOn(PoolModule, "loadPoolData").mockResolvedValue(leafPoolData);
       vi.spyOn(VeNFTStateModule, "loadVeNFTState").mockResolvedValue(
         mockVeNFTState,
       );
@@ -845,10 +816,7 @@ describe("CrossChainPendingResolution", () => {
         UserStatsPerPoolModule,
         "loadOrCreateUserData",
       ).mockResolvedValue(mockUserStats);
-      vi.spyOn(
-        LiquidityPoolAggregatorModule,
-        "updateLiquidityPoolAggregator",
-      ).mockResolvedValue(undefined);
+      vi.spyOn(PoolModule, "updatePool").mockResolvedValue(undefined);
       vi.spyOn(
         UserStatsPerPoolModule,
         "updateUserStatsPerPool",
@@ -860,7 +828,7 @@ describe("CrossChainPendingResolution", () => {
       const context = {
         RootPool_LeafPool: { getWhere: rootPoolLeafPoolGetWhere },
         PendingVote: { getWhere: pendingVoteGetWhere, deleteUnsafe },
-        LiquidityPoolAggregator: {
+        Pool: {
           get: vi.fn().mockResolvedValue(leafPool),
           set: vi.fn(),
         },
@@ -1114,7 +1082,7 @@ describe("CrossChainPendingResolution", () => {
       };
       const tokenGet = vi.fn().mockResolvedValue(mockToken);
       const loadPoolDataSpy = vi
-        .spyOn(LiquidityPoolAggregatorModule, "loadPoolData")
+        .spyOn(PoolModule, "loadPoolData")
         .mockResolvedValue(null);
       const context = {
         Token: { get: tokenGet },
@@ -1140,11 +1108,7 @@ describe("CrossChainPendingResolution", () => {
     });
 
     it("should apply LP diff when reward token and leaf pool data exist", async () => {
-      const {
-        createMockLiquidityPoolAggregator,
-        mockToken0Data,
-        mockToken1Data,
-      } = common;
+      const { createMockPool, mockToken0Data, mockToken1Data } = common;
       const pending = makePendingDistribution();
       const rewardTokenAddress = CHAIN_CONSTANTS[rootChainId].rewardToken(
         Number(pending.blockNumber),
@@ -1157,7 +1121,7 @@ describe("CrossChainPendingResolution", () => {
         decimals: 18n,
         chainId: rootChainId,
       };
-      const leafPool = createMockLiquidityPoolAggregator({
+      const leafPool = createMockPool({
         id: PoolId(leafChainId, leafPoolAddress),
         chainId: leafChainId,
         poolAddress: leafPoolAddress,
@@ -1169,9 +1133,7 @@ describe("CrossChainPendingResolution", () => {
         token1Instance: mockToken1Data,
       };
 
-      vi.spyOn(LiquidityPoolAggregatorModule, "loadPoolData").mockResolvedValue(
-        leafPoolData,
-      );
+      vi.spyOn(PoolModule, "loadPoolData").mockResolvedValue(leafPoolData);
       vi.spyOn(PriceOracle, "refreshTokenPrice").mockResolvedValue(
         mockRewardToken as never,
       );
@@ -1186,7 +1148,7 @@ describe("CrossChainPendingResolution", () => {
         normalizedVotesDepositedAmountUsd: 100n,
       });
       const updatePoolSpy = vi
-        .spyOn(LiquidityPoolAggregatorModule, "updateLiquidityPoolAggregator")
+        .spyOn(PoolModule, "updatePool")
         .mockResolvedValue(undefined);
 
       const context = {
@@ -1206,12 +1168,10 @@ describe("CrossChainPendingResolution", () => {
       expect(result).toBe(true);
 
       // Cross-chain fix: loadPoolData must NOT receive blockNumber/blockTimestamp
-      const loadPoolDataSpy = vi.mocked(
-        LiquidityPoolAggregatorModule.loadPoolData,
-      );
+      const loadPoolDataSpy = vi.mocked(PoolModule.loadPoolData);
       expect(loadPoolDataSpy.mock.calls[0]).toHaveLength(3);
 
-      // Cross-chain fix: updateLiquidityPoolAggregator must receive rootChainId
+      // Cross-chain fix: updatePool must receive rootChainId
       // (not leafChainId) so the updateDynamicFeePools guard detects the chain
       // mismatch and skips the fee query (which would use root block on leaf RPC).
       expect(updatePoolSpy).toHaveBeenCalledTimes(1);
@@ -1323,12 +1283,8 @@ describe("CrossChainPendingResolution", () => {
       const pendingDistributionGetWhere = vi.fn().mockResolvedValue([pending]);
       const deleteUnsafe = vi.fn();
 
-      const {
-        createMockLiquidityPoolAggregator,
-        mockToken0Data,
-        mockToken1Data,
-      } = common;
-      const leafPool = createMockLiquidityPoolAggregator({
+      const { createMockPool, mockToken0Data, mockToken1Data } = common;
+      const leafPool = createMockPool({
         id: PoolId(leafChainId, leafPoolAddress),
         chainId: leafChainId,
         poolAddress: leafPoolAddress,
@@ -1350,9 +1306,7 @@ describe("CrossChainPendingResolution", () => {
         chainId: rootChainId,
       };
 
-      vi.spyOn(LiquidityPoolAggregatorModule, "loadPoolData").mockResolvedValue(
-        leafPoolData,
-      );
+      vi.spyOn(PoolModule, "loadPoolData").mockResolvedValue(leafPoolData);
       vi.spyOn(PriceOracle, "refreshTokenPrice").mockResolvedValue(
         mockRewardToken as never,
       );
@@ -1366,10 +1320,7 @@ describe("CrossChainPendingResolution", () => {
         normalizedEmissionsAmountUsd: 50n,
         normalizedVotesDepositedAmountUsd: 100n,
       });
-      vi.spyOn(
-        LiquidityPoolAggregatorModule,
-        "updateLiquidityPoolAggregator",
-      ).mockResolvedValue(undefined);
+      vi.spyOn(PoolModule, "updatePool").mockResolvedValue(undefined);
 
       const context = {
         RootPool_LeafPool: { getWhere: rootPoolLeafPoolGetWhere },
@@ -1455,12 +1406,8 @@ describe("CrossChainPendingResolution", () => {
         .mockResolvedValue([pending1, pending2]);
       const deleteUnsafe = vi.fn();
 
-      const {
-        createMockLiquidityPoolAggregator,
-        mockToken0Data,
-        mockToken1Data,
-      } = common;
-      const leafPool = createMockLiquidityPoolAggregator({
+      const { createMockPool, mockToken0Data, mockToken1Data } = common;
+      const leafPool = createMockPool({
         id: PoolId(leafChainId, leafPoolAddress),
         chainId: leafChainId,
         poolAddress: leafPoolAddress,
@@ -1481,9 +1428,7 @@ describe("CrossChainPendingResolution", () => {
         chainId: rootChainId,
       };
 
-      vi.spyOn(LiquidityPoolAggregatorModule, "loadPoolData").mockResolvedValue(
-        leafPoolData,
-      );
+      vi.spyOn(PoolModule, "loadPoolData").mockResolvedValue(leafPoolData);
       vi.spyOn(PriceOracle, "refreshTokenPrice").mockResolvedValue(
         mockRewardToken as never,
       );
@@ -1498,7 +1443,7 @@ describe("CrossChainPendingResolution", () => {
         normalizedVotesDepositedAmountUsd: 100n,
       });
       const processError = new Error("processPendingDistribution failed");
-      vi.spyOn(LiquidityPoolAggregatorModule, "updateLiquidityPoolAggregator")
+      vi.spyOn(PoolModule, "updatePool")
         .mockRejectedValueOnce(processError)
         .mockResolvedValue(undefined);
 
@@ -1546,12 +1491,8 @@ describe("CrossChainPendingResolution", () => {
         throw deleteError;
       });
 
-      const {
-        createMockLiquidityPoolAggregator,
-        mockToken0Data,
-        mockToken1Data,
-      } = common;
-      const leafPool = createMockLiquidityPoolAggregator({
+      const { createMockPool, mockToken0Data, mockToken1Data } = common;
+      const leafPool = createMockPool({
         id: PoolId(leafChainId, leafPoolAddress),
         chainId: leafChainId,
         poolAddress: leafPoolAddress,
@@ -1573,9 +1514,7 @@ describe("CrossChainPendingResolution", () => {
         chainId: rootChainId,
       };
 
-      vi.spyOn(LiquidityPoolAggregatorModule, "loadPoolData").mockResolvedValue(
-        leafPoolData,
-      );
+      vi.spyOn(PoolModule, "loadPoolData").mockResolvedValue(leafPoolData);
       vi.spyOn(PriceOracle, "refreshTokenPrice").mockResolvedValue(
         mockRewardToken as never,
       );
@@ -1589,10 +1528,7 @@ describe("CrossChainPendingResolution", () => {
         normalizedEmissionsAmountUsd: 50n,
         normalizedVotesDepositedAmountUsd: 100n,
       });
-      vi.spyOn(
-        LiquidityPoolAggregatorModule,
-        "updateLiquidityPoolAggregator",
-      ).mockResolvedValue(undefined);
+      vi.spyOn(PoolModule, "updatePool").mockResolvedValue(undefined);
 
       const errors: string[] = [];
       const context = {

--- a/test/EventHandlers/Voter/DistributeRewardEmissionsUSD.test.ts
+++ b/test/EventHandlers/Voter/DistributeRewardEmissionsUSD.test.ts
@@ -88,8 +88,8 @@ describe("Voter.DistributeReward → totalEmissionsUSD regression (#673)", () =>
   }
 
   it("writes totalEmissionsUSD = emission * reward-token price when price is non-zero", async () => {
-    const { createMockLiquidityPoolAggregator } = setupCommon();
-    const liquidityPool = createMockLiquidityPoolAggregator({
+    const { createMockPool } = setupCommon();
+    const liquidityPool = createMockPool({
       id: PoolId(chainId, poolAddress),
       chainId,
       poolAddress,
@@ -105,13 +105,13 @@ describe("Voter.DistributeReward → totalEmissionsUSD regression (#673)", () =>
 
     let db = MockDb.createMockDb();
     db = db.entities.Token.set(rewardToken);
-    db = db.entities.LiquidityPoolAggregator.set(liquidityPool);
+    db = db.entities.Pool.set(liquidityPool);
 
     const resultDB = await db.processEvents([
       makeDistributeRewardEvent(amountEmitted),
     ]);
 
-    const updatedPool = resultDB.entities.LiquidityPoolAggregator.get(
+    const updatedPool = resultDB.entities.Pool.get(
       PoolId(chainId, poolAddress),
     );
     expect(updatedPool?.totalEmissions).toBe(amountEmitted);
@@ -124,12 +124,8 @@ describe("Voter.DistributeReward → totalEmissionsUSD regression (#673)", () =>
     // price, the USD result would be 1000 * $1 = $1000 (matching neither $7000
     // nor a decimals-mismatched USDC variant), so the $7000 expectation forces
     // the right token to be picked.
-    const {
-      createMockLiquidityPoolAggregator,
-      mockToken0Data,
-      mockToken1Data,
-    } = setupCommon();
-    const liquidityPool = createMockLiquidityPoolAggregator({
+    const { createMockPool, mockToken0Data, mockToken1Data } = setupCommon();
+    const liquidityPool = createMockPool({
       id: PoolId(chainId, poolAddress),
       chainId,
       poolAddress,
@@ -149,13 +145,13 @@ describe("Voter.DistributeReward → totalEmissionsUSD regression (#673)", () =>
     db = db.entities.Token.set(mockToken0Data);
     db = db.entities.Token.set(mockToken1Data);
     db = db.entities.Token.set(rewardToken);
-    db = db.entities.LiquidityPoolAggregator.set(liquidityPool);
+    db = db.entities.Pool.set(liquidityPool);
 
     const resultDB = await db.processEvents([
       makeDistributeRewardEvent(amountEmitted),
     ]);
 
-    const updatedPool = resultDB.entities.LiquidityPoolAggregator.get(
+    const updatedPool = resultDB.entities.Pool.get(
       PoolId(chainId, poolAddress),
     );
     expect(updatedPool?.totalEmissionsUSD).toBe(7000n * 10n ** 18n);
@@ -171,8 +167,8 @@ describe("Voter.DistributeReward → totalEmissionsUSD regression (#673)", () =>
     // To make refreshTokenPrice a no-op against a $0-priced token, set
     // `lastUpdatedTimestamp` to the block time so the 1-hour throttle skips
     // the RPC call and the stored $0 price is what feeds the USD calc.
-    const { createMockLiquidityPoolAggregator } = setupCommon();
-    const liquidityPool = createMockLiquidityPoolAggregator({
+    const { createMockPool } = setupCommon();
+    const liquidityPool = createMockPool({
       id: PoolId(chainId, poolAddress),
       chainId,
       poolAddress,
@@ -190,13 +186,13 @@ describe("Voter.DistributeReward → totalEmissionsUSD regression (#673)", () =>
 
     let db = MockDb.createMockDb();
     db = db.entities.Token.set(rewardToken);
-    db = db.entities.LiquidityPoolAggregator.set(liquidityPool);
+    db = db.entities.Pool.set(liquidityPool);
 
     const resultDB = await db.processEvents([
       makeDistributeRewardEvent(amountEmitted),
     ]);
 
-    const updatedPool = resultDB.entities.LiquidityPoolAggregator.get(
+    const updatedPool = resultDB.entities.Pool.get(
       PoolId(chainId, poolAddress),
     );
     expect(updatedPool?.totalEmissions).toBe(amountEmitted);

--- a/test/EventHandlers/Voter/SuperchainLeafVoter.test.ts
+++ b/test/EventHandlers/Voter/SuperchainLeafVoter.test.ts
@@ -1,13 +1,13 @@
 import type { Token } from "generated";
 import { MockDb, SuperchainLeafVoter } from "generated/src/TestHelpers.gen";
-import * as LiquidityPoolAggregatorModule from "../../../src/Aggregators/LiquidityPoolAggregator";
+import * as PoolModule from "../../../src/Aggregators/Pool";
 import {
   SUPERCHAIN_LEAF_VOTER_CLPOOLS_FACTORY_LIST,
   SUPERCHAIN_LEAF_VOTER_NONCL_POOLS_FACTORY_LIST,
   TokenId,
   toChecksumAddress,
 } from "../../../src/Constants";
-import { type MockLiquidityPoolAggregator, setupCommon } from "../Pool/common";
+import { type MockPool, setupCommon } from "../Pool/common";
 
 describe("SuperchainLeafVoter Events", () => {
   beforeEach(() => {
@@ -18,7 +18,7 @@ describe("SuperchainLeafVoter Events", () => {
     vi.restoreAllMocks();
   });
 
-  const { createMockLiquidityPoolAggregator } = setupCommon();
+  const { createMockPool } = setupCommon();
 
   describe("GaugeCreated Event", () => {
     let mockDb: ReturnType<typeof MockDb.createMockDb>;
@@ -67,24 +67,22 @@ describe("SuperchainLeafVoter Events", () => {
 
     describe("when pool entity exists", () => {
       let resultDB: ReturnType<typeof MockDb.createMockDb>;
-      let mockLiquidityPool: MockLiquidityPoolAggregator;
+      let mockLiquidityPool: MockPool;
 
       beforeEach(async () => {
-        mockLiquidityPool = createMockLiquidityPoolAggregator({
+        mockLiquidityPool = createMockPool({
           poolAddress: poolAddress,
           chainId: chainId,
           gaugeAddress: "", // Initially empty
         });
 
-        mockDb = mockDb.entities.LiquidityPoolAggregator.set(mockLiquidityPool);
+        mockDb = mockDb.entities.Pool.set(mockLiquidityPool);
 
         resultDB = await mockDb.processEvents([mockEvent]);
       });
 
       it("should update pool entity with gauge address and voting reward addresses", () => {
-        const updatedPool = resultDB.entities.LiquidityPoolAggregator.get(
-          mockLiquidityPool.id,
-        );
+        const updatedPool = resultDB.entities.Pool.get(mockLiquidityPool.id);
         expect(updatedPool).toBeDefined();
         expect(updatedPool?.gaugeAddress).toBe(gaugeAddress);
         expect(updatedPool?.feeVotingRewardAddress).toBe(
@@ -176,9 +174,7 @@ describe("SuperchainLeafVoter Events", () => {
       it("should not create any entities", async () => {
         const resultDB = await mockDb.processEvents([mockEvent]);
 
-        expect(
-          Array.from(resultDB.entities.LiquidityPoolAggregator.getAll()),
-        ).toHaveLength(0);
+        expect(Array.from(resultDB.entities.Pool.getAll())).toHaveLength(0);
       });
     });
   });
@@ -380,7 +376,7 @@ describe("SuperchainLeafVoter Events", () => {
 
     describe("when pool entity exists", () => {
       let resultDB: ReturnType<typeof MockDb.createMockDb>;
-      let mockLiquidityPool: MockLiquidityPoolAggregator;
+      let mockLiquidityPool: MockPool;
       const feeVotingRewardAddress = toChecksumAddress(
         "0x6572b2b30f63B960608f3aA5205711C558998398",
       );
@@ -389,7 +385,7 @@ describe("SuperchainLeafVoter Events", () => {
       );
 
       beforeEach(async () => {
-        mockLiquidityPool = createMockLiquidityPoolAggregator({
+        mockLiquidityPool = createMockPool({
           poolAddress: poolAddress,
           chainId: chainId,
           gaugeAddress: gaugeAddress, // Initially has gauge address
@@ -399,20 +395,17 @@ describe("SuperchainLeafVoter Events", () => {
         });
 
         // Mock findPoolByGaugeAddress to return the pool
-        vi.spyOn(
-          LiquidityPoolAggregatorModule,
-          "findPoolByGaugeAddress",
-        ).mockResolvedValue(mockLiquidityPool);
+        vi.spyOn(PoolModule, "findPoolByGaugeAddress").mockResolvedValue(
+          mockLiquidityPool,
+        );
 
-        mockDb = mockDb.entities.LiquidityPoolAggregator.set(mockLiquidityPool);
+        mockDb = mockDb.entities.Pool.set(mockLiquidityPool);
 
         resultDB = await mockDb.processEvents([mockEvent]);
       });
 
       it("should set gaugeIsAlive to false but preserve gauge address and voting reward addresses as historical data", () => {
-        const updatedPool = resultDB.entities.LiquidityPoolAggregator.get(
-          mockLiquidityPool.id,
-        );
+        const updatedPool = resultDB.entities.Pool.get(mockLiquidityPool.id);
         expect(updatedPool).toBeDefined();
         expect(updatedPool?.gaugeIsAlive).toBe(false); // Should be set to false
         // Gauge address should be preserved as historical data
@@ -433,16 +426,11 @@ describe("SuperchainLeafVoter Events", () => {
     describe("when pool entity does not exist", () => {
       it("should not create any entities", async () => {
         // Mock findPoolByGaugeAddress to return null
-        vi.spyOn(
-          LiquidityPoolAggregatorModule,
-          "findPoolByGaugeAddress",
-        ).mockResolvedValue(null);
+        vi.spyOn(PoolModule, "findPoolByGaugeAddress").mockResolvedValue(null);
 
         const resultDB = await mockDb.processEvents([mockEvent]);
 
-        expect(
-          Array.from(resultDB.entities.LiquidityPoolAggregator.getAll()),
-        ).toHaveLength(0);
+        expect(Array.from(resultDB.entities.Pool.getAll())).toHaveLength(0);
       });
     });
   });
@@ -478,7 +466,7 @@ describe("SuperchainLeafVoter Events", () => {
 
     describe("when pool entity exists", () => {
       let resultDB: ReturnType<typeof MockDb.createMockDb>;
-      let mockLiquidityPool: MockLiquidityPoolAggregator;
+      let mockLiquidityPool: MockPool;
       const feeVotingRewardAddress = toChecksumAddress(
         "0x6572b2b30f63B960608f3aA5205711C558998398",
       );
@@ -487,7 +475,7 @@ describe("SuperchainLeafVoter Events", () => {
       );
 
       beforeEach(async () => {
-        mockLiquidityPool = createMockLiquidityPoolAggregator({
+        mockLiquidityPool = createMockPool({
           poolAddress: poolAddress,
           chainId: chainId,
           gaugeAddress: gaugeAddress, // Has gauge address
@@ -497,20 +485,17 @@ describe("SuperchainLeafVoter Events", () => {
         });
 
         // Mock findPoolByGaugeAddress to return the pool
-        vi.spyOn(
-          LiquidityPoolAggregatorModule,
-          "findPoolByGaugeAddress",
-        ).mockResolvedValue(mockLiquidityPool);
+        vi.spyOn(PoolModule, "findPoolByGaugeAddress").mockResolvedValue(
+          mockLiquidityPool,
+        );
 
-        mockDb = mockDb.entities.LiquidityPoolAggregator.set(mockLiquidityPool);
+        mockDb = mockDb.entities.Pool.set(mockLiquidityPool);
 
         resultDB = await mockDb.processEvents([mockEvent]);
       });
 
       it("should set gaugeIsAlive to true", () => {
-        const updatedPool = resultDB.entities.LiquidityPoolAggregator.get(
-          mockLiquidityPool.id,
-        );
+        const updatedPool = resultDB.entities.Pool.get(mockLiquidityPool.id);
         expect(updatedPool).toBeDefined();
         expect(updatedPool?.gaugeIsAlive).toBe(true); // Should be set to true
         expect(updatedPool?.lastUpdatedTimestamp).toEqual(
@@ -522,16 +507,11 @@ describe("SuperchainLeafVoter Events", () => {
     describe("when pool entity does not exist", () => {
       it("should not create any entities", async () => {
         // Mock findPoolByGaugeAddress to return null
-        vi.spyOn(
-          LiquidityPoolAggregatorModule,
-          "findPoolByGaugeAddress",
-        ).mockResolvedValue(null);
+        vi.spyOn(PoolModule, "findPoolByGaugeAddress").mockResolvedValue(null);
 
         const resultDB = await mockDb.processEvents([mockEvent]);
 
-        expect(
-          Array.from(resultDB.entities.LiquidityPoolAggregator.getAll()),
-        ).toHaveLength(0);
+        expect(Array.from(resultDB.entities.Pool.getAll())).toHaveLength(0);
       });
     });
   });

--- a/test/EventHandlers/Voter/Voter.test.ts
+++ b/test/EventHandlers/Voter/Voter.test.ts
@@ -5,7 +5,7 @@ import {
   VeNFT,
   Voter,
 } from "generated/src/TestHelpers.gen";
-import * as LiquidityPoolAggregatorModule from "../../../src/Aggregators/LiquidityPoolAggregator";
+import * as PoolModule from "../../../src/Aggregators/Pool";
 import {
   CHAIN_CONSTANTS,
   PendingDistributionId,
@@ -22,7 +22,7 @@ import {
   toChecksumAddress,
 } from "../../../src/Constants";
 import { getTokensDeposited } from "../../../src/Effects/Voter";
-import { type MockLiquidityPoolAggregator, setupCommon } from "../Pool/common";
+import { type MockPool, setupCommon } from "../Pool/common";
 
 type MockUserStatsPerPool = ReturnType<
   ReturnType<typeof setupCommon>["createMockUserStatsPerPool"]
@@ -147,20 +147,20 @@ describe("Voter Events", () => {
 
     describe("when pool data exists", () => {
       let resultDB: ReturnType<typeof MockDb.createMockDb>;
-      let mockLiquidityPool: MockLiquidityPoolAggregator;
+      let mockLiquidityPool: MockPool;
       let mockUserStats: MockUserStatsPerPool;
       let mockVeNFTState: VeNFTState;
 
       beforeEach(async () => {
         const {
-          createMockLiquidityPoolAggregator,
+          createMockPool,
           mockToken0Data,
           mockToken1Data,
           createMockUserStatsPerPool,
           createMockVeNFTState,
         } = setupCommon();
 
-        mockLiquidityPool = createMockLiquidityPoolAggregator({
+        mockLiquidityPool = createMockPool({
           id: PoolId(chainId, poolAddress),
           chainId: chainId,
           poolAddress: poolAddress,
@@ -184,7 +184,7 @@ describe("Voter Events", () => {
         });
 
         // Setup mock database with required entities
-        mockDb = mockDb.entities.LiquidityPoolAggregator.set(mockLiquidityPool);
+        mockDb = mockDb.entities.Pool.set(mockLiquidityPool);
         mockDb = mockDb.entities.UserStatsPerPool.set(mockUserStats);
         mockDb = mockDb.entities.Token.set(mockToken0Data);
         mockDb = mockDb.entities.Token.set(mockToken1Data);
@@ -194,7 +194,7 @@ describe("Voter Events", () => {
       });
 
       it("should update liquidity pool aggregator with voting data", () => {
-        const updatedPool = resultDB.entities.LiquidityPoolAggregator.get(
+        const updatedPool = resultDB.entities.Pool.get(
           PoolId(chainId, poolAddress),
         );
         expect(updatedPool).toBeDefined();
@@ -244,27 +244,22 @@ describe("Voter Events", () => {
 
     describe("when pool data exists but VeNFTState is missing", () => {
       it("should return early without updating pool or creating vote entities", async () => {
-        const {
-          createMockLiquidityPoolAggregator,
-          mockToken0Data,
-          mockToken1Data,
-        } = setupCommon();
-        const poolWithZeroStaked = createMockLiquidityPoolAggregator({
+        const { createMockPool, mockToken0Data, mockToken1Data } =
+          setupCommon();
+        const poolWithZeroStaked = createMockPool({
           id: PoolId(chainId, poolAddress),
           chainId,
           poolAddress,
           veNFTamountStaked: 0n,
         });
         let db = MockDb.createMockDb();
-        db = db.entities.LiquidityPoolAggregator.set(poolWithZeroStaked);
+        db = db.entities.Pool.set(poolWithZeroStaked);
         db = db.entities.Token.set(mockToken0Data);
         db = db.entities.Token.set(mockToken1Data);
 
         const resultDB = await db.processEvents([mockEvent]);
 
-        const pool = resultDB.entities.LiquidityPoolAggregator.get(
-          PoolId(chainId, poolAddress),
-        );
+        const pool = resultDB.entities.Pool.get(PoolId(chainId, poolAddress));
         expect(pool?.veNFTamountStaked).toBe(0n);
         expect(
           Array.from(resultDB.entities.UserStatsPerPool.getAll()),
@@ -279,10 +274,8 @@ describe("Voter Events", () => {
       it("should return early without creating pool entities", async () => {
         const resultDB = await mockDb.processEvents([mockEvent]);
 
-        // Should not create LiquidityPoolAggregator entity
-        expect(
-          Array.from(resultDB.entities.LiquidityPoolAggregator.getAll()),
-        ).toHaveLength(0);
+        // Should not create Pool entity
+        expect(Array.from(resultDB.entities.Pool.getAll())).toHaveLength(0);
         expect(
           Array.from(resultDB.entities.UserStatsPerPool.getAll()),
         ).toHaveLength(0);
@@ -375,9 +368,7 @@ describe("Voter Events", () => {
         expect(pendingVote?.blockNumber).toBe(BigInt(blockNumber));
         expect(pendingVote?.transactionHash).toBe(txHash);
 
-        expect(
-          Array.from(resultDB.entities.LiquidityPoolAggregator.getAll()),
-        ).toHaveLength(0);
+        expect(Array.from(resultDB.entities.Pool.getAll())).toHaveLength(0);
         expect(
           Array.from(resultDB.entities.UserStatsPerPool.getAll()),
         ).toHaveLength(0);
@@ -431,9 +422,7 @@ describe("Voter Events", () => {
         expect(pendingVote?.eventType).toBe("Abstained");
         expect(pendingVote?.weight).toBe(100n);
 
-        expect(
-          Array.from(resultDB.entities.LiquidityPoolAggregator.getAll()),
-        ).toHaveLength(0);
+        expect(Array.from(resultDB.entities.Pool.getAll())).toHaveLength(0);
         expect(
           Array.from(resultDB.entities.UserStatsPerPool.getAll()),
         ).toHaveLength(0);
@@ -480,9 +469,7 @@ describe("Voter Events", () => {
         expect(Array.from(resultDB.entities.PendingVote.getAll())).toHaveLength(
           0,
         );
-        expect(
-          Array.from(resultDB.entities.LiquidityPoolAggregator.getAll()),
-        ).toHaveLength(0);
+        expect(Array.from(resultDB.entities.Pool.getAll())).toHaveLength(0);
         expect(
           Array.from(resultDB.entities.UserStatsPerPool.getAll()),
         ).toHaveLength(0);
@@ -529,9 +516,7 @@ describe("Voter Events", () => {
         expect(Array.from(resultDB.entities.PendingVote.getAll())).toHaveLength(
           0,
         );
-        expect(
-          Array.from(resultDB.entities.LiquidityPoolAggregator.getAll()),
-        ).toHaveLength(0);
+        expect(Array.from(resultDB.entities.Pool.getAll())).toHaveLength(0);
         expect(
           Array.from(resultDB.entities.UserStatsPerPool.getAll()),
         ).toHaveLength(0);
@@ -583,9 +568,7 @@ describe("Voter Events", () => {
         expect(Array.from(resultDB.entities.PendingVote.getAll())).toHaveLength(
           0,
         );
-        expect(
-          Array.from(resultDB.entities.LiquidityPoolAggregator.getAll()),
-        ).toHaveLength(0);
+        expect(Array.from(resultDB.entities.Pool.getAll())).toHaveLength(0);
       });
 
       it("drops Abstained silently without creating PendingVote", async () => {
@@ -621,9 +604,7 @@ describe("Voter Events", () => {
         expect(Array.from(resultDB.entities.PendingVote.getAll())).toHaveLength(
           0,
         );
-        expect(
-          Array.from(resultDB.entities.LiquidityPoolAggregator.getAll()),
-        ).toHaveLength(0);
+        expect(Array.from(resultDB.entities.Pool.getAll())).toHaveLength(0);
       });
     });
 
@@ -731,9 +712,7 @@ describe("Voter Events", () => {
         expect(
           Array.from(resultDB.entities.RootPool_LeafPool.getAll()),
         ).toHaveLength(0);
-        expect(
-          Array.from(resultDB.entities.LiquidityPoolAggregator.getAll()),
-        ).toHaveLength(0);
+        expect(Array.from(resultDB.entities.Pool.getAll())).toHaveLength(0);
       });
 
       it("should create PendingRootPoolMapping and PendingVote when RootPoolCreated then Abstained (no leaf pool yet)", async () => {
@@ -917,7 +896,7 @@ describe("Voter Events", () => {
       const realTimestamp = 1734595305;
       const rootChainId = 10; // Optimism
       const leafChainId = 252; // Fraxtal
-      let mockLeafPool: MockLiquidityPoolAggregator;
+      let mockLeafPool: MockPool;
       let mockUserStats: MockUserStatsPerPool;
       let mockVeNFTState: VeNFTState;
 
@@ -926,7 +905,7 @@ describe("Voter Events", () => {
           mockToken0Data,
           mockToken1Data,
           createMockUserStatsPerPool,
-          createMockLiquidityPoolAggregator,
+          createMockPool,
           createMockVeNFTState,
         } = setupCommon();
 
@@ -943,7 +922,7 @@ describe("Voter Events", () => {
         };
 
         // Create leaf pool using helper function
-        mockLeafPool = createMockLiquidityPoolAggregator({
+        mockLeafPool = createMockPool({
           id: PoolId(leafChainId, leafPoolAddress),
           chainId: leafChainId,
           poolAddress: leafPoolAddress,
@@ -984,7 +963,7 @@ describe("Voter Events", () => {
         };
 
         // Setup mock database with leaf pool and RootPool_LeafPool mapping
-        mockDb = mockDb.entities.LiquidityPoolAggregator.set(mockLeafPool);
+        mockDb = mockDb.entities.Pool.set(mockLeafPool);
         mockDb = mockDb.entities.RootPool_LeafPool.set(rootPoolLeafPool);
         mockDb = mockDb.entities.UserStatsPerPool.set(mockUserStats);
         mockDb = mockDb.entities.Token.set(leafToken0Data);
@@ -1013,7 +992,7 @@ describe("Voter Events", () => {
       });
 
       it("should update leaf pool aggregator with voting data", () => {
-        const updatedPool = resultDB.entities.LiquidityPoolAggregator.get(
+        const updatedPool = resultDB.entities.Pool.get(
           PoolId(leafChainId, leafPoolAddress),
         );
         expect(updatedPool).toBeDefined();
@@ -1045,7 +1024,7 @@ describe("Voter Events", () => {
           mockToken0Data,
           mockToken1Data,
           createMockUserStatsPerPool,
-          createMockLiquidityPoolAggregator,
+          createMockPool,
           createMockVeNFTState,
         } = setupCommon();
 
@@ -1053,7 +1032,7 @@ describe("Voter Events", () => {
           "0x3333333333333333333333333333333333333333",
         );
 
-        const liquidityPool = createMockLiquidityPoolAggregator({
+        const liquidityPool = createMockPool({
           id: PoolId(chainId, poolAddress),
           chainId: chainId,
           poolAddress: poolAddress,
@@ -1084,7 +1063,7 @@ describe("Voter Events", () => {
         });
 
         let db = MockDb.createMockDb();
-        db = db.entities.LiquidityPoolAggregator.set(liquidityPool);
+        db = db.entities.Pool.set(liquidityPool);
         db = db.entities.UserStatsPerPool.set(userStats);
         db = db.entities.Token.set(mockToken0Data);
         db = db.entities.Token.set(mockToken1Data);
@@ -1175,7 +1154,7 @@ describe("Voter Events", () => {
 
     describe("when pool data exists", () => {
       let resultDB: ReturnType<typeof MockDb.createMockDb>;
-      let mockLiquidityPool: MockLiquidityPoolAggregator;
+      let mockLiquidityPool: MockPool;
       let mockUserStats: MockUserStatsPerPool;
       let mockVeNFTState: VeNFTState;
       let mockVeNFTPoolVote: VeNFTPoolVote;
@@ -1184,13 +1163,13 @@ describe("Voter Events", () => {
         const {
           mockToken0Data,
           mockToken1Data,
-          createMockLiquidityPoolAggregator,
+          createMockPool,
           createMockUserStatsPerPool,
           createMockVeNFTState,
           createMockVeNFTPoolVote,
         } = setupCommon();
 
-        mockLiquidityPool = createMockLiquidityPoolAggregator({
+        mockLiquidityPool = createMockPool({
           id: PoolId(chainId, poolAddress),
           chainId: chainId,
           poolAddress: poolAddress,
@@ -1222,7 +1201,7 @@ describe("Voter Events", () => {
         });
 
         // Setup mock database with required entities
-        mockDb = mockDb.entities.LiquidityPoolAggregator.set(mockLiquidityPool);
+        mockDb = mockDb.entities.Pool.set(mockLiquidityPool);
         mockDb = mockDb.entities.UserStatsPerPool.set(mockUserStats);
         mockDb = mockDb.entities.Token.set(mockToken0Data);
         mockDb = mockDb.entities.Token.set(mockToken1Data);
@@ -1233,7 +1212,7 @@ describe("Voter Events", () => {
       });
 
       it("should update liquidity pool aggregator with total weight (absolute value)", () => {
-        const updatedPool = resultDB.entities.LiquidityPoolAggregator.get(
+        const updatedPool = resultDB.entities.Pool.get(
           PoolId(chainId, poolAddress),
         );
         expect(updatedPool).toBeDefined();
@@ -1271,26 +1250,21 @@ describe("Voter Events", () => {
 
     describe("when pool data exists but VeNFTState is missing", () => {
       it("should return early without updating pool or creating vote entities", async () => {
-        const {
-          createMockLiquidityPoolAggregator,
-          mockToken0Data,
-          mockToken1Data,
-        } = setupCommon();
-        const poolWithStaked = createMockLiquidityPoolAggregator({
+        const { createMockPool, mockToken0Data, mockToken1Data } =
+          setupCommon();
+        const poolWithStaked = createMockPool({
           id: PoolId(chainId, poolAddress),
           chainId,
           veNFTamountStaked: 1000n,
         });
         let db = MockDb.createMockDb();
-        db = db.entities.LiquidityPoolAggregator.set(poolWithStaked);
+        db = db.entities.Pool.set(poolWithStaked);
         db = db.entities.Token.set(mockToken0Data);
         db = db.entities.Token.set(mockToken1Data);
 
         const resultDB = await db.processEvents([mockEvent]);
 
-        const pool = resultDB.entities.LiquidityPoolAggregator.get(
-          PoolId(chainId, poolAddress),
-        );
+        const pool = resultDB.entities.Pool.get(PoolId(chainId, poolAddress));
         expect(pool?.veNFTamountStaked).toBe(1000n);
         expect(
           Array.from(resultDB.entities.UserStatsPerPool.getAll()),
@@ -1305,10 +1279,8 @@ describe("Voter Events", () => {
       it("should return early without creating pool entities", async () => {
         const resultDB = await mockDb.processEvents([mockEvent]);
 
-        // Should not create LiquidityPoolAggregator entity
-        expect(
-          Array.from(resultDB.entities.LiquidityPoolAggregator.getAll()),
-        ).toHaveLength(0);
+        // Should not create Pool entity
+        expect(Array.from(resultDB.entities.Pool.getAll())).toHaveLength(0);
         expect(
           Array.from(resultDB.entities.UserStatsPerPool.getAll()),
         ).toHaveLength(0);
@@ -1338,7 +1310,7 @@ describe("Voter Events", () => {
       const rootChainId = 10; // Optimism
       const leafChainId = 252; // Fraxtal
       const initialUserStaked = 50000000000000000000000n; // 50k tokens (18 decimals) - initial amount before withdrawal
-      let mockLeafPool: MockLiquidityPoolAggregator;
+      let mockLeafPool: MockPool;
       let mockUserStats: MockUserStatsPerPool;
       let mockVeNFTState: VeNFTState;
       let mockVeNFTPoolVote: VeNFTPoolVote;
@@ -1348,7 +1320,7 @@ describe("Voter Events", () => {
           mockToken0Data,
           mockToken1Data,
           createMockUserStatsPerPool,
-          createMockLiquidityPoolAggregator,
+          createMockPool,
           createMockVeNFTState,
           createMockVeNFTPoolVote,
         } = setupCommon();
@@ -1366,7 +1338,7 @@ describe("Voter Events", () => {
         };
 
         // Create leaf pool using helper function with initial staked amount
-        mockLeafPool = createMockLiquidityPoolAggregator({
+        mockLeafPool = createMockPool({
           id: PoolId(leafChainId, leafPoolAddress),
           chainId: leafChainId,
           poolAddress: leafPoolAddress,
@@ -1415,7 +1387,7 @@ describe("Voter Events", () => {
         };
 
         // Setup mock database with leaf pool and RootPool_LeafPool mapping
-        mockDb = mockDb.entities.LiquidityPoolAggregator.set(mockLeafPool);
+        mockDb = mockDb.entities.Pool.set(mockLeafPool);
         mockDb = mockDb.entities.RootPool_LeafPool.set(rootPoolLeafPool);
         mockDb = mockDb.entities.UserStatsPerPool.set(mockUserStats);
         mockDb = mockDb.entities.Token.set(leafToken0Data);
@@ -1445,7 +1417,7 @@ describe("Voter Events", () => {
       });
 
       it("should update leaf pool aggregator with total weight (absolute value)", () => {
-        const updatedPool = resultDB.entities.LiquidityPoolAggregator.get(
+        const updatedPool = resultDB.entities.Pool.get(
           PoolId(leafChainId, leafPoolAddress),
         );
 
@@ -1533,7 +1505,7 @@ describe("Voter Events", () => {
       const {
         mockToken0Data,
         mockToken1Data,
-        createMockLiquidityPoolAggregator,
+        createMockPool,
         createMockVeNFTState,
       } = setupCommon();
 
@@ -1565,7 +1537,7 @@ describe("Voter Events", () => {
         chainId: leafChainId,
       };
 
-      const leafPool = createMockLiquidityPoolAggregator({
+      const leafPool = createMockPool({
         id: PoolId(leafChainId, leafPoolAddress),
         chainId: leafChainId,
         poolAddress: leafPoolAddress,
@@ -1595,7 +1567,7 @@ describe("Voter Events", () => {
       };
 
       let db = MockDb.createMockDb();
-      db = db.entities.LiquidityPoolAggregator.set(leafPool);
+      db = db.entities.Pool.set(leafPool);
       db = db.entities.RootPool_LeafPool.set(rootPoolLeafPool);
       db = db.entities.Token.set(leafToken0Data);
       db = db.entities.Token.set(leafToken1Data);
@@ -1742,24 +1714,24 @@ describe("Voter Events", () => {
 
     describe("when pool entity exists", () => {
       let resultDB: ReturnType<typeof MockDb.createMockDb>;
-      let mockLiquidityPool: MockLiquidityPoolAggregator;
+      let mockLiquidityPool: MockPool;
 
       beforeEach(async () => {
-        const { createMockLiquidityPoolAggregator } = setupCommon();
+        const { createMockPool } = setupCommon();
 
-        mockLiquidityPool = createMockLiquidityPoolAggregator({
+        mockLiquidityPool = createMockPool({
           id: PoolId(chainId, poolAddress),
           chainId: chainId,
           gaugeAddress: "", // Initially empty
         });
 
-        mockDb = mockDb.entities.LiquidityPoolAggregator.set(mockLiquidityPool);
+        mockDb = mockDb.entities.Pool.set(mockLiquidityPool);
 
         resultDB = await mockDb.processEvents([mockEvent]);
       });
 
       it("should update pool entity with gauge address and voting reward addresses", () => {
-        const updatedPool = resultDB.entities.LiquidityPoolAggregator.get(
+        const updatedPool = resultDB.entities.Pool.get(
           PoolId(chainId, poolAddress),
         );
         expect(updatedPool).toBeDefined();
@@ -1780,9 +1752,7 @@ describe("Voter Events", () => {
       it("should create RootGauge_RootPool for cross-chain DistributeReward resolution", async () => {
         const resultDB = await mockDb.processEvents([mockEvent]);
 
-        expect(
-          Array.from(resultDB.entities.LiquidityPoolAggregator.getAll()),
-        ).toHaveLength(0);
+        expect(Array.from(resultDB.entities.Pool.getAll())).toHaveLength(0);
 
         const expectedId = RootGaugeRootPoolId(chainId, gaugeAddress);
         const rootGaugeRootPool =
@@ -1796,13 +1766,13 @@ describe("Voter Events", () => {
 
     describe("when pool factory is CL factory", () => {
       let resultDB: ReturnType<typeof MockDb.createMockDb>;
-      let mockLiquidityPool: MockLiquidityPoolAggregator;
+      let mockLiquidityPool: MockPool;
       let clFactoryEvent: ReturnType<typeof Voter.GaugeCreated.createMockEvent>;
 
       beforeEach(async () => {
-        const { createMockLiquidityPoolAggregator } = setupCommon();
+        const { createMockPool } = setupCommon();
 
-        mockLiquidityPool = createMockLiquidityPoolAggregator({
+        mockLiquidityPool = createMockPool({
           id: PoolId(chainId, poolAddress),
           chainId: chainId,
           gaugeAddress: "", // Initially empty
@@ -1841,13 +1811,13 @@ describe("Voter Events", () => {
           },
         });
 
-        mockDb = mockDb.entities.LiquidityPoolAggregator.set(mockLiquidityPool);
+        mockDb = mockDb.entities.Pool.set(mockLiquidityPool);
 
         resultDB = await mockDb.processEvents([clFactoryEvent]);
       });
 
       it("should update pool entity with gauge address (CL factory path)", () => {
-        const updatedPool = resultDB.entities.LiquidityPoolAggregator.get(
+        const updatedPool = resultDB.entities.Pool.get(
           PoolId(chainId, poolAddress),
         );
         expect(updatedPool).toBeDefined();
@@ -1891,7 +1861,7 @@ describe("Voter Events", () => {
 
     describe("when pool entity exists", () => {
       let resultDB: ReturnType<typeof MockDb.createMockDb>;
-      let mockLiquidityPool: MockLiquidityPoolAggregator;
+      let mockLiquidityPool: MockPool;
       const feeVotingRewardAddress = toChecksumAddress(
         "0x6572b2b30f63B960608f3aA5205711C558998398",
       );
@@ -1900,9 +1870,9 @@ describe("Voter Events", () => {
       );
 
       beforeEach(async () => {
-        const { createMockLiquidityPoolAggregator } = setupCommon();
+        const { createMockPool } = setupCommon();
 
-        mockLiquidityPool = createMockLiquidityPoolAggregator({
+        mockLiquidityPool = createMockPool({
           id: PoolId(chainId, poolAddress),
           chainId: chainId,
           gaugeAddress: gaugeAddress, // Initially has gauge address
@@ -1912,18 +1882,17 @@ describe("Voter Events", () => {
         });
 
         // Mock findPoolByGaugeAddress to return the pool
-        vi.spyOn(
-          LiquidityPoolAggregatorModule,
-          "findPoolByGaugeAddress",
-        ).mockResolvedValue(mockLiquidityPool);
+        vi.spyOn(PoolModule, "findPoolByGaugeAddress").mockResolvedValue(
+          mockLiquidityPool,
+        );
 
-        mockDb = mockDb.entities.LiquidityPoolAggregator.set(mockLiquidityPool);
+        mockDb = mockDb.entities.Pool.set(mockLiquidityPool);
 
         resultDB = await mockDb.processEvents([mockEvent]);
       });
 
       it("should set gaugeIsAlive to false but preserve gauge address and voting reward addresses as historical data", () => {
-        const updatedPool = resultDB.entities.LiquidityPoolAggregator.get(
+        const updatedPool = resultDB.entities.Pool.get(
           PoolId(chainId, poolAddress),
         );
         expect(updatedPool).toBeDefined();
@@ -1946,16 +1915,11 @@ describe("Voter Events", () => {
     describe("when pool entity does not exist", () => {
       it("should not create any entities", async () => {
         // Mock findPoolByGaugeAddress to return null
-        vi.spyOn(
-          LiquidityPoolAggregatorModule,
-          "findPoolByGaugeAddress",
-        ).mockResolvedValue(null);
+        vi.spyOn(PoolModule, "findPoolByGaugeAddress").mockResolvedValue(null);
 
         const resultDB = await mockDb.processEvents([mockEvent]);
 
-        expect(
-          Array.from(resultDB.entities.LiquidityPoolAggregator.getAll()),
-        ).toHaveLength(0);
+        expect(Array.from(resultDB.entities.Pool.getAll())).toHaveLength(0);
       });
     });
   });
@@ -1989,7 +1953,7 @@ describe("Voter Events", () => {
 
     describe("when pool entity exists", () => {
       let resultDB: ReturnType<typeof MockDb.createMockDb>;
-      let mockLiquidityPool: MockLiquidityPoolAggregator;
+      let mockLiquidityPool: MockPool;
       const feeVotingRewardAddress = toChecksumAddress(
         "0x6572b2b30f63B960608f3aA5205711C558998398",
       );
@@ -1998,9 +1962,9 @@ describe("Voter Events", () => {
       );
 
       beforeEach(async () => {
-        const { createMockLiquidityPoolAggregator } = setupCommon();
+        const { createMockPool } = setupCommon();
 
-        mockLiquidityPool = createMockLiquidityPoolAggregator({
+        mockLiquidityPool = createMockPool({
           id: PoolId(chainId, poolAddress),
           chainId: chainId,
           gaugeAddress: gaugeAddress, // Has gauge address
@@ -2010,18 +1974,17 @@ describe("Voter Events", () => {
         });
 
         // Mock findPoolByGaugeAddress to return the pool
-        vi.spyOn(
-          LiquidityPoolAggregatorModule,
-          "findPoolByGaugeAddress",
-        ).mockResolvedValue(mockLiquidityPool);
+        vi.spyOn(PoolModule, "findPoolByGaugeAddress").mockResolvedValue(
+          mockLiquidityPool,
+        );
 
-        mockDb = mockDb.entities.LiquidityPoolAggregator.set(mockLiquidityPool);
+        mockDb = mockDb.entities.Pool.set(mockLiquidityPool);
 
         resultDB = await mockDb.processEvents([mockEvent]);
       });
 
       it("should set gaugeIsAlive to true", () => {
-        const updatedPool = resultDB.entities.LiquidityPoolAggregator.get(
+        const updatedPool = resultDB.entities.Pool.get(
           PoolId(chainId, poolAddress),
         );
         expect(updatedPool).toBeDefined();
@@ -2035,16 +1998,11 @@ describe("Voter Events", () => {
     describe("when pool entity does not exist", () => {
       it("should not create any entities", async () => {
         // Mock findPoolByGaugeAddress to return null
-        vi.spyOn(
-          LiquidityPoolAggregatorModule,
-          "findPoolByGaugeAddress",
-        ).mockResolvedValue(null);
+        vi.spyOn(PoolModule, "findPoolByGaugeAddress").mockResolvedValue(null);
 
         const resultDB = await mockDb.processEvents([mockEvent]);
 
-        expect(
-          Array.from(resultDB.entities.LiquidityPoolAggregator.getAll()),
-        ).toHaveLength(0);
+        expect(Array.from(resultDB.entities.Pool.getAll())).toHaveLength(0);
       });
     });
   });
@@ -2201,7 +2159,7 @@ describe("Voter Events", () => {
       let updatedDB: ReturnType<typeof MockDb.createMockDb>;
       let cleanup: () => void;
 
-      const { createMockLiquidityPoolAggregator } = setupCommon();
+      const { createMockPool } = setupCommon();
 
       let expectations: {
         totalEmissions: bigint;
@@ -2211,7 +2169,7 @@ describe("Voter Events", () => {
       };
 
       beforeEach(async () => {
-        const liquidityPool = createMockLiquidityPoolAggregator({
+        const liquidityPool = createMockPool({
           id: PoolId(chainId, poolAddress),
           chainId: chainId,
           totalEmissions: 0n,
@@ -2236,15 +2194,13 @@ describe("Voter Events", () => {
         cleanup = cleanupFn;
 
         // Mock findPoolByGaugeAddress to return the pool
-        vi.spyOn(
-          LiquidityPoolAggregatorModule,
-          "findPoolByGaugeAddress",
-        ).mockResolvedValue(liquidityPool);
+        vi.spyOn(PoolModule, "findPoolByGaugeAddress").mockResolvedValue(
+          liquidityPool,
+        );
 
         // Set entities in the mock database
         updatedDB = mockDb.entities.Token.set(rewardToken);
-        updatedDB =
-          updatedDB.entities.LiquidityPoolAggregator.set(liquidityPool);
+        updatedDB = updatedDB.entities.Pool.set(liquidityPool);
 
         // Process the event
         resultDB = await updatedDB.processEvents([mockEvent]);
@@ -2256,8 +2212,7 @@ describe("Voter Events", () => {
 
       // TODO: Skip until envio migrates to createTestIndexer — vi.spyOn can't intercept tsx-loaded modules (alpha.18)
       it.skip("should update the liquidity pool aggregator with emissions data", () => {
-        const updatedPool =
-          resultDB.entities.LiquidityPoolAggregator.get(poolId);
+        const updatedPool = resultDB.entities.Pool.get(poolId);
         expect(updatedPool).toBeDefined();
         expect(updatedPool?.totalEmissions).toBe(expectations.totalEmissions);
         expect(updatedPool?.totalEmissionsUSD).toBe(
@@ -2272,8 +2227,7 @@ describe("Voter Events", () => {
       });
       // TODO: Skip until envio migrates to createTestIndexer — vi.spyOn can't intercept tsx-loaded modules (alpha.18)
       it.skip("should update the liquidity pool aggregator with votes deposited data", () => {
-        const updatedPool =
-          resultDB.entities.LiquidityPoolAggregator.get(poolId);
+        const updatedPool = resultDB.entities.Pool.get(poolId);
         expect(updatedPool).toBeDefined();
         expect(updatedPool?.totalVotesDeposited).toBe(
           expectations.getTokensDeposited,
@@ -2287,8 +2241,7 @@ describe("Voter Events", () => {
         expect(updatedPool?.gaugeAddress).toBe(gaugeAddress);
       });
       it("should not modify gaugeIsAlive (preserves existing value) when false", () => {
-        const updatedPool =
-          resultDB.entities.LiquidityPoolAggregator.get(poolId);
+        const updatedPool = resultDB.entities.Pool.get(poolId);
         expect(updatedPool).toBeDefined();
         expect(updatedPool?.gaugeIsAlive).toBe(false);
       });
@@ -2298,7 +2251,7 @@ describe("Voter Events", () => {
         let originalChainConstantsAlive: (typeof CHAIN_CONSTANTS)[typeof chainId];
 
         beforeEach(async () => {
-          const liquidityPool = createMockLiquidityPoolAggregator({
+          const liquidityPool = createMockPool({
             id: PoolId(chainId, poolAddress),
             chainId: chainId,
             totalEmissions: 0n,
@@ -2320,10 +2273,9 @@ describe("Voter Events", () => {
             lastUpdatedTimestamp: new Date(1000000 * 1000),
           } as Token;
 
-          vi.spyOn(
-            LiquidityPoolAggregatorModule,
-            "findPoolByGaugeAddress",
-          ).mockResolvedValue(liquidityPool);
+          vi.spyOn(PoolModule, "findPoolByGaugeAddress").mockResolvedValue(
+            liquidityPool,
+          );
 
           vi.spyOn(
             getTokensDeposited as unknown as EffectWithHandler<
@@ -2345,7 +2297,7 @@ describe("Voter Events", () => {
           };
 
           let db = mockDb.entities.Token.set(rewardToken);
-          db = db.entities.LiquidityPoolAggregator.set(liquidityPool);
+          db = db.entities.Pool.set(liquidityPool);
           resultDBWithAliveGauge = await db.processEvents([mockEvent]);
         });
 
@@ -2354,8 +2306,7 @@ describe("Voter Events", () => {
         });
 
         it("should not modify gaugeIsAlive (preserves existing value) when true", () => {
-          const updatedPool =
-            resultDBWithAliveGauge.entities.LiquidityPoolAggregator.get(poolId);
+          const updatedPool = resultDBWithAliveGauge.entities.Pool.get(poolId);
           expect(updatedPool).toBeDefined();
           expect(updatedPool?.gaugeIsAlive).toBe(true);
         });
@@ -2374,17 +2325,12 @@ describe("Voter Events", () => {
         };
 
         // Mock findPoolByGaugeAddress to return null (root gauge, no local pool)
-        vi.spyOn(
-          LiquidityPoolAggregatorModule,
-          "findPoolByGaugeAddress",
-        ).mockResolvedValue(null);
+        vi.spyOn(PoolModule, "findPoolByGaugeAddress").mockResolvedValue(null);
 
         const resultDB = await mockDb.processEvents([mockEvent]);
 
         // Should not create any pool entities when pool doesn't exist and no root-gauge mapping
-        expect(
-          Array.from(resultDB.entities.LiquidityPoolAggregator.getAll()),
-        ).toHaveLength(0);
+        expect(Array.from(resultDB.entities.Pool.getAll())).toHaveLength(0);
       });
 
       afterEach(() => {
@@ -2535,9 +2481,7 @@ describe("Voter Events", () => {
         expect(pendingDistribution?.gaugeAddress).toBe(gaugeAddress);
         expect(pendingDistribution?.amount).toBe(1000n * 10n ** 18n);
 
-        expect(
-          Array.from(resultDB.entities.LiquidityPoolAggregator.getAll()),
-        ).toHaveLength(0);
+        expect(Array.from(resultDB.entities.Pool.getAll())).toHaveLength(0);
       });
 
       afterEach(() => {
@@ -2553,10 +2497,7 @@ describe("Voter Events", () => {
           rewardToken: vi.fn().mockReturnValue(rewardTokenAddress),
         };
 
-        vi.spyOn(
-          LiquidityPoolAggregatorModule,
-          "findPoolByGaugeAddress",
-        ).mockResolvedValue(null);
+        vi.spyOn(PoolModule, "findPoolByGaugeAddress").mockResolvedValue(null);
 
         const rootPoolAddressForAmbiguous = poolAddress;
         const leafChainId = 252;
@@ -2657,9 +2598,7 @@ describe("Voter Events", () => {
         expect(pendingDistribution?.logIndex).toBe(logIndex);
 
         // Distribution was deferred; no pool should have been updated
-        expect(
-          Array.from(resultDB.entities.LiquidityPoolAggregator.getAll()),
-        ).toHaveLength(0);
+        expect(Array.from(resultDB.entities.Pool.getAll())).toHaveLength(0);
       });
     });
 
@@ -2724,9 +2663,7 @@ describe("Voter Events", () => {
         expect(
           Array.from(resultDB.entities.PendingDistribution.getAll()),
         ).toHaveLength(0);
-        expect(
-          Array.from(resultDB.entities.LiquidityPoolAggregator.getAll()),
-        ).toHaveLength(0);
+        expect(Array.from(resultDB.entities.Pool.getAll())).toHaveLength(0);
       });
     });
 
@@ -2744,15 +2681,12 @@ describe("Voter Events", () => {
 
       // TODO: Skip until envio migrates to createTestIndexer — vi.spyOn can't intercept tsx-loaded modules (alpha.18)
       it.skip("should apply distribution to leaf pool without overwriting gaugeAddress", async () => {
-        const {
-          createMockLiquidityPoolAggregator,
-          mockToken0Data,
-          mockToken1Data,
-        } = setupCommon();
+        const { createMockPool, mockToken0Data, mockToken1Data } =
+          setupCommon();
 
         const leafToken0Id = TokenId(leafChainId, mockToken0Data.address);
         const leafToken1Id = TokenId(leafChainId, mockToken1Data.address);
-        const leafPool = createMockLiquidityPoolAggregator({
+        const leafPool = createMockPool({
           id: leafPoolId,
           poolAddress: leafPoolAddress as `0x${string}`,
           chainId: leafChainId,
@@ -2791,10 +2725,7 @@ describe("Voter Events", () => {
           chainId: leafChainId,
         };
 
-        vi.spyOn(
-          LiquidityPoolAggregatorModule,
-          "findPoolByGaugeAddress",
-        ).mockResolvedValue(null);
+        vi.spyOn(PoolModule, "findPoolByGaugeAddress").mockResolvedValue(null);
 
         vi.spyOn(
           getTokensDeposited as unknown as EffectWithHandler<
@@ -2826,7 +2757,7 @@ describe("Voter Events", () => {
         let db = mockDb.entities.Token.set(rewardToken);
         db = db.entities.Token.set(leafToken0);
         db = db.entities.Token.set(leafToken1);
-        db = db.entities.LiquidityPoolAggregator.set(leafPool);
+        db = db.entities.Pool.set(leafPool);
         db = db.entities.RootGauge_RootPool.set({
           id: rootGaugeRootPoolId,
           rootChainId: chainId,
@@ -2843,8 +2774,7 @@ describe("Voter Events", () => {
 
         const resultDB = await db.processEvents([mockEvent]);
 
-        const updatedLeafPool =
-          resultDB.entities.LiquidityPoolAggregator.get(leafPoolId);
+        const updatedLeafPool = resultDB.entities.Pool.get(leafPoolId);
         expect(updatedLeafPool).toBeDefined();
         expect(updatedLeafPool?.totalEmissions).toBe(1000n * 10n ** 18n);
         expect(updatedLeafPool?.totalEmissionsUSD).toBe(2000n * 10n ** 18n);
@@ -2864,8 +2794,8 @@ describe("Voter Events", () => {
       let originalChainConstantsForRewardTest: (typeof CHAIN_CONSTANTS)[typeof chainId];
 
       it("should log warning and return early when reward token is missing", async () => {
-        const { createMockLiquidityPoolAggregator } = setupCommon();
-        const liquidityPool = createMockLiquidityPoolAggregator({
+        const { createMockPool } = setupCommon();
+        const liquidityPool = createMockPool({
           id: PoolId(chainId, poolAddress),
           chainId: chainId,
           totalEmissions: 0n, // Start with 0 to test that it remains unchanged
@@ -2879,25 +2809,19 @@ describe("Voter Events", () => {
         };
 
         // Mock findPoolByGaugeAddress to return the pool
-        vi.spyOn(
-          LiquidityPoolAggregatorModule,
-          "findPoolByGaugeAddress",
-        ).mockResolvedValue(liquidityPool);
+        vi.spyOn(PoolModule, "findPoolByGaugeAddress").mockResolvedValue(
+          liquidityPool,
+        );
 
         // Create a fresh database with only the liquidity pool, no reward token
         const freshDb = MockDb.createMockDb();
-        const testDb =
-          freshDb.entities.LiquidityPoolAggregator.set(liquidityPool);
+        const testDb = freshDb.entities.Pool.set(liquidityPool);
 
         const resultDB = await testDb.processEvents([mockEvent]);
 
         // Should not update any entities when reward token is missing
-        expect(
-          Array.from(resultDB.entities.LiquidityPoolAggregator.getAll()),
-        ).toHaveLength(1);
-        const pool = resultDB.entities.LiquidityPoolAggregator.get(
-          PoolId(chainId, poolAddress),
-        );
+        expect(Array.from(resultDB.entities.Pool.getAll())).toHaveLength(1);
+        const pool = resultDB.entities.Pool.get(PoolId(chainId, poolAddress));
         expect(pool?.totalEmissions).toBe(0n); // Should remain unchanged
       });
 

--- a/test/EventHandlers/Voter/VoterCommonLogic.test.ts
+++ b/test/EventHandlers/Voter/VoterCommonLogic.test.ts
@@ -1,11 +1,5 @@
-import type {
-  LiquidityPoolAggregator,
-  PendingVote,
-  Token,
-  VeNFTState,
-  handlerContext,
-} from "generated";
-import * as LiquidityPoolAggregatorModule from "../../../src/Aggregators/LiquidityPoolAggregator";
+import type { PendingVote, Token, VeNFTState, handlerContext } from "generated";
+import * as PoolModule from "../../../src/Aggregators/Pool";
 import {
   PendingVoteId,
   RootGaugeRootPoolId,
@@ -15,6 +9,7 @@ import {
   getTokenDetails,
   getTokensDeposited,
 } from "../../../src/Effects/Index";
+import type { Pool } from "../../../src/EntityTypes";
 import type { VoterCommonResult } from "../../../src/EventHandlers/Voter/VoterCommonLogic";
 import {
   VoterEventType,
@@ -519,9 +514,7 @@ describe("resolveLeafPoolForRootGauge", () => {
   });
 
   it("returns null and logs when loadPoolData returns null", async () => {
-    vi.spyOn(LiquidityPoolAggregatorModule, "loadPoolData").mockResolvedValue(
-      null,
-    );
+    vi.spyOn(PoolModule, "loadPoolData").mockResolvedValue(null);
 
     const warns: string[] = [];
     const context = makeResolveContext({
@@ -565,9 +558,9 @@ describe("resolveLeafPoolForRootGauge", () => {
       id: `10-${leafPoolAddress}`,
       poolAddress: leafPoolAddress,
       chainId: leafChainId,
-    } as unknown as LiquidityPoolAggregator;
+    } as unknown as Pool;
 
-    vi.spyOn(LiquidityPoolAggregatorModule, "loadPoolData").mockResolvedValue({
+    vi.spyOn(PoolModule, "loadPoolData").mockResolvedValue({
       liquidityPoolAggregator: mockPool,
       token0Instance: {} as Token,
       token1Instance: {} as Token,
@@ -583,7 +576,7 @@ describe("resolveLeafPoolForRootGauge", () => {
     expect(result).not.toBeNull();
     expect(result?.pool).toBe(mockPool);
     expect(result?.isCrossChain).toBe(true);
-    expect(LiquidityPoolAggregatorModule.loadPoolData).toHaveBeenCalledWith(
+    expect(PoolModule.loadPoolData).toHaveBeenCalledWith(
       leafPoolAddress,
       leafChainId,
       context,
@@ -592,8 +585,7 @@ describe("resolveLeafPoolForRootGauge", () => {
     // Cross-chain fix: loadPoolData must NOT receive blockNumber/blockTimestamp
     // because they belong to the root chain and would cause "Unknown block" errors
     // on the leaf chain's RPC.
-    const callArgs = vi.mocked(LiquidityPoolAggregatorModule.loadPoolData).mock
-      .calls[0];
+    const callArgs = vi.mocked(PoolModule.loadPoolData).mock.calls[0];
     expect(callArgs).toHaveLength(3);
   });
 });

--- a/test/EventHandlers/VotingReward/BribesVotingReward.test.ts
+++ b/test/EventHandlers/VotingReward/BribesVotingReward.test.ts
@@ -5,14 +5,14 @@ import {
 } from "../../../generated/src/TestHelpers.gen";
 import { TokenId, toChecksumAddress } from "../../../src/Constants";
 import * as VotingRewardSharedLogic from "../../../src/EventHandlers/VotingReward/VotingRewardSharedLogic";
-import { type MockLiquidityPoolAggregator, setupCommon } from "../Pool/common";
+import { type MockPool, setupCommon } from "../Pool/common";
 
 describe("BribesVotingReward Events", () => {
   const {
     mockToken0Data,
     mockToken1Data,
     mockLiquidityPoolData,
-    createMockLiquidityPoolAggregator,
+    createMockPool,
     createMockUserStatsPerPool,
   } = setupCommon();
   const poolAddress = mockLiquidityPoolData.poolAddress;
@@ -28,7 +28,7 @@ describe("BribesVotingReward Events", () => {
   );
 
   let mockDb: ReturnType<typeof MockDb.createMockDb>;
-  let liquidityPool: MockLiquidityPoolAggregator;
+  let liquidityPool: MockPool;
   let userStats: ReturnType<
     ReturnType<typeof setupCommon>["createMockUserStatsPerPool"]
   >;
@@ -39,7 +39,7 @@ describe("BribesVotingReward Events", () => {
     mockDb = MockDb.createMockDb();
 
     // Set up liquidity pool with bribe voting reward address
-    liquidityPool = createMockLiquidityPoolAggregator({
+    liquidityPool = createMockPool({
       bribeVotingRewardAddress: toChecksumAddress(votingRewardAddress),
       feeVotingRewardAddress: "",
     });
@@ -66,7 +66,7 @@ describe("BribesVotingReward Events", () => {
     } as Token;
 
     // Set up entities in mock DB
-    mockDb = mockDb.entities.LiquidityPoolAggregator.set(liquidityPool);
+    mockDb = mockDb.entities.Pool.set(liquidityPool);
     mockDb = mockDb.entities.UserStatsPerPool.set(userStats);
     mockDb = mockDb.entities.Token.set(mockToken0Data as Token);
     mockDb = mockDb.entities.Token.set(mockToken1Data as Token);
@@ -116,9 +116,7 @@ describe("BribesVotingReward Events", () => {
     });
 
     it("should update pool aggregator with bribe claimed", () => {
-      const updatedPool = resultDB.entities.LiquidityPoolAggregator.get(
-        mockLiquidityPoolData.id,
-      );
+      const updatedPool = resultDB.entities.Pool.get(mockLiquidityPoolData.id);
       expect(updatedPool).toBeDefined();
       // The actual values depend on the price calculation, but should be updated
       expect(updatedPool?.totalBribeClaimed).toBeGreaterThan(0n);

--- a/test/EventHandlers/VotingReward/FeesVotingReward.test.ts
+++ b/test/EventHandlers/VotingReward/FeesVotingReward.test.ts
@@ -5,7 +5,7 @@ import {
 } from "../../../generated/src/TestHelpers.gen";
 import { TokenId, toChecksumAddress } from "../../../src/Constants";
 import * as VotingRewardSharedLogic from "../../../src/EventHandlers/VotingReward/VotingRewardSharedLogic";
-import { type MockLiquidityPoolAggregator, setupCommon } from "../Pool/common";
+import { type MockPool, setupCommon } from "../Pool/common";
 
 describe("FeesVotingReward Events", () => {
   const {
@@ -13,7 +13,7 @@ describe("FeesVotingReward Events", () => {
     mockToken1Data,
     mockLiquidityPoolData,
     createMockUserStatsPerPool,
-    createMockLiquidityPoolAggregator,
+    createMockPool,
   } = setupCommon();
   const poolAddress = mockLiquidityPoolData.poolAddress;
   const chainId = 10;
@@ -28,7 +28,7 @@ describe("FeesVotingReward Events", () => {
   );
 
   let mockDb: ReturnType<typeof MockDb.createMockDb>;
-  let liquidityPool: MockLiquidityPoolAggregator;
+  let liquidityPool: MockPool;
   let userStats: ReturnType<typeof createMockUserStatsPerPool>;
   let rewardToken: Token;
 
@@ -37,7 +37,7 @@ describe("FeesVotingReward Events", () => {
     mockDb = MockDb.createMockDb();
 
     // Set up liquidity pool with fee voting reward address
-    liquidityPool = createMockLiquidityPoolAggregator({
+    liquidityPool = createMockPool({
       feeVotingRewardAddress: toChecksumAddress(votingRewardAddress),
       bribeVotingRewardAddress: "",
     });
@@ -64,7 +64,7 @@ describe("FeesVotingReward Events", () => {
     } as Token;
 
     // Set up entities in mock DB
-    mockDb = mockDb.entities.LiquidityPoolAggregator.set(liquidityPool);
+    mockDb = mockDb.entities.Pool.set(liquidityPool);
     mockDb = mockDb.entities.UserStatsPerPool.set(userStats);
     mockDb = mockDb.entities.Token.set(mockToken0Data as Token);
     mockDb = mockDb.entities.Token.set(mockToken1Data as Token);
@@ -114,9 +114,7 @@ describe("FeesVotingReward Events", () => {
     });
 
     it("should update pool aggregator with fee reward claimed", () => {
-      const updatedPool = resultDB.entities.LiquidityPoolAggregator.get(
-        mockLiquidityPoolData.id,
-      );
+      const updatedPool = resultDB.entities.Pool.get(mockLiquidityPoolData.id);
       expect(updatedPool).toBeDefined();
       // The actual values depend on the price calculation, but should be updated
       expect(updatedPool?.totalFeeRewardClaimed).toBeGreaterThan(0n);

--- a/test/EventHandlers/VotingReward/SuperchainIncentiveVotingReward.test.ts
+++ b/test/EventHandlers/VotingReward/SuperchainIncentiveVotingReward.test.ts
@@ -5,7 +5,7 @@ import {
 } from "../../../generated/src/TestHelpers.gen";
 import { TokenId, VeNFTId, toChecksumAddress } from "../../../src/Constants";
 import * as VotingRewardSharedLogic from "../../../src/EventHandlers/VotingReward/VotingRewardSharedLogic";
-import { type MockLiquidityPoolAggregator, setupCommon } from "../Pool/common";
+import { type MockPool, setupCommon } from "../Pool/common";
 
 describe("SuperchainIncentiveVotingReward Events", () => {
   const { mockToken0Data, mockToken1Data } = setupCommon();
@@ -22,7 +22,7 @@ describe("SuperchainIncentiveVotingReward Events", () => {
   const tokenId = 1n;
 
   let mockDb: ReturnType<typeof MockDb.createMockDb>;
-  let liquidityPool: MockLiquidityPoolAggregator;
+  let liquidityPool: MockPool;
   let userStats: ReturnType<
     ReturnType<typeof setupCommon>["createMockUserStatsPerPool"]
   >;
@@ -31,11 +31,10 @@ describe("SuperchainIncentiveVotingReward Events", () => {
 
   beforeEach(() => {
     mockDb = MockDb.createMockDb();
-    const { createMockUserStatsPerPool, createMockLiquidityPoolAggregator } =
-      setupCommon();
+    const { createMockUserStatsPerPool, createMockPool } = setupCommon();
 
     // Set up liquidity pool with bribe voting reward address
-    liquidityPool = createMockLiquidityPoolAggregator({
+    liquidityPool = createMockPool({
       chainId: chainId,
       bribeVotingRewardAddress: votingRewardAddress,
       feeVotingRewardAddress: "",
@@ -78,7 +77,7 @@ describe("SuperchainIncentiveVotingReward Events", () => {
     } as Token;
 
     // Set up entities in mock DB
-    mockDb = mockDb.entities.LiquidityPoolAggregator.set(liquidityPool);
+    mockDb = mockDb.entities.Pool.set(liquidityPool);
     mockDb = mockDb.entities.UserStatsPerPool.set(userStats);
     mockDb = mockDb.entities.VeNFTState.set(veNFT);
     mockDb = mockDb.entities.Token.set(mockToken0Data as Token);
@@ -144,9 +143,7 @@ describe("SuperchainIncentiveVotingReward Events", () => {
     });
 
     it("should update pool aggregator with bribe claimed", () => {
-      const updatedPool = resultDB.entities.LiquidityPoolAggregator.get(
-        liquidityPool.id,
-      );
+      const updatedPool = resultDB.entities.Pool.get(liquidityPool.id);
       expect(updatedPool).toBeDefined();
       expect(updatedPool?.totalBribeClaimed).toBe(1000000n);
       expect(updatedPool?.totalBribeClaimedUSD).toBe(1000000n);
@@ -171,17 +168,14 @@ describe("SuperchainIncentiveVotingReward Events", () => {
 
         // Create fresh mockDb with initial entities to avoid interference from parent's processEvents
         freshMockDb = MockDb.createMockDb();
-        freshMockDb =
-          freshMockDb.entities.LiquidityPoolAggregator.set(liquidityPool);
+        freshMockDb = freshMockDb.entities.Pool.set(liquidityPool);
         freshMockDb = freshMockDb.entities.UserStatsPerPool.set(userStats);
         freshMockDb = freshMockDb.entities.Token.set(rewardToken);
         resultDB = await freshMockDb.processEvents([mockEvent]);
       });
 
       it("should not update pool or user stats", () => {
-        const updatedPool = resultDB.entities.LiquidityPoolAggregator.get(
-          liquidityPool.id,
-        );
+        const updatedPool = resultDB.entities.Pool.get(liquidityPool.id);
         expect(updatedPool?.totalBribeClaimed).toBe(
           liquidityPool.totalBribeClaimed,
         );

--- a/test/EventHandlers/VotingReward/VotingRewardSharedLogic.test.ts
+++ b/test/EventHandlers/VotingReward/VotingRewardSharedLogic.test.ts
@@ -1,6 +1,6 @@
 import type { Token } from "generated";
-import * as LiquidityPoolAggregatorModule from "../../../src/Aggregators/LiquidityPoolAggregator";
-import { PoolAddressField } from "../../../src/Aggregators/LiquidityPoolAggregator";
+import * as PoolModule from "../../../src/Aggregators/Pool";
+import { PoolAddressField } from "../../../src/Aggregators/Pool";
 import * as UserStatsPerPoolModule from "../../../src/Aggregators/UserStatsPerPool";
 import { toChecksumAddress } from "../../../src/Constants";
 import {
@@ -242,22 +242,15 @@ describe("VotingRewardSharedLogic", () => {
   describe("loadVotingRewardData", () => {
     it("should call loadPoolData and loadOrCreateUserData with pool.poolAddress not pool.id", async () => {
       const common = setupCommon();
-      const {
-        mockToken0Data,
-        mockToken1Data,
-        createMockLiquidityPoolAggregator,
-      } = common;
+      const { mockToken0Data, mockToken1Data, createMockPool } = common;
 
       const chainId = 10;
-      const pool = createMockLiquidityPoolAggregator({
+      const pool = createMockPool({
         chainId,
         bribeVotingRewardAddress: mockVotingRewardAddress,
       });
 
-      const loadPoolDataSpy = vi.spyOn(
-        LiquidityPoolAggregatorModule,
-        "loadPoolData",
-      );
+      const loadPoolDataSpy = vi.spyOn(PoolModule, "loadPoolData");
       const loadOrCreateUserDataSpy = vi.spyOn(
         UserStatsPerPoolModule,
         "loadOrCreateUserData",
@@ -266,7 +259,7 @@ describe("VotingRewardSharedLogic", () => {
       const userStatsStorage = new Map<string, unknown>();
       const context = {
         log: { error: () => {}, warn: () => {}, info: () => {} },
-        LiquidityPoolAggregator: {
+        Pool: {
           getWhere: async (q: {
             bribeVotingRewardAddress?: { _eq: string };
           }) =>

--- a/test/Helpers.test.ts
+++ b/test/Helpers.test.ts
@@ -3,9 +3,10 @@ import {
   TickMath,
   maxLiquidityForAmounts,
 } from "@uniswap/v3-sdk";
-import type { LiquidityPoolAggregator, Token, handlerContext } from "generated";
+import type { Token, handlerContext } from "generated";
 import JSBI from "jsbi";
 import { toChecksumAddress } from "../src/Constants";
+import type { Pool } from "../src/EntityTypes";
 import {
   calculatePositionAmountsFromLiquidity,
   calculateTotalUSD,
@@ -926,13 +927,13 @@ describe("Helpers", () => {
       const reserve1 = 1000n * 10n ** 6n;
       const totalSupply = 1000n * 10n ** 18n;
 
-      const poolEntity: LiquidityPoolAggregator = {
+      const poolEntity: Pool = {
         ...mockPool,
         isCL: false,
         reserve0,
         reserve1,
         totalLPTokenSupply: totalSupply,
-      } as LiquidityPoolAggregator;
+      } as Pool;
 
       const amount0 = (stakeAmount * reserve0) / totalSupply;
       const amount1 = (stakeAmount * reserve1) / totalSupply;
@@ -965,7 +966,7 @@ describe("Helpers", () => {
         reserve0: 1000n,
         reserve1: 1000n,
         totalLPTokenSupply: 1000n,
-      } as LiquidityPoolAggregator;
+      } as Pool;
 
       const result = computeNonCLStakedUSD(
         0n,
@@ -988,7 +989,7 @@ describe("Helpers", () => {
         reserve0: 1000n,
         reserve1: 1000n,
         totalLPTokenSupply: 0n,
-      } as LiquidityPoolAggregator;
+      } as Pool;
 
       const result = computeNonCLStakedUSD(
         100n,
@@ -1011,7 +1012,7 @@ describe("Helpers", () => {
         reserve0: 1000n,
         reserve1: 1000n,
         totalLPTokenSupply: undefined,
-      } as unknown as LiquidityPoolAggregator;
+      } as unknown as Pool;
 
       const result = computeNonCLStakedUSD(
         100n,

--- a/test/IdNormalization.test.ts
+++ b/test/IdNormalization.test.ts
@@ -5,7 +5,6 @@ import {
   ALMLPWrapperTransferInTxId,
   CLPoolMintEventId,
   CLPositionPendingPrincipalId,
-  LiquidityPoolAggregatorSnapshotId,
   MailboxMessageId,
   NonFungiblePositionId,
   NonFungiblePositionSnapshotId,
@@ -14,6 +13,7 @@ import {
   PendingRootPoolMappingId,
   PendingVoteId,
   PoolId,
+  PoolSnapshotId,
   PoolTransferInTxId,
   RootGaugeRootPoolId,
   RootPoolLeafPoolId,
@@ -162,8 +162,8 @@ describe("ID helpers preserve EIP-55 checksum input (issue #633)", () => {
       expected: `${CHAIN_ID}-${POOL}-${POOL_2}-${TICK_LOWER}-${TICK_UPPER}`,
     },
     {
-      name: "LiquidityPoolAggregatorSnapshotId",
-      actual: () => LiquidityPoolAggregatorSnapshotId(CHAIN_ID, POOL, EPOCH_MS),
+      name: "PoolSnapshotId",
+      actual: () => PoolSnapshotId(CHAIN_ID, POOL, EPOCH_MS),
       expected: `${CHAIN_ID}-${POOL}-${EPOCH_MS}`,
     },
     {

--- a/test/Snapshots/PoolSnapshot.test.ts
+++ b/test/Snapshots/PoolSnapshot.test.ts
@@ -1,15 +1,12 @@
+import { PoolSnapshotId, SNAPSHOT_INTERVAL_IN_MS } from "../../src/Constants";
 import {
-  LiquidityPoolAggregatorSnapshotId,
-  SNAPSHOT_INTERVAL_IN_MS,
-} from "../../src/Constants";
-import {
-  createLiquidityPoolAggregatorSnapshot,
-  setLiquidityPoolAggregatorSnapshot,
-} from "../../src/Snapshots/LiquidityPoolAggregatorSnapshot";
+  createPoolSnapshot,
+  setPoolSnapshot,
+} from "../../src/Snapshots/PoolSnapshot";
 import { getSnapshotEpoch } from "../../src/Snapshots/Shared";
 import { setupCommon } from "../EventHandlers/Pool/common";
 
-describe("LiquidityPoolAggregatorSnapshot", () => {
+describe("PoolSnapshot", () => {
   let common: ReturnType<typeof setupCommon>;
   const baseTimestamp = new Date(SNAPSHOT_INTERVAL_IN_MS * 5); // epoch boundary
 
@@ -18,30 +15,23 @@ describe("LiquidityPoolAggregatorSnapshot", () => {
     vi.restoreAllMocks();
   });
 
-  describe("createLiquidityPoolAggregatorSnapshot", () => {
+  describe("createPoolSnapshot", () => {
     it("should return epoch-aligned snapshot with correct id and timestamp", () => {
-      const pool = common.createMockLiquidityPoolAggregator();
+      const pool = common.createMockPool();
       const timestamp = new Date(baseTimestamp.getTime() + 30 * 60 * 1000);
       const expectedEpochMs = SNAPSHOT_INTERVAL_IN_MS * 5;
 
-      const snapshot = createLiquidityPoolAggregatorSnapshot(pool, timestamp);
+      const snapshot = createPoolSnapshot(pool, timestamp);
 
       expect(snapshot.id).toBe(
-        LiquidityPoolAggregatorSnapshotId(
-          pool.chainId,
-          pool.poolAddress,
-          expectedEpochMs,
-        ),
+        PoolSnapshotId(pool.chainId, pool.poolAddress, expectedEpochMs),
       );
       expect(snapshot.timestamp.getTime()).toBe(expectedEpochMs);
     });
 
     it("should copy pool fields into snapshot without persisting", () => {
-      const pool = common.createMockLiquidityPoolAggregator();
-      const snapshot = createLiquidityPoolAggregatorSnapshot(
-        pool,
-        baseTimestamp,
-      );
+      const pool = common.createMockPool();
+      const snapshot = createPoolSnapshot(pool, baseTimestamp);
 
       expect(snapshot.poolAddress).toBe(pool.poolAddress);
       expect(snapshot.chainId).toBe(pool.chainId);
@@ -67,24 +57,18 @@ describe("LiquidityPoolAggregatorSnapshot", () => {
 
   it("should set snapshot with epoch-aligned timestamp and correct id", () => {
     const context = common.createMockContext({
-      LiquidityPoolAggregatorSnapshot: { set: vi.fn() },
+      PoolSnapshot: { set: vi.fn() },
     });
-    const pool = common.createMockLiquidityPoolAggregator();
+    const pool = common.createMockPool();
     const timestamp = new Date(baseTimestamp.getTime() + 30 * 60 * 1000); // 30 min into epoch
     const expectedEpochMs = SNAPSHOT_INTERVAL_IN_MS * 5;
 
-    setLiquidityPoolAggregatorSnapshot(pool, timestamp, context);
+    setPoolSnapshot(pool, timestamp, context);
 
-    expect(context.LiquidityPoolAggregatorSnapshot.set).toHaveBeenCalledTimes(
-      1,
-    );
-    expect(context.LiquidityPoolAggregatorSnapshot.set).toHaveBeenCalledWith(
+    expect(context.PoolSnapshot.set).toHaveBeenCalledTimes(1);
+    expect(context.PoolSnapshot.set).toHaveBeenCalledWith(
       expect.objectContaining({
-        id: LiquidityPoolAggregatorSnapshotId(
-          pool.chainId,
-          pool.poolAddress,
-          expectedEpochMs,
-        ),
+        id: PoolSnapshotId(pool.chainId, pool.poolAddress, expectedEpochMs),
         timestamp: new Date(expectedEpochMs),
         poolAddress: pool.poolAddress,
         chainId: pool.chainId,
@@ -94,16 +78,16 @@ describe("LiquidityPoolAggregatorSnapshot", () => {
 
   it("should set all snapshot fields from pool (with id and timestamp from epoch)", () => {
     const context = common.createMockContext({
-      LiquidityPoolAggregatorSnapshot: { set: vi.fn() },
+      PoolSnapshot: { set: vi.fn() },
     });
-    const pool = common.createMockLiquidityPoolAggregator();
+    const pool = common.createMockPool();
     const expectedEpoch = getSnapshotEpoch(baseTimestamp);
 
-    setLiquidityPoolAggregatorSnapshot(pool, baseTimestamp, context);
+    setPoolSnapshot(pool, baseTimestamp, context);
 
-    expect(context.LiquidityPoolAggregatorSnapshot.set).toHaveBeenCalledWith(
+    expect(context.PoolSnapshot.set).toHaveBeenCalledWith(
       expect.objectContaining({
-        id: LiquidityPoolAggregatorSnapshotId(
+        id: PoolSnapshotId(
           pool.chainId,
           pool.poolAddress,
           expectedEpoch.getTime(),
@@ -112,9 +96,8 @@ describe("LiquidityPoolAggregatorSnapshot", () => {
       }),
     );
 
-    // Snapshot only includes fields defined on LiquidityPoolAggregatorSnapshot.
-    const setArg = vi.mocked(context.LiquidityPoolAggregatorSnapshot.set).mock
-      .calls[0][0];
+    // Snapshot only includes fields defined on PoolSnapshot.
+    const setArg = vi.mocked(context.PoolSnapshot.set).mock.calls[0][0];
     const snapshotKeysFromPool = (
       Object.keys(pool) as (keyof typeof pool)[]
     ).filter(

--- a/test/Snapshots/SchemaParity.test.ts
+++ b/test/Snapshots/SchemaParity.test.ts
@@ -33,7 +33,7 @@ describe("Snapshot schema parity", () => {
   const schemaTypes = parseSchemaTypes(schemaText);
   const allowedOmissions = new Map<string, string[]>([
     [
-      "LiquidityPoolAggregator",
+      "Pool",
       [
         "tickSpacing",
         "lastUpdatedTimestamp",

--- a/test/Snapshots/Shared.test.ts
+++ b/test/Snapshots/Shared.test.ts
@@ -3,8 +3,8 @@ import {
   toChecksumAddress,
 } from "../../src/Constants";
 import { createALMLPWrapperSnapshot } from "../../src/Snapshots/ALMLPWrapperSnapshot";
-import { createLiquidityPoolAggregatorSnapshot } from "../../src/Snapshots/LiquidityPoolAggregatorSnapshot";
 import { createNonFungiblePositionSnapshot } from "../../src/Snapshots/NonFungiblePositionSnapshot";
+import { createPoolSnapshot } from "../../src/Snapshots/PoolSnapshot";
 import {
   type SnapshotForPersist,
   SnapshotType,
@@ -79,26 +79,19 @@ describe("Snapshots Shared", () => {
   describe("persistSnapshot", () => {
     const oneHourMs = SNAPSHOT_INTERVAL_IN_MS;
 
-    it("should call LiquidityPoolAggregatorSnapshot.set when type is LiquidityPoolAggregator", () => {
+    it("should call PoolSnapshot.set when type is Pool", () => {
       const common = setupCommon();
       const context = common.createMockContext({
-        LiquidityPoolAggregatorSnapshot: { set: vi.fn() },
+        PoolSnapshot: { set: vi.fn() },
       });
-      const pool = common.createMockLiquidityPoolAggregator();
+      const pool = common.createMockPool();
       const timestamp = new Date(oneHourMs * 5);
-      const snapshot = createLiquidityPoolAggregatorSnapshot(pool, timestamp);
+      const snapshot = createPoolSnapshot(pool, timestamp);
 
-      persistSnapshot(
-        { type: SnapshotType.LiquidityPoolAggregator, snapshot },
-        context,
-      );
+      persistSnapshot({ type: SnapshotType.Pool, snapshot }, context);
 
-      expect(context.LiquidityPoolAggregatorSnapshot.set).toHaveBeenCalledTimes(
-        1,
-      );
-      expect(context.LiquidityPoolAggregatorSnapshot.set).toHaveBeenCalledWith(
-        snapshot,
-      );
+      expect(context.PoolSnapshot.set).toHaveBeenCalledTimes(1);
+      expect(context.PoolSnapshot.set).toHaveBeenCalledWith(snapshot);
     });
 
     it("should call UserStatsPerPoolSnapshot.set when type is UserStatsPerPool", () => {
@@ -228,7 +221,7 @@ describe("Snapshots Shared", () => {
     it("should hit default branch and not call any set when type is unknown (exhaustiveness)", () => {
       const common = setupCommon();
       const context = common.createMockContext({
-        LiquidityPoolAggregatorSnapshot: { set: vi.fn() },
+        PoolSnapshot: { set: vi.fn() },
         UserStatsPerPoolSnapshot: { set: vi.fn() },
         NonFungiblePositionSnapshot: { set: vi.fn() },
         ALM_LP_WrapperSnapshot: { set: vi.fn() },
@@ -243,9 +236,7 @@ describe("Snapshots Shared", () => {
 
       persistSnapshot(invalidItem, context);
 
-      expect(
-        context.LiquidityPoolAggregatorSnapshot.set,
-      ).not.toHaveBeenCalled();
+      expect(context.PoolSnapshot.set).not.toHaveBeenCalled();
       expect(context.UserStatsPerPoolSnapshot.set).not.toHaveBeenCalled();
       expect(context.NonFungiblePositionSnapshot.set).not.toHaveBeenCalled();
       expect(context.ALM_LP_WrapperSnapshot.set).not.toHaveBeenCalled();

--- a/test/testHelpers.ts
+++ b/test/testHelpers.ts
@@ -1,7 +1,8 @@
-import type { LiquidityPoolAggregator, NonFungiblePosition } from "generated";
+import type { NonFungiblePosition } from "generated";
 import type { PublicClient } from "viem";
 import type { MockDb } from "../generated/src/TestHelpers.gen";
 import { CHAIN_CONSTANTS, PoolId, toChecksumAddress } from "../src/Constants";
+import type { Pool } from "../src/EntityTypes";
 
 /** Cast string to V3 Address type for mock event data */
 export const asAddress = (s: string): `0x${string}` => s as `0x${string}`;
@@ -94,21 +95,21 @@ export function mutateChainConstants(
 }
 
 /**
- * Helper function to set up LiquidityPoolAggregator on a mockDb.
+ * Helper function to set up Pool on a mockDb.
  * Returns the updated mockDb.
  *
  * @param mockDb - The mock database to update
  * @param mockLiquidityPoolData - Base liquidity pool data
  * @param poolAddress - The pool address
- * @returns The updated mockDb with LiquidityPoolAggregator set
+ * @returns The updated mockDb with Pool set
  */
-export function setupLiquidityPoolAggregator(
+export function setupPool(
   mockDb: ReturnType<typeof MockDb.createMockDb>,
-  mockLiquidityPoolData: LiquidityPoolAggregator,
+  mockLiquidityPoolData: Pool,
   poolAddress: string,
 ): ReturnType<typeof MockDb.createMockDb> {
   const poolId = PoolId(mockLiquidityPoolData.chainId, poolAddress);
-  const mockLiquidityPoolAggregator = {
+  const mockPool = {
     ...mockLiquidityPoolData,
     id: poolId,
     poolAddress: poolAddress,
@@ -117,7 +118,5 @@ export function setupLiquidityPoolAggregator(
     stakedTickEdges: [...mockLiquidityPoolData.stakedTickEdges],
     stakedTickEdgeNets: [...mockLiquidityPoolData.stakedTickEdgeNets],
   };
-  return mockDb.entities.LiquidityPoolAggregator.set(
-    mockLiquidityPoolAggregator,
-  );
+  return mockDb.entities.Pool.set(mockPool);
 }


### PR DESCRIPTION
## Summary

Renames the indexer's central pool entities to shorter, intent-clearer names matching the convention used across the AMM-indexer ecosystem.

- `LiquidityPoolAggregator` → `Pool`
- `LiquidityPoolAggregatorSnapshot` → `PoolSnapshot`

The `Aggregator` suffix was an internal implementation detail; the GraphQL surface is what every downstream consumer (Hasura, Dune, analytics integrations) queries — the shorter name makes every query more readable.

## ⚠️ BREAKING — downstream migration required

Every Hasura/Dune query and dashboard that references `LiquidityPoolAggregator` will need to be updated **before this is merged**.

```graphql
# Before
query {
  LiquidityPoolAggregator(where: { chainId: { _eq: 10 } }) {
    id
    totalLiquidityUSD
  }
  LiquidityPoolAggregatorSnapshot(where: { ... }) { ... }
}

# After
query {
  Pool(where: { chainId: { _eq: 10 } }) {
    id
    totalLiquidityUSD
  }
  PoolSnapshot(where: { ... }) { ... }
}
```

All field names within the entities are unchanged.

## TypeScript-side note

Renaming the GraphQL entity to `Pool` introduces a name collision with the V2 `Pool` contract namespace that Envio codegen exports as a value (`Pool.Swap.handler(...)`). At the `generated` package barrel, the value re-export shadows the `export type *` type re-export — so `import type { Pool } from "generated"` resolves to a value, not the entity type.

Workaround: a thin project-local module `src/EntityTypes.ts` re-exports `Pool` / `PoolSnapshot` directly from `generated/src/Types.ts`. All TypeScript files that need the entity *type* import it from there instead of the `generated` barrel. This is purely internal — no GraphQL impact.

## Diff shape

- `schema.graphql` — rename entity definitions and cross-references
- `src/Aggregators/LiquidityPoolAggregator.ts` → `src/Aggregators/Pool.ts` (with `git mv`, history preserved)
- `src/Snapshots/LiquidityPoolAggregatorSnapshot.ts` → `src/Snapshots/PoolSnapshot.ts`
- Test files renamed similarly
- ~1226 identifier replacements across `src/` and `test/` (functions like `updateLiquidityPoolAggregator` → `updatePool`, etc.)
- New: `src/EntityTypes.ts` (workaround for the value/type collision above)
- `CLAUDE.md` updated to reflect renamed file paths

## Test plan

- [x] `schema.graphql` defines `Pool` and `PoolSnapshot`; zero remaining `LiquidityPoolAggregator` refs anywhere in `schema.graphql`, `src/`, `test/`, or `CLAUDE.md`
- [x] `pnpm envio codegen` succeeds
- [x] `tsc --noEmit` clean
- [x] `pnpm test` — 1259 passed, 33 skipped (no failures introduced)
- [x] `pnpm qa --write` — 86 files reformatted by Biome
- [ ] Coordination with downstream consumers (dashboards, Dune queries, analytics) — **must happen before merge**

## Closes

Closes #709