### PR TITLE
perf(price-oracle): cut getTokenPrice eth_call fan-out 7→1 per miss (closes #748)

### DIFF
--- a/src/Effects/RpcGateway.ts
+++ b/src/Effects/RpcGateway.ts
@@ -66,6 +66,11 @@ const RPC_GATEWAY_OPERATIONS = {
       tokenAddress: S.string,
       chainId: S.number,
       blockNumber: S.number,
+      // Source-token decimals supplied by the caller when known (issue #748).
+      // When present, skips the source-token fetchTokenDetails RPC (~3 eth_calls
+      // per cache miss). Absent on cross-chain cold-sync against an unloaded
+      // source Token; handler falls back to the fetch path.
+      tokenDecimals: S.optional(S.number),
     },
     outputSchema: {
       pricePerUSDNew: S.bigint,
@@ -162,6 +167,7 @@ type RpcGatewayInputPayloadByType = {
     tokenAddress: string;
     chainId: number;
     blockNumber: number;
+    tokenDecimals?: number;
   };
   [EffectType.GET_TOKENS_DEPOSITED]: {
     rewardTokenAddress: string;
@@ -377,7 +383,7 @@ async function handleGetTokenPrice(
   i: RpcGatewayInputByType[EffectType.GET_TOKEN_PRICE],
   context: RpcGatewayHandlerContext,
 ): Promise<RpcGatewayOutputByType[EffectType.GET_TOKEN_PRICE]> {
-  const { tokenAddress, chainId, blockNumber } = i;
+  const { tokenAddress, chainId, blockNumber, tokenDecimals } = i;
   const chain = CHAIN_CONSTANTS[chainId];
   if (!chain) {
     context.log.error(
@@ -411,16 +417,35 @@ async function handleGetTokenPrice(
     };
   }
 
-  const DESTINATION_TOKEN_DETAILS_FALLBACK = {
-    name: "DestinationToken",
-    symbol: "DestinationToken",
-    decimals: chain.destinationTokenDecimals,
-  };
+  // Issue #748: short-circuit pre-deploy BEFORE any token-detail fetch so
+  // chains/blocks before oracle deploy don't pay metadata calls just to return 0n.
+  // Pre-deploy zero is a real, cacheable answer (the oracle does not exist yet),
+  // not the fallback constant — keep usedDefault: false so the result stays in the cache.
+  const ORACLE_DEPLOYED = chain.oracle.startBlock <= blockNumber;
+  if (!ORACLE_DEPLOYED) {
+    return {
+      pricePerUSDNew: 0n,
+      priceOracleType: chain.oracle.getType(blockNumber).toString(),
+      usedDefault: false,
+      errorClass: undefined,
+    };
+  }
 
   const fallbackClient = createFallbackRpcClient(chainId);
 
-  const [tokenDetails, destinationTokenDetails] = await Promise.all([
-    executeRpcWithFallback(
+  // Issue #748: source token decimals come from the caller when known
+  // (skipping ~3 redundant eth_calls per cache miss). Destination decimals
+  // always come from chain.destinationTokenDecimals — the destination is
+  // constant per chain and name/symbol of it are never used downstream
+  // (only decimals feeds the V3/V4 normalization at the bottom of this fn).
+  const destinationTokenDecimals = chain.destinationTokenDecimals;
+  let sourceTokenDecimals: number;
+  let sourceTokenUsedDefault = false;
+  let sourceTokenErrorClass: ErrorType | undefined;
+  if (tokenDecimals !== undefined) {
+    sourceTokenDecimals = tokenDecimals;
+  } else {
+    const tokenDetails = await executeRpcWithFallback(
       context,
       rpcGatewayOpName(EffectType.GET_TOKEN_PRICE, "tokenDetails"),
       { contractAddress: tokenAddress, chainId },
@@ -429,29 +454,10 @@ async function handleGetTokenPrice(
       fallbackClient
         ? () => fetchTokenDetails(tokenAddress, fallbackClient)
         : undefined,
-    ),
-    executeRpcWithFallback(
-      context,
-      rpcGatewayOpName(EffectType.GET_TOKEN_PRICE, "destinationTokenDetails"),
-      { contractAddress: DESTINATION_TOKEN_ADDRESS, chainId },
-      DESTINATION_TOKEN_DETAILS_FALLBACK,
-      () => fetchTokenDetails(DESTINATION_TOKEN_ADDRESS, chain.eth_client),
-      fallbackClient
-        ? () => fetchTokenDetails(DESTINATION_TOKEN_ADDRESS, fallbackClient)
-        : undefined,
-    ),
-  ]);
-
-  const ORACLE_DEPLOYED = chain.oracle.startBlock <= blockNumber;
-  if (!ORACLE_DEPLOYED) {
-    // Pre-deploy zero is a real, cacheable answer (the oracle does not exist yet),
-    // not the fallback constant — keep usedDefault: false so the result stays in the cache.
-    return {
-      pricePerUSDNew: 0n,
-      priceOracleType: chain.oracle.getType(blockNumber).toString(),
-      usedDefault: false,
-      errorClass: undefined,
-    };
+    );
+    sourceTokenDecimals = tokenDetails.value.decimals;
+    sourceTokenUsedDefault = tokenDetails.usedDefault;
+    sourceTokenErrorClass = tokenDetails.errorClass;
   }
 
   const WETH_ADDRESS = chain.weth;
@@ -512,29 +518,27 @@ async function handleGetTokenPrice(
     priceData.priceOracleType === PriceOracleType.V4
   ) {
     currentPrice =
-      (priceData.pricePerUSDNew * 10n ** BigInt(tokenDetails.value.decimals)) /
-      10n ** BigInt(destinationTokenDetails.value.decimals);
+      (priceData.pricePerUSDNew * 10n ** BigInt(sourceTokenDecimals)) /
+      10n ** BigInt(destinationTokenDecimals);
   } else {
     currentPrice = priceData.pricePerUSDNew;
   }
 
   // Any leg that returned the fallback constant means the composed price is
-  // synthetic — the price RPC itself, or either token-details RPC backing the
-  // decimal conversion. OR all three so the outer effect can skip caching.
-  const usedDefault =
-    priceResult.usedDefault ||
-    tokenDetails.usedDefault ||
-    destinationTokenDetails.usedDefault;
+  // synthetic — the price RPC itself, or the source token-details RPC (when
+  // tokenDecimals wasn't supplied by the caller, #748). The destination side
+  // is no longer fetched — its decimals are read directly from chain
+  // constants — so it cannot contribute a fallback.
+  const usedDefault = priceResult.usedDefault || sourceTokenUsedDefault;
 
-  // Compose errorClass across the three legs: a single transient/network leg
-  // forces the whole result to look transient (less cacheable) even if the
-  // other legs reverted deterministically. Only when every defaulted leg is
-  // CONTRACT_REVERT does the composed result inherit the cacheable revert
-  // class. Stays null when no leg defaulted.
+  // Compose errorClass across the legs that actually fetched: a single
+  // transient/network leg forces the whole result to look transient (less
+  // cacheable) even if other legs reverted deterministically. Only when every
+  // defaulted leg is CONTRACT_REVERT does the composed result inherit the
+  // cacheable revert class. Stays null when no leg defaulted.
   const errorClass = mostCacheBlockingErrorClass(
     priceResult.errorClass,
-    tokenDetails.errorClass,
-    destinationTokenDetails.errorClass,
+    sourceTokenErrorClass,
   );
 
   return {

--- a/src/Effects/Token.ts
+++ b/src/Effects/Token.ts
@@ -97,6 +97,10 @@ function shouldSkipCacheOnDefault(
  * @param input.tokenAddress - Token to price.
  * @param input.chainId - Chain ID for oracle and RPC.
  * @param input.blockNumber - Block at which to read (often rounded via {@link roundBlockToInterval}).
+ * @param input.tokenDecimals - Optional source-token decimals (issue #748). When supplied,
+ *   skips the source-token `fetchTokenDetails` RPC (3 redundant `eth_call`s per cache miss).
+ *   Omit when the caller doesn't hold a trustworthy stored decimals (e.g. cross-chain
+ *   cold-sync against an unloaded source Token); the gateway falls back to fetching.
  * @returns Promise resolving to { pricePerUSDNew, priceOracleType }.
  */
 export const getTokenPrice = createEffect(
@@ -106,6 +110,7 @@ export const getTokenPrice = createEffect(
       tokenAddress: S.string,
       chainId: S.number,
       blockNumber: S.number,
+      tokenDecimals: S.optional(S.number),
     },
     output: {
       pricePerUSDNew: S.bigint,
@@ -120,6 +125,7 @@ export const getTokenPrice = createEffect(
       tokenAddress: input.tokenAddress,
       chainId: input.chainId,
       blockNumber: input.blockNumber,
+      tokenDecimals: input.tokenDecimals,
     });
 
     // Skip caching only on transient-RPC fallbacks (issue #691 + #692).

--- a/src/PriceOracle.ts
+++ b/src/PriceOracle.ts
@@ -191,6 +191,11 @@ export async function refreshTokenPrice(
           tokenAddress: rebindTarget.address,
           chainId: rebindTarget.chainId,
           blockNumber: sourceBlockRounded,
+          // Issue #748: pass source decimals when the source Token entity is
+          // already loaded so the gateway skips the source `fetchTokenDetails`
+          // RPC. When sourceToken is undefined (truly cold-sync), omit so the
+          // gateway falls back to fetching.
+          tokenDecimals: sourceToken ? Number(sourceToken.decimals) : undefined,
         });
         sourcePrice = prefetched.pricePerUSDNew;
       }
@@ -233,6 +238,11 @@ export async function refreshTokenPrice(
       tokenAddress: token.address,
       chainId,
       blockNumber: roundedBlockNumber,
+      // Issue #748: source-token decimals come from the stored Token entity
+      // (the same value downstream USD math consumes), so the gateway can
+      // skip the source `fetchTokenDetails` RPC (~3 redundant eth_calls per
+      // cache miss).
+      tokenDecimals: Number(token.decimals),
     });
     let currentPrice = priceData.pricePerUSDNew;
 

--- a/test/Effects/Token.test.ts
+++ b/test/Effects/Token.test.ts
@@ -325,6 +325,7 @@ describe("Token Effects", () => {
     it("should return 0 price when oracle is not deployed", async () => {
       setupChainConstants(PriceOracleType.V3, { startBlock: 999999 });
       vi.mocked(TokenEffects.fetchTokenPrice).mockClear();
+      vi.mocked(mockEthClient.readContract).mockClear();
 
       const result = await mockContext.effect(getTokenPrice as never, {
         tokenAddress: TEST_TOKEN_ADDRESS,
@@ -337,6 +338,100 @@ describe("Token Effects", () => {
         priceOracleType: PriceOracleType.V3.toString(),
       });
       expect(TokenEffects.fetchTokenPrice).not.toHaveBeenCalled();
+      // Issue #748: pre-deploy short-circuits BEFORE any token-detail fetch,
+      // so no underlying eth_calls are issued (previously paid 6 metadata calls).
+      expect(mockEthClient.readContract).not.toHaveBeenCalled();
+    });
+
+    it("issue #748: when tokenDecimals is supplied, skips source-token fetchTokenDetails RPC", async () => {
+      setupChainConstants(PriceOracleType.V3);
+      // 1e18 in hex (V3 oracle return) → after normalization with src=8 dst=6:
+      // 1e18 * 10^8 / 10^6 = 1e20.
+      vi.mocked(mockEthClient.readContract).mockResolvedValue([
+        "0x0000000000000000000000000000000000000000000000000DE0B6B3A7640000",
+      ] as unknown as readonly bigint[]);
+
+      const result = await mockContext.effect(getTokenPrice as never, {
+        tokenAddress: TEST_TOKEN_ADDRESS,
+        chainId: TEST_CHAIN_ID,
+        blockNumber: TEST_BLOCK_NUMBER,
+        tokenDecimals: 8,
+      });
+
+      const readCalls = vi.mocked(mockEthClient.readContract).mock.calls;
+      const tokenDetailCalls = readCalls.filter((call: unknown[]) => {
+        const fn = (call[0] as { functionName?: string }).functionName;
+        return fn === "name" || fn === "decimals" || fn === "symbol";
+      });
+      // Zero name/decimals/symbol calls: source skipped via caller-supplied
+      // decimals, destination always reads chain.destinationTokenDecimals.
+      expect(tokenDetailCalls).toHaveLength(0);
+
+      expect(result).toEqual({
+        pricePerUSDNew: 10n ** 20n,
+        priceOracleType: PriceOracleType.V3.toString(),
+      });
+    });
+
+    it("issue #748: when tokenDecimals is absent, source-token fetchTokenDetails RPC still runs (cold-sync fallback)", async () => {
+      setupChainConstants(PriceOracleType.V3);
+      vi.mocked(mockEthClient.readContract)
+        .mockResolvedValueOnce("TKN" as unknown as string)
+        .mockResolvedValueOnce(8 as unknown as number)
+        .mockResolvedValueOnce("TKN" as unknown as string)
+        .mockResolvedValue([
+          "0x0000000000000000000000000000000000000000000000000DE0B6B3A7640000",
+        ] as unknown as readonly bigint[]);
+
+      const result = await mockContext.effect(getTokenPrice as never, {
+        tokenAddress: TEST_TOKEN_ADDRESS,
+        chainId: TEST_CHAIN_ID,
+        blockNumber: TEST_BLOCK_NUMBER,
+        // tokenDecimals intentionally omitted (cold-sync against unloaded source).
+      });
+
+      const readCalls = vi.mocked(mockEthClient.readContract).mock.calls;
+      const sourceTokenDetailCalls = readCalls.filter((call: unknown[]) => {
+        const arg = call[0] as { functionName?: string; address?: string };
+        const isTokenAddr =
+          (arg.address ?? "").toLowerCase() ===
+          TEST_TOKEN_ADDRESS.toLowerCase();
+        const isDetailFn =
+          arg.functionName === "name" ||
+          arg.functionName === "decimals" ||
+          arg.functionName === "symbol";
+        return isTokenAddr && isDetailFn;
+      });
+      expect(sourceTokenDetailCalls).toHaveLength(3);
+
+      // Fetched decimals=8 drives the same normalization → identical result.
+      expect(result).toEqual({
+        pricePerUSDNew: 10n ** 20n,
+        priceOracleType: PriceOracleType.V3.toString(),
+      });
+    });
+
+    it("issue #748: destination-token fetchTokenDetails RPC is never called (decimals come from chain constant)", async () => {
+      setupChainConstants(PriceOracleType.V3);
+      vi.mocked(mockEthClient.readContract).mockResolvedValue([
+        "0x0000000000000000000000000000000000000000000000000DE0B6B3A7640000",
+      ] as unknown as readonly bigint[]);
+
+      await mockContext.effect(getTokenPrice as never, {
+        tokenAddress: TEST_TOKEN_ADDRESS,
+        chainId: TEST_CHAIN_ID,
+        blockNumber: TEST_BLOCK_NUMBER,
+        tokenDecimals: 18,
+      });
+
+      const readCalls = vi.mocked(mockEthClient.readContract).mock.calls;
+      const destinationCalls = readCalls.filter((call: unknown[]) => {
+        const arg = call[0] as { address?: string };
+        return (
+          (arg.address ?? "").toLowerCase() === TEST_USDC_ADDRESS.toLowerCase()
+        );
+      });
+      expect(destinationCalls).toHaveLength(0);
     });
 
     it("should set context.cache = false when gateway signals usedDefault:true with a transient errorClass", async () => {
@@ -473,15 +568,13 @@ describe("Token Effects", () => {
           },
         ],
       });
-      // RpcGateway calls fetchTokenDetails x2 then fetchTokenPrice; set up 6 token-detail reads then oracle
+      // Issue #748: RpcGateway calls fetchTokenDetails for source only (3 reads)
+      // then fetchTokenPrice. Destination decimals come from chain constants now.
       const mockReadContract = vi.mocked(mockEthClient.readContract);
       mockReadContract
         .mockResolvedValueOnce("TKN" as unknown as string)
         .mockResolvedValueOnce(18 as unknown as number)
         .mockResolvedValueOnce("TKN" as unknown as string)
-        .mockResolvedValueOnce("USDC" as unknown as string)
-        .mockResolvedValueOnce(6 as unknown as number)
-        .mockResolvedValueOnce("USDC" as unknown as string)
         .mockResolvedValue([
           "0x0000000000000000000000000000000000000000000000001bc16d674ec80000",
         ] as unknown as readonly bigint[]);
@@ -493,7 +586,7 @@ describe("Token Effects", () => {
       });
 
       expect(mockReadContract).toHaveBeenCalled();
-      // First 6 calls are fetchTokenDetails (name, decimals, symbol x2); 7th is oracle
+      // First 3 calls are fetchTokenDetails (source only); 4th is oracle.
       const oracleCall = mockReadContract.mock.calls.find(
         (call: unknown[]) =>
           (call[0] as { functionName?: string }).functionName ===


### PR DESCRIPTION
## Summary

- Hoists the `ORACLE_DEPLOYED` gate in `handleGetTokenPrice` above any token-detail fetch — pre-deploy blocks short-circuit without RPC traffic (was paying 6 metadata calls just to return `0n`).
- Drops the destination-token `fetchTokenDetails` entirely. Only `decimals` is consumed downstream, and `chain.destinationTokenDecimals` is the same value the previous fallback constant already used (`RpcGateway.ts:417` pre-change).
- Adds optional `input.tokenDecimals` to the `getTokenPrice` effect. Both PriceOracle.ts call sites supply it from the stored `Token.decimals` (refresh path) or from `sourceToken.decimals` when loaded (cross-chain cold-sync prefetch). When absent (truly cold-sync against an unloaded source `Token`), the handler falls back to the existing fetch path.

V3/V4 `pricePerUSDNew` is byte-identical for the same inputs — the destination value was already a constant via the fallback path, and source decimals come from the same stored `Token.decimals` that downstream USD math already consumes.

From the Prometheus snapshot in #748: ~3.9M cache misses × 6 saved underlying eth_calls ≈ **~23M underlying `eth_call`s saved per indexer run** (~40% of the indexer's total eth_call volume).

### Cache key change

The new optional input field changes the effect's cache key, so existing cached entries are unreachable after deploy. The existing cache hit rate was only 1–2% per the Prometheus snapshot, so the cache wasn't doing much steady-state work. The one-time rewarm under the new schema costs ~4M RPC calls — still 6× cheaper than the old 27M-per-run steady state, so the rewarm pays for itself in well under one indexer run.

## Test plan

- [x] `vitest run test/Effects/Token.test.ts` — 38 passed (3 new tests + 1 strengthened pre-deploy assertion).
- [x] `pnpm test` (full suite) — 1284 passed, 33 skipped, 0 failed.
- [x] `tsc --noEmit` — no errors.
- [x] `pnpm qa` (biome) — clean.
- [x] Manual trace of V3/V4 normalization: destination fallback already used `chain.destinationTokenDecimals`; new code uses the same constant directly. Source: caller passes `Number(token.decimals)` which is the value `fetchTokenDetails` previously cached. Output identical for the same `(token, chain, block)` tuple.

🤖 Generated with [Claude Code](https://claude.com/claude-code)