### PR TITLE
feat(price-trust): introduce two-tier gate module (slice 1 of #755)

### DIFF
--- a/src/PriceTrust.ts
+++ b/src/PriceTrust.ts
@@ -1,0 +1,85 @@
+import type { Token } from "generated";
+import { calculateTokenAmountUSD } from "./Helpers";
+import { isBlacklistedToken } from "./PriceOverrides";
+
+/**
+ * Reason a token did or did not pass the price-trust gate. Useful for triage
+ * logs and the per-token `priceTrustReason` field added in a later slice.
+ *
+ * - `"WL"` — protocol-whitelisted and not in the operator BLACKLIST (trusted)
+ * - `"BLACKLISTED"` — protocol-whitelisted but operator BLACKLIST overrides
+ * - `"NON_WL"` — not protocol-whitelisted (regardless of BLACKLIST membership)
+ */
+export type PriceTrustReason = "WL" | "NON_WL" | "BLACKLISTED";
+
+export interface PriceTrustDecision {
+  readonly trusted: boolean;
+  readonly reason: PriceTrustReason;
+}
+
+/**
+ * Two-tier price-trust gate. Returns true iff the token is on-chain
+ * whitelisted by the protocol's Voter contract AND is not present in the
+ * operator-maintained BLACKLIST override.
+ *
+ * The gate consults only signals the indexer already has: the Token entity's
+ * `isWhitelisted` (sourced from `WhitelistToken` events) and the static
+ * BLACKLIST set in `PriceOverrides`. No RPC, no entity reads, no heuristics
+ * — pure function, O(1).
+ *
+ * @param token - Token entity from the indexer. Undefined inputs are
+ *   treated as untrusted (the indexer cannot trust what it does not have).
+ * @returns true when the token's price may be multiplied into USD aggregates;
+ *   false otherwise
+ */
+export function isTrusted(token: Token | undefined): boolean {
+  if (!token) return false;
+  if (!token.isWhitelisted) return false;
+  return !isBlacklistedToken(token.chainId, token.address);
+}
+
+/**
+ * USD-from-amount wrapper gated by {@link isTrusted}. Returns the trusted
+ * USD value (1e18-base) for the given raw token amount, or `0n` when the
+ * token fails the gate. This is the call-site convenience helper that every
+ * USD-aggregation site should route through.
+ *
+ * @param amount - Raw token amount in the token's native decimal base
+ * @param token - Token entity carrying decimals + pricePerUSDNew. Undefined
+ *   or untrusted tokens contribute `0n`.
+ * @returns USD value in 1e18-base, or `0n` when the gate denies trust
+ */
+export function getTrustedUSD(
+  amount: bigint,
+  token: Token | undefined,
+): bigint {
+  if (!token || !isTrusted(token)) return 0n;
+  return calculateTokenAmountUSD(
+    amount,
+    Number(token.decimals),
+    token.pricePerUSDNew,
+  );
+}
+
+/**
+ * Debug helper returning the gate's boolean outcome plus the reason it fired.
+ * Intended for triage logs and the per-token `priceTrustReason` field added
+ * by a later slice; not used on the aggregator hot path.
+ *
+ * Reason precedence: `NON_WL` dominates `BLACKLISTED` when both apply, since
+ * the protocol-whitelist signal is the load-bearing one — a token's path to
+ * trust runs through whitelisting, not through removing a blacklist entry.
+ *
+ * @param token - Token entity. Undefined is reported as `NON_WL` (no
+ *   whitelist attestation exists).
+ * @returns `{ trusted, reason }` decision
+ */
+export function getGateDecision(token: Token | undefined): PriceTrustDecision {
+  if (!token || !token.isWhitelisted) {
+    return { trusted: false, reason: "NON_WL" };
+  }
+  if (isBlacklistedToken(token.chainId, token.address)) {
+    return { trusted: false, reason: "BLACKLISTED" };
+  }
+  return { trusted: true, reason: "WL" };
+}

--- a/test/PriceTrust.test.ts
+++ b/test/PriceTrust.test.ts
@@ -1,0 +1,171 @@
+import type { Token } from "generated";
+import { TEN_TO_THE_18_BI, TokenId, toChecksumAddress } from "../src/Constants";
+import { getGateDecision, getTrustedUSD, isTrusted } from "../src/PriceTrust";
+
+// Real BLACKLIST entries (from src/PriceOverrides.ts) used to exercise the
+// blacklist override path without rebuilding the override fixture.
+const MANATEE_OP = toChecksumAddress(
+  "0x7909Bda52eAf7C3cc12745E727Eb527a485241D8",
+);
+const ION_LISK = toChecksumAddress(
+  "0x3f608A49a3ab475dA7fBb167C1Be6b7a45cD7013",
+);
+
+// A canonical, never-blacklisted token (WETH on Optimism).
+const WETH_OP = toChecksumAddress("0x4200000000000000000000000000000000000006");
+
+function makeToken(overrides: Partial<Token> = {}): Token {
+  const chainId = overrides.chainId ?? 10;
+  const address = overrides.address ?? WETH_OP;
+  return {
+    id: TokenId(chainId, address),
+    address: address as `0x${string}`,
+    symbol: "WETH",
+    name: "Wrapped Ether",
+    chainId,
+    decimals: 18n,
+    pricePerUSDNew: 1n * TEN_TO_THE_18_BI,
+    isWhitelisted: true,
+    lastUpdatedTimestamp: new Date(),
+    lastSuccessfulPriceTimestamp: new Date(),
+    ...overrides,
+  };
+}
+
+describe("PriceTrust", () => {
+  describe("isTrusted", () => {
+    it("returns true for WL + not-BL", () => {
+      expect(isTrusted(makeToken({ isWhitelisted: true }))).toBe(true);
+    });
+
+    it("returns false for WL + BL (operator override beats protocol whitelist)", () => {
+      const token = makeToken({
+        chainId: 1135,
+        address: ION_LISK,
+        isWhitelisted: true,
+      });
+      expect(isTrusted(token)).toBe(false);
+    });
+
+    it("returns false for non-WL + not-BL", () => {
+      expect(isTrusted(makeToken({ isWhitelisted: false }))).toBe(false);
+    });
+
+    it("returns false for non-WL + BL (both signals agree)", () => {
+      const token = makeToken({
+        chainId: 10,
+        address: MANATEE_OP,
+        isWhitelisted: false,
+      });
+      expect(isTrusted(token)).toBe(false);
+    });
+
+    it("returns false for undefined token", () => {
+      expect(isTrusted(undefined)).toBe(false);
+    });
+  });
+
+  describe("getGateDecision", () => {
+    it("returns trusted=true and reason='WL' for WL + not-BL", () => {
+      expect(getGateDecision(makeToken())).toEqual({
+        trusted: true,
+        reason: "WL",
+      });
+    });
+
+    it("returns trusted=false and reason='BLACKLISTED' for WL + BL", () => {
+      const token = makeToken({
+        chainId: 1135,
+        address: ION_LISK,
+        isWhitelisted: true,
+      });
+      expect(getGateDecision(token)).toEqual({
+        trusted: false,
+        reason: "BLACKLISTED",
+      });
+    });
+
+    it("returns trusted=false and reason='NON_WL' for non-WL (not blacklisted)", () => {
+      expect(getGateDecision(makeToken({ isWhitelisted: false }))).toEqual({
+        trusted: false,
+        reason: "NON_WL",
+      });
+    });
+
+    it("returns trusted=false and reason='NON_WL' for non-WL (even if also blacklisted)", () => {
+      const token = makeToken({
+        chainId: 10,
+        address: MANATEE_OP,
+        isWhitelisted: false,
+      });
+      expect(getGateDecision(token)).toEqual({
+        trusted: false,
+        reason: "NON_WL",
+      });
+    });
+
+    it("returns trusted=false and reason='NON_WL' for undefined token", () => {
+      expect(getGateDecision(undefined)).toEqual({
+        trusted: false,
+        reason: "NON_WL",
+      });
+    });
+  });
+
+  describe("getTrustedUSD", () => {
+    it("returns amount × price (1e18-base) for a trusted 18-decimal token", () => {
+      const token = makeToken({
+        decimals: 18n,
+        pricePerUSDNew: 1n * TEN_TO_THE_18_BI,
+      });
+      expect(getTrustedUSD(2n * TEN_TO_THE_18_BI, token)).toBe(
+        2n * TEN_TO_THE_18_BI,
+      );
+    });
+
+    it("normalises across decimals (1 unit of a 6-decimal token at $1 → 1e18)", () => {
+      const token = makeToken({
+        decimals: 6n,
+        pricePerUSDNew: 1n * TEN_TO_THE_18_BI,
+      });
+      const oneUnit = 1_000_000n;
+      expect(getTrustedUSD(oneUnit, token)).toBe(1n * TEN_TO_THE_18_BI);
+    });
+
+    it("scales with pricePerUSDNew (1 WETH at $2000 → 2000e18)", () => {
+      const token = makeToken({
+        decimals: 18n,
+        pricePerUSDNew: 2000n * TEN_TO_THE_18_BI,
+      });
+      expect(getTrustedUSD(1n * TEN_TO_THE_18_BI, token)).toBe(
+        2000n * TEN_TO_THE_18_BI,
+      );
+    });
+
+    it("returns 0n for a non-whitelisted token regardless of price", () => {
+      const token = makeToken({
+        isWhitelisted: false,
+        pricePerUSDNew: 1n * TEN_TO_THE_18_BI,
+      });
+      expect(getTrustedUSD(2n * TEN_TO_THE_18_BI, token)).toBe(0n);
+    });
+
+    it("returns 0n for a WL + BL token (blacklist overrides oracle output)", () => {
+      const token = makeToken({
+        chainId: 1135,
+        address: ION_LISK,
+        isWhitelisted: true,
+        pricePerUSDNew: 5n * TEN_TO_THE_18_BI,
+      });
+      expect(getTrustedUSD(100n * TEN_TO_THE_18_BI, token)).toBe(0n);
+    });
+
+    it("returns 0n for a zero amount on a trusted token", () => {
+      expect(getTrustedUSD(0n, makeToken())).toBe(0n);
+    });
+
+    it("returns 0n for an undefined token", () => {
+      expect(getTrustedUSD(2n * TEN_TO_THE_18_BI, undefined)).toBe(0n);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Slice 1 of #755 — the foundational pure module for the two-tier price-trust gate that the rest of the rollout will hang off of. No integration, no schema changes, no callsite migration in this PR.

- New `src/PriceTrust.ts` exporting `isTrusted(token)`, `getTrustedUSD(amount, token)`, and a `getGateDecision(token)` triage helper.
- Gate consults only `Token.isWhitelisted` (sourced from `WhitelistToken` events) plus the operator BLACKLIST in `PriceOverrides`. No RPC, no entity reads, no heuristics — pure function, O(1).
- `getGateDecision` reasons: `"WL"` (trusted) / `"BLACKLISTED"` (WL but overridden) / `"NON_WL"` (everything else, including undefined).
- 17 unit tests covering the 4-cell truth table, decimal normalisation across 6/18-decimal tokens, blacklist-override path with real ION/Lisk + Manatee/OP entries, and the undefined / zero-amount edges.

Routes the future single seam for every `amount × pricePerUSDNew → USD` aggregation; later slices migrate `calculateTotalUSD`, `pickTrustedSwapVolumeUSD`, `calculateWhitelistedFeesUSD`, emissions, and bribes through this gate one PR at a time per the tracer-bullet plan in #755.

## Test plan

- [x] `pnpm test:file test/PriceTrust.test.ts` — 17 / 17 pass
- [x] `pnpm test:file test/PriceTrust.test.ts test/Helpers.test.ts test/PriceOverrides.test.ts` — 79 / 79 pass (no regression in adjacent suites)
- [x] `pnpm qa` — clean
- [x] `tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added token validation system with whitelist and blacklist support
  * Enabled USD price calculations exclusively for approved, non-blacklisted tokens

* **Tests**
  * Comprehensive test suite covering token validation and USD price calculations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/velodrome-finance/indexer/pull/756?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->