### PR TITLE
fix(swap-fee): clamp getSwapFee rounding to pool deployment block (closes #759)

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -9,6 +9,7 @@ type Pool {
   token1_address: String! # token1 address
   isStable: Boolean! # whether the pool is a stable AMM or a volatile AMM
   isCL: Boolean! # whether the pool is a CL pool
+  createdBlockNumber: BigInt! @config(precision: 76) # Block number at which PoolCreated fired; used to clamp roundBlockToInterval so getSwapFee/getTokenPrice never query before pool deployment (#759)
   tickSpacing: BigInt! @config(precision: 24) # Tick spacing of the pool; 0 for non-CL pools
   reserve0: BigInt! @config(precision: 76) # reserve of token0 in token units
   reserve1: BigInt! @config(precision: 76) # reserve of token1 in token units

--- a/src/Aggregators/Pool.ts
+++ b/src/Aggregators/Pool.ts
@@ -196,11 +196,19 @@ export async function updateDynamicFeePools(
   // stable within an hour. Matches the pattern getTokenPrice uses
   // (src/PriceOracle.ts) and lets preload dual-pass + re-index back-fills
   // hit the cache instead of producing a fresh slot per raw block.
+  // Issue #759: clamp the rounded block up to the pool's deployment block so
+  // SwapFeeModule reads never land before pool bytecode exists (would revert).
+  // The `?? BigInt(blockNumber)` fallback covers legacy pools indexed before
+  // the createdBlockNumber field was added (non-genesis-reindex / hot-deploy windows);
+  // Number(undefined) would yield NaN and break the Math.max clamp.
+  const minBlock = Number(
+    liquidityPoolAggregator.createdBlockNumber ?? BigInt(blockNumber),
+  );
   const currentFee = await context.effect(getSwapFee, {
     poolAddress,
     factoryAddress,
     chainId,
-    blockNumber: roundBlockToInterval(blockNumber, chainId),
+    blockNumber: roundBlockToInterval(blockNumber, chainId, minBlock),
   });
 
   if (currentFee === undefined) {
@@ -808,6 +816,10 @@ export function createPoolEntity(params: {
   nfpmAddress?: string | null;
   baseFee: bigint;
   currentFee: bigint;
+  // Block at which the pool was deployed (PoolCreated.event.block.number).
+  // Stamped once at creation and used by updateDynamicFeePools to clamp
+  // hour-rounded SwapFeeModule reads above the pool's bytecode boundary (#759).
+  createdBlockNumber: bigint;
 }): Pool {
   const {
     poolAddress,
@@ -825,6 +837,7 @@ export function createPoolEntity(params: {
     nfpmAddress,
     baseFee,
     currentFee,
+    createdBlockNumber,
   } = params;
 
   return {
@@ -843,6 +856,7 @@ export function createPoolEntity(params: {
     token0_address: token0Address,
     token1_address: token1Address,
     isStable: isStable,
+    createdBlockNumber: createdBlockNumber,
     tickSpacing: tickSpacing ? BigInt(tickSpacing) : 0n, // 0 for non-CL pools
     reserve0: 0n,
     reserve1: 0n,

--- a/src/Effects/Token.ts
+++ b/src/Effects/Token.ts
@@ -9,20 +9,27 @@ export { fetchTokenDetails, fetchTokenPrice } from "./fetchers/Token";
  * Uses approximate block times: 2s for most L2s, 12s for Ethereum mainnet. Call before getTokenPrice
  * so the effect cache key is stable within the same hour.
  *
+ * When `minBlock` is supplied, the rounded result is clamped up to `minBlock`. This prevents
+ * callers (e.g. `updateDynamicFeePools` — issue #759) from querying contract state at a block
+ * earlier than the contract's deployment, which would revert with empty bytecode.
+ *
  * @param blockNumber - Block number to round.
  * @param chainId - Chain ID (1 = mainnet 12s blocks; others use 2s).
- * @returns The largest block number that is a multiple of (blocks per hour) and ≤ blockNumber.
+ * @param minBlock - Optional floor (typically the contract's deployment block) below which the rounded value will be clamped up.
+ * @returns The largest multiple of (blocks per hour) that is ≤ blockNumber, clamped up to minBlock when supplied.
  */
 export function roundBlockToInterval(
   blockNumber: number,
   chainId: number,
+  minBlock?: number,
 ): number {
   // Approximate block times per chain (in seconds)
   // Most L2s (Base, Optimism, Mode, etc.) are ~2 seconds
   // Ethereum mainnet is ~12 seconds
   const blockTimeSeconds = chainId === 1 ? 12 : 2;
   const blocksPerHour = Math.floor(3600 / blockTimeSeconds);
-  return Math.floor(blockNumber / blocksPerHour) * blocksPerHour;
+  const rounded = Math.floor(blockNumber / blocksPerHour) * blocksPerHour;
+  return minBlock === undefined ? rounded : Math.max(rounded, minBlock);
 }
 
 /**

--- a/src/EventHandlers/CLFactory/CLFactoryPoolCreatedLogic.ts
+++ b/src/EventHandlers/CLFactory/CLFactoryPoolCreatedLogic.ts
@@ -126,6 +126,7 @@ export async function processCLFactoryPoolCreated(
       // CLFactoryPool constructor calls enableTickSpacing which emits TickSpacingEnabled event
       baseFee: feeToTickSpacingMapping.fee,
       currentFee: feeToTickSpacingMapping.fee,
+      createdBlockNumber: BigInt(event.block.number),
     });
 
     // Slipstream same-tx ordering: CLPool.Initialize buffered the opening

--- a/src/EventHandlers/PoolFactory.ts
+++ b/src/EventHandlers/PoolFactory.ts
@@ -96,6 +96,7 @@ PoolFactory.PoolCreated.handler(async ({ event, context }) => {
     factoryAddress: event.srcAddress,
     baseFee: fee,
     currentFee: fee,
+    createdBlockNumber: BigInt(event.block.number),
   });
 
   // For new pool creation, set the entity directly (updatePool is for updates, not creation)

--- a/test/Aggregators/Pool.test.ts
+++ b/test/Aggregators/Pool.test.ts
@@ -271,6 +271,89 @@ describe("Pool Functions", () => {
       expect(updatedPool).toBe(liquidityPoolAggregator);
       expect(effectMock).not.toHaveBeenCalled();
     });
+
+    // Regression test for issue #759: rounding-before-deploy revert.
+    // For a pool whose deployment block falls inside an hour but after the
+    // hour's start, the legacy code would query getSwapFee at the (earlier)
+    // rounded boundary where pool bytecode is empty and the call reverts.
+    // The fix clamps the rounded block up to the pool's createdBlockNumber.
+    it("clamps the queried blockNumber up to createdBlockNumber to avoid pre-deploy reverts", async () => {
+      // Swell (chainId 1923 → 2s blocks → 1800/hour). Pool deployed at 3920396,
+      // hour boundary is 3918600 — before deployment. The mock throws if
+      // getSwapFee is invoked at a block earlier than createdBlockNumber.
+      expect(mockContext.effect).toBeDefined();
+      // biome-ignore lint/style/noNonNullAssertion: effect is verified to be defined above
+      const effectMock = vi.mocked(mockContext.effect!);
+      const createdBlockNumber = 3920396n;
+      effectMock.mockImplementation(async (effectFn, input) => {
+        if (effectFn === getSwapFee) {
+          const { blockNumber: queriedBlock } = input as {
+            blockNumber: number;
+          };
+          if (BigInt(queriedBlock) < createdBlockNumber) {
+            throw new Error(
+              `getSwapFee queried at ${queriedBlock}, before pool deployment ${createdBlockNumber}`,
+            );
+          }
+          return 100n;
+        }
+        return {};
+      });
+
+      const pool = {
+        ...liquidityPoolAggregator,
+        chainId: 1923,
+        createdBlockNumber,
+      } as Pool;
+
+      const updatedPool = await updateDynamicFeePools(
+        pool,
+        mockContext as handlerContext,
+        1923,
+        Number(createdBlockNumber),
+      );
+
+      expect(updatedPool.currentFee).toBe(100n);
+      const swapFeeCall = effectMock.mock.calls.find(
+        (call) => call[0] === getSwapFee,
+      );
+      expect(swapFeeCall).toBeDefined();
+      // biome-ignore lint/style/noNonNullAssertion: existence verified above
+      const input = swapFeeCall![1] as { blockNumber: number };
+      expect(input.blockNumber).toBe(Number(createdBlockNumber));
+    });
+
+    // Defensive fallback (#759 AC): legacy pools indexed before the
+    // createdBlockNumber schema field existed will read it back as undefined.
+    // `Number(undefined)` is NaN — without the `?? BigInt(blockNumber)` fallback,
+    // `Math.max(rounded, NaN)` returns NaN and crashes the SwapFeeModule call.
+    it("falls back to the event blockNumber when createdBlockNumber is undefined (legacy pool)", async () => {
+      const legacyPool = {
+        ...liquidityPoolAggregator,
+        chainId: 10,
+        createdBlockNumber: undefined,
+      } as unknown as Pool;
+
+      await updateDynamicFeePools(
+        legacyPool,
+        mockContext as handlerContext,
+        10,
+        blockNumber,
+      );
+
+      // biome-ignore lint/style/noNonNullAssertion: effect is verified to be defined above
+      const effectMock = vi.mocked(mockContext.effect!);
+      const swapFeeCall = effectMock.mock.calls.find(
+        (call) => call[0] === getSwapFee,
+      );
+      expect(swapFeeCall).toBeDefined();
+      // biome-ignore lint/style/noNonNullAssertion: existence verified above
+      const input = swapFeeCall![1] as { blockNumber: number };
+      // With fallback minBlock = blockNumber, the clamp restores the event block
+      // (rounded 131536800 would be less than the fallback 131536921).
+      expect(Number.isNaN(input.blockNumber)).toBe(false);
+      expect(input.blockNumber).toBe(blockNumber);
+    });
   });
 
   describe("Snapshot Creation", () => {

--- a/test/Effects/Token.test.ts
+++ b/test/Effects/Token.test.ts
@@ -66,6 +66,29 @@ describe("roundBlockToInterval", () => {
       expect(roundBlockToInterval(3599, 10)).toBe(1800);
     });
   });
+
+  // Issue #759: optional minBlock clamps the rounded result up to the pool's
+  // deployment block, so SwapFeeModule reads never query before bytecode exists.
+  describe("minBlock clamp (#759)", () => {
+    it("no-clamp: omitting minBlock preserves legacy behavior", () => {
+      expect(roundBlockToInterval(3920396, 1923)).toBe(3918600);
+      expect(roundBlockToInterval(3601, 1)).toBe(3600);
+    });
+
+    it("clamp-triggers: rounded < minBlock returns minBlock (Swell repro)", () => {
+      // Pool 0x818eC3...3F4653 deployed at Swell block 3920396; rounding to the
+      // 1800-block hour boundary would land at 3918600, before deployment.
+      // The clamp restores the deploy block so getSwapFee hits bytecode.
+      expect(roundBlockToInterval(3920396, 1923, 3920396)).toBe(3920396);
+    });
+
+    it("clamp-noop: rounded >= minBlock returns rounded (clamp is identity)", () => {
+      // First event in the hour after deployment: rounded === minBlock.
+      expect(roundBlockToInterval(3920396, 1923, 3918600)).toBe(3918600);
+      // Several hours after deployment: rounded > minBlock.
+      expect(roundBlockToInterval(3940000, 1923, 3920396)).toBe(3938400);
+    });
+  });
 });
 
 describe("Token Effects", () => {

--- a/test/EventHandlers/Pool/common.ts
+++ b/test/EventHandlers/Pool/common.ts
@@ -106,6 +106,9 @@ export function setupCommon() {
     token0_address: mockToken0Data.address as `0x${string}`,
     token1_address: mockToken1Data.address as `0x${string}`,
     isStable: false,
+    // Default mock createdBlockNumber: 0n so existing tests using arbitrary blockNumber values
+    // never hit the #759 minBlock clamp; tests covering the clamp set this explicitly.
+    createdBlockNumber: 0n,
     reserve0: 200n * TEN_TO_THE_18_BI,
     reserve1: 200n * TEN_TO_THE_6_BI,
     totalLPTokenSupply: 0n,

--- a/test/Snapshots/SchemaParity.test.ts
+++ b/test/Snapshots/SchemaParity.test.ts
@@ -42,6 +42,10 @@ describe("Snapshot schema parity", () => {
         "factoryAddress",
         "nfpmAddress",
         "poolLauncherPoolId",
+        // Static creation-time metadata (#759): stamped once at PoolCreated and
+        // never changes — no analytical value in trending it hourly. Used only
+        // to clamp roundBlockToInterval above the pool's bytecode boundary.
+        "createdBlockNumber",
         // Control-flow latch for processTickCrossingsForStaked — once true, stays
         // true. No analytical value in trending it over time.
         "hasStakes",


### PR DESCRIPTION
## Summary

- Add `Pool.createdBlockNumber: BigInt!` to the schema, stamped at `PoolCreated`.
- Extend `roundBlockToInterval(blockNumber, chainId, minBlock?)` with an optional clamp-up.
- Pass `pool.createdBlockNumber` to `getSwapFee` so SwapFeeModule reads never query before pool bytecode exists. Includes a defensive `?? BigInt(blockNumber)` fallback for legacy entities (pre-schema-field) so `Number(undefined)` doesn't poison `Math.max`.

Closes #759.

## Background

`updateDynamicFeePools` hour-rounds the block number DOWN before calling `getSwapFee`. For pools deployed mid-hour (e.g. Swell pool `0x818eC3…3F4653` at block `3920396`, rounded to `3918600`), the SwapFeeModule call reverts because pool bytecode is empty at the queried block. Impact is bounded today (graceful `undefined` fallback, `currentFee` retains the Initialize value), but the deployment-hour cache slot is wasted and the warn is misleading.

## Implementation notes

**Pool-creation call sites:** The issue lists five sites, but only **two** actually call `createPoolEntity` and need to stamp `createdBlockNumber`:

| Site | Action | Stamps `createdBlockNumber`? |
| --- | --- | --- |
| `EventHandlers/PoolFactory.ts:86` | `createPoolEntity({...})` | ✅ added |
| `EventHandlers/CLFactory/CLFactoryPoolCreatedLogic.ts:107` | `createPoolEntity({...})` | ✅ added |
| `EventHandlers/PoolLauncher/PoolLauncherLogic.ts:77` | `context.Pool.set({...existingPool, …})` | ⚪️ inherited via spread |
| `EventHandlers/CLGaugeFactory/CLGaugeFactorySharedLogic.ts:144` | `context.Pool.set({...poolEntity, …})` | ⚪️ inherited via spread |
| `EventHandlers/CLGaugeFactory/CLGaugeFactoryV3.ts:49` | `context.Pool.set({...pool, …})` | ⚪️ inherited via spread |

Three are *update* sites that propagate `createdBlockNumber` automatically via object spread, so no edits needed.

**Out-of-scope `roundBlockToInterval` callers** keep the legacy 2-arg form: `PriceOracle.ts:194,239` and `EventHandlers/VotingReward/VotingRewardSharedLogic.ts:109`. They share the same latent race but the failure mode is silent-zero, not revert; see the issue's Out-of-scope section.

**Deployment:** purely additive schema field — **full reindex required** to backfill `createdBlockNumber` on existing pools.

## Test plan

- [x] Unit tests for `roundBlockToInterval` (`test/Effects/Token.test.ts`):
  - no-clamp (omitted `minBlock` preserves legacy behavior)
  - clamp-triggers using the Swell repro: `roundBlockToInterval(3920396, 1923, 3920396)` → `3920396`
  - clamp-noop when rounded ≥ minBlock
- [x] Integration test in `test/Aggregators/Pool.test.ts`: `updateDynamicFeePools` against a pool with `createdBlockNumber=3920396n` on Swell; `getSwapFee` mock throws if invoked with `blockNumber < createdBlockNumber`, confirming the clamp.
- [x] Defensive-fallback test: legacy pool with `createdBlockNumber: undefined` falls back to event `blockNumber` (no NaN crash).
- [x] Snapshot parity allowlist updated — `createdBlockNumber` is immutable per-pool metadata, same category as `tickSpacing` / `factoryAddress`.
- [x] `tsc --noEmit` clean.
- [x] `biome check --write` clean.
- [x] Full `pnpm test`: 1354 passed / 33 skipped / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pools now track their creation block number to ensure queries align with pool deployment.

* **Bug Fixes**
  * Fixed errors when querying swap fees before pool deployment by clamping queries to the pool's creation block, with fallback support for legacy pools.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/velodrome-finance/indexer/pull/760?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->