### PR TITLE
fix(swap): gate single-leg volume fallback on whitelist (closes #737)

### DIFF
--- a/src/EventHandlers/CLPool/CLPoolSwapLogic.ts
+++ b/src/EventHandlers/CLPool/CLPoolSwapLogic.ts
@@ -73,10 +73,16 @@ export function calculateSwapVolume(
       )
     : 0n;
 
-  // Pick the more-trusted USD leg — min when both are priced, fallback to the
-  // non-zero one otherwise. Guards against scam-token / poisoned-oracle
-  // inflation poisoning aggregate volume (issue #699).
-  const volumeInUSD = pickTrustedSwapVolumeUSD(token0UsdValue, token1UsdValue);
+  // Pick the more-trusted USD leg — min when both are priced; single-leg
+  // fallback is gated on the priced token being whitelisted, which guards
+  // against scam-token / poisoned-oracle inflation poisoning aggregate
+  // volume (issues #699 and #737).
+  const volumeInUSD = pickTrustedSwapVolumeUSD(
+    token0UsdValue,
+    token1UsdValue,
+    token0Instance?.isWhitelisted ?? false,
+    token1Instance?.isWhitelisted ?? false,
+  );
 
   // Calculate whitelisted volume (at least one token must be whitelisted,
   // consistent with calculateWhitelistedFeesUSD which uses the same rule)

--- a/src/EventHandlers/Pool/PoolSwapLogic.ts
+++ b/src/EventHandlers/Pool/PoolSwapLogic.ts
@@ -36,10 +36,16 @@ export function processPoolSwap(
     token1Instance.pricePerUSDNew,
   );
 
-  // Pick the more-trusted USD leg — min when both are priced, fallback to the
-  // non-zero one otherwise. Guards against scam-token / poisoned-oracle
-  // inflation poisoning aggregate volume (issue #699).
-  const volumeInUSD = pickTrustedSwapVolumeUSD(token0UsdValue, token1UsdValue);
+  // Pick the more-trusted USD leg — min when both are priced; single-leg
+  // fallback is gated on the priced token being whitelisted, which guards
+  // against scam-token / poisoned-oracle inflation poisoning aggregate
+  // volume (issues #699 and #737).
+  const volumeInUSD = pickTrustedSwapVolumeUSD(
+    token0UsdValue,
+    token1UsdValue,
+    token0Instance.isWhitelisted,
+    token1Instance.isWhitelisted,
+  );
 
   // Calculate whitelisted volume (at least one token must be whitelisted,
   // consistent with calculateWhitelistedFeesUSD which uses the same rule)

--- a/src/Helpers.ts
+++ b/src/Helpers.ts
@@ -85,22 +85,34 @@ export function calculateTokenAmountUSD(
  * prices (poisoned oracle paths, scam tokens) are universally *inflated*
  * — see issue #699, where a fake-USDC's `pricePerUSDNew` of ~1.5e35 polluted
  * `totalVolumeUSD` for any pool paired against it. The honest leg is reliably
- * the smaller of the two. When only one leg is priced (the other is `0n` or
- * `undefined`), falls back to that leg.
+ * the smaller of the two.
+ *
+ * When only one leg is priced (the other is `0n` or `undefined`), the
+ * single-leg fallback is only trusted when the priced token is whitelisted.
+ * For non-whitelisted single-leg cases the function returns `0n` — issue
+ * #737 documented a Ragdoll/RAGDOLL pair where token0's `pricePerUSDNew = 0`
+ * paired with token1's inflated $0.998 (non-whitelisted) yielded a
+ * $1.125e19 phantom volume. Restricting the fallback to whitelisted tokens
+ * closes that residual of #699.
  *
  * @param token0UsdValue - Token0's USD leg, or `undefined` when token0 is unpriced
  * @param token1UsdValue - Token1's USD leg, or `undefined` when token1 is unpriced
- * @returns The picked volume in USD, or `0n` when neither leg is priced
+ * @param token0IsWhitelisted - Whether token0 is on the canonical whitelist
+ * @param token1IsWhitelisted - Whether token1 is on the canonical whitelist
+ * @returns The picked volume in USD, or `0n` when neither leg is priced — or
+ *   when only one leg is priced and that leg's token is not whitelisted
  */
 export function pickTrustedSwapVolumeUSD(
   token0UsdValue: bigint | undefined,
   token1UsdValue: bigint | undefined,
+  token0IsWhitelisted: boolean,
+  token1IsWhitelisted: boolean,
 ): bigint {
   const t0 = token0UsdValue ?? 0n;
   const t1 = token1UsdValue ?? 0n;
   if (t0 !== 0n && t1 !== 0n) return t0 < t1 ? t0 : t1;
-  if (t0 !== 0n) return t0;
-  if (t1 !== 0n) return t1;
+  if (t0 !== 0n) return token0IsWhitelisted ? t0 : 0n;
+  if (t1 !== 0n) return token1IsWhitelisted ? t1 : 0n;
   return 0n;
 }
 

--- a/test/EventHandlers/CLPool/CLPoolSwapLogic.test.ts
+++ b/test/EventHandlers/CLPool/CLPoolSwapLogic.test.ts
@@ -110,7 +110,10 @@ describe("CLPoolSwapLogic", () => {
       expect(result.volumeInUSDWhitelisted).toBe(0n); // Neither token is whitelisted
     });
 
-    it("should calculate volume using token1 when token0 value is zero", () => {
+    it("refuses single-leg fallback when the priced leg is not whitelisted (#737)", () => {
+      // token0 has amount=0 → unpriced. token1 priced ($4) but isWhitelisted=false.
+      // The Ragdoll-pair case: returning t1 here would let an unverified token's
+      // price (potentially inflated) poison aggregate volume. Expect 0n.
       const eventWithZeroToken0: CLPool_Swap_event = {
         ...mockEvent,
         params: { ...mockEvent.params, amount0: 0n },
@@ -120,6 +123,24 @@ describe("CLPoolSwapLogic", () => {
         eventWithZeroToken0,
         mockToken0,
         mockToken1,
+      );
+
+      expect(result.volumeInUSD).toBe(0n);
+    });
+
+    it("trusts single-leg fallback when the priced leg IS whitelisted", () => {
+      // Mirror of the #737 case, but with the priced token whitelisted:
+      // we trust the canonical-token amount as the swap's USD volume.
+      const eventWithZeroToken0: CLPool_Swap_event = {
+        ...mockEvent,
+        params: { ...mockEvent.params, amount0: 0n },
+      };
+      const whitelistedToken1: Token = { ...mockToken1, isWhitelisted: true };
+
+      const result = calculateSwapVolume(
+        eventWithZeroToken0,
+        mockToken0,
+        whitelistedToken1,
       );
 
       // token1: 2 tokens * $2 = $4

--- a/test/EventHandlers/Pool/PoolSwapLogic.test.ts
+++ b/test/EventHandlers/Pool/PoolSwapLogic.test.ts
@@ -200,7 +200,7 @@ describe("PoolSwapLogic", () => {
       expect(result.liquidityPoolDiff?.incrementalTotalVolumeUSD).toBe(1000n);
     });
 
-    it("should use token1 USD value when token0 is zero", () => {
+    it("should use token1 USD value when token0 is zero AND token1 is whitelisted", () => {
       const eventWithZeroToken0: Pool_Swap_event = {
         ...mockEvent,
         params: {
@@ -210,6 +210,7 @@ describe("PoolSwapLogic", () => {
         },
       };
 
+      // mockToken0/mockToken1 both default to isWhitelisted: true
       const result = processPoolSwap(
         eventWithZeroToken0,
         mockToken0,
@@ -225,6 +226,32 @@ describe("PoolSwapLogic", () => {
       expect(result.liquidityPoolDiff?.incrementalTotalVolumeUSD).toBe(
         500000000000000n,
       );
+    });
+
+    it("returns 0 volume when token0 is zero AND token1 is not whitelisted (#737)", () => {
+      // Ragdoll-pair regression: pool with unpriced token0 + non-whitelisted
+      // priced token1 must not contribute any volume. The pool
+      // 8453-0x0129798a373f68b47AaE97d8562d861F10967650 produced a
+      // $1.125e19 phantom volume from exactly this shape.
+      const eventWithZeroToken0: Pool_Swap_event = {
+        ...mockEvent,
+        params: {
+          ...mockEvent.params,
+          amount0In: 0n,
+          amount0Out: 0n,
+        },
+      };
+
+      const result = processPoolSwap(
+        eventWithZeroToken0,
+        { ...mockToken0, isWhitelisted: false },
+        { ...mockToken1, isWhitelisted: false },
+      );
+
+      expect(result.liquidityPoolDiff?.incrementalTotalVolumeUSD).toBe(0n);
+      expect(
+        result.liquidityPoolDiff?.incrementalTotalVolumeUSDWhitelisted,
+      ).toBe(0n);
     });
 
     it("should handle undefined token0UsdValue when both tokens are whitelisted", () => {

--- a/test/Helpers.test.ts
+++ b/test/Helpers.test.ts
@@ -1030,25 +1030,40 @@ describe("Helpers", () => {
   });
 
   describe("pickTrustedSwapVolumeUSD", () => {
-    it("returns min when both legs are non-zero", () => {
-      expect(pickTrustedSwapVolumeUSD(100n, 99n)).toBe(99n);
-      expect(pickTrustedSwapVolumeUSD(99n, 100n)).toBe(99n);
+    it("returns min when both legs are non-zero (whitelist irrelevant)", () => {
+      expect(pickTrustedSwapVolumeUSD(100n, 99n, true, true)).toBe(99n);
+      expect(pickTrustedSwapVolumeUSD(99n, 100n, true, true)).toBe(99n);
+      expect(pickTrustedSwapVolumeUSD(100n, 99n, false, false)).toBe(99n);
     });
 
-    it("falls back to the non-zero leg when one is zero", () => {
-      expect(pickTrustedSwapVolumeUSD(0n, 500n)).toBe(500n);
-      expect(pickTrustedSwapVolumeUSD(500n, 0n)).toBe(500n);
+    it("falls back to the non-zero leg when one is zero and that leg is whitelisted", () => {
+      expect(pickTrustedSwapVolumeUSD(0n, 500n, true, true)).toBe(500n);
+      expect(pickTrustedSwapVolumeUSD(500n, 0n, true, true)).toBe(500n);
     });
 
-    it("treats undefined as zero", () => {
-      expect(pickTrustedSwapVolumeUSD(undefined, 500n)).toBe(500n);
-      expect(pickTrustedSwapVolumeUSD(500n, undefined)).toBe(500n);
+    it("returns 0n when only one leg is priced AND that leg is not whitelisted (#737)", () => {
+      // Ragdoll / RAGDOLL case: token0 unpriced, token1 priced but non-whitelisted.
+      // Old behaviour returned token1's value (potentially inflated). New behaviour
+      // returns 0n to refuse the suspect single-leg fallback.
+      expect(pickTrustedSwapVolumeUSD(0n, 500n, true, false)).toBe(0n);
+      // Symmetric: token1 unpriced, token0 priced but non-whitelisted.
+      expect(pickTrustedSwapVolumeUSD(500n, 0n, false, true)).toBe(0n);
+    });
+
+    it("treats undefined as zero (whitelisted fallback still allowed)", () => {
+      expect(pickTrustedSwapVolumeUSD(undefined, 500n, true, true)).toBe(500n);
+      expect(pickTrustedSwapVolumeUSD(500n, undefined, true, true)).toBe(500n);
+      // And refuses undefined-paired non-whitelisted single legs.
+      expect(pickTrustedSwapVolumeUSD(undefined, 500n, true, false)).toBe(0n);
+      expect(pickTrustedSwapVolumeUSD(500n, undefined, false, true)).toBe(0n);
     });
 
     it("returns 0n when both legs are zero/undefined", () => {
-      expect(pickTrustedSwapVolumeUSD(0n, 0n)).toBe(0n);
-      expect(pickTrustedSwapVolumeUSD(undefined, undefined)).toBe(0n);
-      expect(pickTrustedSwapVolumeUSD(undefined, 0n)).toBe(0n);
+      expect(pickTrustedSwapVolumeUSD(0n, 0n, true, true)).toBe(0n);
+      expect(pickTrustedSwapVolumeUSD(undefined, undefined, true, true)).toBe(
+        0n,
+      );
+      expect(pickTrustedSwapVolumeUSD(undefined, 0n, true, true)).toBe(0n);
     });
   });
 });


### PR DESCRIPTION
## Why this PR is needed

`pickTrustedSwapVolumeUSD` was added in PR #715 to fix #699 — it picks `min(t0, t1)` when both swap legs have a USD value, so a corrupted oracle reading on one side is discarded by the honest side. That worked for the both-priced case.

But when only **one** leg is priced, there is no min to take. The function just returned that leg. That fallback is fine when the priced leg is a canonical token (WETH, USDC, etc.) and dangerous when it isn't — a non-whitelisted token with a plausible-looking-but-wrong stored price will pollute aggregate volume by orders of magnitude.

**Verified case — Ragdoll/RAGDOLL pool on Base** (`8453-0x0129798a373f68b47AaE97d8562d861F10967650`):
- token0 `Ragdoll`: `pricePerUSDNew = 0` (failed oracle)
- token1 `RAGDOLL`: `pricePerUSDNew ≈ $0.998` (looks fine, but the on-chain DAI/RAGDOLL pool has 9.97e9 RAGDOLL vs **1 wei DAI** — reserve-implied real price ≈ $10⁻²⁸, off by ~10²⁸×)
- `totalVolumeUSD` recorded: **$1.125 × 10¹⁹** (eleven quintillion dollars from 3 swaps)

A scan against the live indexer found **46 pools** matching the same `wl=0` + absurd-volume shape; none of them are caught by the existing `pricePerUSDNew > 10²⁸` BLACKLIST heuristic because the stored *prices* look plausible — it's the *product* that explodes.

## How the fix behaves — worked examples

All USD values shown below are in the indexer's 1e18-fixed precision; `$1 = 1_000000000000000000n`.

### Example 1 — Both legs priced (healthy WETH/USDC swap)

| | token0 (WETH) | token1 (USDC) |
|---|---|---|
| Leg USD value | $2,500 | $2,500 |
| Whitelisted? | true | true |

```ts
pickTrustedSwapVolumeUSD($2500, $2500, true, true)
→ both nonzero → return min($2500, $2500) = $2500
```
**Result: $2,500.** Whitelist booleans don't matter in this branch.

### Example 2 — Both priced but one is corrupted (#699 case)

`WETH/fakeUSDC`, fakeUSDC oracle reports `$10⁵` per token, user swaps 1 WETH.

| | token0 (WETH) | token1 (fakeUSDC) |
|---|---|---|
| Leg USD value | $2,500 | $250,000,000 |
| Whitelisted? | true | false |

```ts
pickTrustedSwapVolumeUSD($2500, $250_000_000, true, false)
→ both nonzero → return min(...) = $2500
```
**Result: $2,500.** The #699 `min` guard discards the inflated leg.

### Example 3 — Only one leg priced, that leg IS whitelisted

`WETH/RandomNewToken`, RandomNewToken has no oracle yet, user swaps 1 WETH.

| | token0 (WETH) | token1 (RandomNewToken) |
|---|---|---|
| Leg USD value | $2,500 | `0n` |
| Whitelisted? | true | false |

```ts
pickTrustedSwapVolumeUSD($2500, 0n, true, false)
→ t1 zero, t0 nonzero → token0IsWhitelisted ? t0 : 0n
→ true ? $2500 : 0n → $2500
```
**Result: $2,500.** WETH is canonical; single-leg fallback trusted. Same as old behavior.

### Example 4 — Only one leg priced, that leg is NOT whitelisted (#737 Ragdoll)

`Ragdoll/RAGDOLL`. token0 unpriced; token1 has the locked-anchor $0.998. Single swap is ~4e18 normalized units of RAGDOLL.

| | token0 (Ragdoll) | token1 (RAGDOLL) |
|---|---|---|
| Leg USD value | `0n` | ~$3.7 × 10¹⁸ (fantasy) |
| Whitelisted? | false | false |

**Old behavior (before #740):**
```ts
pickTrustedSwapVolumeUSD(0n, $3.7e18)
→ t0 zero, t1 nonzero → return t1
→ $3.7 × 10¹⁸  ← poisons aggregate volume
```

**New behavior (this PR):**
```ts
pickTrustedSwapVolumeUSD(0n, $3.7e18, false, false)
→ t0 zero, t1 nonzero → token1IsWhitelisted ? t1 : 0n
→ false ? ... : 0n → 0n
```
**Result: $0.** The 46 Ragdoll-class pools all hit this branch.

### Example 5 — Symmetric: t1 unpriced, t0 priced non-whitelisted

| | token0 (Memecoin) | token1 (Unpriced) |
|---|---|---|
| Leg USD value | $1,000,000 | `0n` |
| Whitelisted? | false | false |

```ts
pickTrustedSwapVolumeUSD($1_000_000, 0n, false, false)
→ t0 nonzero, t1 zero → token0IsWhitelisted ? t0 : 0n → 0n
```
**Result: $0.** Same defense, mirrored.

### Example 6 — Neither leg priced

```ts
pickTrustedSwapVolumeUSD(0n, 0n, false, false) → 0n
```
**Result: $0.** Unchanged.

### Summary of behavior changes

| Scenario | Old (PR #715) | New (PR #740) |
|---|---|---|
| Both priced (healthy) | `min` | `min` |
| Both priced, one corrupted | `min` (= honest leg) | `min` (= honest leg) |
| Single leg priced, whitelisted | leg value | leg value |
| **Single leg priced, NOT whitelisted** | **leg value (poison)** | **`0n`** |
| Neither priced | `0n` | `0n` |

Only the bolded row changed.

## Summary
- Tightens `pickTrustedSwapVolumeUSD` so the single-leg fallback is only trusted when the priced token is whitelisted. Non-whitelisted single-leg cases now return `0n`, refusing to feed unverified prices into aggregate volume.
- Closes the #699 residual surfaced as #737: the Ragdoll/RAGDOLL pair on Base (`0x0129798a373f68b47AaE97d8562d861F10967650`) produced a \$1.125e19 phantom volume because token0 was unpriced and token1 was non-whitelisted with an inflated \$0.998 price.
- Plumbs `isWhitelisted` through both swap-volume callers (`PoolSwapLogic`, `CLPoolSwapLogic`). Min-leg behavior when both legs are priced (the #699 fix) is unchanged.

## Acceptance criteria
- [x] `pickTrustedSwapVolumeUSD` accepts whitelisted flags for both legs
- [x] `t0===0 && t1!==0` returns t1 only if token1 whitelisted, else `0n`
- [x] Symmetric: `t1===0 && t0!==0` returns t0 only if token0 whitelisted, else `0n`
- [x] Min-USD-leg behavior preserved when both legs are priced (no #699 regression)
- [x] Ragdoll-pair regression test added at helper + Pool + CL caller layers
- [x] Whitelisted single-side regression test added at helper + Pool + CL caller layers
- [x] Callers in `PoolSwapLogic.ts` and `CLPoolSwapLogic.ts` plumb `isWhitelisted` through

## Test plan
- [x] `pnpm test:file test/Helpers.test.ts test/EventHandlers/Pool/PoolSwapLogic.test.ts test/EventHandlers/CLPool/CLPoolSwapLogic.test.ts` — 87/87 green
- [x] `tsc --noEmit` after `pnpm envio codegen` — no errors
- [x] `pnpm qa --write` — clean (no fixes applied)

## Empirical coverage (live indexer audit)

Queried the live indexer for pools with `totalVolumeUSDWhitelisted = 0 AND totalVolumeUSD > $1T-equivalent`:
- **46 pools** match the Ragdoll signature, across Base (45) and Optimism (1).
- **56 distinct non-whitelisted tokens** involved.
- **0** of those tokens are caught by the existing `pricePerUSDNew > 10²⁸` BLACKLIST (their stored prices look plausible).
- **0** pools in the $1B+ range with a whitelisted leg show any corruption — bucket separation between `wl=0` (broken) and `wl>0` (legitimate Aerodrome/Velodrome blue-chip pairs) is clean.

The fix is forward-only — existing polluted `totalVolumeUSD` totals on the 46 pools require a reindex or one-shot SQL update to heal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)