### PR TITLE
fix(price-oracle): spike-guard hardening — timestamp aliasing + asymmetric upward-only (closes #730)

### DIFF
--- a/src/PriceOracle.ts
+++ b/src/PriceOracle.ts
@@ -264,6 +264,15 @@ export async function refreshTokenPrice(
     // anchor. First-fetch (anchor == 0) and stale-anchor (anchor older than
     // PRICE_SPIKE_STALENESS_MS) are exempt — neither shape can be a transient
     // oracle glitch poisoning a previously-good baseline.
+    //
+    // Issue #730: return early on rejection without writing back. The earlier
+    // implementation fell through to the final `Token.set` write below, which
+    // bumped `lastUpdatedTimestamp` (and `lastSuccessfulPriceTimestamp`) on
+    // every rejected refresh — that resets `anchorAgeMs` each time, making
+    // the 14-day staleness exit unreachable while refresh events keep
+    // arriving. Skipping the write here is the same fix shape PR #696 applied
+    // to the V3 fallback path for issue #694: the staleness clock must be
+    // anchored to the original accepted timestamp, not the latest attempt.
     const anchorPrice = token.pricePerUSDNew;
     const anchorAgeMs = token.lastUpdatedTimestamp
       ? blockTimestampMs - token.lastUpdatedTimestamp.getTime()
@@ -277,7 +286,7 @@ export async function refreshTokenPrice(
       context.log.warn(
         `[priceSpikeRejected] ${token.address} chain=${chainId} anchor=${anchorPrice} candidate=${currentPrice}`,
       );
-      currentPrice = anchorPrice;
+      return token;
     }
 
     // If price fetch returned 0, it could mean:

--- a/src/PriceOracle.ts
+++ b/src/PriceOracle.ts
@@ -234,7 +234,7 @@ export async function refreshTokenPrice(
       chainId,
       blockNumber: roundedBlockNumber,
     });
-    let currentPrice = priceData.pricePerUSDNew;
+    const currentPrice = priceData.pricePerUSDNew;
 
     // Issue #728: cap-reject the first non-zero anchor for non-BTC symbols.
     // The spike guard below requires anchor > 0, so without this gate a single
@@ -260,29 +260,33 @@ export async function refreshTokenPrice(
       return capped;
     }
 
-    // Issue #668: reject refreshes that jump ≥10× vs a still-fresh accepted
-    // anchor. First-fetch (anchor == 0) and stale-anchor (anchor older than
-    // PRICE_SPIKE_STALENESS_MS) are exempt — neither shape can be a transient
-    // oracle glitch poisoning a previously-good baseline.
+    // Issue #668: reject upward refreshes that jump ≥10× vs a still-fresh
+    // accepted anchor. First-fetch (anchor == 0) and stale-anchor (anchor
+    // older than PRICE_SPIKE_STALENESS_MS) are exempt — neither shape can
+    // be a transient oracle glitch poisoning a previously-good baseline.
     //
-    // Issue #730: return early on rejection without writing back. The earlier
-    // implementation fell through to the final `Token.set` write below, which
-    // bumped `lastUpdatedTimestamp` (and `lastSuccessfulPriceTimestamp`) on
-    // every rejected refresh — that resets `anchorAgeMs` each time, making
-    // the 14-day staleness exit unreachable while refresh events keep
-    // arriving. Skipping the write here is the same fix shape PR #696 applied
-    // to the V3 fallback path for issue #694: the staleness clock must be
-    // anchored to the original accepted timestamp, not the latest attempt.
+    // Issue #730: the guard is upward-only. The two directions have
+    // asymmetric failure costs:
+    //
+    // - Upward false-accept (candidate wrongly high) is brief; the next
+    //   refresh self-heals once the oracle returns to baseline.
+    // - Downward false-reject (anchor wrongly high, candidate correct) is
+    //   permanent; every subsequent correct reading keeps getting rejected
+    //   and the inflated anchor is held forever (DTF kept $8.18 vs
+    //   DefiLlama $0.0008466 for 111 days).
+    //
+    // Also returns early on rejection rather than writing back — the
+    // earlier fall-through bumped `lastUpdatedTimestamp` on every rejected
+    // refresh, resetting `anchorAgeMs` so the 14-day exit was unreachable.
+    // Same fix shape PR #696 applied to the V3 fallback path for #694.
     const anchorPrice = token.pricePerUSDNew;
     const anchorAgeMs = token.lastUpdatedTimestamp
       ? blockTimestampMs - token.lastUpdatedTimestamp.getTime()
       : Number.POSITIVE_INFINITY;
-    const ratioExceeds =
+    const upwardSpike =
       anchorPrice > 0n &&
-      currentPrice > 0n &&
-      (currentPrice >= anchorPrice * PRICE_SPIKE_RATIO_THRESHOLD ||
-        anchorPrice >= currentPrice * PRICE_SPIKE_RATIO_THRESHOLD);
-    if (ratioExceeds && anchorAgeMs < PRICE_SPIKE_STALENESS_MS) {
+      currentPrice >= anchorPrice * PRICE_SPIKE_RATIO_THRESHOLD;
+    if (upwardSpike && anchorAgeMs < PRICE_SPIKE_STALENESS_MS) {
       context.log.warn(
         `[priceSpikeRejected] ${token.address} chain=${chainId} anchor=${anchorPrice} candidate=${currentPrice}`,
       );

--- a/test/PriceOracle.test.ts
+++ b/test/PriceOracle.test.ts
@@ -1063,34 +1063,38 @@ describe("PriceOracle", () => {
         expect(afterRecovery.pricePerUSDNew).toBe(recoveryPrice);
       });
 
-      it("rejects a DOWN-spike (≥10×) symmetrically", async () => {
-        // Anchor at $100; oracle returns $1 — 100× drop, must be rejected.
-        // Mirrors FXB20291231's Jan 2 2025 collapse to constant 485 wei.
+      it("accepts a DOWN candidate (≥10× drop) — asymmetric guard, issue #730", async () => {
+        // Issue #730: the failure modes are asymmetric. An upward
+        // false-accept (candidate wrongly high) self-heals on the next
+        // refresh; a downward false-reject (anchor wrongly high, candidate
+        // correct) is permanent — every subsequent correct reading is
+        // rejected forever. The DTF case (kept anchor $8.18, rejected
+        // candidate $0.000827 — within 2.4% of DefiLlama) is exactly this
+        // shape. Drop the symmetric branch so downward candidates are
+        // accepted immediately.
         const anchorPrice = 100n * 10n ** 18n;
-        const spikePrice = 1n * 10n ** 18n;
+        const recoveryPrice = 1n * 10n ** 18n;
 
         vi.mocked(mockContext.effect)?.mockImplementation(async (effect) => {
           if ((effect as { name?: string }).name === "getTokenPrice") {
-            return { pricePerUSDNew: spikePrice };
+            return { pricePerUSDNew: recoveryPrice };
           }
           return {};
         });
 
-        const fetchedToken = {
-          ...mockToken0Data,
-          pricePerUSDNew: anchorPrice,
-          lastUpdatedTimestamp: oneHourOneMinuteAgo(),
-        };
-
         const result = await PriceOracle.refreshTokenPrice(
-          fetchedToken,
+          {
+            ...mockToken0Data,
+            pricePerUSDNew: anchorPrice,
+            lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+          },
           blockNumber,
           blockDatetime.getTime() / 1000,
           chainId,
           mockContext as handlerContext,
         );
 
-        expect(result.pricePerUSDNew).toBe(anchorPrice);
+        expect(result.pricePerUSDNew).toBe(recoveryPrice);
       });
     });
 

--- a/test/PriceOracle.test.ts
+++ b/test/PriceOracle.test.ts
@@ -819,7 +819,7 @@ describe("PriceOracle", () => {
         vi.mocked(mockContext.log?.warn)?.mockClear();
       });
 
-      it("rejects an UP-spike (≥10×) and persists the previous accepted price", async () => {
+      it("rejects an UP-spike (≥10×) and preserves the previous accepted price", async () => {
         // Anchor at $1; oracle returns $100 — 100× jump, must be rejected.
         // Also pins the [priceSpikeRejected] warn line that downstream
         // observability (alerts, log scans) is expected to grep for.
@@ -839,7 +839,7 @@ describe("PriceOracle", () => {
           lastUpdatedTimestamp: oneHourOneMinuteAgo(),
         };
 
-        await PriceOracle.refreshTokenPrice(
+        const result = await PriceOracle.refreshTokenPrice(
           fetchedToken,
           blockNumber,
           blockDatetime.getTime() / 1000,
@@ -847,11 +847,47 @@ describe("PriceOracle", () => {
           mockContext as handlerContext,
         );
 
-        const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
-          .lastCall?.[0] as Token;
-        expect(updatedToken.pricePerUSDNew).toBe(anchorPrice);
+        expect(result.pricePerUSDNew).toBe(anchorPrice);
         const warnCall = vi.mocked(mockContext.log?.warn)?.mock.lastCall;
         expect(warnCall?.[0]).toContain("[priceSpikeRejected]");
+      });
+
+      it("preserves lastUpdatedTimestamp on rejection so the 14-day staleness exit can fire", async () => {
+        // Issue #730: prior to the fix, the rejection branch bumped
+        // `lastUpdatedTimestamp` on every rejected refresh, which reset the
+        // `anchorAgeMs` clock. The 14-day staleness exit became unreachable
+        // while refresh events kept arriving — anchors stayed poisoned
+        // indefinitely (e.g. DTF 8.18 vs DefiLlama 0.0008466 for 111 days).
+        // After the fix, rejection is an early return that leaves the anchor
+        // timestamp intact, so anchor age grows monotonically and the exit
+        // fires once the window elapses.
+        const anchorPrice = 1n * 10n ** 18n;
+        const spikePrice = 100n * 10n ** 18n;
+        const anchorTimestamp = new Date(
+          blockDatetime.getTime() - 13 * 24 * 60 * 60 * 1000,
+        );
+
+        vi.mocked(mockContext.effect)?.mockImplementation(async (effect) => {
+          if ((effect as { name?: string }).name === "getTokenPrice") {
+            return { pricePerUSDNew: spikePrice };
+          }
+          return {};
+        });
+
+        const result = await PriceOracle.refreshTokenPrice(
+          {
+            ...mockToken0Data,
+            pricePerUSDNew: anchorPrice,
+            lastUpdatedTimestamp: anchorTimestamp,
+          },
+          blockNumber,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        expect(result.lastUpdatedTimestamp).toEqual(anchorTimestamp);
+        expect(result.pricePerUSDNew).toBe(anchorPrice);
       });
 
       it("rejects an exact 10× boundary jump", async () => {
@@ -868,7 +904,7 @@ describe("PriceOracle", () => {
           return {};
         });
 
-        await PriceOracle.refreshTokenPrice(
+        const result = await PriceOracle.refreshTokenPrice(
           {
             ...mockToken0Data,
             pricePerUSDNew: anchorPrice,
@@ -880,9 +916,7 @@ describe("PriceOracle", () => {
           mockContext as handlerContext,
         );
 
-        const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
-          .lastCall?.[0] as Token;
-        expect(updatedToken.pricePerUSDNew).toBe(anchorPrice);
+        expect(result.pricePerUSDNew).toBe(anchorPrice);
       });
 
       it("accepts a sub-threshold jump (5×) as a normal price update", async () => {
@@ -1048,7 +1082,7 @@ describe("PriceOracle", () => {
           lastUpdatedTimestamp: oneHourOneMinuteAgo(),
         };
 
-        await PriceOracle.refreshTokenPrice(
+        const result = await PriceOracle.refreshTokenPrice(
           fetchedToken,
           blockNumber,
           blockDatetime.getTime() / 1000,
@@ -1056,9 +1090,7 @@ describe("PriceOracle", () => {
           mockContext as handlerContext,
         );
 
-        const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
-          .lastCall?.[0] as Token;
-        expect(updatedToken.pricePerUSDNew).toBe(anchorPrice);
+        expect(result.pricePerUSDNew).toBe(anchorPrice);
       });
     });
 


### PR DESCRIPTION
## Summary

Closes #730. Two-commit fix to the `refreshTokenPrice` spike guard added in PR #689.

- **Commit 1 — timestamp aliasing:** the rejection branch fell through to the final `Token.set` write, bumping `lastUpdatedTimestamp` on every rejected refresh and resetting `anchorAgeMs`. The 14-day staleness exit was unreachable while refresh events kept arriving. Returning early on rejection preserves the original anchor timestamp so age grows monotonically (same shape as PR #696 for the V3 fallback path / #694).
- **Commit 2 — asymmetric guard:** drops the `anchor ≫ candidate` branch. Upward false-accepts self-heal next refresh; downward false-rejects are permanent (DTF held \$8.18 vs DefiLlama \$0.0008466 for 111+ days; MON held \$399.82 vs \$0.114 for 80+ days). Keep upward protection (the original #668 sfrxETH/Fraxtal case).

## Test plan

- [x] `pnpm vitest run test/PriceOracle.test.ts` — 45 tests pass
- [x] `pnpm vitest run` — full suite 1282 / 1282 green
- [x] `pnpm qa` — biome clean
- [x] `tsc --noEmit` — no type errors

### AC coverage

- [x] **Regression: UP-spike (≥10×) still rejected** — `rejects an UP-spike` + `rejects an exact 10× boundary jump`
- [x] **Regression: DOWN candidate (≥10× drop) accepted immediately** — `accepts a DOWN candidate (≥10× drop) — asymmetric guard, issue #730`
- [x] **Regression: timestamp aliasing — staleness exit reachable after commit 1** — `preserves lastUpdatedTimestamp on rejection so the 14-day staleness exit can fire`, plus existing `accepts a 10×+ jump when the anchor is older than the staleness window` covers the end-to-end UP-spike staleness exit
- [x] **No regression on #668 sfrxETH/Fraxtal fixture** — all pre-existing UP-spike tests retained and pass
- [ ] **DTF/MON converge to DefiLlama within 10% after fresh re-sync** — cannot verify in unit tests; requires a full re-sync run

🤖 Generated with [Claude Code](https://claude.com/claude-code)