### PR TITLE
fix(cl-staked): backfill stakedReserve0/1 from edges at CLPool.Initialize (closes #732)

### DIFF
--- a/src/Aggregators/CLStakedLiquidity.ts
+++ b/src/Aggregators/CLStakedLiquidity.ts
@@ -262,6 +262,78 @@ export function deriveStakedLiquidityInRange(
 }
 
 /**
+ * Derives `stakedReserve0`/`stakedReserve1` from the canonical edge state at a
+ * given sqrt price. Walks each segment between consecutive edges, accumulates
+ * the cumulative staked liquidity (Σ nets[0..i]), and adds the segment's
+ * Uniswap v3 amount contribution evaluated against `sqrtPriceX96`.
+ *
+ *   - Segment entirely above sqrt (sqrt <= sqrtLower): all token0 capacity.
+ *     amount0 += L * Q96 * (sqrtUpper - sqrtLower) / (sqrtLower * sqrtUpper)
+ *   - Segment entirely below sqrt (sqrt >= sqrtUpper): all token1 capacity.
+ *     amount1 += L * (sqrtUpper - sqrtLower) / Q96
+ *   - Segment straddles sqrt: split at sqrt and apply both formulas.
+ *
+ * Used to backfill staked reserves at `CLPool.Initialize` time for pools where
+ * one or more gauge Deposit / NFPM IncreaseLiquidity events fired while
+ * `sqrtPriceX96 === 0n` (e.g., the Initialize event was missed or fired in a
+ * different tx than `PoolCreated`). Those events update the edge map but the
+ * `sqrtPriceX96 !== 0n` gate in `computeCLStakedReservesOnGaugeEvent` /
+ * `updateStakedPositionLiquidity` skipped the per-event reserve increment, so
+ * the running counter was never anchored — leaving `stakedReserve0/1` stuck at
+ * 0 while edges represented real stakes. Subsequent swap-path per-segment
+ * attribution then accumulates relative to a missing anchor, and the
+ * gauge Withdraw decrement leaves a negative residue. Deriving from edges at
+ * Initialize plants the missing anchor so the lifecycle telescopes to zero.
+ *
+ * Cost: O(E) where E = edges.length. Invoked only at Initialize (once per pool)
+ * and in tests — never on the hot swap path.
+ *
+ * Short-circuits:
+ *   - `sqrtPriceX96 <= 0n`: returns (0, 0); reserves are undefined without a price.
+ *   - `edges.length < 2`: returns (0, 0); no segments to walk.
+ *
+ * @param sqrtPriceX96 - Pool's sqrt price (Q64.96) at the moment of derivation
+ * @param edges - Sorted-ascending stakedTickEdges
+ * @param nets - Parallel stakedTickEdgeNets (same length, same index)
+ * @returns `{ stakedReserve0, stakedReserve1 }` accumulated across all segments
+ */
+export function deriveStakedReservesFromEdges(
+  sqrtPriceX96: bigint,
+  edges: readonly bigint[],
+  nets: readonly bigint[],
+): { stakedReserve0: bigint; stakedReserve1: bigint } {
+  if (sqrtPriceX96 <= 0n || edges.length < 2) {
+    return { stakedReserve0: 0n, stakedReserve1: 0n };
+  }
+
+  let cumulativeL = 0n;
+  let stakedReserve0 = 0n;
+  let stakedReserve1 = 0n;
+
+  for (let i = 0; i < edges.length - 1; i++) {
+    cumulativeL += nets[i];
+    if (cumulativeL === 0n) continue;
+
+    const sqrtLower = sqrtRatioAtTick(edges[i]);
+    const sqrtUpper = sqrtRatioAtTick(edges[i + 1]);
+
+    if (sqrtPriceX96 <= sqrtLower) {
+      stakedReserve0 +=
+        (cumulativeL * Q96 * (sqrtUpper - sqrtLower)) / (sqrtLower * sqrtUpper);
+    } else if (sqrtPriceX96 >= sqrtUpper) {
+      stakedReserve1 += (cumulativeL * (sqrtUpper - sqrtLower)) / Q96;
+    } else {
+      stakedReserve0 +=
+        (cumulativeL * Q96 * (sqrtUpper - sqrtPriceX96)) /
+        (sqrtPriceX96 * sqrtUpper);
+      stakedReserve1 += (cumulativeL * (sqrtPriceX96 - sqrtLower)) / Q96;
+    }
+  }
+
+  return { stakedReserve0, stakedReserve1 };
+}
+
+/**
  * Per-segment Uniswap v3 swap math at constant L. The pool's sqrt price moves
  * from `segStart` to `segEnd` while staked liquidity in range is `stakedLiq`.
  *

--- a/src/EventHandlers/CLPool.ts
+++ b/src/EventHandlers/CLPool.ts
@@ -1,4 +1,8 @@
 import { CLPool } from "generated";
+import {
+  deriveStakedLiquidityInRange,
+  deriveStakedReservesFromEdges,
+} from "../Aggregators/CLStakedLiquidity";
 import { createOUSDTSwapEntity } from "../Aggregators/OUSDTSwaps";
 import { loadPoolData, updatePool } from "../Aggregators/Pool";
 import {
@@ -278,9 +282,46 @@ CLPool.IncreaseObservationCardinalityNext.handler(
 // apply it on creation and delete the entry. Closes the pre-first-swap
 // dead-zone where NFPM handlers silently dropped range math for positions
 // minted before any swap had occurred (see velodrome-finance/indexer#654).
+//
+// When the aggregator already exists (e.g., the Slipstream same-tx buffer was
+// lost, or a non-Slipstream factory emits Initialize in a later tx), apply
+// sqrtPriceX96/tick directly AND backfill `stakedReserve0/1` from the edge
+// state — pre-Initialize gauge Deposit / NFPM IncreaseLiquidity events update
+// the edge map but skip the per-event reserve increment when sqrtPriceX96 is
+// 0n. Without the backfill, the swap-path running counter never gets an anchor
+// and the lifetime telescoping (deposit + swap-deltas − withdraw) lands at
+// −P(L, sqrt_init) instead of 0, producing the residual negative drift on the
+// 58 CL pools from velodrome-finance/indexer#732.
 CLPool.Initialize.handler(async ({ event, context }) => {
+  const poolId = PoolId(event.chainId, event.srcAddress);
+  const existing = await context.Pool.get(poolId);
+
+  if (existing) {
+    const sqrtPriceX96 = event.params.sqrtPriceX96;
+    const tick = event.params.tick;
+    const { stakedReserve0, stakedReserve1 } = deriveStakedReservesFromEdges(
+      sqrtPriceX96,
+      existing.stakedTickEdges,
+      existing.stakedTickEdgeNets,
+    );
+    const stakedLiquidityInRange = deriveStakedLiquidityInRange(
+      tick,
+      existing.stakedTickEdges,
+      existing.stakedTickEdgeNets,
+    );
+    context.Pool.set({
+      ...existing,
+      sqrtPriceX96,
+      tick,
+      stakedReserve0,
+      stakedReserve1,
+      stakedLiquidityInRange,
+    });
+    return;
+  }
+
   context.CLPoolPendingInitialize.set({
-    id: PoolId(event.chainId, event.srcAddress),
+    id: poolId,
     chainId: event.chainId,
     poolAddress: event.srcAddress,
     sqrtPriceX96: event.params.sqrtPriceX96,

--- a/test/Aggregators/CLStakedLiquidity.test.ts
+++ b/test/Aggregators/CLStakedLiquidity.test.ts
@@ -2,6 +2,7 @@ import type { handlerContext } from "generated";
 import {
   applyStakedPositionToEdges,
   deriveStakedLiquidityInRange,
+  deriveStakedReservesFromEdges,
   isPositionInRange,
   processTickCrossingsForStaked,
 } from "../../src/Aggregators/CLStakedLiquidity";
@@ -938,6 +939,435 @@ describe("CLStakedLiquidity", () => {
         expect(result.stakedDelta0).toBe(0n);
         expect(result.stakedDelta1).toBe(0n);
       });
+    });
+
+    /**
+     * Regression coverage for issue #732. The residue of #666: per-segment
+     * v3 attribution looks correct on a single swap, but 58 CL pools still
+     * exhibit negative `stakedReserve0/1` after currentLiquidityStaked has
+     * round-tripped to 0n. These tests exercise the running stakedReserve
+     * counter through full lifecycles (Deposit → swaps → Withdraw) the way
+     * the indexer assembles them — Deposit/Withdraw amounts come from
+     * `calculatePositionAmountsFromLiquidity` and swap deltas come from
+     * `processTickCrossingsForStaked`. The closed invariant: the three
+     * incremental contributions sum to zero (within bigint-truncation wei).
+     */
+    describe("#732 stakedReserve telescoping across full lifecycle", () => {
+      const noDbContext = {
+        log: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+      } as unknown as handlerContext;
+
+      /**
+       * Walks a series of swaps and returns the accumulated stakedDelta0/1.
+       * Mirrors what the indexer does: for each swap event, call
+       * `processTickCrossingsForStaked(oldTick, newTick, oldSqrt, newSqrt, ...)`
+       * and add stakedDelta0/1 to the running counter.
+       */
+      function runSwaps(
+        ticks: bigint[],
+        edges: readonly bigint[],
+        nets: readonly bigint[],
+      ): { stakedDelta0: bigint; stakedDelta1: bigint; finalTick: bigint } {
+        let totalDelta0 = 0n;
+        let totalDelta1 = 0n;
+        for (let i = 0; i < ticks.length - 1; i++) {
+          const oldTick = ticks[i];
+          const newTick = ticks[i + 1];
+          const r = processTickCrossingsForStaked(
+            CHAIN_ID,
+            POOL_ADDRESS,
+            oldTick,
+            newTick,
+            sqrtAt(oldTick),
+            sqrtAt(newTick),
+            1n,
+            noDbContext,
+            deriveStakedLiquidityInRange(oldTick, edges, nets),
+            true,
+            edges,
+            nets,
+          );
+          totalDelta0 += r.stakedDelta0;
+          totalDelta1 += r.stakedDelta1;
+        }
+        return {
+          stakedDelta0: totalDelta0,
+          stakedDelta1: totalDelta1,
+          finalTick: ticks[ticks.length - 1],
+        };
+      }
+
+      it("(a) telescopes across many in-range swaps oscillating around the deposit tick", () => {
+        const L = 10n ** 18n;
+        const tickLower = -1000n;
+        const tickUpper = 1000n;
+        const depositTick = 0n;
+        const edges = [tickLower, tickUpper];
+        const nets = [L, -L];
+
+        // Many in-range swaps; final tick == deposit tick → zero net price move.
+        const journey = [0n, 100n, -200n, 300n, -400n, 500n, -100n, 0n];
+        const swaps = runSwaps(journey, edges, nets);
+        expect(swaps.finalTick).toBe(depositTick);
+
+        const deposit = calculatePositionAmountsFromLiquidity(
+          L,
+          sqrtAt(depositTick),
+          tickLower,
+          tickUpper,
+        );
+        const withdraw = calculatePositionAmountsFromLiquidity(
+          L,
+          sqrtAt(swaps.finalTick),
+          tickLower,
+          tickUpper,
+        );
+
+        const net0 = deposit.amount0 + swaps.stakedDelta0 - withdraw.amount0;
+        const net1 = deposit.amount1 + swaps.stakedDelta1 - withdraw.amount1;
+
+        // Closed-system invariant: stakedReserve must return to 0.
+        expect(net0).toBeGreaterThanOrEqual(-20n);
+        expect(net0).toBeLessThanOrEqual(20n);
+        expect(net1).toBeGreaterThanOrEqual(-20n);
+        expect(net1).toBeLessThanOrEqual(20n);
+      });
+
+      it("(b) telescopes when position exits range and re-enters before withdraw", () => {
+        const L = 10n ** 18n;
+        const tickLower = -100n;
+        const tickUpper = 100n;
+        const depositTick = 50n;
+        const edges = [tickLower, tickUpper];
+        const nets = [L, -L];
+
+        // Exit above (tick 200), then below (tick -200), then back into range.
+        const journey = [depositTick, 200n, 300n, -200n, -300n, 50n];
+        const swaps = runSwaps(journey, edges, nets);
+
+        const deposit = calculatePositionAmountsFromLiquidity(
+          L,
+          sqrtAt(depositTick),
+          tickLower,
+          tickUpper,
+        );
+        const withdraw = calculatePositionAmountsFromLiquidity(
+          L,
+          sqrtAt(swaps.finalTick),
+          tickLower,
+          tickUpper,
+        );
+
+        const net0 = deposit.amount0 + swaps.stakedDelta0 - withdraw.amount0;
+        const net1 = deposit.amount1 + swaps.stakedDelta1 - withdraw.amount1;
+
+        expect(net0).toBeGreaterThanOrEqual(-20n);
+        expect(net0).toBeLessThanOrEqual(20n);
+        expect(net1).toBeGreaterThanOrEqual(-20n);
+        expect(net1).toBeLessThanOrEqual(20n);
+      });
+
+      it("(c) telescopes when withdraw happens at an out-of-range tick (price above)", () => {
+        const L = 10n ** 18n;
+        const tickLower = -100n;
+        const tickUpper = 100n;
+        const depositTick = 50n;
+        const withdrawTick = 200n;
+        const edges = [tickLower, tickUpper];
+        const nets = [L, -L];
+
+        const journey = [depositTick, 99n, 101n, withdrawTick];
+        const swaps = runSwaps(journey, edges, nets);
+
+        const deposit = calculatePositionAmountsFromLiquidity(
+          L,
+          sqrtAt(depositTick),
+          tickLower,
+          tickUpper,
+        );
+        const withdraw = calculatePositionAmountsFromLiquidity(
+          L,
+          sqrtAt(swaps.finalTick),
+          tickLower,
+          tickUpper,
+        );
+
+        const net0 = deposit.amount0 + swaps.stakedDelta0 - withdraw.amount0;
+        const net1 = deposit.amount1 + swaps.stakedDelta1 - withdraw.amount1;
+
+        expect(net0).toBeGreaterThanOrEqual(-20n);
+        expect(net0).toBeLessThanOrEqual(20n);
+        expect(net1).toBeGreaterThanOrEqual(-20n);
+        expect(net1).toBeLessThanOrEqual(20n);
+      });
+
+      it("(d) WETH/OP-style scenario: deposit pre-Initialize → Initialize backfill → swaps → withdraw", () => {
+        // The exact #732 mechanism for an idle CL pool: gauge.Deposit fires
+        // BEFORE the pool's first Initialize-fed swap, so the deposit-side
+        // increment is silently dropped by the `sqrtPriceX96 !== 0n` gate in
+        // GaugeSharedLogic.computeCLStakedReservesOnGaugeEvent / NFPMCommon
+        // Logic.updateStakedPositionLiquidity. Edges are still applied, so
+        // the subsequent swap path's per-segment math walks them correctly.
+        // Without a backfill the drift lands at −P(L, sqrt_at_initialize).
+        //
+        // Fix: the `CLPool.Initialize` handler now derives `stakedReserve0/1`
+        // from the edge state via `deriveStakedReservesFromEdges` whenever the
+        // Pool already exists at Initialize time. That plants the missing
+        // anchor and lets the lifecycle telescope to zero again.
+        const L = 10n ** 18n;
+        const tickLower = -100n;
+        const tickUpper = 100n;
+        const initializeTick = 0n;
+        const withdrawTick = 50n;
+        const edges = [tickLower, tickUpper];
+        const nets = [L, -L];
+
+        // Pre-Initialize Deposit dropped both increments to 0n; the edges were
+        // still recorded. At Initialize, the fix derives the anchor from edges.
+        const anchored = deriveStakedReservesFromEdges(
+          sqrtAt(initializeTick),
+          edges,
+          nets,
+        );
+
+        // Swaps after Initialize (from initialize tick to withdraw tick).
+        const journey = [initializeTick, withdrawTick];
+        const swaps = runSwaps(journey, edges, nets);
+
+        const withdraw = calculatePositionAmountsFromLiquidity(
+          L,
+          sqrtAt(withdrawTick),
+          tickLower,
+          tickUpper,
+        );
+
+        const net0 =
+          anchored.stakedReserve0 + swaps.stakedDelta0 - withdraw.amount0;
+        const net1 =
+          anchored.stakedReserve1 + swaps.stakedDelta1 - withdraw.amount1;
+
+        // Closed-system invariant after the fix: lifecycle telescopes to zero.
+        expect(net0).toBeGreaterThanOrEqual(-20n);
+        expect(net0).toBeLessThanOrEqual(20n);
+        expect(net1).toBeGreaterThanOrEqual(-20n);
+        expect(net1).toBeLessThanOrEqual(20n);
+      });
+    });
+  });
+
+  // Regression coverage for issue #732: deriveStakedReservesFromEdges plants
+  // the missing reserve anchor at CLPool.Initialize for pools that received
+  // gauge Deposits / NFPM IncreaseLiquidity events while sqrtPriceX96 was 0n
+  // (the per-event reserve increment was gated off, leaving edges populated
+  // but reserves at 0). The derivation MUST equal the per-position
+  // calculatePositionAmountsFromLiquidity sum at the Initialize sqrt — that is
+  // the ground truth for what stakedReserve0/1 should have been when the
+  // gauge.Deposit events first fired.
+  describe("deriveStakedReservesFromEdges (#732)", () => {
+    it("returns 0 reserves on empty edge list", () => {
+      const result = deriveStakedReservesFromEdges(sqrtAt(0n), [], []);
+      expect(result.stakedReserve0).toBe(0n);
+      expect(result.stakedReserve1).toBe(0n);
+    });
+
+    it("returns 0 reserves when sqrtPriceX96 is 0n (no price available)", () => {
+      const L = 10n ** 18n;
+      const result = deriveStakedReservesFromEdges(0n, [-100n, 100n], [L, -L]);
+      expect(result.stakedReserve0).toBe(0n);
+      expect(result.stakedReserve1).toBe(0n);
+    });
+
+    it("matches calculatePositionAmountsFromLiquidity for a single in-range position", () => {
+      // Position [-100, 100], L; derivation at sqrtAt(0) (in range) must match
+      // the canonical per-position amounts within bigint-truncation tolerance.
+      const L = 10n ** 18n;
+      const tickLower = -100n;
+      const tickUpper = 100n;
+      const sqrtPriceX96 = sqrtAt(0n);
+
+      const derived = deriveStakedReservesFromEdges(
+        sqrtPriceX96,
+        [tickLower, tickUpper],
+        [L, -L],
+      );
+      const expected = calculatePositionAmountsFromLiquidity(
+        L,
+        sqrtPriceX96,
+        tickLower,
+        tickUpper,
+      );
+
+      expect(derived.stakedReserve0 - expected.amount0).toBeGreaterThanOrEqual(
+        -2n,
+      );
+      expect(derived.stakedReserve0 - expected.amount0).toBeLessThanOrEqual(2n);
+      expect(derived.stakedReserve1 - expected.amount1).toBeGreaterThanOrEqual(
+        -2n,
+      );
+      expect(derived.stakedReserve1 - expected.amount1).toBeLessThanOrEqual(2n);
+    });
+
+    it("matches calculatePositionAmountsFromLiquidity when price is below the position (all token0)", () => {
+      const L = 10n ** 18n;
+      const tickLower = 100n;
+      const tickUpper = 300n;
+      const sqrtPriceX96 = sqrtAt(0n);
+
+      const derived = deriveStakedReservesFromEdges(
+        sqrtPriceX96,
+        [tickLower, tickUpper],
+        [L, -L],
+      );
+      const expected = calculatePositionAmountsFromLiquidity(
+        L,
+        sqrtPriceX96,
+        tickLower,
+        tickUpper,
+      );
+
+      expect(derived.stakedReserve1).toBe(0n);
+      expect(expected.amount1).toBe(0n);
+      expect(derived.stakedReserve0 - expected.amount0).toBeGreaterThanOrEqual(
+        -2n,
+      );
+      expect(derived.stakedReserve0 - expected.amount0).toBeLessThanOrEqual(2n);
+    });
+
+    it("matches calculatePositionAmountsFromLiquidity when price is above the position (all token1)", () => {
+      const L = 10n ** 18n;
+      const tickLower = -300n;
+      const tickUpper = -100n;
+      const sqrtPriceX96 = sqrtAt(0n);
+
+      const derived = deriveStakedReservesFromEdges(
+        sqrtPriceX96,
+        [tickLower, tickUpper],
+        [L, -L],
+      );
+      const expected = calculatePositionAmountsFromLiquidity(
+        L,
+        sqrtPriceX96,
+        tickLower,
+        tickUpper,
+      );
+
+      expect(derived.stakedReserve0).toBe(0n);
+      expect(expected.amount0).toBe(0n);
+      expect(derived.stakedReserve1 - expected.amount1).toBeGreaterThanOrEqual(
+        -2n,
+      );
+      expect(derived.stakedReserve1 - expected.amount1).toBeLessThanOrEqual(2n);
+    });
+
+    it("sums contributions from multiple non-overlapping positions", () => {
+      // Position A: [-300, -100], L_A; Position B: [100, 300], L_B.
+      // At sqrtPriceX96 in the middle (sqrtAt(0)): A is below (all token1),
+      // B is above (all token0). Derived total = A.amount1 + B.amount0.
+      const L_A = 10n ** 18n;
+      const L_B = 2n * 10n ** 18n;
+      const sqrtPriceX96 = sqrtAt(0n);
+
+      const derived = deriveStakedReservesFromEdges(
+        sqrtPriceX96,
+        [-300n, -100n, 100n, 300n],
+        [L_A, -L_A, L_B, -L_B],
+      );
+      const a = calculatePositionAmountsFromLiquidity(
+        L_A,
+        sqrtPriceX96,
+        -300n,
+        -100n,
+      );
+      const b = calculatePositionAmountsFromLiquidity(
+        L_B,
+        sqrtPriceX96,
+        100n,
+        300n,
+      );
+
+      expect(
+        derived.stakedReserve0 - (a.amount0 + b.amount0),
+      ).toBeGreaterThanOrEqual(-2n);
+      expect(
+        derived.stakedReserve0 - (a.amount0 + b.amount0),
+      ).toBeLessThanOrEqual(2n);
+      expect(
+        derived.stakedReserve1 - (a.amount1 + b.amount1),
+      ).toBeGreaterThanOrEqual(-2n);
+      expect(
+        derived.stakedReserve1 - (a.amount1 + b.amount1),
+      ).toBeLessThanOrEqual(2n);
+    });
+
+    it("sums contributions from overlapping positions sharing edges", () => {
+      // Position A: [100, 300], L=500; Position B: [200, 400], L=300.
+      // edges = [100, 200, 300, 400], nets = [+500, +300, -500, -300].
+      // At sqrtPriceX96 in tick=250 (both in range): both contribute.
+      const sqrtPriceX96 = sqrtAt(250n);
+      const derived = deriveStakedReservesFromEdges(
+        sqrtPriceX96,
+        [100n, 200n, 300n, 400n],
+        [500n, 300n, -500n, -300n],
+      );
+      const a = calculatePositionAmountsFromLiquidity(
+        500n,
+        sqrtPriceX96,
+        100n,
+        300n,
+      );
+      const b = calculatePositionAmountsFromLiquidity(
+        300n,
+        sqrtPriceX96,
+        200n,
+        400n,
+      );
+      expect(
+        derived.stakedReserve0 - (a.amount0 + b.amount0),
+      ).toBeGreaterThanOrEqual(-3n);
+      expect(
+        derived.stakedReserve0 - (a.amount0 + b.amount0),
+      ).toBeLessThanOrEqual(3n);
+      expect(
+        derived.stakedReserve1 - (a.amount1 + b.amount1),
+      ).toBeGreaterThanOrEqual(-3n);
+      expect(
+        derived.stakedReserve1 - (a.amount1 + b.amount1),
+      ).toBeLessThanOrEqual(3n);
+    });
+
+    it("skips segments with cumulative L = 0n (gaps between non-overlapping positions)", () => {
+      // Same setup as the non-overlapping pair, but verify the gap segment
+      // [tick=-100, tick=100] (cumulative L=0) contributes nothing — otherwise
+      // we'd see a non-zero spurious term in either reserve.
+      const L_A = 10n ** 18n;
+      const L_B = 2n * 10n ** 18n;
+      const sqrtPriceX96 = sqrtAt(0n); // in the gap
+
+      const derived = deriveStakedReservesFromEdges(
+        sqrtPriceX96,
+        [-300n, -100n, 100n, 300n],
+        [L_A, -L_A, L_B, -L_B],
+      );
+
+      // No segment straddles the gap with non-zero L, so the in-range split
+      // formula must not have fired. Position A is fully below (all token1);
+      // Position B is fully above (all token0).
+      const a = calculatePositionAmountsFromLiquidity(
+        L_A,
+        sqrtPriceX96,
+        -300n,
+        -100n,
+      );
+      const b = calculatePositionAmountsFromLiquidity(
+        L_B,
+        sqrtPriceX96,
+        100n,
+        300n,
+      );
+      expect(a.amount0).toBe(0n);
+      expect(b.amount1).toBe(0n);
+      expect(derived.stakedReserve0).toBe(b.amount0);
+      expect(derived.stakedReserve1).toBe(a.amount1);
     });
   });
 

--- a/test/Aggregators/CLStakedLiquidityEdgeSanity.test.ts
+++ b/test/Aggregators/CLStakedLiquidityEdgeSanity.test.ts
@@ -1,8 +1,9 @@
 import type { Token, handlerContext } from "generated";
-import { CLGauge, MockDb } from "../../generated/src/TestHelpers.gen";
+import { CLGauge, CLPool, MockDb } from "../../generated/src/TestHelpers.gen";
 import {
   applyStakedPositionToEdges,
   deriveStakedLiquidityInRange,
+  deriveStakedReservesFromEdges,
   processTickCrossingsForStaked,
 } from "../../src/Aggregators/CLStakedLiquidity";
 import {
@@ -11,6 +12,7 @@ import {
   toChecksumAddress,
 } from "../../src/Constants";
 import { updateStakedPositionLiquidity } from "../../src/EventHandlers/NFPM/NFPMCommonLogic";
+import { calculatePositionAmountsFromLiquidity } from "../../src/Helpers";
 import { setupCommon } from "../EventHandlers/Pool/common";
 import { sqrtAt } from "./common";
 
@@ -676,6 +678,189 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
         ),
       );
       expect(postWithdraw.stakedLiquidityInRange).toBe(0n);
+    });
+  });
+
+  // Regression coverage for issue #732: the residual of #666 — 58 CL pools
+  // with negative stakedReserve0/1 even after currentLiquidityStaked is back
+  // to 0n. The structural drift: gauge.Deposit / NFPM.IncreaseLiquidity events
+  // that fire while sqrtPriceX96 is 0n update the edge map but skip the per-
+  // event reserve increment (the `sqrtPriceX96 !== 0n` gate). The
+  // CLPool.Initialize handler now backfills stakedReserve0/1 from the edge
+  // state when the Pool already exists at Initialize time, planting the
+  // missing anchor so subsequent swap deltas + Withdraw decrement telescope to
+  // zero again.
+  describe("#732 pre-Initialize stake backfill at CLPool.Initialize", () => {
+    it("backfills stakedReserve0/1 from edges populated by a pre-Initialize gauge Deposit", async () => {
+      let mockDb = MockDb.createMockDb();
+
+      // Pool already exists (PoolCreated has run) but no Initialize has fired:
+      // sqrtPriceX96=0n, tick=0n. This is the structural pre-Initialize state
+      // where edge-modifying handlers update edges but skip reserve increments.
+      const liquidityPool = createMockPool({
+        isCL: true,
+        gaugeAddress,
+        sqrtPriceX96: 0n,
+        tick: 0n,
+        hasStakes: false,
+        stakedReserve0: 0n,
+        stakedReserve1: 0n,
+      });
+      mockDb = mockDb.entities.Pool.set(liquidityPool);
+      mockDb = mockDb.entities.Token.set(mockToken0Data as Token);
+      mockDb = mockDb.entities.Token.set(mockToken1Data as Token);
+
+      const tickLower = -100n;
+      const tickUpper = 100n;
+      const liquidity = 10n ** 18n;
+      const tokenId = 42n;
+      mockDb = mockDb.entities.NonFungiblePosition.set(
+        createMockNonFungiblePosition({
+          tokenId,
+          nfpmAddress: defaultNfpmAddress,
+          pool: liquidityPool.poolAddress,
+          owner: userAddress,
+          tickLower,
+          tickUpper,
+          liquidity,
+        }),
+      );
+
+      // 1) Pre-Initialize gauge Deposit: edges get the +L/-L pair, but the
+      //    `sqrtPriceX96 !== 0n` gate inside computeCLStakedReservesOnGaugeEvent
+      //    drops the per-event reserve increment.
+      const depositEvent = CLGauge.Deposit.createMockEvent({
+        user: userAddress,
+        tokenId,
+        liquidityToStake: liquidity,
+        mockEventData: {
+          srcAddress: gaugeAddress,
+          chainId,
+          block: {
+            number: 1,
+            timestamp: 1_700_000_000,
+            hash: `0x${"a".repeat(64)}`,
+          },
+        },
+      });
+      let resultDb = await mockDb.processEvents([depositEvent]);
+
+      const postDeposit = resultDb.entities.Pool.get(
+        PoolId(chainId, liquidityPool.poolAddress),
+      );
+      expect(postDeposit).toBeDefined();
+      if (!postDeposit) return;
+
+      // Edges absorbed the position; reserves stayed at 0n (the bug residue).
+      expect(postDeposit.stakedTickEdges).toEqual([tickLower, tickUpper]);
+      expect(postDeposit.stakedTickEdgeNets).toEqual([liquidity, -liquidity]);
+      expect(postDeposit.stakedReserve0 ?? 0n).toBe(0n);
+      expect(postDeposit.stakedReserve1 ?? 0n).toBe(0n);
+
+      // 2) CLPool.Initialize fires (e.g., Slipstream same-tx buffer missed, or
+      //    non-Slipstream factory). With the fix, the handler updates
+      //    sqrtPriceX96/tick on the existing Pool AND derives stakedReserve0/1
+      //    from the edge state. The anchor MUST equal what the gauge.Deposit
+      //    should have written if it had had a sqrt to compute against.
+      const initializeTick = 0n;
+      const initializeSqrt = sqrtAt(initializeTick);
+      const initializeEvent = CLPool.Initialize.createMockEvent({
+        sqrtPriceX96: initializeSqrt,
+        tick: initializeTick,
+        mockEventData: {
+          srcAddress: liquidityPool.poolAddress,
+          chainId,
+          block: {
+            number: 2,
+            timestamp: 1_700_000_100,
+            hash: `0x${"b".repeat(64)}`,
+          },
+        },
+      });
+      resultDb = await resultDb.processEvents([initializeEvent]);
+
+      const postInit = resultDb.entities.Pool.get(
+        PoolId(chainId, liquidityPool.poolAddress),
+      );
+      expect(postInit).toBeDefined();
+      if (!postInit) return;
+
+      // Initialize applied the opening price.
+      expect(postInit.sqrtPriceX96).toBe(initializeSqrt);
+      expect(postInit.tick).toBe(initializeTick);
+
+      // The anchor matches the canonical per-position amounts at sqrt_init —
+      // i.e., what gauge.Deposit should have written had it had a sqrt.
+      const expected = calculatePositionAmountsFromLiquidity(
+        liquidity,
+        initializeSqrt,
+        tickLower,
+        tickUpper,
+      );
+      expect(
+        (postInit.stakedReserve0 ?? 0n) - expected.amount0,
+      ).toBeGreaterThanOrEqual(-2n);
+      expect(
+        (postInit.stakedReserve0 ?? 0n) - expected.amount0,
+      ).toBeLessThanOrEqual(2n);
+      expect(
+        (postInit.stakedReserve1 ?? 0n) - expected.amount1,
+      ).toBeGreaterThanOrEqual(-2n);
+      expect(
+        (postInit.stakedReserve1 ?? 0n) - expected.amount1,
+      ).toBeLessThanOrEqual(2n);
+
+      // And the in-range counter heals to the derivation at the new tick.
+      expect(postInit.stakedLiquidityInRange).toBe(
+        deriveStakedLiquidityInRange(
+          postInit.tick ?? 0n,
+          postInit.stakedTickEdges,
+          postInit.stakedTickEdgeNets,
+        ),
+      );
+      // Sanity: a sum-of-derivations check on the same inputs lines up.
+      const sanity = deriveStakedReservesFromEdges(
+        initializeSqrt,
+        postInit.stakedTickEdges,
+        postInit.stakedTickEdgeNets,
+      );
+      expect(postInit.stakedReserve0).toBe(sanity.stakedReserve0);
+      expect(postInit.stakedReserve1).toBe(sanity.stakedReserve1);
+    });
+
+    it("still buffers Initialize when the Pool aggregator does not exist yet (Slipstream same-tx flow)", async () => {
+      // Slipstream emits CLPool.Initialize at a LOWER log index than the
+      // CLFactory.PoolCreated within the same tx, so the Initialize handler
+      // is expected to buffer into CLPoolPendingInitialize for PoolCreated to
+      // consume. The fix MUST preserve this path; otherwise newly-created CL
+      // pools would lose the opening-price routing (#654).
+      let mockDb = MockDb.createMockDb();
+      const newPoolAddress = toChecksumAddress(
+        "0x4444444444444444444444444444444444444444",
+      );
+      const initializeSqrt = sqrtAt(0n);
+      const initializeEvent = CLPool.Initialize.createMockEvent({
+        sqrtPriceX96: initializeSqrt,
+        tick: 0n,
+        mockEventData: {
+          srcAddress: newPoolAddress,
+          chainId,
+          block: {
+            number: 1,
+            timestamp: 1_700_000_000,
+            hash: `0x${"c".repeat(64)}`,
+          },
+        },
+      });
+
+      mockDb = await mockDb.processEvents([initializeEvent]);
+      const buffered = mockDb.entities.CLPoolPendingInitialize.get(
+        PoolId(chainId, newPoolAddress),
+      );
+      expect(buffered).toBeDefined();
+      if (!buffered) return;
+      expect(buffered.sqrtPriceX96).toBe(initializeSqrt);
+      expect(buffered.tick).toBe(0n);
     });
   });
 });


### PR DESCRIPTION
## Summary

- **Root cause**: Pre-Initialize `gauge.Deposit` / `NFPM.IncreaseLiquidity` events update the edge map (`stakedTickEdges` / `stakedTickEdgeNets`) but skip the per-event reserve increment when `sqrtPriceX96 === 0n` (the existing guard in `computeCLStakedReservesOnGaugeEvent` / `updateStakedPositionLiquidity`). Subsequent swap-path per-segment attribution then accumulates against a missing anchor, and the gauge `Withdraw` decrement leaves a residual `-P(L, sqrt_at_initialize)` — the negative `stakedReserve0/1` drift observed on 58 CL pools after `currentLiquidityStaked` round-trips back to 0n.
- **Fix at the source**: `CLPool.Initialize` now plants the missing anchor. When the Pool aggregator already exists at Initialize time (Slipstream same-tx buffer missed, or non-Slipstream factory emits Initialize in a later tx), the handler:
  1. Writes `sqrtPriceX96` / `tick` directly onto the Pool.
  2. Backfills `stakedReserve0/1` via a new `deriveStakedReservesFromEdges` pure helper that walks each edge segment, accumulates cumulative L, and adds the Uniswap v3 amount contribution at the opening sqrt. The Slipstream same-tx flow (Initialize → `CLPoolPendingInitialize` buffer → `CLFactory.PoolCreated` consumes) is preserved when the Pool doesn't exist yet.
- No symptom-clamping at the writeback site — the existing `[NEGATIVE_STAKED_RESERVE_DRIFT]` warn-log (mirror of `NEG_STAKED_LIQ_GUARD` from #725) is left in place as a regression guard.

## Acceptance criteria

- [x] Root cause identified and documented (see commit message + code comments in `src/EventHandlers/CLPool.ts` and `src/Aggregators/CLStakedLiquidity.ts`).
- [x] Math fix lands at the source — no clamp at writeback.
- [x] Regression test reproducing the WETH/OP-style sequence: stake-pre-Initialize → Initialize → swaps → unstake-all telescopes to 0 (within bigint-truncation wei). See `test/Aggregators/CLStakedLiquidity.test.ts` "(d) WETH/OP-style scenario" and `test/Aggregators/CLStakedLiquidityEdgeSanity.test.ts` "#732 pre-Initialize stake backfill" describe block.
- [x] Existing tests in `CLPoolSwapLogic.test.ts` / `processTickCrossingsForStaked` test suite pass (full suite: 1295 tests passing).
- [ ] Fresh sync run yields 0 pools with negative `stakedReserve0/1` (runtime verification — confirm before merge).
- [x] Optional warn-log retained as regression guard (`NEGATIVE_STAKED_RESERVE_DRIFT` at `src/Aggregators/Pool.ts:550-559`).

## Test plan

- [x] `pnpm test` — full suite (1295 tests).
- [x] `tsc --noEmit` — clean.
- [x] `biome check` — clean.
- [ ] Sync a chain with previously-affected pools (Optimism: WETH/OP, etc.) end-to-end and confirm the `[NEGATIVE_STAKED_RESERVE_DRIFT]` warn-log no longer fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved calculation of staked reserves during Concentrated Liquidity pool initialization, ensuring accurate reserve tracking when stakes occur before pool setup.

* **Tests**
  * Added comprehensive regression test coverage for staked liquidity calculations across various pool lifecycle scenarios, including edge cases and initialization handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/velodrome-finance/indexer/pull/747?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->