### PR TITLE
docs(schema): note legacy $0 totalEmissionsUSD on 188 pre-oracle pools (#738)

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -34,6 +34,13 @@ type Pool {
   totalVotesDeposited: BigInt! @config(precision: 76) # total votes deposited in veToken units
   totalVotesDepositedUSD: BigInt! @config(precision: 76) # total votes deposited in USD
   totalEmissions: BigInt! @config(precision: 76) # total emissions for the pool in reward token units (VELO form Optimism and AERO for Base)
+  # Cumulative across all DistributeReward events using the reward token's price at
+  # each event's block (incrementalTotalEmissionsUSD = amount × pricePerUSDNew, see
+  # src/EventHandlers/Voter/VoterCommonLogic.ts). For gauges that stopped emitting
+  # before the chain's V3 oracle reliably priced the reward token (AERO/Base pre
+  # 2024-06-14, VELO/OP pre 2024-01-10), this cumulative will be permanently $0
+  # even when totalEmissions > 0 — affects 188 legacy pools (143 Base + 45 OP).
+  # See issue #738 for context.
   totalEmissionsUSD: BigInt! @config(precision: 76) # total emissions for the pool in USD
   totalEmissionsRedistributed: BigInt! @config(precision: 76) # cumulative reward tokens this pool's gauge received from the Redistributor (Redistributed events)
   totalEmissionsForfeited: BigInt! @config(precision: 76) # cumulative reward tokens this pool's gauge forwarded to the Redistributor or minter because it was over its cap (Deposited events)


### PR DESCRIPTION
## Summary

- Adds a multi-line `#` comment above `Pool.totalEmissionsUSD` in `schema.graphql` documenting that 143 Base + 45 OP gauges (188 total) have `totalEmissions > 0` but `totalEmissionsUSD = 0` because they stopped emitting before the chain's V3 oracle reliably priced the reward token (AERO/Base pre 2024-06-14, VELO/OP pre 2024-01-10).
- This is **accepted legacy state**, not a code fix — companion note to #673/#685. There is no in-handler recovery path since `incrementalTotalEmissionsUSD = amount × pricePerUSDNew` and historical `pricePerUSDNew = 0n` at the relevant blocks.

Closes #738.

## Test plan

- [x] Note added to `schema.graphql` (CONTEXT.md does not exist at repo root, so schema is the chosen convention)
- [x] References issue #738 in the comment block
- [x] No code logic changed — pure schema comment; generated types unchanged
- [x] `pnpm qa --write` clean (262 files, no fixes applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation for the totalEmissionsUSD field, providing clarity on how cumulative emissions in USD are calculated and addressing edge cases where values may remain zero.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/velodrome-finance/indexer/pull/739?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->