### PR TITLE
Add Token.priceTrustOutcome + priceTrustReason schema fields (#755 slice 2)

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -374,6 +374,26 @@ type Token {
   lastUpdatedTimestamp: Timestamp! # timestamp of last refresh attempt (used by 1-hour throttle)
   lastSuccessfulPriceTimestamp: Timestamp # timestamp of last non-zero oracle write (used by 7-day fallback staleness window, #694)
   isWhitelisted: Boolean! # whether the token is whitelisted
+
+  # Price-trust gate per-token decision surface (issue #755 slice 2). Populated
+  # at every Token construction site (Voter.WhitelistToken, SuperchainLeafVoter
+  # .WhitelistToken, PriceOracle.createTokenEntity, VotingReward reward-token
+  # bootstrap) via `PriceTrust.getGateDecisionFromSignals`; subsequent refreshes
+  # preserve the stamped values via spread until slice-3+ aggregator paths
+  # re-evaluate via `PriceTrust.getGateDecision` at consume time. Null only on
+  # rows that predate the field's introduction.
+  #
+  # Stored as String (not enum) so values can extend without an Envio schema
+  # migration. The TypeScript value sets are pinned by the `PRICE_TRUST_OUTCOME`
+  # / `PRICE_TRUST_REASON` const objects in `src/PriceTrust.ts` — call sites
+  # should reference those constants rather than bare string literals.
+  #
+  # Trusted-USD aggregates are written into the existing `*USD` fields on Pool
+  # — no `*USDTrusted` companion fields. Per-chain rollback uses the migration
+  # mode flag introduced in slice 4; A/B comparison against pre-gate values is
+  # done offline via the diff script (issue #755 US #19).
+  priceTrustOutcome: String
+  priceTrustReason: String
 }
 
 # Snapshot of the Token entity

--- a/src/EventHandlers/Voter/SuperchainLeafVoter.ts
+++ b/src/EventHandlers/Voter/SuperchainLeafVoter.ts
@@ -9,6 +9,7 @@ import {
   TokenId,
 } from "../../Constants";
 import { getTokenDetails, hasContractBytecode } from "../../Effects/Index";
+import { getGateDecisionFromSignals } from "../../PriceTrust";
 
 SuperchainLeafVoter.GaugeCreated.contractRegister(({ event, context }) => {
   const pf = event.params.poolFactory;
@@ -152,6 +153,11 @@ SuperchainLeafVoter.WhitelistToken.handler(async ({ event, context }) => {
       contractAddress: event.params.token,
       chainId: event.chainId,
     });
+    const decision = getGateDecisionFromSignals(
+      event.chainId,
+      event.params.token,
+      event.params._bool,
+    );
     const updatedToken: Token = {
       id: TokenId(event.chainId, event.params.token),
       name: tokenDetails.name,
@@ -163,6 +169,8 @@ SuperchainLeafVoter.WhitelistToken.handler(async ({ event, context }) => {
       isWhitelisted: event.params._bool,
       lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
       lastSuccessfulPriceTimestamp: undefined,
+      priceTrustOutcome: decision.outcome,
+      priceTrustReason: decision.reason,
     };
     context.Token.set(updatedToken);
   } catch (error) {

--- a/src/EventHandlers/Voter/Voter.ts
+++ b/src/EventHandlers/Voter/Voter.ts
@@ -28,6 +28,7 @@ import {
 } from "../../Constants";
 import { getTokenDetails, hasContractBytecode } from "../../Effects/Index";
 import { refreshTokenPrice } from "../../PriceOracle";
+import { getGateDecisionFromSignals } from "../../PriceTrust";
 import {
   VoterEventType,
   buildPoolDiffFromDistribute,
@@ -438,6 +439,11 @@ Voter.WhitelistToken.handler(async ({ event, context }) => {
       contractAddress: event.params.token,
       chainId: event.chainId,
     });
+    const decision = getGateDecisionFromSignals(
+      event.chainId,
+      event.params.token,
+      event.params._bool,
+    );
     const updatedToken: Token = {
       id: TokenId(event.chainId, event.params.token),
       name: tokenDetails.name,
@@ -449,6 +455,8 @@ Voter.WhitelistToken.handler(async ({ event, context }) => {
       isWhitelisted: event.params._bool,
       lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
       lastSuccessfulPriceTimestamp: undefined,
+      priceTrustOutcome: decision.outcome,
+      priceTrustReason: decision.reason,
     };
     context.Token.set(updatedToken);
   } catch (error) {

--- a/src/EventHandlers/VotingReward/VotingRewardSharedLogic.ts
+++ b/src/EventHandlers/VotingReward/VotingRewardSharedLogic.ts
@@ -19,6 +19,7 @@ import {
 import type { Pool } from "../../EntityTypes";
 import { calculateTokenAmountUSD } from "../../Helpers";
 import { refreshTokenPrice } from "../../PriceOracle";
+import { getGateDecisionFromSignals } from "../../PriceTrust";
 
 export interface VotingRewardEventData {
   votingRewardAddress: string;
@@ -124,6 +125,11 @@ export async function processVotingRewardClaimRewards(
       }),
     ]);
 
+    const decision = getGateDecisionFromSignals(
+      data.chainId,
+      data.reward,
+      true,
+    );
     const newToken: Token = {
       id: TokenId(data.chainId, data.reward),
       address: data.reward,
@@ -138,6 +144,8 @@ export async function processVotingRewardClaimRewards(
           ? new Date(data.timestamp * 1000)
           : undefined,
       isWhitelisted: true,
+      priceTrustOutcome: decision.outcome,
+      priceTrustReason: decision.reason,
     };
 
     context.Token.set(newToken);

--- a/src/PriceOracle.ts
+++ b/src/PriceOracle.ts
@@ -14,6 +14,7 @@ import {
   roundBlockToInterval,
 } from "./Effects/Index";
 import { getRebindTarget, isBlacklistedToken } from "./PriceOverrides";
+import { getGateDecisionFromSignals } from "./PriceTrust";
 import { setTokenPriceSnapshot } from "./Snapshots/TokenPriceSnapshot";
 export interface TokenPriceData {
   pricePerUSDNew: bigint;
@@ -84,6 +85,7 @@ export async function createTokenEntity(
     chainId,
   });
 
+  const decision = getGateDecisionFromSignals(chainId, tokenAddress, false);
   const tokenEntity: Token = {
     id: TokenId(chainId, tokenAddress),
     address: tokenAddress,
@@ -95,6 +97,8 @@ export async function createTokenEntity(
     lastUpdatedTimestamp: blockDatetime,
     lastSuccessfulPriceTimestamp: undefined,
     isWhitelisted: false,
+    priceTrustOutcome: decision.outcome,
+    priceTrustReason: decision.reason,
   };
 
   context.Token.set(tokenEntity);

--- a/src/PriceTrust.ts
+++ b/src/PriceTrust.ts
@@ -3,17 +3,35 @@ import { calculateTokenAmountUSD } from "./Helpers";
 import { isBlacklistedToken } from "./PriceOverrides";
 
 /**
- * Reason a token did or did not pass the price-trust gate. Useful for triage
- * logs and the per-token `priceTrustReason` field added in a later slice.
- *
- * - `"WL"` — protocol-whitelisted and not in the operator BLACKLIST (trusted)
- * - `"BLACKLISTED"` — protocol-whitelisted but operator BLACKLIST overrides
- * - `"NON_WL"` — not protocol-whitelisted (regardless of BLACKLIST membership)
+ * Centralised values for the per-token `priceTrustOutcome` schema field.
+ * Use these constants at call sites instead of bare string literals so the
+ * value set is grep-discoverable and a typo fails to type-check.
  */
-export type PriceTrustReason = "WL" | "NON_WL" | "BLACKLISTED";
+export const PRICE_TRUST_OUTCOME = {
+  TRUSTED: "TRUSTED",
+  UNTRUSTED: "UNTRUSTED",
+} as const;
+export type PriceTrustOutcome =
+  (typeof PRICE_TRUST_OUTCOME)[keyof typeof PRICE_TRUST_OUTCOME];
+
+/**
+ * Centralised values for the per-token `priceTrustReason` schema field.
+ *
+ * - `WL` — protocol-whitelisted and not in the operator BLACKLIST (trusted)
+ * - `BLACKLISTED` — protocol-whitelisted but operator BLACKLIST overrides
+ * - `NON_WL` — not protocol-whitelisted (regardless of BLACKLIST membership)
+ */
+export const PRICE_TRUST_REASON = {
+  WL: "WL",
+  NON_WL: "NON_WL",
+  BLACKLISTED: "BLACKLISTED",
+} as const;
+export type PriceTrustReason =
+  (typeof PRICE_TRUST_REASON)[keyof typeof PRICE_TRUST_REASON];
 
 export interface PriceTrustDecision {
   readonly trusted: boolean;
+  readonly outcome: PriceTrustOutcome;
   readonly reason: PriceTrustReason;
 }
 
@@ -62,24 +80,66 @@ export function getTrustedUSD(
 }
 
 /**
- * Debug helper returning the gate's boolean outcome plus the reason it fired.
- * Intended for triage logs and the per-token `priceTrustReason` field added
- * by a later slice; not used on the aggregator hot path.
+ * Gate decision from raw signals, without a Token entity. Used at Token
+ * construction time (handlers + tests) so the persisted
+ * `priceTrustOutcome` / `priceTrustReason` fields are populated in lockstep
+ * with `isWhitelisted` rather than left null until the first aggregator consult.
  *
  * Reason precedence: `NON_WL` dominates `BLACKLISTED` when both apply, since
  * the protocol-whitelist signal is the load-bearing one — a token's path to
  * trust runs through whitelisting, not through removing a blacklist entry.
+ *
+ * @param chainId - Chain ID for BLACKLIST lookup
+ * @param address - Token address (EIP-55 checksum) for BLACKLIST lookup
+ * @param isWhitelisted - Protocol-whitelist signal from the Voter contract
+ * @returns `{ trusted, reason }` decision
+ */
+export function getGateDecisionFromSignals(
+  chainId: number,
+  address: string,
+  isWhitelisted: boolean,
+): PriceTrustDecision {
+  if (!isWhitelisted) {
+    return {
+      trusted: false,
+      outcome: PRICE_TRUST_OUTCOME.UNTRUSTED,
+      reason: PRICE_TRUST_REASON.NON_WL,
+    };
+  }
+  if (isBlacklistedToken(chainId, address)) {
+    return {
+      trusted: false,
+      outcome: PRICE_TRUST_OUTCOME.UNTRUSTED,
+      reason: PRICE_TRUST_REASON.BLACKLISTED,
+    };
+  }
+  return {
+    trusted: true,
+    outcome: PRICE_TRUST_OUTCOME.TRUSTED,
+    reason: PRICE_TRUST_REASON.WL,
+  };
+}
+
+/**
+ * Gate decision from a Token entity. Thin wrapper over
+ * {@link getGateDecisionFromSignals} for callers that already have a Token
+ * loaded (typically aggregator paths in slice 3+).
  *
  * @param token - Token entity. Undefined is reported as `NON_WL` (no
  *   whitelist attestation exists).
  * @returns `{ trusted, reason }` decision
  */
 export function getGateDecision(token: Token | undefined): PriceTrustDecision {
-  if (!token || !token.isWhitelisted) {
-    return { trusted: false, reason: "NON_WL" };
+  if (!token) {
+    return {
+      trusted: false,
+      outcome: PRICE_TRUST_OUTCOME.UNTRUSTED,
+      reason: PRICE_TRUST_REASON.NON_WL,
+    };
   }
-  if (isBlacklistedToken(token.chainId, token.address)) {
-    return { trusted: false, reason: "BLACKLISTED" };
-  }
-  return { trusted: true, reason: "WL" };
+  return getGateDecisionFromSignals(
+    token.chainId,
+    token.address,
+    token.isWhitelisted,
+  );
 }

--- a/test/EventHandlers/CLFactory.test.ts
+++ b/test/EventHandlers/CLFactory.test.ts
@@ -24,6 +24,7 @@ import { getTokensDeposited } from "../../src/Effects/Voter";
 import type { Pool } from "../../src/EntityTypes";
 import * as CLFactoryPoolCreatedLogic from "../../src/EventHandlers/CLFactory/CLFactoryPoolCreatedLogic";
 import * as PriceOracle from "../../src/PriceOracle";
+import { PRICE_TRUST_OUTCOME, PRICE_TRUST_REASON } from "../../src/PriceTrust";
 import { setupCommon } from "./Pool/common";
 
 describe("CLFactory Events", () => {
@@ -103,6 +104,8 @@ describe("CLFactory Events", () => {
         isWhitelisted: false,
         lastUpdatedTimestamp: new Date(1000000 * 1000),
         lastSuccessfulPriceTimestamp: undefined,
+        priceTrustOutcome: PRICE_TRUST_OUTCOME.UNTRUSTED,
+        priceTrustReason: PRICE_TRUST_REASON.NON_WL,
       }),
     );
 
@@ -1131,6 +1134,8 @@ describe("CLFactory.PoolCreated ↔ CLPoolPendingInitialize buffer", () => {
         isWhitelisted: false,
         lastUpdatedTimestamp: new Date(1000000 * 1000),
         lastSuccessfulPriceTimestamp: undefined,
+        priceTrustOutcome: PRICE_TRUST_OUTCOME.UNTRUSTED,
+        priceTrustReason: PRICE_TRUST_REASON.NON_WL,
       }),
     );
   });

--- a/test/EventHandlers/CLFactory/CLFactoryPoolCreatedLogic.test.ts
+++ b/test/EventHandlers/CLFactory/CLFactoryPoolCreatedLogic.test.ts
@@ -20,6 +20,10 @@ import {
 } from "../../../src/EventHandlers/CLFactory/CLFactoryPoolCreatedLogic";
 import * as CrossChainPendingResolution from "../../../src/EventHandlers/Voter/CrossChainPendingResolution";
 import * as PriceOracle from "../../../src/PriceOracle";
+import {
+  PRICE_TRUST_OUTCOME,
+  PRICE_TRUST_REASON,
+} from "../../../src/PriceTrust";
 import { setupCommon } from "../Pool/common";
 
 describe("CLFactoryPoolCreatedLogic", () => {
@@ -40,6 +44,8 @@ describe("CLFactoryPoolCreatedLogic", () => {
         isWhitelisted: false,
         lastUpdatedTimestamp: new Date(1000000 * 1000),
         lastSuccessfulPriceTimestamp: undefined,
+        priceTrustOutcome: PRICE_TRUST_OUTCOME.UNTRUSTED,
+        priceTrustReason: PRICE_TRUST_REASON.NON_WL,
       }),
     );
   });

--- a/test/EventHandlers/Gauges/GaugeSharedLogic.test.ts
+++ b/test/EventHandlers/Gauges/GaugeSharedLogic.test.ts
@@ -17,6 +17,10 @@ import {
   processGaugeDeposit,
   processGaugeWithdraw,
 } from "../../../src/EventHandlers/Gauges/GaugeSharedLogic";
+import {
+  PRICE_TRUST_OUTCOME,
+  PRICE_TRUST_REASON,
+} from "../../../src/PriceTrust";
 import { type MockPool, setupCommon } from "../Pool/common";
 
 describe("GaugeSharedLogic", () => {
@@ -147,6 +151,8 @@ describe("GaugeSharedLogic", () => {
       lastUpdatedTimestamp: mockTimestamp,
       lastSuccessfulPriceTimestamp: mockTimestamp,
       isWhitelisted: true,
+      priceTrustOutcome: PRICE_TRUST_OUTCOME.TRUSTED,
+      priceTrustReason: PRICE_TRUST_REASON.WL,
     };
 
     mockDb = MockDb.createMockDb();

--- a/test/EventHandlers/Pool/common.ts
+++ b/test/EventHandlers/Pool/common.ts
@@ -22,6 +22,10 @@ import {
 } from "../../../src/Constants";
 import type { Pool } from "../../../src/EntityTypes";
 import { calculateTokenAmountUSD } from "../../../src/Helpers";
+import {
+  PRICE_TRUST_OUTCOME,
+  PRICE_TRUST_REASON,
+} from "../../../src/PriceTrust";
 
 // Canonical NFPM used for mock NonFungiblePosition fixtures (Optimism-old NFPM).
 // Named `default*` rather than a SCREAMING_CASE module constant because it's the
@@ -71,6 +75,8 @@ export function setupCommon() {
     isWhitelisted: true,
     lastUpdatedTimestamp: new Date(),
     lastSuccessfulPriceTimestamp: new Date(),
+    priceTrustOutcome: PRICE_TRUST_OUTCOME.TRUSTED,
+    priceTrustReason: PRICE_TRUST_REASON.WL,
   };
 
   const mockToken1Data: Token = {
@@ -84,6 +90,8 @@ export function setupCommon() {
     isWhitelisted: true,
     lastUpdatedTimestamp: new Date(),
     lastSuccessfulPriceTimestamp: new Date(),
+    priceTrustOutcome: PRICE_TRUST_OUTCOME.TRUSTED,
+    priceTrustReason: PRICE_TRUST_REASON.WL,
   };
 
   // Not annotated as Pool to avoid readonly bigint[] vs bigint[] mismatch

--- a/test/PriceTrust.test.ts
+++ b/test/PriceTrust.test.ts
@@ -1,6 +1,13 @@
 import type { Token } from "generated";
 import { TEN_TO_THE_18_BI, TokenId, toChecksumAddress } from "../src/Constants";
-import { getGateDecision, getTrustedUSD, isTrusted } from "../src/PriceTrust";
+import {
+  PRICE_TRUST_OUTCOME,
+  PRICE_TRUST_REASON,
+  getGateDecision,
+  getGateDecisionFromSignals,
+  getTrustedUSD,
+  isTrusted,
+} from "../src/PriceTrust";
 
 // Real BLACKLIST entries (from src/PriceOverrides.ts) used to exercise the
 // blacklist override path without rebuilding the override fixture.
@@ -17,6 +24,12 @@ const WETH_OP = toChecksumAddress("0x4200000000000000000000000000000000000006");
 function makeToken(overrides: Partial<Token> = {}): Token {
   const chainId = overrides.chainId ?? 10;
   const address = overrides.address ?? WETH_OP;
+  const isWhitelisted = overrides.isWhitelisted ?? true;
+  // Derive the stored gate decision from the fixture's own signals so the
+  // mock matches what prod will store after Token construction routes through
+  // PriceTrust.getGateDecisionFromSignals. Overrides spread last and can still
+  // pin specific values for tests that need to exercise stale-decision paths.
+  const decision = getGateDecisionFromSignals(chainId, address, isWhitelisted);
   return {
     id: TokenId(chainId, address),
     address: address as `0x${string}`,
@@ -25,9 +38,11 @@ function makeToken(overrides: Partial<Token> = {}): Token {
     chainId,
     decimals: 18n,
     pricePerUSDNew: 1n * TEN_TO_THE_18_BI,
-    isWhitelisted: true,
+    isWhitelisted,
     lastUpdatedTimestamp: new Date(),
     lastSuccessfulPriceTimestamp: new Date(),
+    priceTrustOutcome: decision.outcome,
+    priceTrustReason: decision.reason,
     ...overrides,
   };
 }
@@ -69,7 +84,8 @@ describe("PriceTrust", () => {
     it("returns trusted=true and reason='WL' for WL + not-BL", () => {
       expect(getGateDecision(makeToken())).toEqual({
         trusted: true,
-        reason: "WL",
+        outcome: PRICE_TRUST_OUTCOME.TRUSTED,
+        reason: PRICE_TRUST_REASON.WL,
       });
     });
 
@@ -81,14 +97,16 @@ describe("PriceTrust", () => {
       });
       expect(getGateDecision(token)).toEqual({
         trusted: false,
-        reason: "BLACKLISTED",
+        outcome: PRICE_TRUST_OUTCOME.UNTRUSTED,
+        reason: PRICE_TRUST_REASON.BLACKLISTED,
       });
     });
 
     it("returns trusted=false and reason='NON_WL' for non-WL (not blacklisted)", () => {
       expect(getGateDecision(makeToken({ isWhitelisted: false }))).toEqual({
         trusted: false,
-        reason: "NON_WL",
+        outcome: PRICE_TRUST_OUTCOME.UNTRUSTED,
+        reason: PRICE_TRUST_REASON.NON_WL,
       });
     });
 
@@ -100,14 +118,16 @@ describe("PriceTrust", () => {
       });
       expect(getGateDecision(token)).toEqual({
         trusted: false,
-        reason: "NON_WL",
+        outcome: PRICE_TRUST_OUTCOME.UNTRUSTED,
+        reason: PRICE_TRUST_REASON.NON_WL,
       });
     });
 
     it("returns trusted=false and reason='NON_WL' for undefined token", () => {
       expect(getGateDecision(undefined)).toEqual({
         trusted: false,
-        reason: "NON_WL",
+        outcome: PRICE_TRUST_OUTCOME.UNTRUSTED,
+        reason: PRICE_TRUST_REASON.NON_WL,
       });
     });
   });


### PR DESCRIPTION
Slice 2 of 5 for #755 (the price-trust gate epic) — schema additions + per-token decision plumbing.

Stacked on top of #756 (slice 1: the pure `PriceTrust` module + unit tests). Base will flip to `main` once #756 merges. After that merges, rebase with:
`git rebase --onto main worktree-issue-755-price-trust-module worktree-issue-755-slice2-schema`

## Summary
- Add two `String` fields on the `Token` entity: `priceTrustOutcome` (carries `"TRUSTED"` / `"UNTRUSTED"`) and `priceTrustReason` (carries `"WL"` / `"NON_WL"` / `"BLACKLISTED"`).
- Populate the new fields at every existing Token construction site so the stored values stay in lockstep with `isWhitelisted` instead of being null until the first aggregator consult: `Voter.WhitelistToken`, `SuperchainLeafVoter.WhitelistToken`, `PriceOracle.createTokenEntity`, and `VotingRewardSharedLogic`'s reward-token bootstrap. Subsequent refresh paths preserve the stamped values via `{...existing}` spread.
- Add `PriceTrust.getGateDecisionFromSignals(chainId, address, isWhitelisted)` — a signals-based variant sitting alongside the entity-based `getGateDecision` from slice 1, so handlers don't need to construct a full `Token` just to compute a decision.
- Centralise the literal values into `PRICE_TRUST_OUTCOME` and `PRICE_TRUST_REASON` const objects in `src/PriceTrust.ts`. The `PriceTrustOutcome` / `PriceTrustReason` types are derived from those const objects (`as const` + indexed-access type), so a typo at any call site fails to type-check. Bare string literals replaced across handlers + test mocks.
- Choose `String` over GraphQL enum on the schema side so the value set can extend without an Envio schema migration; type-safety lives in the TS const objects.

## Scope deliberately trimmed vs. PRD

The PRD's "Schema/API contract changes" section also lists `*USDTrusted` and `*USDUntrustedLegCount` companion fields on each pool-level USD aggregate (8 pairs × 2 entities = 32 schema fields). **Not added here**, because:

- The existing `*USD` fields will hold gated values directly once slice 3+ migrates each aggregator through `PriceTrust.getTrustedUSD` — no parallel storage needed.
- The per-chain mode flag (slice 4) handles rollback per US #24, so we don't need both legacy + gated values co-stored for safety.
- A/B comparison against pre-gate values is done offline via the diff script (US #19), not via cohabiting schema fields.
- If a future requirement surfaces a real need for an untrusted-leg-count metric (US #13 — monitoring whitelist coverage shrink), it can be added as a single `Int` field in the slice that needs it, not eagerly across 8 aggregates.

## Test plan
- [x] `pnpm envio codegen` succeeds (generated types include the two nullable fields on `Token`)
- [x] `tsc --noEmit` passes (0 errors)
- [x] `pnpm qa --write` clean (Biome reordered one import block; no other diffs)
- [x] Focused suites pass: PriceTrust (truth-table tests updated to assert on the new `outcome` field + use the const objects), Pool/common, Gauges/GaugeSharedLogic, CLFactory, PriceOracle, Helpers, PriceOverrides (186 passing, 0 failing)
- [x] Full unit-test suite: 999 passing / 33 skipped — matches the pre-change baseline; the 329 failing tests are all `ENVIO_API_TOKEN required` from HyperSync setup in `processEvents` (environment-only, documented in the handoff for this branch)
- [ ] *(needs human — slice 3 will write gated values into the existing `*USD` fields and exercise the new `priceTrustOutcome` / `priceTrustReason` fields at consume time; the runtime check is deferred to that PR)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)