### PR TITLE
fix(price-oracle): correct Base USDe connector createdBlock to 15768548 (closes #763)

### DIFF
--- a/src/constants/price_connectors.json
+++ b/src/constants/price_connectors.json
@@ -108,7 +108,7 @@
     },
     {
       "address": "0x5d3a1Ff2b6BAb83b63cd9AD0787074081a52ef34",
-      "createdBlock": 1
+      "createdBlock": 15768548
     }
   ],
   "mode": [

--- a/test/Effects/RpcGateway.test.ts
+++ b/test/Effects/RpcGateway.test.ts
@@ -598,4 +598,38 @@ describe("RpcGateway", () => {
       expect(a).toBe(b);
     });
   });
+
+  // Issue #763: USDe (0x5d3a1Ff2…) was registered with createdBlock=1, so the
+  // RpcGateway connector filter (c.createdBlock <= blockNumber) kept it in the
+  // V1 connector list for the entire Base pre-deploy window (3219857..15768547).
+  // The V1 oracle's path-finder then reverted on the empty USDe address, zeroing
+  // pricePerUSDNew for whitelisted Base tokens (TOSHI, DEGEN, BRETT, HIGHER, …)
+  // during Aug 2023 → Mar 2024. This test locks the createdBlock fix in place.
+  describe("Base price_connectors USDe deploy-block gate (#763)", () => {
+    const BASE_CHAIN_ID = 8453;
+    const USDE_ADDRESS = toChecksumAddress(
+      "0x5d3a1Ff2b6BAb83b63cd9AD0787074081a52ef34",
+    );
+    const USDE_DEPLOY_BLOCK = 15768548;
+    const PRE_DEPLOY_BLOCK = 15293733;
+
+    const filteredAddresses = (blockNumber: number) =>
+      CHAIN_CONSTANTS[BASE_CHAIN_ID].oracle.priceConnectors
+        .filter((c) => c.createdBlock <= blockNumber)
+        .map((c) => c.address);
+
+    it("strips USDe from connectors at a Base pre-deploy block", () => {
+      expect(filteredAddresses(PRE_DEPLOY_BLOCK)).not.toContain(USDE_ADDRESS);
+    });
+
+    it("strips USDe one block before its deploy block", () => {
+      expect(filteredAddresses(USDE_DEPLOY_BLOCK - 1)).not.toContain(
+        USDE_ADDRESS,
+      );
+    });
+
+    it("includes USDe at its deploy block and after", () => {
+      expect(filteredAddresses(USDE_DEPLOY_BLOCK)).toContain(USDE_ADDRESS);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- `src/constants/price_connectors.json` had USDe (`0x5d3a1Ff2…`) registered under the `base` key with `createdBlock: 1`. The RpcGateway filter (`c.createdBlock <= blockNumber`, src/Effects/RpcGateway.ts:466) therefore kept USDe in the V1 connector list across the entire Base pre-deploy window (3219857..15768547). The V1 oracle's path-finder reverted on the empty USDe address, zeroing `pricePerUSDNew` for whitelisted Base tokens (TOSHI, DEGEN, BRETT, HIGHER, …) during Aug 2023 → Mar 2024. PriceTrust slice 3 (#755) accepts the whitelisted zero, so every Base USD aggregate that involved those tokens in that window is undercounted today.
- Fix: change the `createdBlock` of the Base USDe entry from `1` to `15768548` (verified via on-chain `eth_getCode` binary search). Same class as the #688 V1/V2 blacklist patch.
- Adds a regression test in `test/Effects/RpcGateway.test.ts` that asserts the connector filter strips USDe at a Base pre-deploy block (15293733) and at `deploy_block - 1`, and includes USDe at/after block 15768548.

## Caveat

This fix only takes effect for **cache misses**. Existing Envio effect-cache entries with `pricePerUSDNew: 0n` for `(getTokenPrice, chainId=8453, blockNumber ≤ 15768547)` will continue to return the stale 0 until invalidated or until the deployment re-indexes from scratch. Out of scope for #763.

## Out of scope

The same `createdBlock: 1` value also appears for USDe under the `mode`, `fraxtal`, `ink`, and `swellchain` keys. The broader audit of all connector `createdBlock` values is tracked separately in #764.

## Test plan

- [x] `pnpm qa --write` — clean
- [x] `pnpm test` — 1357 passed, 33 skipped, 0 failed
- [x] `tsc --noEmit` — no errors
- [x] New regression tests in `test/Effects/RpcGateway.test.ts` cover: USDe stripped at pre-deploy block 15293733, stripped at `deploy_block - 1`, present at deploy block 15768548
- [ ] (Optional, marked optional in #763) live V1 oracle `eth_call` at block 15293733 no longer reverts — not exercised in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Base network price connector configuration for proper token activation handling.

* **Tests**
  * Added test coverage for oracle price connector filtering logic on the Base network.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/velodrome-finance/indexer/pull/765?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->