### PR TITLE
perf(swap-fee): hour-round blockNumber for getSwapFee cache key (closes #749)

### DIFF
--- a/src/Aggregators/Pool.ts
+++ b/src/Aggregators/Pool.ts
@@ -1,6 +1,6 @@
 import type { CLGaugeConfig, Token, handlerContext } from "generated";
 import { PoolId, TokenId, isKnownSinkRootPool } from "../Constants";
-import { getSwapFee } from "../Effects/Index";
+import { getSwapFee, roundBlockToInterval } from "../Effects/Index";
 import type { Pool } from "../EntityTypes";
 import { calculateTotalUSD, generatePoolName } from "../Helpers";
 import { refreshTokenPrice } from "../PriceOracle";
@@ -194,11 +194,15 @@ export async function updateDynamicFeePools(
     return liquidityPoolAggregator;
   }
 
+  // Issue #749: round block to the hour boundary so the effect cache key is
+  // stable within an hour. Matches the pattern getTokenPrice uses
+  // (src/PriceOracle.ts) and lets preload dual-pass + re-index back-fills
+  // hit the cache instead of producing a fresh slot per raw block.
   const currentFee = await context.effect(getSwapFee, {
     poolAddress,
     factoryAddress,
     chainId,
-    blockNumber,
+    blockNumber: roundBlockToInterval(blockNumber, chainId),
   });
 
   if (currentFee === undefined) {

--- a/test/Aggregators/Pool.test.ts
+++ b/test/Aggregators/Pool.test.ts
@@ -13,6 +13,7 @@ import {
   toChecksumAddress,
 } from "../../src/Constants";
 import { getSwapFee } from "../../src/Effects/SwapFee";
+import { roundBlockToInterval } from "../../src/Effects/Token";
 import type { Pool } from "../../src/EntityTypes";
 import * as PriceOracle from "../../src/PriceOracle";
 import { setPoolSnapshot } from "../../src/Snapshots/PoolSnapshot";
@@ -201,7 +202,8 @@ describe("Pool Functions", () => {
       // Should log a warning
       expect(vi.mocked(mockContext.log?.warn)).toHaveBeenCalled();
 
-      // Verify that the effect was called with the expected arguments
+      // Verify that the effect was called with the hour-rounded blockNumber
+      // (issue #749: cache key must be stable within an hour for L1/preload reuse)
       // biome-ignore lint/style/noNonNullAssertion: effect is verified to be defined above
       const effectMock = vi.mocked(mockContext.effect!);
       expect(effectMock).toHaveBeenCalledWith(getSwapFee, {
@@ -210,8 +212,49 @@ describe("Pool Functions", () => {
           "0x548118C7E0B865C2CfA94D15EC86B666468ac758",
         ),
         chainId: liquidityPoolAggregator.chainId,
-        blockNumber,
+        blockNumber: roundBlockToInterval(
+          blockNumber,
+          // biome-ignore lint/style/noNonNullAssertion: chainId is set in beforeEach
+          liquidityPoolAggregator.chainId!,
+        ),
       });
+    });
+
+    // Regression test for issue #749: getSwapFee's effect cache key must be
+    // hour-stable so preload dual-pass and re-index back-fills hit the cache
+    // instead of producing a new slot per raw block.
+    it("should pass an hour-rounded blockNumber so cache key is stable within the hour", async () => {
+      const blocksPerHour = 1800; // 2s blocks on Optimism (chainId 10)
+      const firstBlockInHour =
+        Math.floor(blockNumber / blocksPerHour) * blocksPerHour;
+      const lastBlockInHour = firstBlockInHour + blocksPerHour - 1;
+
+      await updateDynamicFeePools(
+        liquidityPoolAggregator as Pool,
+        mockContext as handlerContext,
+        10,
+        firstBlockInHour,
+      );
+      await updateDynamicFeePools(
+        liquidityPoolAggregator as Pool,
+        mockContext as handlerContext,
+        10,
+        lastBlockInHour,
+      );
+
+      // biome-ignore lint/style/noNonNullAssertion: effect is verified to be defined above
+      const effectMock = vi.mocked(mockContext.effect!);
+      const swapFeeCalls = effectMock.mock.calls.filter(
+        (call) => call[0] === getSwapFee,
+      );
+      expect(swapFeeCalls).toHaveLength(2);
+      const [firstCall, secondCall] = swapFeeCalls;
+      // biome-ignore lint/style/noNonNullAssertion: filtered for length 2 above
+      const firstInput = firstCall![1] as { blockNumber: number };
+      // biome-ignore lint/style/noNonNullAssertion: filtered for length 2 above
+      const secondInput = secondCall![1] as { blockNumber: number };
+      expect(firstInput.blockNumber).toBe(firstBlockInHour);
+      expect(secondInput.blockNumber).toBe(firstBlockInHour);
     });
 
     it("should skip dynamic fee updates when event chain doesn’t match pool chain", async () => {


### PR DESCRIPTION
## Summary

- Wraps `blockNumber` with `roundBlockToInterval(blockNumber, chainId)` at the `getSwapFee` call site in `updateDynamicFeePools` (`src/Aggregators/Pool.ts:201-205`), matching the existing pattern in `getTokenPrice` (`src/PriceOracle.ts:227`).
- Stabilizes the effect cache key within an hour so preload dual-pass execution and re-index back-fills hit the cache instead of producing a new slot per raw block.
- Surgical scope: no change to the `getSwapFee` effect signature, `fetchSwapFee`, or any persisted state semantics. The L1 throttle in `setPoolAggregator` already enforces ≤1 update/hour/pool, so the rounded block doesn't reduce data resolution.

## Acceptance criteria (issue #749)

- [x] `updateDynamicFeePools` rounds `blockNumber` via `roundBlockToInterval` before passing to `getSwapFee`.
- [x] `currentFee` written to the `Pool` entity remains semantically correct (fees are extremely stable within an hour bucket; same trade-off `getTokenPrice` already makes).
- [x] No behavior change to `getSwapFee` effect signature or `fetchSwapFee` itself.
- [x] Tests covering `updateDynamicFeePools` still pass; a new test asserts the cache key is hour-stable across two distinct in-hour blocks.

## Test plan

- [x] `vitest run test/Aggregators/Pool.test.ts` — 54 pass (4 covering `updateDynamicFeePools`, including the new hour-stability regression test).
- [x] `vitest run test/Effects/SwapFee.test.ts test/EventHandlers/Voter/CrossChainPendingResolution.test.ts` — 52 pass (no collateral damage in code paths touching `getSwapFee`).
- [x] `tsc --noEmit` — clean after `pnpm envio codegen`.
- [x] `biome check` (via `pnpm qa --write`) — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of dynamic fee calculations by optimizing block data processing within hourly intervals.
  * Added regression test coverage to prevent caching inconsistencies in fee computation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/velodrome-finance/indexer/pull/750?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->