### PR TITLE
fix(cl-staked): derive stakedLiquidityInRange from edges + clamp negatives

### DIFF
--- a/src/Aggregators/CLStakedLiquidity.ts
+++ b/src/Aggregators/CLStakedLiquidity.ts
@@ -227,6 +227,41 @@ export function applyStakedPositionToEdges(
 }
 
 /**
+ * Derives `stakedLiquidityInRange` from the canonical edge state at a given
+ * tick — replaces the running counter that drifted in issue #719.
+ *
+ *   stakedLiquidityInRange = Σ stakedTickEdgeNets[i]  where stakedTickEdges[i] <= currentTick
+ *
+ * Equivalent to the Uniswap v3 liquidityNet sum across all ticks the pool has
+ * crossed going up. Uses the same upper-exclusive convention as
+ * `isPositionInRange` (a position with tickUpper === currentTick is OUT of
+ * range, so its net at tickUpper is included and cancels its tickLower entry).
+ *
+ * Cost: O(log E + K) — binary-search the upper bound, then sum the prefix.
+ * For per-pool edge counts up to a few thousand the prefix scan is a handful
+ * of microseconds; cheap enough to invoke on every staked-position write so
+ * the cached counter cannot drift from the edge truth.
+ *
+ * @param currentTick - The pool's current tick
+ * @param edges - Sorted-ascending stakedTickEdges from the aggregator
+ * @param nets - Parallel stakedTickEdgeNets (same length, same index)
+ * @returns Σ nets[i] for edges[i] <= currentTick; 0n on empty edge list
+ */
+export function deriveStakedLiquidityInRange(
+  currentTick: bigint,
+  edges: readonly bigint[],
+  nets: readonly bigint[],
+): bigint {
+  // First index strictly above currentTick — everything before it is in range.
+  const upper = lowerBound(edges, currentTick + 1n);
+  let sum = 0n;
+  for (let i = 0; i < upper; i++) {
+    sum += nets[i];
+  }
+  return sum;
+}
+
+/**
  * Per-segment Uniswap v3 swap math at constant L. The pool's sqrt price moves
  * from `segStart` to `segEnd` while staked liquidity in range is `stakedLiq`.
  *
@@ -321,7 +356,11 @@ function segmentStakedReserveDelta(
  * @param tickSpacing - Pool's tick spacing (used only to short-circuit when 0)
  * @param context - Envio handler context — used ONLY for context.log.error;
  *                  must not touch entity APIs (see note above)
- * @param currentStakedLiqInRange - Staked in-range liquidity before the swap
+ * @param currentStakedLiqInRange - Staked in-range liquidity before the swap.
+ *   Kept for signature stability and consulted ONLY on early-exit paths
+ *   (out-of-range ticks, uninitialized pool, zero sqrt prices); the normal
+ *   walking path seeds itself from `deriveStakedLiquidityInRange(oldTick, ...)`
+ *   so the swap heals any prior counter drift (issue #719).
  * @param hasStakes - Whether this pool has ever had a staked position
  * @param stakedTickEdges - Sorted, dedup'd tick edges from the aggregator
  * @param stakedTickEdgeNets - Parallel nets (same index as stakedTickEdges)
@@ -377,7 +416,16 @@ export function processTickCrossingsForStaked(
     };
   }
 
-  let stakedLiq = currentStakedLiqInRange;
+  // Seed the walker from canonical edge state (issue #719). The cached
+  // counter `currentStakedLiqInRange` can drift away from the truth in
+  // edge-merge rejection / pre-Initialize / NFPM-between-stake scenarios;
+  // re-deriving from edges at oldTick ensures the per-segment attribution
+  // and the returned counter both reflect what the staked share actually is.
+  let stakedLiq = deriveStakedLiquidityInRange(
+    oldTick,
+    stakedTickEdges,
+    stakedTickEdgeNets,
+  );
   let segStart = oldSqrtPriceX96;
   let stakedDelta0 = 0n;
   let stakedDelta1 = 0n;

--- a/src/Aggregators/Pool.ts
+++ b/src/Aggregators/Pool.ts
@@ -256,6 +256,11 @@ export async function updatePool(
     );
     diff.stakedTickEdges = undefined;
     diff.stakedTickEdgeNets = undefined;
+    // Issue #719: writer-side derivation means diff.stakedLiquidityInRange was
+    // computed from the now-rejected edge pair. Drop it too so the clamp block
+    // below falls back to current.stakedLiquidityInRange, preserving consistency
+    // between the retained edges and the persisted counter.
+    diff.stakedLiquidityInRange = undefined;
   } else if (
     edgesSet &&
     netsSet &&
@@ -268,6 +273,8 @@ export async function updatePool(
     );
     diff.stakedTickEdges = undefined;
     diff.stakedTickEdgeNets = undefined;
+    // Issue #719: see comment above — keep counter aligned with retained edges.
+    diff.stakedLiquidityInRange = undefined;
   }
 
   // Clamp reserve0 / reserve1 to >= 0n at the accumulator path (issue #702).
@@ -291,6 +298,23 @@ export async function updatePool(
   if (reserve1Sum < 0n) {
     context.log.warn(
       `[NEG_RESERVE_GUARD][updatePool] field=reserve1 poolAddress=${current.poolAddress} chainId=${current.chainId} priorReserve=${current.reserve1} delta=${reserve1Delta} clampedTo=${clampedReserve1}`,
+    );
+  }
+
+  // Clamp stakedLiquidityInRange to >= 0n at the accumulator path (issue #719).
+  // The structural fix at the three writer sites derives this field from edge
+  // state on every update; this tactical clamp is the belt-and-suspenders that
+  // guarantees a negative value can never persist, even if a future caller
+  // bypasses derivation or supplies a poisoned diff. Mirrors PR #718's
+  // reserve-clamp shape (see [NEG_RESERVE_GUARD] above) — same clamp-and-log
+  // pattern, different field.
+  const stakedLiqReplacement =
+    diff.stakedLiquidityInRange ?? current.stakedLiquidityInRange ?? 0n;
+  const clampedStakedLiquidityInRange =
+    stakedLiqReplacement < 0n ? 0n : stakedLiqReplacement;
+  if (stakedLiqReplacement < 0n) {
+    context.log.warn(
+      `[NEG_STAKED_LIQ_GUARD][updatePool] field=stakedLiquidityInRange poolAddress=${current.poolAddress} chainId=${current.chainId} priorStakedLiqInRange=${current.stakedLiquidityInRange} replacement=${stakedLiqReplacement} clampedTo=${clampedStakedLiquidityInRange}`,
     );
   }
 
@@ -415,8 +439,7 @@ export async function updatePool(
       diff.liquidityInRange ??
       (diff.incrementalLiquidityInRange ?? 0n) +
         (current.liquidityInRange ?? 0n),
-    stakedLiquidityInRange:
-      diff.stakedLiquidityInRange ?? current.stakedLiquidityInRange,
+    stakedLiquidityInRange: clampedStakedLiquidityInRange,
     stakedReserve0:
       (current.stakedReserve0 ?? 0n) + (diff.incrementalStakedReserve0 ?? 0n),
     stakedReserve1:

--- a/src/EventHandlers/Gauges/GaugeSharedLogic.ts
+++ b/src/EventHandlers/Gauges/GaugeSharedLogic.ts
@@ -1,7 +1,7 @@
 import type { handlerContext } from "generated";
 import {
   applyStakedPositionToEdges,
-  isPositionInRange,
+  deriveStakedLiquidityInRange,
 } from "../../Aggregators/CLStakedLiquidity";
 import type { PoolData } from "../../Aggregators/Pool";
 import {
@@ -95,20 +95,20 @@ async function computeCLStakedReservesOnGaugeEvent(
     );
   }
 
-  // stakedLiquidityInRange only changes when the position is in range (drives swap proportional attribution).
-  // Gate on sqrtPriceX96 !== 0n: before the pool's first Swap initializes price,
-  // `tick` falls back to 0n, which would falsely classify any position spanning
-  // tick 0 as "in range" and permanently poison stakedLiquidityInRange.
-  // Also gate on !edgesRejected: if applyStakedPositionToEdges rejected the merge,
-  // the sparse edge map is unchanged, so updating the running in-range total would
-  // make it disagree with the edge set the swap path crosses and drift permanently.
-  const stakedLiquidityInRange =
-    !edgesRejected &&
-    sqrtPriceX96 !== 0n &&
-    isPositionInRange(position.tickLower, position.tickUpper, currentTick)
-      ? (liquidityPoolAggregator.stakedLiquidityInRange ?? 0n) +
-        direction * position.liquidity
-      : undefined;
+  // Derive stakedLiquidityInRange from the (possibly updated) edge state at
+  // currentTick (issue #719). The previous gated running-counter approach
+  // dropped updates on three asymmetric paths — pre-Initialize deposit,
+  // edge-merge rejection, and out-of-range NFPM changes between stake and
+  // unstake — letting the counter drift away from the edges over time.
+  // Derivation guarantees the counter and edges stay consistent on every
+  // write, regardless of in-range / sqrt / rejection status; if the position
+  // was rejected, the unchanged arrays still produce the prior consistent
+  // value.
+  const stakedLiquidityInRange = deriveStakedLiquidityInRange(
+    currentTick,
+    stakedTickEdges,
+    stakedTickEdgeNets,
+  );
 
   // stakedReserve0/1 track ALL staked token holdings (in-range + out-of-range) for USD valuation.
   // Out-of-range positions still hold tokens (100% token0 if below, 100% token1 if above),

--- a/src/EventHandlers/NFPM/NFPMCommonLogic.ts
+++ b/src/EventHandlers/NFPM/NFPMCommonLogic.ts
@@ -1,7 +1,7 @@
 import type { NonFungiblePosition, handlerContext } from "generated";
 import {
   applyStakedPositionToEdges,
-  isPositionInRange,
+  deriveStakedLiquidityInRange,
 } from "../../Aggregators/CLStakedLiquidity";
 import type { PoolData } from "../../Aggregators/Pool";
 import { updatePool } from "../../Aggregators/Pool";
@@ -135,6 +135,16 @@ export async function updateStakedPositionLiquidity(
   const currentTick = liquidityPoolAggregator.tick ?? 0n;
   const sqrtPriceX96 = liquidityPoolAggregator.sqrtPriceX96 ?? 0n;
 
+  // Derive stakedLiquidityInRange from the (possibly updated) edge state at
+  // currentTick (issue #719). Applies on both the early-exit path (sqrt=0n)
+  // and the normal path, so NFPM-mediated liquidity changes between gauge
+  // deposit and withdraw can't desync the counter from the edges.
+  const stakedLiquidityInRange = deriveStakedLiquidityInRange(
+    currentTick,
+    stakedTickEdges,
+    stakedTickEdgeNets,
+  );
+
   if (sqrtPriceX96 === 0n) {
     // Defensive fallback: since velodrome-finance/indexer#654 wired
     // CLPool.Initialize to populate sqrtPriceX96/tick on the aggregator, a
@@ -144,7 +154,12 @@ export async function updateStakedPositionLiquidity(
     // established, but skip the amount math that would otherwise produce
     // garbage from sqrtPriceX96=0.
     await updatePool(
-      { stakedTickEdges, stakedTickEdgeNets, hasStakes },
+      {
+        stakedTickEdges,
+        stakedTickEdgeNets,
+        stakedLiquidityInRange,
+        hasStakes,
+      },
       liquidityPoolAggregator,
       timestamp,
       context,
@@ -165,15 +180,6 @@ export async function updateStakedPositionLiquidity(
   );
 
   const direction = liquidityDelta > 0n ? 1n : -1n;
-
-  // stakedLiquidityInRange only changes when the position is in range (drives swap proportional attribution)
-  const stakedLiquidityInRange = isPositionInRange(
-    position.tickLower,
-    position.tickUpper,
-    currentTick,
-  )
-    ? (liquidityPoolAggregator.stakedLiquidityInRange ?? 0n) + liquidityDelta
-    : undefined;
 
   const stakedDiff = {
     stakedLiquidityInRange,

--- a/test/Aggregators/CLStakedLiquidity.test.ts
+++ b/test/Aggregators/CLStakedLiquidity.test.ts
@@ -1,6 +1,7 @@
 import type { handlerContext } from "generated";
 import {
   applyStakedPositionToEdges,
+  deriveStakedLiquidityInRange,
   isPositionInRange,
   processTickCrossingsForStaked,
 } from "../../src/Aggregators/CLStakedLiquidity";
@@ -262,7 +263,13 @@ describe("CLStakedLiquidity", () => {
       } as unknown as handlerContext;
     });
 
-    it("should return unchanged when oldTick === newTick", async () => {
+    it("should derive the in-range counter from edges when oldTick === newTick", async () => {
+      // Even with no movement, the function re-derives stakedLiquidityInRange
+      // from edge state (issue #719): the cached `currentStakedLiqInRange`
+      // input is ignored on the normal path so prior drift heals on the next
+      // touch. Here edges=[100, 200] with nets=[300, -300] and oldTick=100
+      // ⇒ derive(100) = 300 (the tickLower at 100 is in-range, tickUpper at
+      // 200 has not been crossed yet). The 500n input is intentionally stale.
       const result = processTickCrossingsForStaked(
         CHAIN_ID,
         POOL_ADDRESS,
@@ -277,7 +284,7 @@ describe("CLStakedLiquidity", () => {
         [100n, 200n],
         [300n, -300n],
       );
-      expect(result.stakedLiquidityInRange).toBe(500n);
+      expect(result.stakedLiquidityInRange).toBe(300n);
       // Same sqrt → final segment is a no-op → zero deltas
       expect(result.stakedDelta0).toBe(0n);
       expect(result.stakedDelta1).toBe(0n);
@@ -399,7 +406,10 @@ describe("CLStakedLiquidity", () => {
     });
 
     it("should skip edges that fall outside the [oldTick, newTick] window", async () => {
-      // Edges exist at 200 and 400, but swap only crosses 200
+      // Edges exist at 200 and 400, but swap only crosses 200.
+      // derive(oldTick=100) = 0 (no edges <= 100); walker adds nets[200]=150
+      // crossing strictly above oldTick up to newTick=300 (400 is beyond).
+      // The 50n input is stale and ignored on the normal path (issue #719).
       const result = processTickCrossingsForStaked(
         CHAIN_ID,
         POOL_ADDRESS,
@@ -414,7 +424,7 @@ describe("CLStakedLiquidity", () => {
         [200n, 400n],
         [150n, -150n],
       );
-      expect(result.stakedLiquidityInRange).toBe(200n); // 50 + 150 (only 200 crossed, 400 is beyond newTick=300)
+      expect(result.stakedLiquidityInRange).toBe(150n); // derive(100)=0 + 150
     });
 
     it("should handle negative tick ranges", async () => {
@@ -436,7 +446,11 @@ describe("CLStakedLiquidity", () => {
     });
 
     it("should not cross the oldTick itself when going up (strict-above semantics)", async () => {
-      // oldTick=200, edge at 200 — since we search lowerBound(201), edge is skipped
+      // oldTick=200, edge at 200 — since we search lowerBound(201), edge is
+      // skipped. derive(200) on edges=[200],nets=[100] returns 100 (the
+      // tickLower at 200 is in-range by the upper-exclusive convention), so
+      // the walker starts at 100 and crosses no further edges. The seed `0n`
+      // input is stale and ignored on the normal path (issue #719).
       const result = processTickCrossingsForStaked(
         CHAIN_ID,
         POOL_ADDRESS,
@@ -451,7 +465,7 @@ describe("CLStakedLiquidity", () => {
         [200n],
         [100n],
       );
-      expect(result.stakedLiquidityInRange).toBe(0n);
+      expect(result.stakedLiquidityInRange).toBe(100n);
     });
 
     it("should include the oldTick boundary when going down (at-or-below semantics)", async () => {
@@ -924,6 +938,116 @@ describe("CLStakedLiquidity", () => {
         expect(result.stakedDelta0).toBe(0n);
         expect(result.stakedDelta1).toBe(0n);
       });
+    });
+  });
+
+  // Regression coverage for issue #719: the structural fix replaces the
+  // cached running counter `stakedLiquidityInRange` with derivation from the
+  // existing edge state at the current tick. These tests pin the derivation
+  // formula:
+  //   stakedLiquidityInRange = Σ stakedTickEdgeNets[i] where stakedTickEdges[i] <= currentTick
+  // The function must give the same answer the running counter *should* have
+  // tracked, but without any of the drift paths the counter exhibited (pre-
+  // Initialize deposit, edge-merge rejection, NFPM-mediated liquidity change
+  // between gauge deposit and withdraw).
+  describe("deriveStakedLiquidityInRange (#719)", () => {
+    it("returns 0n on empty edge list", () => {
+      expect(deriveStakedLiquidityInRange(0n, [], [])).toBe(0n);
+    });
+
+    it("returns 0n when currentTick is below every edge", () => {
+      // Position [100, 200]: edges=[100, 200], nets=[+L, -L]. currentTick=50
+      // is below both — no entry crossed, so 0.
+      expect(
+        deriveStakedLiquidityInRange(50n, [100n, 200n], [500n, -500n]),
+      ).toBe(0n);
+    });
+
+    it("returns liquidity when currentTick is in range (only tickLower crossed)", () => {
+      // currentTick=150 ≥ 100 (entered) but < 200 (not exited yet).
+      expect(
+        deriveStakedLiquidityInRange(150n, [100n, 200n], [500n, -500n]),
+      ).toBe(500n);
+    });
+
+    it("returns 0n when currentTick is above every edge (entered then exited)", () => {
+      // currentTick=300 ≥ 100 AND ≥ 200 ⇒ +L - L = 0.
+      expect(
+        deriveStakedLiquidityInRange(300n, [100n, 200n], [500n, -500n]),
+      ).toBe(0n);
+    });
+
+    it("includes an edge that equals currentTick (tickLower inclusive)", () => {
+      // Uniswap v3 convention: tickLower <= currentTick < tickUpper.
+      // deriveStakedLiquidityInRange uses edges[i] <= currentTick, so the
+      // tickLower edge is included when currentTick === tickLower.
+      expect(
+        deriveStakedLiquidityInRange(100n, [100n, 200n], [500n, -500n]),
+      ).toBe(500n);
+    });
+
+    it("excludes the tickUpper edge when currentTick === tickUpper (boundary exit)", () => {
+      // currentTick=200 ⇒ both edges <=200 ⇒ +L - L = 0. Matches the upper-
+      // exclusive convention in isPositionInRange.
+      expect(
+        deriveStakedLiquidityInRange(200n, [100n, 200n], [500n, -500n]),
+      ).toBe(0n);
+    });
+
+    it("sums multiple overlapping positions", () => {
+      // Position A: [100, 300], L=500; Position B: [200, 400], L=300.
+      // edges = [100, 200, 300, 400], nets = [+500, +300, -500, -300].
+      // At currentTick=250: A is in (entered at 100, not yet exited at 300),
+      // B is in (entered at 200, not yet exited at 400) ⇒ 500 + 300 = 800.
+      expect(
+        deriveStakedLiquidityInRange(
+          250n,
+          [100n, 200n, 300n, 400n],
+          [500n, 300n, -500n, -300n],
+        ),
+      ).toBe(800n);
+    });
+
+    it("handles negative ticks", () => {
+      // Position [-200, -100], L=500.
+      expect(
+        deriveStakedLiquidityInRange(-150n, [-200n, -100n], [500n, -500n]),
+      ).toBe(500n);
+      expect(
+        deriveStakedLiquidityInRange(-50n, [-200n, -100n], [500n, -500n]),
+      ).toBe(0n);
+    });
+
+    it("agrees with processTickCrossingsForStaked walking up from the lowest edge", () => {
+      // Build a non-trivial edge set and verify deriveStakedLiquidityInRange
+      // matches what processTickCrossingsForStaked produces by walking up from
+      // far below to the target tick.
+      const edges = [-200n, -100n, 100n, 300n];
+      const nets = [400n, 200n, -100n, -500n];
+      const target = 150n;
+
+      const noDbContext = {
+        log: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+      } as unknown as handlerContext;
+
+      const walked = processTickCrossingsForStaked(
+        CHAIN_ID,
+        POOL_ADDRESS,
+        -500n,
+        target,
+        sqrtAt(-500n),
+        sqrtAt(target),
+        1n,
+        noDbContext,
+        0n,
+        true,
+        edges,
+        nets,
+      );
+
+      expect(deriveStakedLiquidityInRange(target, edges, nets)).toBe(
+        walked.stakedLiquidityInRange,
+      );
     });
   });
 });

--- a/test/Aggregators/CLStakedLiquidityEdgeSanity.test.ts
+++ b/test/Aggregators/CLStakedLiquidityEdgeSanity.test.ts
@@ -1,7 +1,8 @@
-import type { Token } from "generated";
+import type { Token, handlerContext } from "generated";
 import { CLGauge, MockDb } from "../../generated/src/TestHelpers.gen";
 import {
   applyStakedPositionToEdges,
+  deriveStakedLiquidityInRange,
   processTickCrossingsForStaked,
 } from "../../src/Aggregators/CLStakedLiquidity";
 import {
@@ -9,6 +10,7 @@ import {
   PoolId,
   toChecksumAddress,
 } from "../../src/Constants";
+import { updateStakedPositionLiquidity } from "../../src/EventHandlers/NFPM/NFPMCommonLogic";
 import { setupCommon } from "../EventHandlers/Pool/common";
 import { sqrtAt } from "./common";
 
@@ -219,11 +221,13 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
     const oldTick = -400n;
     const newTick = 400n;
 
-    // Baseline: walk the map directly and sum liquidityNet for ticks strictly
-    // above oldTick through newTick.
+    // Baseline: walk the map directly and sum liquidityNet for ticks ≤ newTick.
+    // Post-#719, processTickCrossingsForStaked returns derive(newTick) rather
+    // than (seed + delta-across-window) — the function self-heals from edge
+    // state regardless of the cached seed.
     let baselineResult = 0n;
     for (const [tick, net] of baselineNet.entries()) {
-      if (tick > oldTick && tick <= newTick) {
+      if (tick <= newTick) {
         baselineResult += net;
       }
     }
@@ -262,18 +266,16 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
     ).length;
     expect(crossingCount).toBeGreaterThan(5);
 
-    // Also verify the OPPOSITE direction (price moving DOWN). Uniswap v3 sign
-    // convention: on a downward cross the pool does `liquidity -= net[T]`, which
-    // means the sparse walker must subtract (not add) across the same edges,
-    // and the window is `newTick < T <= oldTick` (at-or-below oldTick, strictly
-    // above newTick). Seeding stakedLiq with the result of the up-swap gives us
-    // round-trip parity: up then down should land back on the starting liquidity.
+    // Also verify the OPPOSITE direction (price moving DOWN). Post-#719 the
+    // walker is seeded from derive(oldTick), so the down-swap return value is
+    // derive(newTickDown) regardless of any seed input. Baseline computes
+    // derive(newTickDown) directly: sum of nets for ticks ≤ newTickDown.
     const oldTickDown = newTick;
     const newTickDown = oldTick;
-    let baselineDownResult = baselineResult;
+    let baselineDownResult = 0n;
     for (const [tick, net] of baselineNet.entries()) {
-      if (tick > newTickDown && tick <= oldTickDown) {
-        baselineDownResult -= net;
+      if (tick <= newTickDown) {
+        baselineDownResult += net;
       }
     }
 
@@ -293,8 +295,387 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
     );
 
     expect(downResult.stakedLiquidityInRange).toBe(baselineDownResult);
-    // Round-trip parity: up-swap then down-swap over the same window must
-    // return stakedLiq to its starting value (0n in this test).
-    expect(downResult.stakedLiquidityInRange).toBe(0n);
+    // Sanity: the round trip exits at derive(newTickDown), which on this
+    // edge set is non-zero because several positions have tickLower ≤ -400
+    // (tickLowers start at -500 and step up). The walker's seed input is
+    // no longer load-bearing (issue #719) — the return is purely a function
+    // of (newTickDown, edges, nets).
+    expect(downResult.stakedLiquidityInRange).toBeGreaterThan(0n);
+  });
+
+  // Regression coverage for issue #719: cover the three concrete drift paths
+  // from the bug report plus the closed-system invariant. Each test pins the
+  // structural property that the fix introduces:
+  //   stakedLiquidityInRange === deriveStakedLiquidityInRange(currentTick,
+  //                                                            stakedTickEdges,
+  //                                                            stakedTickEdgeNets)
+  // ALWAYS. The cached running counter is replaced by derivation, so the field
+  // never drifts away from the edge truth regardless of event ordering, gate
+  // outcomes, or NFPM-mediated liquidity changes during a stake.
+  describe("#719 drift paths", () => {
+    it("(c) gauge Deposit before pool Initialize derives counter from edge state", async () => {
+      // Pool has never seen Initialize: sqrtPriceX96=0n, tick=0n. The legacy
+      // gate `sqrtPriceX96 !== 0n` suppressed the counter update on deposit
+      // while still applying the position to the sparse edge nets — the first
+      // Swap on the pool then walked from a wrong baseline. The structural
+      // fix removes the counter/edges asymmetry by deriving the counter from
+      // edges at every write.
+      let mockDb = MockDb.createMockDb();
+      const liquidityPool = createMockPool({
+        isCL: true,
+        gaugeAddress,
+        sqrtPriceX96: 0n,
+        tick: 0n,
+        hasStakes: false,
+      });
+      mockDb = mockDb.entities.Pool.set(liquidityPool);
+      mockDb = mockDb.entities.Token.set(mockToken0Data as Token);
+      mockDb = mockDb.entities.Token.set(mockToken1Data as Token);
+
+      // Position spans tick 0 — it is in-range at the default tick=0n.
+      const tickLower = -100n;
+      const tickUpper = 100n;
+      const liquidity = 500n;
+      const tokenId = 1n;
+      mockDb = mockDb.entities.NonFungiblePosition.set(
+        createMockNonFungiblePosition({
+          tokenId,
+          nfpmAddress: defaultNfpmAddress,
+          pool: liquidityPool.poolAddress,
+          owner: userAddress,
+          tickLower,
+          tickUpper,
+          liquidity,
+        }),
+      );
+
+      const event = CLGauge.Deposit.createMockEvent({
+        user: userAddress,
+        tokenId,
+        liquidityToStake: liquidity,
+        mockEventData: {
+          srcAddress: gaugeAddress,
+          chainId,
+          block: {
+            number: 1,
+            timestamp: 1_700_000_000,
+            hash: `0x${"a".repeat(64)}`,
+          },
+        },
+      });
+
+      const resultDb = await mockDb.processEvents([event]);
+      const updated = resultDb.entities.Pool.get(
+        PoolId(chainId, liquidityPool.poolAddress),
+      );
+      expect(updated).toBeDefined();
+      if (!updated) return;
+
+      // Edges populated by applyStakedPositionToEdges.
+      expect(updated.stakedTickEdges).toEqual([tickLower, tickUpper]);
+      expect(updated.stakedTickEdgeNets).toEqual([liquidity, -liquidity]);
+      // Counter MUST equal derive(currentTick=0n, edges, nets):
+      //   edge -100 ≤ 0 → contributes +500
+      //   edge  100 > 0 → excluded
+      // ⇒ stakedLiquidityInRange = 500. Legacy gated path would leave 0n.
+      expect(updated.stakedLiquidityInRange).toBe(
+        deriveStakedLiquidityInRange(
+          updated.tick ?? 0n,
+          updated.stakedTickEdges,
+          updated.stakedTickEdgeNets,
+        ),
+      );
+      expect(updated.stakedLiquidityInRange).toBe(500n);
+    });
+
+    it("(d) edge-merge rejection heals a previously poisoned counter via derivation", async () => {
+      // Simulates the "edge map disagrees with counter" mode: the aggregator's
+      // stakedLiquidityInRange is poisoned (non-zero with empty edges) from
+      // prior drift, and an incoming Deposit gets rejected by
+      // applyStakedPositionToEdges (degenerate range: tickLower >= tickUpper).
+      // With derivation, the rejection still triggers a heal — the counter is
+      // overwritten with derive(currentTick, edges, nets), which on empty
+      // edges is 0. The legacy gated path skipped the counter on rejection,
+      // so the poison would persist.
+      let mockDb = MockDb.createMockDb();
+      const liquidityPool = createMockPool({
+        isCL: true,
+        gaugeAddress,
+        sqrtPriceX96: sqrtAt(0n),
+        tick: 0n,
+        hasStakes: false,
+        // Poisoned cached counter — edges are empty, so the truth is 0n.
+        stakedLiquidityInRange: 999_999n,
+        stakedTickEdges: [],
+        stakedTickEdgeNets: [],
+      });
+      mockDb = mockDb.entities.Pool.set(liquidityPool);
+      mockDb = mockDb.entities.Token.set(mockToken0Data as Token);
+      mockDb = mockDb.entities.Token.set(mockToken1Data as Token);
+
+      // Degenerate position (tickLower >= tickUpper). Real chains wouldn't
+      // mint this, but the rejection path is the structural concern — any
+      // future rejection cause (out-of-range ticks from an upstream bug,
+      // corrupt RPC data, etc.) must converge the counter to the edge truth.
+      const tokenId = 1n;
+      mockDb = mockDb.entities.NonFungiblePosition.set(
+        createMockNonFungiblePosition({
+          tokenId,
+          nfpmAddress: defaultNfpmAddress,
+          pool: liquidityPool.poolAddress,
+          owner: userAddress,
+          tickLower: 200n,
+          tickUpper: 100n,
+          liquidity: 500n,
+        }),
+      );
+
+      const event = CLGauge.Deposit.createMockEvent({
+        user: userAddress,
+        tokenId,
+        liquidityToStake: 500n,
+        mockEventData: {
+          srcAddress: gaugeAddress,
+          chainId,
+          block: {
+            number: 1,
+            timestamp: 1_700_000_000,
+            hash: `0x${"a".repeat(64)}`,
+          },
+        },
+      });
+
+      const resultDb = await mockDb.processEvents([event]);
+      const updated = resultDb.entities.Pool.get(
+        PoolId(chainId, liquidityPool.poolAddress),
+      );
+      expect(updated).toBeDefined();
+      if (!updated) return;
+
+      // Rejection means edges are unchanged (still empty).
+      expect(updated.stakedTickEdges).toEqual([]);
+      expect(updated.stakedTickEdgeNets).toEqual([]);
+      // The healing invariant: counter must equal derive at the current tick.
+      expect(updated.stakedLiquidityInRange).toBe(
+        deriveStakedLiquidityInRange(
+          updated.tick ?? 0n,
+          updated.stakedTickEdges,
+          updated.stakedTickEdgeNets,
+        ),
+      );
+      expect(updated.stakedLiquidityInRange).toBe(0n);
+    });
+
+    it("(e) NFPM IncreaseLiquidity while price is out of range heals the counter", async () => {
+      // The exact #719 path 3 asymmetry: gauge Deposit adds +L while price is
+      // in range (counter += L). Price moves out of range. NFPM
+      // IncreaseLiquidity bumps position liquidity, but the legacy gate
+      // `isPositionInRange(...)` skips the counter update while the edge
+      // nets still update via applyStakedPositionToEdges. With derivation,
+      // the counter is recomputed from the updated edges at the (out-of-range)
+      // tick — both edges land ≤ currentTick, so the nets sum to zero and the
+      // counter heals from "stale L" to "0".
+      const tickLower = -100n;
+      const tickUpper = 100n;
+      const positionLiquidity = 100n;
+      const tokenId = 7n;
+
+      const liquidityPool = createMockPool({
+        isCL: true,
+        gaugeAddress,
+        // Price is now ABOVE the position's range (tick=500 > tickUpper=100).
+        sqrtPriceX96: sqrtAt(500n),
+        tick: 500n,
+        hasStakes: true,
+        // Pre-deposit state: counter=positionLiquidity (correct WHILE in range
+        // — set as if the deposit fired earlier at a price in range).
+        stakedLiquidityInRange: positionLiquidity,
+        stakedTickEdges: [tickLower, tickUpper],
+        stakedTickEdgeNets: [positionLiquidity, -positionLiquidity],
+      });
+
+      // Position is already staked in gauge (so updateStakedPositionLiquidity
+      // is the function NFPM.IncreaseLiquidity would invoke for it).
+      const position = createMockNonFungiblePosition({
+        tokenId,
+        nfpmAddress: defaultNfpmAddress,
+        pool: liquidityPool.poolAddress,
+        owner: userAddress,
+        tickLower,
+        tickUpper,
+        liquidity: positionLiquidity,
+        isStakedInGauge: true,
+      });
+
+      // Drive updateStakedPositionLiquidity directly: it's the function NFPM
+      // delegates to for staked positions, and bypassing the full event chain
+      // keeps the test focused on the counter-update path the issue exposes.
+      const setSpy = vi.fn();
+      const mockContext = {
+        Pool: { set: setSpy },
+        PoolSnapshot: { set: vi.fn() },
+        Token: { get: vi.fn().mockResolvedValue(undefined) },
+        log: {
+          error: vi.fn(),
+          warn: vi.fn(),
+          info: vi.fn(),
+          debug: vi.fn(),
+        },
+      } as unknown as handlerContext;
+
+      const increaseDelta = 50n;
+      await updateStakedPositionLiquidity(
+        position,
+        // biome-ignore lint/suspicious/noExplicitAny: trimmed PoolData for test
+        { liquidityPoolAggregator: liquidityPool } as any,
+        increaseDelta,
+        mockContext,
+        new Date(1_700_000_000_000),
+        chainId,
+        1,
+      );
+
+      expect(setSpy).toHaveBeenCalledTimes(1);
+      const written = setSpy.mock.calls[0][0] as {
+        stakedLiquidityInRange: bigint;
+        stakedTickEdges: bigint[];
+        stakedTickEdgeNets: bigint[];
+        tick: bigint;
+      };
+
+      // Edges absorbed the +increaseDelta (consistent with applyStakedPositionToEdges).
+      expect(written.stakedTickEdges).toEqual([tickLower, tickUpper]);
+      expect(written.stakedTickEdgeNets).toEqual([
+        positionLiquidity + increaseDelta,
+        -(positionLiquidity + increaseDelta),
+      ]);
+      // The healing invariant at the post-write tick. With tick=500, both
+      // edges contribute → +(L+Δ) - (L+Δ) = 0. The legacy code would have
+      // kept the counter at `positionLiquidity` (stale).
+      expect(written.stakedLiquidityInRange).toBe(
+        deriveStakedLiquidityInRange(
+          written.tick ?? 0n,
+          written.stakedTickEdges,
+          written.stakedTickEdgeNets,
+        ),
+      );
+      expect(written.stakedLiquidityInRange).toBe(0n);
+    });
+
+    it("(f) edge-sanity invariant: gauge Deposit + Withdraw round-trips counter to 0n", async () => {
+      // AC item: after deposit + N swaps + withdraw the counter MUST land on
+      // 0n. Swaps are emulated by mutating the aggregator's tick between
+      // Deposit and Withdraw — the structural fix means the counter is
+      // recomputed from edges at every write, so any number of intervening
+      // tick moves cannot poison the round-trip.
+      let mockDb = MockDb.createMockDb();
+      const liquidityPool = createMockPool({
+        isCL: true,
+        gaugeAddress,
+        sqrtPriceX96: sqrtAt(0n),
+        tick: 0n,
+        hasStakes: false,
+      });
+      mockDb = mockDb.entities.Pool.set(liquidityPool);
+      mockDb = mockDb.entities.Token.set(mockToken0Data as Token);
+      mockDb = mockDb.entities.Token.set(mockToken1Data as Token);
+
+      const tickLower = -100n;
+      const tickUpper = 100n;
+      const liquidity = 500n;
+      const tokenId = 1n;
+      mockDb = mockDb.entities.NonFungiblePosition.set(
+        createMockNonFungiblePosition({
+          tokenId,
+          nfpmAddress: defaultNfpmAddress,
+          pool: liquidityPool.poolAddress,
+          owner: userAddress,
+          tickLower,
+          tickUpper,
+          liquidity,
+        }),
+      );
+
+      // 1) Deposit at in-range tick.
+      const depositEvent = CLGauge.Deposit.createMockEvent({
+        user: userAddress,
+        tokenId,
+        liquidityToStake: liquidity,
+        mockEventData: {
+          srcAddress: gaugeAddress,
+          chainId,
+          block: {
+            number: 1,
+            timestamp: 1_700_000_000,
+            hash: `0x${"a".repeat(64)}`,
+          },
+        },
+      });
+      let resultDb = await mockDb.processEvents([depositEvent]);
+
+      const postDeposit = resultDb.entities.Pool.get(
+        PoolId(chainId, liquidityPool.poolAddress),
+      );
+      expect(postDeposit).toBeDefined();
+      if (!postDeposit) return;
+      expect(postDeposit.stakedLiquidityInRange).toBe(
+        deriveStakedLiquidityInRange(
+          postDeposit.tick ?? 0n,
+          postDeposit.stakedTickEdges,
+          postDeposit.stakedTickEdgeNets,
+        ),
+      );
+
+      // 2) Emulate N "swaps" by jiggling tick across the range and out the
+      // far side. Each pause writes the new (sqrtPriceX96, tick) state the
+      // way a Swap handler would have. The invariant must hold at every step.
+      const tickJourney = [50n, 99n, 500n, -300n, 0n];
+      for (const t of tickJourney) {
+        const current = resultDb.entities.Pool.get(
+          PoolId(chainId, liquidityPool.poolAddress),
+        );
+        if (!current) throw new Error("aggregator vanished mid-journey");
+        resultDb = resultDb.entities.Pool.set({
+          ...current,
+          tick: t,
+          sqrtPriceX96: sqrtAt(t),
+        });
+      }
+
+      // 3) Withdraw at the final tick (back in range).
+      const withdrawEvent = CLGauge.Withdraw.createMockEvent({
+        user: userAddress,
+        tokenId,
+        liquidityToStake: liquidity,
+        mockEventData: {
+          srcAddress: gaugeAddress,
+          chainId,
+          block: {
+            number: 2,
+            timestamp: 1_700_100_000,
+            hash: `0x${"b".repeat(64)}`,
+          },
+        },
+      });
+      resultDb = await resultDb.processEvents([withdrawEvent]);
+
+      const postWithdraw = resultDb.entities.Pool.get(
+        PoolId(chainId, liquidityPool.poolAddress),
+      );
+      expect(postWithdraw).toBeDefined();
+      if (!postWithdraw) return;
+
+      // After the round-trip, edges and counter must be empty/zero.
+      expect(postWithdraw.stakedTickEdges).toEqual([]);
+      expect(postWithdraw.stakedTickEdgeNets).toEqual([]);
+      expect(postWithdraw.stakedLiquidityInRange).toBe(
+        deriveStakedLiquidityInRange(
+          postWithdraw.tick ?? 0n,
+          postWithdraw.stakedTickEdges,
+          postWithdraw.stakedTickEdgeNets,
+        ),
+      );
+      expect(postWithdraw.stakedLiquidityInRange).toBe(0n);
+    });
   });
 });

--- a/test/Aggregators/Pool.test.ts
+++ b/test/Aggregators/Pool.test.ts
@@ -753,6 +753,102 @@ describe("Pool Functions", () => {
         expect(negReserveGuardLogs().length).toBe(2);
       });
     });
+
+    // Regression test for issue #719: stakedLiquidityInRange must never
+    // persist negative. Mirrors the #702 reserve-clamp shape but for the
+    // staked-in-range field. The aggregator emits [NEG_STAKED_LIQ_GUARD]
+    // with {poolAddress, chainId, priorStakedLiqInRange, replacement,
+    // clampedTo} when the diff would drive the field below zero.
+    describe("negative stakedLiquidityInRange clamp guard (issue #719)", () => {
+      const sameEpochAsTimestamp = () => timestamp;
+
+      const negStakedLiqGuardLogs = () => {
+        const warnMock = vi.mocked(mockContext.log?.warn);
+        const calls = warnMock?.mock.calls ?? [];
+        return calls.filter((args) =>
+          String(args[0] ?? "").includes("[NEG_STAKED_LIQ_GUARD]"),
+        );
+      };
+
+      const lastSet = (): Pool => {
+        const setMock = vi.mocked(mockContext.Pool?.set);
+        return setMock?.mock.lastCall?.[0] as Pool;
+      };
+
+      it("clamps stakedLiquidityInRange to 0n and logs guard when diff is negative", async () => {
+        await updatePool(
+          { stakedLiquidityInRange: -250n },
+          {
+            ...(liquidityPoolAggregator as Pool),
+            stakedLiquidityInRange: 100n,
+            lastSnapshotTimestamp: sameEpochAsTimestamp(),
+            lastUpdatedTimestamp: sameEpochAsTimestamp(),
+          },
+          timestamp,
+          mockContext as handlerContext,
+          8453,
+          blockNumber,
+        );
+
+        expect(lastSet().stakedLiquidityInRange).toBe(0n);
+
+        const logs = negStakedLiqGuardLogs();
+        expect(logs.length).toBe(1);
+        const msg = String(logs[0]?.[0] ?? "");
+        expect(msg).toContain("stakedLiquidityInRange");
+        expect(msg).toContain("priorStakedLiqInRange=100");
+        expect(msg).toContain("replacement=-250");
+        expect(msg).toContain("clampedTo=0");
+        expect(msg).toContain(
+          `chainId=${(liquidityPoolAggregator as Pool).chainId}`,
+        );
+        expect(msg).toContain(
+          `poolAddress=${(liquidityPoolAggregator as Pool).poolAddress}`,
+        );
+      });
+
+      it("clamps when current value is already negative and diff omits stakedLiquidityInRange", async () => {
+        // Simulates the legacy poisoned-state case: pool's persisted
+        // stakedLiquidityInRange is already < 0n from prior drift, and the
+        // current update doesn't supply a replacement. The clamp still fires
+        // because the post-replace value falls back to the negative current.
+        await updatePool(
+          {},
+          {
+            ...(liquidityPoolAggregator as Pool),
+            stakedLiquidityInRange: -1_000_000n,
+            lastSnapshotTimestamp: sameEpochAsTimestamp(),
+            lastUpdatedTimestamp: sameEpochAsTimestamp(),
+          },
+          timestamp,
+          mockContext as handlerContext,
+          8453,
+          blockNumber,
+        );
+
+        expect(lastSet().stakedLiquidityInRange).toBe(0n);
+        expect(negStakedLiqGuardLogs().length).toBe(1);
+      });
+
+      it("does not clamp or log when stakedLiquidityInRange stays non-negative", async () => {
+        await updatePool(
+          { stakedLiquidityInRange: 50n },
+          {
+            ...(liquidityPoolAggregator as Pool),
+            stakedLiquidityInRange: 100n,
+            lastSnapshotTimestamp: sameEpochAsTimestamp(),
+            lastUpdatedTimestamp: sameEpochAsTimestamp(),
+          },
+          timestamp,
+          mockContext as handlerContext,
+          8453,
+          blockNumber,
+        );
+
+        expect(lastSet().stakedLiquidityInRange).toBe(50n);
+        expect(negStakedLiqGuardLogs().length).toBe(0);
+      });
+    });
   });
 
   describe("Updating the Liquidity Pool Aggregator", () => {

--- a/test/EventHandlers/CLPool/CLPoolSwapLogic.test.ts
+++ b/test/EventHandlers/CLPool/CLPoolSwapLogic.test.ts
@@ -622,11 +622,17 @@ describe("CLPoolSwapLogic", () => {
       );
     });
 
-    it("should compute staked reserve deltas proportionally", async () => {
+    it("should compute staked reserve deltas from edge state", async () => {
+      // Post-#719 stakedLiquidityInRange is derived from
+      // (oldTick, stakedTickEdges, stakedTickEdgeNets) rather than trusted
+      // from the cached seed. With an empty edge list, derive returns 0n
+      // regardless of what the legacy counter says.
       const poolWithStaked = {
         ...mockPool,
         tick: 500n, // Different from event tick (1000n) to trigger tick crossing
         tickSpacing: 200n,
+        // Cached counter is intentionally inconsistent with the empty edge
+        // list to demonstrate the structural heal.
         stakedLiquidityInRange: 200n,
       };
 
@@ -638,10 +644,8 @@ describe("CLPoolSwapLogic", () => {
         mockContext,
       );
 
-      // No tick entities exist → stakedLiquidityInRange stays 200n
-      // reserveDelta0/1 are proportioned by 200/1000000000000000000000 (event liquidity)
-      // With such small staked vs total, staked deltas will be ~0 due to bigint truncation
-      expect(result.liquidityPoolDiff.stakedLiquidityInRange).toBe(200n);
+      // derive(oldTick=500n, [], []) === 0n; the empty edge list IS the truth.
+      expect(result.liquidityPoolDiff.stakedLiquidityInRange).toBe(0n);
       expect(result.liquidityPoolDiff.incrementalStakedReserve0).toBeDefined();
       expect(result.liquidityPoolDiff.incrementalStakedReserve1).toBeDefined();
     });
@@ -665,12 +669,15 @@ describe("CLPoolSwapLogic", () => {
       expect(result.liquidityPoolDiff.stakedLiquidityInRange).toBe(0n);
     });
 
-    it("should skip tick crossings when tick unchanged", async () => {
+    it("should derive stakedLiquidityInRange from edges even when tick unchanged", async () => {
+      // Post-#719: the seed input is consulted only on early-exit paths;
+      // the normal walking path derives from edges at oldTick. With empty
+      // edges, derive yields 0n no matter what the cached counter says.
       const poolSameTick = {
         ...mockPool,
         tick: mockEvent.params.tick, // Same tick → no crossing
         tickSpacing: 200n,
-        stakedLiquidityInRange: 500n,
+        stakedLiquidityInRange: 500n, // intentionally stale vs empty edges
       };
 
       const result = await processCLPoolSwap(
@@ -681,8 +688,8 @@ describe("CLPoolSwapLogic", () => {
         mockContext,
       );
 
-      // No tick crossing → stakedLiquidityInRange unchanged
-      expect(result.liquidityPoolDiff.stakedLiquidityInRange).toBe(500n);
+      // No crossings + empty edges → derive(oldTick) = 0n.
+      expect(result.liquidityPoolDiff.stakedLiquidityInRange).toBe(0n);
     });
   });
 

--- a/test/EventHandlers/NFPM/NFPMCommonLogic.test.ts
+++ b/test/EventHandlers/NFPM/NFPMCommonLogic.test.ts
@@ -3,7 +3,7 @@ import type { NonFungiblePosition, handlerContext } from "generated";
 import { MockDb } from "../../../generated/src/TestHelpers.gen";
 import {
   applyStakedPositionToEdges,
-  isPositionInRange,
+  deriveStakedLiquidityInRange,
 } from "../../../src/Aggregators/CLStakedLiquidity";
 import { type PoolData, updatePool } from "../../../src/Aggregators/Pool";
 import {
@@ -283,7 +283,7 @@ describe("NFPMCommonLogic", () => {
     const blockNumber = 123456;
 
     beforeEach(() => {
-      vi.mocked(isPositionInRange).mockReset();
+      vi.mocked(deriveStakedLiquidityInRange).mockReset();
       vi.mocked(updatePool).mockReset();
       vi.mocked(updatePool).mockResolvedValue(undefined);
       vi.mocked(calculatePositionAmountsFromLiquidity).mockReset();
@@ -300,8 +300,8 @@ describe("NFPMCommonLogic", () => {
       });
     });
 
-    it("should apply the liquidity delta to the aggregator edge list regardless of in-range status", async () => {
-      vi.mocked(isPositionInRange).mockReturnValue(false);
+    it("should apply the liquidity delta to the aggregator edge list", async () => {
+      vi.mocked(deriveStakedLiquidityInRange).mockReturnValue(0n);
 
       await updateStakedPositionLiquidity(
         stakedPosition,
@@ -322,8 +322,11 @@ describe("NFPMCommonLogic", () => {
       );
     });
 
-    it("should update total staked reserves and stakedLiquidityInRange when position is in range", async () => {
-      vi.mocked(isPositionInRange).mockReturnValue(true);
+    it("should derive stakedLiquidityInRange from updated edges at the current tick", async () => {
+      // Post-#719 the counter is no longer "current + delta"; it is rederived
+      // from the edges on every write, so the test pins the value the
+      // (mocked) deriveStakedLiquidityInRange returns.
+      vi.mocked(deriveStakedLiquidityInRange).mockReturnValue(6000n);
 
       await updateStakedPositionLiquidity(
         stakedPosition,
@@ -335,7 +338,13 @@ describe("NFPMCommonLogic", () => {
         blockNumber,
       );
 
-      expect(isPositionInRange).toHaveBeenCalledWith(-200n, 200n, 0n);
+      // Derivation is called with (currentTick, updatedEdges, updatedNets) —
+      // the edges/nets produced by the (mocked) applyStakedPositionToEdges.
+      expect(deriveStakedLiquidityInRange).toHaveBeenCalledWith(
+        0n,
+        [-200n, 200n],
+        [5000n, -5000n],
+      );
       expect(calculatePositionAmountsFromLiquidity).toHaveBeenCalledWith(
         5000n,
         sqrtPriceX96AtTick0,
@@ -344,7 +353,7 @@ describe("NFPMCommonLogic", () => {
       );
       expect(updatePool).toHaveBeenCalledWith(
         {
-          stakedLiquidityInRange: 6000n, // 1000 + 5000
+          stakedLiquidityInRange: 6000n, // pinned by the derive mock
           incrementalStakedReserve0: 100n, // direction=+1 * 100
           incrementalStakedReserve1: 200n, // direction=+1 * 200
           stakedTickEdges: [-200n, 200n],
@@ -360,7 +369,7 @@ describe("NFPMCommonLogic", () => {
     });
 
     it("should use negative direction for decrease (negative liquidityDelta)", async () => {
-      vi.mocked(isPositionInRange).mockReturnValue(true);
+      vi.mocked(deriveStakedLiquidityInRange).mockReturnValue(-2000n);
 
       await updateStakedPositionLiquidity(
         stakedPosition,
@@ -381,7 +390,7 @@ describe("NFPMCommonLogic", () => {
       );
       expect(updatePool).toHaveBeenCalledWith(
         {
-          stakedLiquidityInRange: -2000n, // 1000 + (-3000)
+          stakedLiquidityInRange: -2000n, // pinned by the derive mock (clamped at the aggregator)
           incrementalStakedReserve0: -100n, // direction=-1 * 100
           incrementalStakedReserve1: -200n, // direction=-1 * 200
           stakedTickEdges: [-200n, 200n],
@@ -396,8 +405,11 @@ describe("NFPMCommonLogic", () => {
       );
     });
 
-    it("should update total staked reserves but not stakedLiquidityInRange when position is out of range", async () => {
-      vi.mocked(isPositionInRange).mockReturnValue(false);
+    it("should always emit stakedLiquidityInRange from derivation, even when position is out of range at currentTick", async () => {
+      // Derivation is structural — there is no longer an "in-range" gate.
+      // The function pins the value (representing derive at an out-of-range
+      // tick, which would naturally be 0n for a single-position edge set).
+      vi.mocked(deriveStakedLiquidityInRange).mockReturnValue(0n);
 
       await updateStakedPositionLiquidity(
         stakedPosition,
@@ -417,7 +429,7 @@ describe("NFPMCommonLogic", () => {
       );
       expect(updatePool).toHaveBeenCalledWith(
         {
-          stakedLiquidityInRange: undefined, // not in range, so unchanged
+          stakedLiquidityInRange: 0n, // derived, not undefined
           incrementalStakedReserve0: 100n,
           incrementalStakedReserve1: 200n,
           stakedTickEdges: [-200n, 200n],
@@ -432,8 +444,11 @@ describe("NFPMCommonLogic", () => {
       );
     });
 
-    it("should persist edge-list updates even when sqrtPriceX96 is zero", async () => {
-      vi.mocked(isPositionInRange).mockReturnValue(true);
+    it("should persist edge-list updates AND derived counter even when sqrtPriceX96 is zero", async () => {
+      // Pre-#719 the sqrt=0 path skipped the counter update entirely (so
+      // pre-Initialize deposits drifted). Now the counter is derived even on
+      // the sqrt=0 early-exit path so the aggregator stays consistent.
+      vi.mocked(deriveStakedLiquidityInRange).mockReturnValue(42n);
 
       const poolDataZeroPrice: PoolData = {
         ...poolData,
@@ -460,6 +475,7 @@ describe("NFPMCommonLogic", () => {
         {
           stakedTickEdges: [-200n, 200n],
           stakedTickEdgeNets: [5000n, -5000n],
+          stakedLiquidityInRange: 42n, // derived even on sqrt=0 path (issue #719)
           hasStakes: true,
         },
         poolDataZeroPrice.liquidityPoolAggregator,


### PR DESCRIPTION
## Summary

Closes #719. Two-layer fix for the asymmetric `stakedLiquidityInRange` updates that drove 8 OP CL pools to negative values:

1. **Structural derivation** — replaces the cached running counter at the three writer sites (`GaugeSharedLogic`, `NFPMCommonLogic`, `processTickCrossingsForStaked`) with a new `deriveStakedLiquidityInRange(currentTick, edges, nets)`. The counter and edge nets were asymmetrically gated on `sqrtPriceX96 !== 0n`, `!edgesRejected`, and `isPositionInRange`; the counter drifted on three concrete paths (pre-Initialize deposit, edge-merge rejection, out-of-range NFPM liquidity change between gauge stake and withdraw). Derivation pins counter ≡ edges on every write and self-heals pre-existing drift on the next touch.

2. **Tactical clamp** — adds a `[NEG_STAKED_LIQ_GUARD]` clamp at `updateLiquidityPoolAggregator` mirroring PR #718's reserve clamp, so a negative value can never persist even if a future writer bypasses derivation.

## Acceptance criteria (issue #719)
- [x] Tactical clamp lands — `stakedLiquidityInRange` cannot be persisted < 0
- [x] `[NEG_STAKED_LIQ_GUARD]` log line with `poolAddress`, `chainId`, `priorStakedLiqInRange`, `replacement`, `clampedTo`
- [x] Structural derivation replaces running-counter writes in `GaugeSharedLogic.ts`, `NFPMCommonLogic.ts`, `CLStakedLiquidity.ts`
- [x] Unit tests cover all three drift paths (pre-Initialize, edge-merge rejection, NFPM mid-stake)
- [x] Edge-sanity invariant test: Deposit + N tick moves + Withdraw → counter == 0n
- [x] `tsc --noEmit` + `pnpm test` + `pnpm qa --write` clean
- [ ] Full reindex on Optimism to clear the 8 currently-negative pools — deferred to ops; the fix self-heals on the next gauge/NFPM/swap event per pool

## Test plan
- [ ] CI green (`pnpm test`, lint, type-check)
- [ ] Spot-check one of the 8 affected OP pools (e.g. `10-0x3241738149B24C9164dA14Fa2040159FFC6Dd237`) after deploy: confirm `stakedLiquidityInRange` heals from negative toward consistency with `stakedTickEdges`/`stakedTickEdgeNets` after subsequent gauge/swap events
- [ ] Watch logs for `[NEG_STAKED_LIQ_GUARD]` — should be rare; any hit signals a remaining producer path that bypasses derivation
- [ ] Confirm no regression in `stakedReserve0/1` (per-segment attribution path is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed staked liquidity tracking inconsistencies across position operations (deposits, withdrawals, swaps)
  * Added safeguard to prevent negative staked liquidity values with warning logging

* **Tests**
  * Expanded test coverage for liquidity calculation edge cases and regressions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/velodrome-finance/indexer/pull/725)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->