### PR TITLE
fix(price-overrides): blacklist 17 Base inflated-price tokens (#731)

### DIFF
--- a/src/PriceOverrides.ts
+++ b/src/PriceOverrides.ts
@@ -469,6 +469,74 @@ const BLACKLIST: ReadonlySet<string> = new Set([
     8453,
     toChecksumAddress("0x3F328768C598F6A685B0698E269E09B267C3EBdD"),
   ), // 🍕 (~$13.8K)
+  // Issue #731: second-pass audit extension — Base tokens driving the bulk of
+  // the $2.29-sextillion top-1000 Base V2 TVL inflation. All are Mode A
+  // locked-anchor shape (stored pricePerUSDNew on the order of $0.998-$128 vs
+  // realistic value ~$0.001-$0.005, or symbol-spoofs of legitimate USDC/BTC).
+  TokenId(
+    8453,
+    toChecksumAddress("0x047Cfd8f966F97c20528e5c1aEB549dB52F613ff"),
+  ), // HENLO (stored $128.57 vs ~$0.005 real)
+  TokenId(
+    8453,
+    toChecksumAddress("0x5C985C58562FA7b2F017490c72817ba4984313E7"),
+  ), // DE / Degen (stored $0.998 vs ~$0.001)
+  TokenId(
+    8453,
+    toChecksumAddress("0xf9fac6ccA82D7acea96Eb33880d628fdcbf07c96"),
+  ), // Ragdoll (variant 1)
+  TokenId(
+    8453,
+    toChecksumAddress("0xF5E89006CBeFf2dabCfda0Def5Bf45Ebe7f8429f"),
+  ), // Ragdoll (variant 2)
+  TokenId(
+    8453,
+    toChecksumAddress("0x0fb741B7203c610585206b8cb56E0a0b45062ff2"),
+  ), // CHIDO
+  TokenId(
+    8453,
+    toChecksumAddress("0x62b1473641f38AC7cD57054DB093a2008BB9C577"),
+  ), // AUD
+  TokenId(
+    8453,
+    toChecksumAddress("0xFC366d0F92F5E03f25d867C82B451B89E17907a3"),
+  ), // ET / Base (Optimism counterpart at same address already blacklisted via #720)
+  TokenId(
+    8453,
+    toChecksumAddress("0x52fA342C288060b37776caDF98D8f81C57EBA2B9"),
+  ), // USBA (variant 1)
+  TokenId(
+    8453,
+    toChecksumAddress("0xb0e400A463F1e0b20Eb831B32DC19eD32EF9Ce61"),
+  ), // USBA (variant 2)
+  TokenId(
+    8453,
+    toChecksumAddress("0x8feeE3Dc6F8bA55dd54228a909D883bE78422870"),
+  ), // TOORBOLG / GLOB-ROOT
+  TokenId(
+    8453,
+    toChecksumAddress("0xa7F9101d91121251d6bA7C1383B39a7f1321cDF3"),
+  ), // FD121
+  TokenId(
+    8453,
+    toChecksumAddress("0x9D848D49819897738FB82C4026414140fEED7eb2"),
+  ), // FDOTC
+  TokenId(
+    8453,
+    toChecksumAddress("0x5Bca90d1481081c36E6ac308e8ba5403D6c99e1b"),
+  ), // HTE
+  TokenId(
+    8453,
+    toChecksumAddress("0x4753ee21f0521B953e0Ac99449126dD457e85080"),
+  ), // PTTH
+  TokenId(
+    8453,
+    toChecksumAddress("0xEF708582Ab333d602aBcFc740410224352e71D83"),
+  ), // CTB
+  TokenId(
+    8453,
+    toChecksumAddress("0x44B6FBbA989F018c2C0fE7EE0bf4340B21255C2C"),
+  ), // ORC
 ]);
 
 /**

--- a/src/PriceOverrides.ts
+++ b/src/PriceOverrides.ts
@@ -537,6 +537,15 @@ const BLACKLIST: ReadonlySet<string> = new Set([
     8453,
     toChecksumAddress("0x44B6FBbA989F018c2C0fE7EE0bf4340B21255C2C"),
   ), // ORC
+  // Issue #731 follow-up: BAIBAI on Base. Oracle output is structurally
+  // broken — V4 returns ~$5e+8/token at recent blocks against a memecoin
+  // whose totalSupply is 10^15 raw (0.001 whole tokens at 18 decimals). The
+  // 8× jump from the stored $65M anchor → $528M oracle output is below the
+  // ≥10× spike-guard threshold, so neither #689 nor #742 catches it.
+  TokenId(
+    8453,
+    toChecksumAddress("0x23FA9a1a634222C03F3C02124242DFf56bD90787"),
+  ), // BAIBAI
 ]);
 
 /**

--- a/test/PriceOverrides.test.ts
+++ b/test/PriceOverrides.test.ts
@@ -59,6 +59,30 @@ describe("PriceOverrides", () => {
       },
     );
 
+    it.each([
+      ["HENLO", "0x047Cfd8f966F97c20528e5c1aEB549dB52F613ff"],
+      ["DE / Degen", "0x5C985C58562FA7b2F017490c72817ba4984313E7"],
+      ["Ragdoll v1", "0xf9fac6ccA82D7acea96Eb33880d628fdcbf07c96"],
+      ["Ragdoll v2", "0xF5E89006CBeFf2dabCfda0Def5Bf45Ebe7f8429f"],
+      ["CHIDO", "0x0fb741B7203c610585206b8cb56E0a0b45062ff2"],
+      ["AUD", "0x62b1473641f38AC7cD57054DB093a2008BB9C577"],
+      ["ET / Base", "0xFC366d0F92F5E03f25d867C82B451B89E17907a3"],
+      ["USBA v1", "0x52fA342C288060b37776caDF98D8f81C57EBA2B9"],
+      ["USBA v2", "0xb0e400A463F1e0b20Eb831B32DC19eD32EF9Ce61"],
+      ["TOORBOLG", "0x8feeE3Dc6F8bA55dd54228a909D883bE78422870"],
+      ["FD121", "0xa7F9101d91121251d6bA7C1383B39a7f1321cDF3"],
+      ["FDOTC", "0x9D848D49819897738FB82C4026414140fEED7eb2"],
+      ["HTE", "0x5Bca90d1481081c36E6ac308e8ba5403D6c99e1b"],
+      ["PTTH", "0x4753ee21f0521B953e0Ac99449126dD457e85080"],
+      ["CTB", "0xEF708582Ab333d602aBcFc740410224352e71D83"],
+      ["ORC", "0x44B6FBbA989F018c2C0fE7EE0bf4340B21255C2C"],
+    ])(
+      "returns true for %s (Base inflated-price token, issue #731)",
+      (_, address) => {
+        expect(isBlacklistedToken(8453, toChecksumAddress(address))).toBe(true);
+      },
+    );
+
     it("does not blacklist the canonical AERO on Base", () => {
       expect(
         isBlacklistedToken(

--- a/test/PriceOverrides.test.ts
+++ b/test/PriceOverrides.test.ts
@@ -76,6 +76,7 @@ describe("PriceOverrides", () => {
       ["PTTH", "0x4753ee21f0521B953e0Ac99449126dD457e85080"],
       ["CTB", "0xEF708582Ab333d602aBcFc740410224352e71D83"],
       ["ORC", "0x44B6FBbA989F018c2C0fE7EE0bf4340B21255C2C"],
+      ["BAIBAI", "0x23FA9a1a634222C03F3C02124242DFf56bD90787"],
     ])(
       "returns true for %s (Base inflated-price token, issue #731)",
       (_, address) => {


### PR DESCRIPTION
## Summary

Closes #731. Adds **17 Base tokens** to the Mode A inflated-price `BLACKLIST` in `src/PriceOverrides.ts`, sized to remove the bulk of the ~$2.29-sextillion top-1000 Base V2 TVL inflation (DefiLlama pegs the chain's real TVL at $278.6M — ~10^13 off without these entries).

All entries share the same shape: stored `pricePerUSDNew` is a locked anchor from a single inflated oracle read, with no realistic spot price to back it. None are caught by any existing defensive layer.

## Entries added

**First pass (16 tokens, commit `9d3da1b`):**
HENLO, DE/Degen, Ragdoll (×2), CHIDO, AUD, ET/Base (counterpart of the OP entry blacklisted in #720), USBA (×2), TOORBOLG/GLOB-ROOT, FD121, FDOTC, HTE, PTTH, CTB, ORC

**Second pass (1 token, commit `6af11a9`):** uncovered by a follow-up `>$10K` sweep
- **BAIBAI** — V4 oracle returns ~$5e+8/token at recent blocks against a memecoin whose `totalSupply` is `10^15` raw (0.001 whole tokens at 18 decimals). The 8× jump from the stored $65M anchor → $528M oracle output sits below the ≥10× spike-guard threshold, so neither #689 nor #742 catches it.

`uDOT` and `uXLM` were initially included in the second pass but **removed** after multi-block oracle probes confirmed both have sane oracle output (uDOT ~$1.27, uXLM ~$0.15) across V3 and V4 — they are uDOT-shape false positives (cache stuck on a transient spike) that will heal naturally on next refresh under #742's asymmetric upward-only spike guard. Blacklisting them would zero a real price.

## Why other defensive layers don't cover BAIBAI

| Layer | Why it doesn't help |
| --- | --- |
| `#729` first-fetch $10K cap | Only fires while `lastSuccessfulPriceTimestamp` is null — existing anchors are immune |
| `#689` / `#742` spike guard | Upward-only after #742; an 8× jump (anchor → oracle) is below the 10× threshold |
| `#693` 1h throttle | Heals `$0 → non-zero` only; not non-zero → corrected |
| `#690` / `#743` bytecode/decimals gates | BAIBAI passes — it's a valid ERC20 |

## Note on the 16 first-pass entries

Post-merge probe of all 16 first-pass tokens against current Base V4 oracle (block ~46.2M) shows oracle currently returns `$0` (or sub-cent dust for AUD) for every one of them. These BL entries are therefore **defensive but inert under current conditions** — they prevent re-inflation if any of these tokens are ever re-paired with a connector pool, but they don't actively zero a non-zero price today. They are kept as a defensive layer; only BAIBAI is the load-bearing fix in this PR.

## Cross-chain WL audit

Every blacklist entry's `isWhitelisted` was re-verified against the deployed indexer at `3d71402`. Non-Base chains were independently audited at the `>10^28` and `>$10K` thresholds:

| Chain | Total blacklisted | WL | non-WL |
| --- | --- | --- | --- |
| Optimism (10) | 10 | 0 | 10 |
| Unichain (130) | 1 | 0 | 1 |
| Lisk (1135) | 1 | 1 (ION — see #671) | 0 |
| Soneium (1868) | 1 | 0 | 1 |
| Swell (1923) | 1 | 1 (KING — see #721) | 0 |
| Base (8453) | 109 | 0 | 109 |
| Ink (57073) | 2 | 1 (XAUt0 — see #721) | 1 |

The 3 WL-blacklisted entries (ION, KING, XAUt0) are deliberate and documented in `PriceOverrides.ts` header comments. The new candidates are all non-WL, matching the rest of the Base block.

Non-Base findings beyond the existing coverage: 3 Soneium "BTC-shaped" tokens (~$75K) with empty stored symbol/name turned out via on-chain RPC probe to be legitimate WBTC/SolvBTC/xSolvBTC — their metadata will heal under #735 on next deploy. Their oracle output, however, is near-zero on current Soneium V3 — a separate Class C concern worth a dedicated follow-up issue.

## Why earlier scope changes were dropped

The original PR carried 4 additional change classes that were collapsed out after deeper investigation:

1. **Stablecoin-pin layer (`STABLECOIN_PINS` map)** — duplicated by the per-chain `chain.stablecoins` set in `Constants.ts` + the `$1` short-circuit in `RpcGateway` line 405. Removed.
2. **WBTC/Base canonical-rebind to cbBTC/Base** — independent RPC probe confirmed Base's V4 oracle returns ~$77,854 for WBTC at the current head; no rebind needed.
3. **Restaking-token canonical-rebinds (Mode/Fraxtal/Lisk)** — the deployed indexer's $0 anchors come from the pre-`#693` 30-day backoff; `#693`'s 1-hour throttle heals them on the next redeploy.
4. **Mog/HAUS triage** — `isWhitelisted=false` on the deployed indexer means contamination is bounded by `#737`'s trusted-volume gate, no blacklist warranted.

## Test plan
- [x] `vitest run test/PriceOverrides.test.ts` — 39 tests pass, including 16+1 new `it.each` cases asserting each Base addition is blacklisted
- [x] `pnpm qa --write` — biome clean
