### PR TITLE
feat(price-oracle): cap first-fetch anchor at $10K for non-BTC tokens (closes #728)

### DIFF
--- a/src/PriceOracle.ts
+++ b/src/PriceOracle.ts
@@ -4,6 +4,7 @@ import {
   CHAIN_CONSTANTS,
   MS_IN_AN_HOUR,
   PriceOracleType,
+  TEN_TO_THE_18_BI,
   TokenId,
 } from "./Constants";
 import {
@@ -29,6 +30,18 @@ export interface TokenPriceData {
 // issue body for the heuristic calibration.
 const PRICE_SPIKE_RATIO_THRESHOLD = 10n;
 const PRICE_SPIKE_STALENESS_MS = 14 * 24 * 60 * 60 * 1000;
+
+// Issue #728: locked-anchor poisoning defense. The #668 spike guard needs a
+// prior non-zero anchor to compare ≥10× against, so the very first non-zero
+// oracle read has nothing to validate it. If that read is inflated, the
+// locked anchor poisons every subsequent pool calc until the token is
+// reactively blacklisted (see PR #722). Cap rejects any first non-zero anchor
+// > $10K for non-BTC symbols. Empirical scan against the deployed indexer
+// found zero legitimate non-BTC tokens ever priced above $10K — every >$10K
+// observation was a known poison case handled by REBIND / BLACKLIST /
+// stablecoin pin. BTC symbols (WBTC, cbBTC, SolvBTC, …) are exempt because
+// they routinely price in the tens of thousands.
+const FIRST_FETCH_CAP = 10_000n * TEN_TO_THE_18_BI;
 
 /**
  * Creates and persists a Token entity at first sight, gated on the address
@@ -222,6 +235,30 @@ export async function refreshTokenPrice(
       blockNumber: roundedBlockNumber,
     });
     let currentPrice = priceData.pricePerUSDNew;
+
+    // Issue #728: cap-reject the first non-zero anchor for non-BTC symbols.
+    // The spike guard below requires anchor > 0, so without this gate a single
+    // inflated read at first sight permanently poisons the anchor. Bumping
+    // `lastUpdatedTimestamp` keeps the 1-hour throttle ticking so the next
+    // refresh retries. Conditions are ordered so the cheap bigint compares
+    // short-circuit before the symbol string allocation on the hot path.
+    if (
+      token.pricePerUSDNew === 0n &&
+      currentPrice > FIRST_FETCH_CAP &&
+      !token.symbol.toUpperCase().includes("BTC")
+    ) {
+      context.log.warn(
+        `[FIRST_FETCH_CAP] chain=${chainId} address=${token.address} symbol=${token.symbol} proposed=${currentPrice} cap=${FIRST_FETCH_CAP} — rejecting first anchor write, keeping price=0`,
+      );
+      const capped: Token = {
+        ...token,
+        ...healedMetadata,
+        pricePerUSDNew: 0n,
+        lastUpdatedTimestamp: new Date(blockTimestampMs),
+      };
+      context.Token.set(capped);
+      return capped;
+    }
 
     // Issue #668: reject refreshes that jump ≥10× vs a still-fresh accepted
     // anchor. First-fetch (anchor == 0) and stale-anchor (anchor older than

--- a/test/PriceOracle.test.ts
+++ b/test/PriceOracle.test.ts
@@ -1062,6 +1062,219 @@ describe("PriceOracle", () => {
       });
     });
 
+    // Issue #728: locked-anchor poisoning defense. The #668 spike guard needs
+    // a prior non-zero anchor to compare ≥10× against, so the very first
+    // non-zero oracle read has nothing to validate it. If that first read is
+    // inflated, the locked anchor poisons every subsequent pool calc until
+    // the token is reactively blacklisted (see PR #722's pattern). Cap rejects
+    // any first non-zero anchor > $10K for non-BTC symbols and lets the next
+    // hourly refresh retry. Empirical scan: no legitimate non-BTC token has
+    // ever priced above $10K — every >$10K observation was a known poison
+    // case already handled by REBIND / BLACKLIST / stablecoin pin.
+    describe("first-fetch cap (issue #728)", () => {
+      const oneHourOneMinuteAgo = () =>
+        new Date(blockDatetime.getTime() - 61 * 60 * 1000);
+
+      beforeEach(() => {
+        vi.mocked(mockContext.Token?.set)?.mockClear();
+        vi.mocked(mockContext.TokenPriceSnapshot?.set)?.mockClear();
+        vi.mocked(mockContext.log?.warn)?.mockClear();
+      });
+
+      it("rejects a non-BTC first-fetch above $10K and logs [FIRST_FETCH_CAP]", async () => {
+        // Anchor 0, oracle returns $50K for symbol "USDT" — must be rejected.
+        // Mirrors the PR #722 pattern (36 tokens, $13.8K to $2B inflated anchors).
+        const inflatedPrice = 50_000n * 10n ** 18n;
+
+        vi.mocked(mockContext.effect)?.mockImplementation(async (effect) => {
+          if ((effect as { name?: string }).name === "getTokenPrice") {
+            return { pricePerUSDNew: inflatedPrice };
+          }
+          return {};
+        });
+
+        await PriceOracle.refreshTokenPrice(
+          {
+            ...mockToken0Data,
+            symbol: "USDT",
+            pricePerUSDNew: 0n,
+            lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+          },
+          blockNumber,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        expect(updatedToken.pricePerUSDNew).toBe(0n);
+        expect(
+          vi.mocked(mockContext.TokenPriceSnapshot?.set),
+        ).not.toHaveBeenCalled();
+        const warnCall = vi.mocked(mockContext.log?.warn)?.mock.lastCall;
+        expect(warnCall?.[0]).toContain("[FIRST_FETCH_CAP]");
+      });
+
+      it("accepts a BTC-symbol first-fetch above $10K", async () => {
+        // WBTC routinely prices in the tens of thousands; the cap must NOT
+        // reject any symbol containing "BTC". $80K is a realistic mid-cycle.
+        const btcPrice = 80_000n * 10n ** 18n;
+
+        vi.mocked(mockContext.effect)?.mockImplementation(async (effect) => {
+          if ((effect as { name?: string }).name === "getTokenPrice") {
+            return { pricePerUSDNew: btcPrice };
+          }
+          return {};
+        });
+
+        await PriceOracle.refreshTokenPrice(
+          {
+            ...mockToken0Data,
+            symbol: "WBTC",
+            pricePerUSDNew: 0n,
+            lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+          },
+          blockNumber,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        expect(updatedToken.pricePerUSDNew).toBe(btcPrice);
+      });
+
+      it("matches the BTC substring case-insensitively (e.g. cbbtc, SolvBTC)", async () => {
+        // Substring match must be case-insensitive so lowercase variants like
+        // "cbbtc" and mixed-case "SolvBTC" both bypass the cap.
+        const btcPrice = 75_000n * 10n ** 18n;
+
+        vi.mocked(mockContext.effect)?.mockImplementation(async (effect) => {
+          if ((effect as { name?: string }).name === "getTokenPrice") {
+            return { pricePerUSDNew: btcPrice };
+          }
+          return {};
+        });
+
+        await PriceOracle.refreshTokenPrice(
+          {
+            ...mockToken0Data,
+            symbol: "cbbtc",
+            pricePerUSDNew: 0n,
+            lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+          },
+          blockNumber,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        expect(updatedToken.pricePerUSDNew).toBe(btcPrice);
+      });
+
+      it("accepts a non-BTC first-fetch at exactly the $10K cap (boundary)", async () => {
+        // Cap is strictly greater-than: a $10,000.00 first-fetch must pass.
+        // Regression guard against off-by-one boundary regressions.
+        const exactCapPrice = 10_000n * 10n ** 18n;
+
+        vi.mocked(mockContext.effect)?.mockImplementation(async (effect) => {
+          if ((effect as { name?: string }).name === "getTokenPrice") {
+            return { pricePerUSDNew: exactCapPrice };
+          }
+          return {};
+        });
+
+        await PriceOracle.refreshTokenPrice(
+          {
+            ...mockToken0Data,
+            symbol: "USDT",
+            pricePerUSDNew: 0n,
+            lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+          },
+          blockNumber,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        expect(updatedToken.pricePerUSDNew).toBe(exactCapPrice);
+      });
+
+      it("accepts a non-BTC first-fetch well below the cap", async () => {
+        // Sanity: ordinary first-fetches (a few dollars) must pass through
+        // untouched. Pins the common case so a refactor that gets the
+        // condition inverted is caught immediately.
+        const normalPrice = 2n * 10n ** 18n;
+
+        vi.mocked(mockContext.effect)?.mockImplementation(async (effect) => {
+          if ((effect as { name?: string }).name === "getTokenPrice") {
+            return { pricePerUSDNew: normalPrice };
+          }
+          return {};
+        });
+
+        await PriceOracle.refreshTokenPrice(
+          {
+            ...mockToken0Data,
+            symbol: "USDT",
+            pricePerUSDNew: 0n,
+            lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+          },
+          blockNumber,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        expect(updatedToken.pricePerUSDNew).toBe(normalPrice);
+      });
+
+      it("does NOT cap subsequent (non-first) fetches; spike guard takes over", async () => {
+        // Token already has a non-zero anchor — the cap path is for the first
+        // anchor only. A 4× jump from $5K to $20K is below the 10× spike
+        // threshold, so it should be persisted as-is. Pins the AC line that
+        // subsequent fetches are NOT capped.
+        const anchorPrice = 5_000n * 10n ** 18n;
+        const newPrice = 20_000n * 10n ** 18n;
+
+        vi.mocked(mockContext.effect)?.mockImplementation(async (effect) => {
+          if ((effect as { name?: string }).name === "getTokenPrice") {
+            return { pricePerUSDNew: newPrice };
+          }
+          return {};
+        });
+
+        await PriceOracle.refreshTokenPrice(
+          {
+            ...mockToken0Data,
+            symbol: "USDT",
+            pricePerUSDNew: anchorPrice,
+            lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+          },
+          blockNumber,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        expect(updatedToken.pricePerUSDNew).toBe(newPrice);
+        const warnCalls = vi.mocked(mockContext.log?.warn)?.mock.calls ?? [];
+        for (const [msg] of warnCalls) {
+          expect(msg).not.toContain("[FIRST_FETCH_CAP]");
+        }
+      });
+    });
+
     // Issue #694: V3 last-known-price fallback used `lastUpdatedTimestamp`
     // for two purposes — the 1-hour throttle and the 7-day staleness window
     // guarding the fallback. Because every refresh attempt (including those


### PR DESCRIPTION
## Summary

- Adds a `FIRST_FETCH_CAP = $10K` guard in `refreshTokenPrice` that rejects any first non-zero anchor write whose symbol does not contain `"BTC"` (case-insensitive)
- Closes the locked-anchor poisoning gap that PR #689's spike guard cannot cover — the very first non-zero oracle read has nothing to validate against, so an inflated read at first sight permanently poisons the anchor until the token is reactively blacklisted (PR #722's pattern)
- Rejection keeps `pricePerUSDNew = 0n` (existing safe path), bumps `lastUpdatedTimestamp` to preserve the 1-hour throttle, and logs `[FIRST_FETCH_CAP]` so the next refresh can self-heal if the oracle stabilizes below the cap
- Cap is calibrated against the deployed indexer: empirical scan found zero legitimate non-BTC tokens ever priced above $10K — every >$10K observation was a known poison case handled by REBIND / BLACKLIST / stablecoin pin

## Test plan

- [x] `pnpm test:file test/PriceOracle.test.ts` — 44 tests pass (38 existing + 6 new)
- [x] `pnpm qa --write` — clean
- [x] `tsc --noEmit` — clean
- [x] Non-BTC first-fetch >$10K rejected, logs `[FIRST_FETCH_CAP]`, writes `price=0n`
- [x] BTC-symbol first-fetch >$10K accepted (WBTC at $80K)
- [x] Case-insensitive `BTC` substring match (lowercase `cbbtc` accepted)
- [x] Non-BTC first-fetch at exactly $10K accepted (cap is strict `>`)
- [x] Non-BTC first-fetch well below cap accepted (sanity)
- [x] Subsequent non-first fetches NOT capped; spike guard takes over
- [ ] Post-deploy: run the AC's audit query against Hasura to confirm no inflated first-fetches slip through *(needs human — Hasura access)*

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)