### PR TITLE
fix(bytecode-gate): probe decimals() to reject non-ERC20 contracts (closes #736)

### DIFF
--- a/src/Effects/Bytecode.ts
+++ b/src/Effects/Bytecode.ts
@@ -5,13 +5,20 @@ import { EffectType, callRpcGateway } from "./RpcGateway";
 export { fetchHasContractBytecode } from "./fetchers/Bytecode";
 
 /**
- * Effect that returns whether `address` has deployed bytecode on `chainId`.
- * Used as a gate at Token-row creation sites to filter EOAs / non-contract
- * addresses (e.g. Lisk 0x1847…34CA) that would otherwise persist Token rows
- * with empty `symbol`/`name` from the static fallback in {@link getTokenDetails}.
+ * Effect that returns whether `address` is an ERC20-compliant contract on
+ * `chainId`. Used as a gate at Token-row creation sites to filter EOAs /
+ * non-contract addresses (e.g. Lisk 0x1847…34CA — issue #677) and contracts
+ * that have bytecode but don't implement ERC20 (e.g. Base 0xBd0bD2F62…5528:
+ * 44,286 bytes of bytecode but `decimals()` reverts — issue #736). Without
+ * the gate, both cases persist Token rows with empty `symbol`/`name` and the
+ * default `decimals = 18` from the static fallback in {@link getTokenDetails}.
  *
- * Caching is enabled so positive bytecode results amortise across runs (one
- * `eth_getCode` per address per cache lifetime). The fail-open path — where
+ * The underlying fetcher does two probes: `eth_getCode` for bytecode and a
+ * `decimals()` read to check ERC20-shape compliance. See
+ * {@link fetchHasContractBytecode} for the reject conditions.
+ *
+ * Caching is enabled so positive results amortise across runs (one pair of
+ * RPC calls per address per cache lifetime). The fail-open path — where
  * {@link handleHasContractBytecode} returns `hasCode: true` after both primary
  * and fallback RPCs are exhausted — is detected via the gateway's `usedDefault`
  * flag (issue #691). Caching is only skipped when the failure was transient

--- a/src/Effects/RpcGateway.ts
+++ b/src/Effects/RpcGateway.ts
@@ -684,14 +684,17 @@ async function handleGetRootPoolAddress(
 }
 
 /**
- * Handles the HAS_CONTRACT_BYTECODE effect via `eth_getCode`.
- * Fail-open on RPC errors (returns `hasCode: true`) so transient outages don't
- * regress current behavior at Token-row creation sites; the caller controls
- * caching of negative results.
+ * Handles the HAS_CONTRACT_BYTECODE effect via `eth_getCode` + a `decimals()`
+ * probe for ERC20-shape compliance (issues #677 / #736). Fail-open on RPC
+ * errors (returns `hasCode: true`) so transient outages don't regress current
+ * behavior at Token-row creation sites; the caller controls caching of
+ * negative results. Deterministic reverts of `decimals()` are caught inside
+ * the fetcher and surface as `hasCode: false, usedDefault: false`.
  *
  * @param i - The input for the effect.
  * @param context - The context for the effect.
- * @returns Object with `hasCode: true` when bytecode is non-empty, `false` otherwise.
+ * @returns Object with `hasCode: true` when bytecode is non-empty AND
+ *   `decimals()` returns a valid uint8, `false` otherwise.
  */
 async function handleHasContractBytecode(
   i: RpcGatewayInputByType[EffectType.HAS_CONTRACT_BYTECODE],

--- a/src/Effects/fetchers/Bytecode.ts
+++ b/src/Effects/fetchers/Bytecode.ts
@@ -1,19 +1,54 @@
 import type { PublicClient } from "viem";
+import ERC20_ABI from "../../../abis/ERC20.json";
+import { ErrorType, getErrorType } from "../Helpers";
 
 /**
- * Returns true when the address has non-empty deployed bytecode.
- * Used as a gate at Token-row creation sites to filter out EOAs / non-contract
- * addresses that would otherwise persist Token rows with empty symbol/name.
+ * Returns true when the address has non-empty deployed bytecode AND looks like
+ * an ERC20 (probed via `decimals()` returning a valid uint8). Used as a gate
+ * at Token-row creation sites to filter EOAs / non-contract addresses (#677)
+ * and non-ERC20 contracts that have bytecode but revert on standard ERC20
+ * calls (#736 — e.g. `8453-0xBd0bD2F62…5528`: 44,286 bytes of bytecode, but
+ * name/symbol/decimals all revert).
+ *
+ * Reject conditions:
+ * - `eth_getCode` returns empty bytecode (`undefined` / `"0x"`) — EOA case.
+ * - `decimals()` reverts deterministically — non-ERC20 contract case. Caught
+ *   here so the caller sees `false` (cacheable negative) rather than the
+ *   gateway's fail-open `true`.
+ * - `decimals()` returns a value outside [0, 255] or a non-numeric value —
+ *   not an ERC20-shaped result.
+ *
+ * Transient/non-revert errors from either RPC call are propagated so
+ * {@link executeRpcWithFallback} can retry and the outer effect can skip
+ * caching the fail-open fallback (issue #692 policy is preserved).
  *
  * @param address - Address to query.
  * @param ethClient - Viem public client for the chain.
- * @returns True if `eth_getCode` returns non-empty bytecode, false for `0x` / undefined.
- * @throws Propagates RPC errors; caller should wrap with executeRpcWithFallback.
+ * @returns True iff bytecode is non-empty and `decimals()` returns a valid uint8.
+ * @throws Propagates non-revert RPC errors; caller should wrap with executeRpcWithFallback.
  */
 export async function fetchHasContractBytecode(
   address: string,
   ethClient: PublicClient,
 ): Promise<boolean> {
   const code = await ethClient.getCode({ address: address as `0x${string}` });
-  return Boolean(code) && code !== "0x";
+  if (!code || code === "0x") {
+    return false;
+  }
+
+  try {
+    const decimals = await ethClient.readContract({
+      address: address as `0x${string}`,
+      abi: ERC20_ABI,
+      functionName: "decimals",
+      args: [],
+    });
+    const n = Number(decimals);
+    return Number.isInteger(n) && n >= 0 && n <= 255;
+  } catch (err) {
+    if (getErrorType(err) === ErrorType.CONTRACT_REVERT) {
+      return false;
+    }
+    throw err;
+  }
 }

--- a/test/Effects/Bytecode.test.ts
+++ b/test/Effects/Bytecode.test.ts
@@ -1,5 +1,9 @@
+import type { PublicClient } from "viem";
 import { toChecksumAddress } from "../../src/Constants";
-import { hasContractBytecode } from "../../src/Effects/Bytecode";
+import {
+  fetchHasContractBytecode,
+  hasContractBytecode,
+} from "../../src/Effects/Bytecode";
 import * as RpcGatewayModule from "../../src/Effects/RpcGateway";
 import { type MockEffectContext, createMockEffectContext } from "./setup";
 
@@ -84,5 +88,156 @@ describe("hasContractBytecode", () => {
     });
 
     expect(mockContext.cache).toBeUndefined();
+  });
+});
+
+/**
+ * Issue #736: hasContractBytecode used to gate solely on `eth_getCode` length,
+ * which lets non-ERC20 contracts (bytecode present but `decimals()` reverts)
+ * past the gate. Verified case: 8453-0xBd0bD2F62…5528 has 44,286 bytes of
+ * bytecode but all of symbol()/name()/decimals() revert. The fetcher is
+ * extended to also probe decimals(); reject when bytecode exists but
+ * decimals() reverts deterministically or returns a non-uint8 value.
+ */
+describe("fetchHasContractBytecode — ERC20-compliance probe (#736)", () => {
+  let mockEthClient: PublicClient;
+
+  beforeEach(() => {
+    mockEthClient = {
+      getCode: vi.fn(),
+      readContract: vi.fn(),
+    } as unknown as PublicClient;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns false when address has no bytecode (EOA)", async () => {
+    vi.mocked(mockEthClient.getCode).mockResolvedValue(undefined);
+
+    const result = await fetchHasContractBytecode(TEST_ADDRESS, mockEthClient);
+
+    expect(result).toBe(false);
+    expect(mockEthClient.readContract).not.toHaveBeenCalled();
+  });
+
+  it("returns false when eth_getCode returns '0x'", async () => {
+    vi.mocked(mockEthClient.getCode).mockResolvedValue("0x");
+
+    const result = await fetchHasContractBytecode(TEST_ADDRESS, mockEthClient);
+
+    expect(result).toBe(false);
+    expect(mockEthClient.readContract).not.toHaveBeenCalled();
+  });
+
+  it("returns true when bytecode exists and decimals() returns a valid uint8", async () => {
+    vi.mocked(mockEthClient.getCode).mockResolvedValue("0x60806040...");
+    vi.mocked(mockEthClient.readContract).mockResolvedValue(
+      18 as unknown as number,
+    );
+
+    const result = await fetchHasContractBytecode(TEST_ADDRESS, mockEthClient);
+
+    expect(result).toBe(true);
+  });
+
+  it("returns true for legit 0-decimal tokens (e.g. IDRX)", async () => {
+    vi.mocked(mockEthClient.getCode).mockResolvedValue("0x60806040...");
+    vi.mocked(mockEthClient.readContract).mockResolvedValue(
+      0 as unknown as number,
+    );
+
+    const result = await fetchHasContractBytecode(TEST_ADDRESS, mockEthClient);
+
+    expect(result).toBe(true);
+  });
+
+  it("returns true at the 255 boundary", async () => {
+    vi.mocked(mockEthClient.getCode).mockResolvedValue("0x60806040...");
+    vi.mocked(mockEthClient.readContract).mockResolvedValue(
+      255 as unknown as number,
+    );
+
+    const result = await fetchHasContractBytecode(TEST_ADDRESS, mockEthClient);
+
+    expect(result).toBe(true);
+  });
+
+  it("returns false when bytecode exists but decimals() reverts (the #736 case)", async () => {
+    vi.mocked(mockEthClient.getCode).mockResolvedValue("0x60806040...");
+    vi.mocked(mockEthClient.readContract).mockRejectedValue(
+      new Error("execution reverted"),
+    );
+
+    const result = await fetchHasContractBytecode(TEST_ADDRESS, mockEthClient);
+
+    expect(result).toBe(false);
+  });
+
+  it("returns false when decimals() returns a value > 255", async () => {
+    vi.mocked(mockEthClient.getCode).mockResolvedValue("0x60806040...");
+    vi.mocked(mockEthClient.readContract).mockResolvedValue(
+      256 as unknown as number,
+    );
+
+    const result = await fetchHasContractBytecode(TEST_ADDRESS, mockEthClient);
+
+    expect(result).toBe(false);
+  });
+
+  it("returns false when decimals() returns a negative value", async () => {
+    vi.mocked(mockEthClient.getCode).mockResolvedValue("0x60806040...");
+    vi.mocked(mockEthClient.readContract).mockResolvedValue(
+      -1 as unknown as number,
+    );
+
+    const result = await fetchHasContractBytecode(TEST_ADDRESS, mockEthClient);
+
+    expect(result).toBe(false);
+  });
+
+  it("returns false when decimals() returns a non-numeric value", async () => {
+    vi.mocked(mockEthClient.getCode).mockResolvedValue("0x60806040...");
+    vi.mocked(mockEthClient.readContract).mockResolvedValue(
+      "not a number" as unknown as number,
+    );
+
+    const result = await fetchHasContractBytecode(TEST_ADDRESS, mockEthClient);
+
+    expect(result).toBe(false);
+  });
+
+  it("propagates transient network errors from decimals() so retry/fallback runs", async () => {
+    vi.mocked(mockEthClient.getCode).mockResolvedValue("0x60806040...");
+    vi.mocked(mockEthClient.readContract).mockRejectedValue(
+      new Error("network error: ETIMEDOUT"),
+    );
+
+    await expect(
+      fetchHasContractBytecode(TEST_ADDRESS, mockEthClient),
+    ).rejects.toThrow("network error: ETIMEDOUT");
+  });
+
+  it("propagates rate-limit errors from decimals() so retry/fallback runs", async () => {
+    vi.mocked(mockEthClient.getCode).mockResolvedValue("0x60806040...");
+    vi.mocked(mockEthClient.readContract).mockRejectedValue(
+      new Error("429 too many requests"),
+    );
+
+    await expect(
+      fetchHasContractBytecode(TEST_ADDRESS, mockEthClient),
+    ).rejects.toThrow("429 too many requests");
+  });
+
+  it("propagates eth_getCode RPC errors so retry/fallback runs", async () => {
+    vi.mocked(mockEthClient.getCode).mockRejectedValue(
+      new Error("network error: connection closed"),
+    );
+
+    await expect(
+      fetchHasContractBytecode(TEST_ADDRESS, mockEthClient),
+    ).rejects.toThrow("connection closed");
+    expect(mockEthClient.readContract).not.toHaveBeenCalled();
   });
 });

--- a/test/Effects/RpcGateway.test.ts
+++ b/test/Effects/RpcGateway.test.ts
@@ -117,10 +117,13 @@ describe("RpcGateway", () => {
       ).toBeGreaterThanOrEqual(1);
     });
 
-    it("returns hasCode=true when getCode returns deployed bytecode (issue #677 gate)", async () => {
+    it("returns hasCode=true when getCode returns deployed bytecode and decimals() returns a valid uint8 (issues #677 / #736 gate)", async () => {
       vi.mocked(
         mockEthClient.getCode as unknown as ReturnType<typeof vi.fn>,
       ).mockResolvedValue("0x60806040");
+      vi.mocked(mockEthClient.readContract).mockResolvedValue(
+        18 as unknown as never,
+      );
 
       const result = await (
         rpcGateway as unknown as { handler: MockEffect["handler"] }
@@ -135,6 +138,32 @@ describe("RpcGateway", () => {
 
       expect(result).toEqual({
         hasCode: true,
+        usedDefault: false,
+        errorClass: undefined,
+      });
+    });
+
+    it("returns hasCode=false when bytecode exists but decimals() reverts (issue #736 non-ERC20 gate)", async () => {
+      vi.mocked(
+        mockEthClient.getCode as unknown as ReturnType<typeof vi.fn>,
+      ).mockResolvedValue("0x60806040");
+      vi.mocked(mockEthClient.readContract).mockRejectedValue(
+        new Error("execution reverted"),
+      );
+
+      const result = await (
+        rpcGateway as unknown as { handler: MockEffect["handler"] }
+      ).handler({
+        input: {
+          type: "hasContractBytecode",
+          chainId: TEST_CHAIN_ID,
+          address: TEST_CONTRACT_ADDRESS,
+        },
+        context: mockContext,
+      });
+
+      expect(result).toEqual({
+        hasCode: false,
         usedDefault: false,
         errorClass: undefined,
       });


### PR DESCRIPTION
## Summary

- Extends the `hasContractBytecode` gate (added in #690 for issue #677) to also probe `decimals()` so non-ERC20 contracts with bytecode (e.g. `8453-0xBd0bD2F62…5528`: 44,286 bytes of bytecode, but `decimals()/name()/symbol()` all revert) get rejected at the four Token-row creation sites.
- All four call sites already use the same effect (`createTokenEntity`, `Voter.WhitelistToken`, `SuperchainLeafVoter.WhitelistToken`, `processVotingRewardClaimRewards`), so no call-site changes were needed — only the fetcher logic.
- Cache policy preserved: deterministic `decimals()` reverts are caught inside `fetchHasContractBytecode` and surface as a cacheable `hasCode:false`; transient errors propagate so `executeRpcWithFallback` retries and the outer effect skips caching the fail-open fallback (#692 policy intact).

## How the gate now works

`fetchHasContractBytecode(address, ethClient)`:
1. `eth_getCode` — if empty / `"0x"` → return `false` (EOA).
2. `decimals()` via `readContract`:
   - Returns a valid uint8 (0–255 integer) → return `true`.
   - Returns out-of-range or non-numeric → return `false`.
   - Throws `CONTRACT_REVERT` → return `false` (deterministic non-ERC20).
   - Throws transient (NETWORK_ERROR / RATE_LIMIT / etc.) → propagate so the retry/fallback path runs.

## Test plan

- [x] `pnpm qa` — biome clean (262 files)
- [x] `tsc --noEmit` — clean
- [x] `pnpm test` — 100/100 test files, 1294 tests pass, 33 skipped
- [x] Fetcher-level tests added (`test/Effects/Bytecode.test.ts`):
  - returns false for EOA / `0x` bytecode (preserves #677 behavior)
  - returns true for valid uint8 decimals (incl. 0 for IDRX and 255 boundary)
  - **returns false when bytecode exists but `decimals()` reverts (the #736 case)**
  - returns false for out-of-range / non-numeric decimals
  - propagates network/rate-limit errors so retry runs
  - propagates `eth_getCode` errors without probing decimals
- [x] Gateway-level test added (`test/Effects/RpcGateway.test.ts`):
  - "returns hasCode=false when bytecode exists but decimals() reverts (issue #736 non-ERC20 gate)"
  - existing positive gate test updated to also mock `readContract` → 18

## Acceptance criteria (issue #736)

- [x] `hasContractBytecode` probes `decimals()` and accepts only when it returns 0–255
- [x] All four Token creation sites use the extended gate (unchanged — same effect API)
- [x] Cache policy preserved: positives cached, transient negatives uncached
- [x] Regression test for the `8453-0xBd0bD2F62…5528` case
- [x] No regression on whitelisted tokens (WETH/AERO/USDC tests still pass)
- [x] Existing tests that mock `hasContractBytecode` updated where they exercise the fetcher path

Closes #736.

🤖 Generated with [Claude Code](https://claude.com/claude-code)