### PR TITLE
fix(swap-fee): derive fee USD from trusted volume (closes #733)

### DIFF
--- a/src/EventHandlers/CLPool/CLPoolSwapLogic.ts
+++ b/src/EventHandlers/CLPool/CLPoolSwapLogic.ts
@@ -12,6 +12,13 @@ import {
 } from "../../Helpers";
 import { abs } from "../../Maths";
 
+// Issue #733 / regression of #670: fees USD must respect the fundamental AMM
+// invariant `cumulative_fees ≤ cumulative_volume × fee_ratio`. Pricing the fee
+// off the input leg's `pricePerUSDNew` inherits poisoned/scam-token prices that
+// the volume path already defends against via `pickTrustedSwapVolumeUSD` — this
+// produced 160 Base pools with `totalFeesGeneratedUSD` up to 10²³× volume.
+// Deriving fee USD from the already-trusted volume restores the invariant.
+
 export interface CLPoolSwapResult {
   liquidityPoolDiff: Partial<PoolDiff>;
   userSwapDiff: Partial<UserStatsPerPoolDiff>;
@@ -92,15 +99,31 @@ export function calculateSwapVolume(
 }
 
 /**
- * Calculates swap fees
- * Fees are stored in 1e18 precision (like USD values) to preserve accuracy
- * Exported for testing purposes only
+ * Calculates swap fees.
+ *
+ * Raw fee amounts (`swapFeesInToken0`, `swapFeesInToken1`) come directly from the
+ * input side of the swap and the pool's fee rate, normalized to 1e18 precision.
+ * USD value (`swapFeesInUSD`) is derived from the already-trusted `volumeInUSD`
+ * via `volumeInUSD × feeRate / CL_FEE_SCALE` — this enforces the AMM invariant
+ * `fees ≤ volume × feeRate` by construction and inherits the volume path's
+ * `pickTrustedSwapVolumeUSD` defense against poisoned-price tokens (issue #733).
+ *
+ * Exported for testing purposes only.
+ *
+ * @param event - CLPool Swap event
+ * @param liquidityPoolAggregator - Pool entity providing the fee rate
+ * @param token0Instance - Token0 for decimals lookup (price unused for USD)
+ * @param token1Instance - Token1 for decimals lookup (price unused for USD)
+ * @param volumeInUSD - Already-trusted swap volume in USD (from `calculateSwapVolume`)
+ * @param context - Handler context for error logging
+ * @returns Raw token-unit fees plus invariant-respecting USD fee
  */
 export function calculateSwapFees(
   event: CLPool_Swap_event,
   liquidityPoolAggregator: Pool,
   token0Instance: Token | undefined,
   token1Instance: Token | undefined,
+  volumeInUSD: bigint,
   context: handlerContext,
 ): SwapFees {
   // Get the current fee, falling back to baseFee if currentFee is undefined
@@ -143,21 +166,8 @@ export function calculateSwapFees(
     token1Decimals,
   );
 
-  // Calculate USD value from the input-side fee only
-  let swapFeesInUSD = 0n;
-  if (swapFeesInToken0Raw > 0n && token0Instance?.pricePerUSDNew) {
-    swapFeesInUSD = calculateTokenAmountUSD(
-      swapFeesInToken0Raw,
-      token0Decimals,
-      token0Instance.pricePerUSDNew,
-    );
-  } else if (swapFeesInToken1Raw > 0n && token1Instance?.pricePerUSDNew) {
-    swapFeesInUSD = calculateTokenAmountUSD(
-      swapFeesInToken1Raw,
-      token1Decimals,
-      token1Instance.pricePerUSDNew,
-    );
-  }
+  // Derive fee USD from trusted volume — see file header for the #733 rationale.
+  const swapFeesInUSD = (volumeInUSD * fee) / CL_FEE_SCALE;
 
   return {
     swapFeesInToken0,
@@ -189,6 +199,7 @@ function calculateSwapVolumeAndFees(
       liquidityPoolAggregator,
       token0Instance,
       token1Instance,
+      volumeInUSD,
       context,
     );
 

--- a/src/EventHandlers/Pool/PoolFeesLogic.ts
+++ b/src/EventHandlers/Pool/PoolFeesLogic.ts
@@ -1,7 +1,11 @@
 import type { Pool_Fees_event, Token } from "generated";
 import type { PoolDiff } from "../../Aggregators/Pool";
 import type { UserStatsPerPoolDiff } from "../../Aggregators/UserStatsPerPool";
-import { calculateTotalUSD, calculateWhitelistedFeesUSD } from "../../Helpers";
+import {
+  calculateTokenAmountUSD,
+  calculateWhitelistedFeesUSD,
+  pickTrustedSwapVolumeUSD,
+} from "../../Helpers";
 
 export interface PoolFeesResult {
   liquidityPoolDiff?: Partial<PoolDiff>;
@@ -9,23 +13,45 @@ export interface PoolFeesResult {
 }
 
 /**
- * Process fees event using already-refreshed token prices from loadPoolData
- * This matches CLPoolCollectFeesLogic and CLPoolCollectLogic pattern
- * For regular pools (non-CL), fees are tracked as unstaked fees
- * since regular pools don't have the staked/unstaked distinction that CL pools have
+ * Process fees event using already-refreshed token prices from loadPoolData.
+ *
+ * For regular pools (non-CL), fees are tracked as unstaked fees since regular
+ * pools don't have the staked/unstaked distinction that CL pools have.
+ *
+ * USD fee value uses `pickTrustedSwapVolumeUSD` (smaller of the two priced legs)
+ * rather than summing both legs — Velodrome V2 takes the fee from the input
+ * side only, so at most one leg is non-zero per event in practice. Summing
+ * inherits poisoned/scam-token prices that volume already defends against
+ * (issue #733, regression of #670). Picking the trusted leg keeps the fee/volume
+ * USD paths symmetric.
+ *
+ * @param event - V2 Pool Fees event
+ * @param token0Instance - Token0 entity with price and decimals
+ * @param token1Instance - Token1 entity with price and decimals
+ * @returns Pool and user diffs with raw token-unit fees and trusted-leg USD fee
  */
 export function processPoolFees(
   event: Pool_Fees_event,
   token0Instance: Token | undefined,
   token1Instance: Token | undefined,
 ): PoolFeesResult {
-  // Calculate total fees USD using already-refreshed token prices
-  const totalFeesUSD = calculateTotalUSD(
-    event.params.amount0,
-    event.params.amount1,
-    token0Instance,
-    token1Instance,
-  );
+  // Symmetric defense with the volume path: price each leg independently, then
+  // pick the trusted (smaller / non-zero fallback) leg. Issue #733.
+  const token0FeeUSD = token0Instance
+    ? calculateTokenAmountUSD(
+        event.params.amount0,
+        Number(token0Instance.decimals),
+        token0Instance.pricePerUSDNew,
+      )
+    : 0n;
+  const token1FeeUSD = token1Instance
+    ? calculateTokenAmountUSD(
+        event.params.amount1,
+        Number(token1Instance.decimals),
+        token1Instance.pricePerUSDNew,
+      )
+    : 0n;
+  const totalFeesUSD = pickTrustedSwapVolumeUSD(token0FeeUSD, token1FeeUSD);
 
   const totalFeesUSDWhitelisted = calculateWhitelistedFeesUSD(
     event.params.amount0,

--- a/test/EventHandlers/CLPool/CLPoolSwapLogic.test.ts
+++ b/test/EventHandlers/CLPool/CLPoolSwapLogic.test.ts
@@ -219,19 +219,30 @@ describe("CLPoolSwapLogic", () => {
   });
 
   describe("calculateSwapFees", () => {
+    // Pre-compute the trusted volume that the swap path produces for `mockEvent`
+    // so the fee-USD expectations below are tied to the same input the
+    // production wiring uses (`calculateSwapVolume` → `calculateSwapFees`).
+    const trustedVolumeForMockEvent = calculateSwapVolume(
+      mockEvent,
+      mockToken0,
+      mockToken1,
+    ).volumeInUSD;
+
     it("should calculate fees correctly with currentFee", () => {
       const result = calculateSwapFees(
         mockEvent,
         mockPool,
         mockToken0,
         mockToken1,
+        trustedVolumeForMockEvent,
         mockContext,
       );
 
       // Fee = 3000 (0.3% in 1e6 scale), only charged on input token (positive amount)
       // token0 (input, +1e18): (1e18 * 3000) / 1000000 = 3e15, normalized to 1e18: 3e15
       // token1 (output, -2e18): 0 (fees only on input side)
-      // USD: calculateTokenAmountUSD(3e15, 18, 1e18) = 3e15
+      // USD now derived from trusted volume: volumeInUSD ($1) × feeRate / scale
+      //        = 1e18 × 3000 / 1e6 = 3e15
       expect(result.swapFeesInToken0).toBe(3000000000000000n); // 3e15
       expect(result.swapFeesInToken1).toBe(0n); // output side — no fee
       expect(result.swapFeesInUSD).toBe(3000000000000000n); // 3e15
@@ -249,6 +260,7 @@ describe("CLPoolSwapLogic", () => {
         poolWithBaseFee,
         mockToken0,
         mockToken1,
+        trustedVolumeForMockEvent,
         mockContext,
       );
 
@@ -271,6 +283,7 @@ describe("CLPoolSwapLogic", () => {
         poolWithoutFee,
         mockToken0,
         mockToken1,
+        trustedVolumeForMockEvent,
         mockContext,
       );
 
@@ -298,6 +311,7 @@ describe("CLPoolSwapLogic", () => {
         mockPool,
         tokenWith6Decimals,
         mockToken1,
+        trustedVolumeForMockEvent,
         mockContext,
       );
 
@@ -308,36 +322,48 @@ describe("CLPoolSwapLogic", () => {
       expect(result.swapFeesInToken1).toBe(0n); // output side — no fee
     });
 
-    it("should calculate USD fees using token0 price when available", () => {
+    it("should derive USD fee from trusted volume rather than re-pricing the input leg", () => {
       const result = calculateSwapFees(
         mockEvent,
         mockPool,
         mockToken0,
         mockToken1,
+        trustedVolumeForMockEvent,
         mockContext,
       );
 
-      // Same fee calculation as first test: 3e15
-      expect(result.swapFeesInUSD).toBe(3000000000000000n); // 3e15
+      // volumeInUSD × feeRate / CL_FEE_SCALE = 1e18 × 3000 / 1e6 = 3e15
+      expect(result.swapFeesInUSD).toBe(
+        (trustedVolumeForMockEvent * CL_FEE_30) / 1000000n,
+      );
     });
 
-    it("should return zero USD fees when input token has no price and output has no fee", () => {
+    it("should still derive USD when input token has no price, falling back to the priced output leg via trusted volume", () => {
       const token0WithZeroPrice: Token = {
         ...mockToken0,
         pricePerUSDNew: 0n,
       };
+
+      // Volume defends via pickTrustedSwapVolumeUSD; fee inherits the defended volume.
+      const fallbackVolume = calculateSwapVolume(
+        mockEvent,
+        token0WithZeroPrice,
+        mockToken1,
+      ).volumeInUSD;
 
       const result = calculateSwapFees(
         mockEvent,
         mockPool,
         token0WithZeroPrice,
         mockToken1,
+        fallbackVolume,
         mockContext,
       );
 
-      // token0 is input (amount0 > 0) but price is 0 → can't price the fee
-      // token1 is output (amount1 < 0) → no fee computed
-      expect(result.swapFeesInUSD).toBe(0n);
+      expect(fallbackVolume).toBeGreaterThan(0n);
+      expect(result.swapFeesInUSD).toBe(
+        (fallbackVolume * CL_FEE_30) / 1000000n,
+      );
     });
 
     it("should return zero USD fees when both token prices are unavailable", () => {
@@ -355,10 +381,57 @@ describe("CLPoolSwapLogic", () => {
         mockPool,
         token0WithZeroPrice,
         token1WithoutPrice,
+        0n,
         mockContext,
       );
 
       expect(result.swapFeesInUSD).toBe(0n);
+    });
+
+    // Regression test for issue #733: a swap where the input token has a
+    // poisoned/scam price must not produce fee USD that exceeds volume × feeRate.
+    // Pre-fix, the input leg's inflated price was multiplied through the fee
+    // computation, producing totalFeesGeneratedUSD up to 10²³× totalVolumeUSD.
+    it("should bound fee USD by trusted volume × feeRate when the input token has a poisoned price (issue #733)", () => {
+      const poisonedPrice = 10n ** 35n; // matches scam-token price range from issue #699
+      const honestPrice = 1n * TEN_TO_THE_18_BI; // $1
+
+      const poisonedToken0: Token = {
+        ...mockToken0,
+        pricePerUSDNew: poisonedPrice,
+      };
+      const honestToken1: Token = {
+        ...mockToken1,
+        pricePerUSDNew: honestPrice,
+      };
+
+      const { volumeInUSD } = calculateSwapVolume(
+        mockEvent,
+        poisonedToken0,
+        honestToken1,
+      );
+
+      const { swapFeesInUSD } = calculateSwapFees(
+        mockEvent,
+        mockPool,
+        poisonedToken0,
+        honestToken1,
+        volumeInUSD,
+        mockContext,
+      );
+
+      // Volume defends by picking the smaller (honest) leg.
+      const honestLegUSD = 2n * TEN_TO_THE_18_BI; // |amount1|=2e18 × $1
+      expect(volumeInUSD).toBe(honestLegUSD);
+
+      // Fee respects the invariant: fees ≤ volume × feeRate.
+      expect(swapFeesInUSD).toBe((volumeInUSD * CL_FEE_30) / 1000000n);
+      expect(swapFeesInUSD * 1000000n).toBeLessThanOrEqual(
+        volumeInUSD * CL_FEE_30,
+      );
+
+      // And critically, fee USD does not inherit the poisoned price magnitude.
+      expect(swapFeesInUSD).toBeLessThan(poisonedPrice);
     });
   });
 

--- a/test/EventHandlers/Pool/Fees.test.ts
+++ b/test/EventHandlers/Pool/Fees.test.ts
@@ -28,14 +28,29 @@ describe("Pool Fees Event", () => {
       mockToken1Data.pricePerUSDNew) /
       10n ** mockToken1Data.decimals;
 
-  expectations.totalFeesGeneratedUSD =
-    mockLiquidityPoolData.totalFeesGeneratedUSD +
+  // After issue #733: totalFeesGeneratedUSD increments by the *trusted* (smaller
+  // / non-zero fallback) leg rather than the sum, mirroring the volume defense
+  // against poisoned/scam-token prices. The whitelisted variant continues to
+  // sum the whitelisted legs (separate filter, separate accumulator).
+  const token0LegUSD =
     (expectations.amount0In / 10n ** mockToken0Data.decimals) *
-      mockToken0Data.pricePerUSDNew +
+    mockToken0Data.pricePerUSDNew;
+  const token1LegUSD =
     (expectations.amount1In / 10n ** mockToken1Data.decimals) *
-      mockToken1Data.pricePerUSDNew;
+    mockToken1Data.pricePerUSDNew;
+  const trustedLegUSD =
+    token0LegUSD === 0n
+      ? token1LegUSD
+      : token1LegUSD === 0n
+        ? token0LegUSD
+        : token0LegUSD < token1LegUSD
+          ? token0LegUSD
+          : token1LegUSD;
+  expectations.totalFeesGeneratedUSD =
+    mockLiquidityPoolData.totalFeesGeneratedUSD + trustedLegUSD;
 
-  expectations.totalFeesUSDWhitelisted = expectations.totalFeesGeneratedUSD;
+  expectations.totalFeesUSDWhitelisted =
+    mockLiquidityPoolData.totalFeesUSDWhitelisted + token0LegUSD + token1LegUSD;
 
   let updatedPool: PoolEntity | undefined;
   let createdUserStats: UserStatsPerPool | undefined;
@@ -128,12 +143,9 @@ describe("Pool Fees Event", () => {
       expectations.amount1In,
     );
 
-    const expectedUserFeesUSD =
-      (expectations.amount0In / 10n ** mockToken0Data.decimals) *
-        mockToken0Data.pricePerUSDNew +
-      (expectations.amount1In / 10n ** mockToken1Data.decimals) *
-        mockToken1Data.pricePerUSDNew;
-    expect(createdUserStats?.totalFeesContributedUSD).toBe(expectedUserFeesUSD);
+    // Per issue #733, user fee USD now follows the trusted-leg pick, same as
+    // the pool's totalFeesGeneratedUSD increment.
+    expect(createdUserStats?.totalFeesContributedUSD).toBe(trustedLegUSD);
   });
 
   it("should set correct timestamps for UserStatsPerPool entity", async () => {

--- a/test/EventHandlers/Pool/PoolFeesLogic.test.ts
+++ b/test/EventHandlers/Pool/PoolFeesLogic.test.ts
@@ -94,23 +94,25 @@ describe("PoolFeesLogic", () => {
     });
 
     describe("fee calculation", () => {
-      it("should calculate USD fees correctly", () => {
+      it("should pick the trusted (smaller) leg for totalFeesGeneratedUSD (issue #733)", () => {
         const result = processPoolFees(
           mockEvent,
           mockToken0Data,
           mockToken1Data,
         );
 
-        // Calculate expected USD values
-        // token0: 1000n (18 decimals) * 1 USD = 1000n USD (normalized to 1e18)
-        // token1: 2000n (6 decimals) * 1 USD = 2000n * 10^12 = 2000000000000000n USD (normalized to 1e18)
-        // totalFeesUSD = 1000n + 2000000000000000n = 2000000000001000n
-        // totalFeesUSDWhitelisted = same (both tokens are whitelisted)
-        const expectedToken0FeesUSD = 1000n; // 1000n * 10^18 / 10^18 * 1e18 / 1e18 = 1000n
-        const expectedToken1FeesUSD = 2000000000000000n; // 2000n * 10^18 / 10^6 * 1e18 / 1e18 = 2000000000000000n
-        const expectedTotalFeesUSD =
-          expectedToken0FeesUSD + expectedToken1FeesUSD; // 2000000000001000n
-        const expectedTotalFeesUSDWhitelisted = expectedTotalFeesUSD; // Both tokens are whitelisted
+        // Per-leg USD values (each priced independently):
+        //   token0: 1000n (18 decimals) * 1 USD → 1000n
+        //   token1: 2000n (6 decimals)  * 1 USD → 2_000_000_000_000_000n
+        // pickTrustedSwapVolumeUSD returns the smaller leg to defend against
+        // scam-token/poisoned-oracle inflation (issue #733).
+        const expectedToken0FeesUSD = 1000n;
+        const expectedTotalFeesUSD = expectedToken0FeesUSD;
+        // Whitelisted total still sums both whitelisted legs (whitelist filter
+        // is the existing defense for that field — separate from the #733 path).
+        const expectedToken1FeesUSD = 2000000000000000n;
+        const expectedTotalFeesUSDWhitelisted =
+          expectedToken0FeesUSD + expectedToken1FeesUSD;
 
         expect(result.liquidityPoolDiff).toBeDefined();
         expect(result.liquidityPoolDiff?.incrementalTotalFeesGeneratedUSD).toBe(
@@ -119,6 +121,35 @@ describe("PoolFeesLogic", () => {
         expect(
           result.liquidityPoolDiff?.incrementalTotalFeesUSDWhitelisted,
         ).toBe(expectedTotalFeesUSDWhitelisted);
+      });
+
+      // Regression for issue #733: a Fees event whose only non-zero leg is on
+      // a poisoned-price token must not inflate totalFeesGeneratedUSD through
+      // the legitimately-priced counterpart. Both legs are priced independently
+      // and the trusted (smaller / non-zero fallback) leg is taken.
+      it("should not inherit a poisoned-price leg when the counterpart leg is honest (issue #733)", () => {
+        const poisonedPrice = 10n ** 35n;
+        const poisonedToken0: Token = {
+          ...mockToken0Data,
+          pricePerUSDNew: poisonedPrice,
+        };
+        // Honest fee on token1 only; token0 (poisoned) amount is 0 in this event.
+        const event: Pool_Fees_event = {
+          ...mockEvent,
+          params: { ...mockEvent.params, amount0: 0n, amount1: 2000n },
+        };
+
+        const result = processPoolFees(event, poisonedToken0, mockToken1Data);
+
+        // Only the honest leg is non-zero, so the trusted-leg pick returns it
+        // and the poisoned price never enters the computation.
+        const honestLegUSD = 2000000000000000n;
+        expect(result.liquidityPoolDiff?.incrementalTotalFeesGeneratedUSD).toBe(
+          honestLegUSD,
+        );
+        expect(
+          result.liquidityPoolDiff?.incrementalTotalFeesGeneratedUSD ?? 0n,
+        ).toBeLessThan(poisonedPrice);
       });
 
       it("should handle different token decimals correctly", () => {


### PR DESCRIPTION
## Summary

- CL `calculateSwapFees` now derives `swapFeesInUSD` from the already-trusted `volumeInUSD` (`volumeInUSD × feeRate / CL_FEE_SCALE`). The AMM invariant `fees ≤ volume × feeRate` now holds by construction — fees inherit the `pickTrustedSwapVolumeUSD` defense that volume already had.
- V2 `processPoolFees` prices each leg independently and picks the trusted (smaller / non-zero fallback) leg via `pickTrustedSwapVolumeUSD`, symmetric with the volume path. `totalFeesUSDWhitelisted` keeps its sum-of-whitelisted semantics (separate accumulator).
- `[FEE_VOLUME_DIVERGENCE]` warn log in `Aggregators/Pool.ts` retained as a regression guard.

## Root cause (closes #733)

Volume path (both V2 and CL) used `pickTrustedSwapVolumeUSD` — the **smaller** of the two priced legs — to defend against poisoned/scam-token `pricePerUSDNew`. The fee paths did not:

- **CL `calculateSwapFees`**: priced the fee using the input token's `pricePerUSDNew`. If the input leg was on a poisoned-price token, the fee USD inherited the inflated price while volume escaped via the smaller leg → ratios up to 10²³×.
- **V2 `processPoolFees`**: used `calculateTotalUSD` (sums both legs). If a poisoned leg was non-zero in the Fees event, its USD polluted the total.

Both fixes restore the fee/volume USD-path symmetry the issue called for.

## Acceptance criteria

- [x] Root cause documented (commit message + code comments on `CLPoolSwapLogic.ts` and `PoolFeesLogic.ts`).
- [x] Fix lands at the source (handler).
- [x] Regression tests reproducing the divergence pattern:
  - `CLPoolSwapLogic.test.ts` → "should bound fee USD by trusted volume × feeRate when the input token has a poisoned price (issue #733)"
  - `PoolFeesLogic.test.ts` → "should not inherit a poisoned-price leg when the counterpart leg is honest (issue #733)"
- [ ] Post-fix fresh sync: 0 pools where `totalFeesGeneratedUSD > totalVolumeUSD × 0.05` — **cannot verify from worktree**. By construction the CL fix produces `fees/volume = feeRate/CL_FEE_SCALE ≤ ~1%` for real fee tiers, so the bulk of the 160 reported Base pools (CL-dominated) is bounded.
- [x] `[FEE_VOLUME_DIVERGENCE]` warn log retained (`src/Aggregators/Pool.ts:537`).

## Test plan

- [x] `pnpm test` — 1283 passed, 33 skipped (pre-existing)
- [x] `node_modules/.bin/tsc --noEmit` — clean
- [x] `biome check --write` — no fixes applied
- [ ] Fresh sync against Base to confirm 0 pools exceed the 5% ratio post-fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)