### PR TITLE
fix(price-trust): recompute trust decision on every WhitelistToken event (#761)

### DIFF
--- a/src/EventHandlers/Voter/SuperchainLeafVoter.ts
+++ b/src/EventHandlers/Voter/SuperchainLeafVoter.ts
@@ -127,9 +127,20 @@ SuperchainLeafVoter.WhitelistToken.handler(async ({ event, context }) => {
 
   // Update the Token entity in the DB, either by updating the existing one or creating a new one
   if (token) {
+    // Recompute the price-trust gate alongside isWhitelisted so the persisted
+    // priceTrustOutcome/priceTrustReason stay in lockstep with the whitelist
+    // signal. Without this, tokens first observed via pool events before
+    // their WhitelistToken event would stay UNTRUSTED/NON_WL forever (#761).
+    const decision = getGateDecisionFromSignals(
+      event.chainId,
+      event.params.token,
+      event.params._bool,
+    );
     const updatedToken: Token = {
       ...token,
       isWhitelisted: event.params._bool,
+      priceTrustOutcome: decision.outcome,
+      priceTrustReason: decision.reason,
       lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
     };
 

--- a/src/EventHandlers/Voter/Voter.ts
+++ b/src/EventHandlers/Voter/Voter.ts
@@ -413,9 +413,20 @@ Voter.WhitelistToken.handler(async ({ event, context }) => {
 
   // Update the Token entity in the DB, either by updating the existing one or creating a new one
   if (token) {
+    // Recompute the price-trust gate alongside isWhitelisted so the persisted
+    // priceTrustOutcome/priceTrustReason stay in lockstep with the whitelist
+    // signal. Without this, tokens first observed via pool events before
+    // their WhitelistToken event would stay UNTRUSTED/NON_WL forever (#761).
+    const decision = getGateDecisionFromSignals(
+      event.chainId,
+      event.params.token,
+      event.params._bool,
+    );
     const updatedToken: Token = {
       ...token,
       isWhitelisted: event.params._bool,
+      priceTrustOutcome: decision.outcome,
+      priceTrustReason: decision.reason,
       lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
     };
 

--- a/test/EventHandlers/Voter/SuperchainLeafVoter.test.ts
+++ b/test/EventHandlers/Voter/SuperchainLeafVoter.test.ts
@@ -7,6 +7,10 @@ import {
   TokenId,
   toChecksumAddress,
 } from "../../../src/Constants";
+import {
+  PRICE_TRUST_OUTCOME,
+  PRICE_TRUST_REASON,
+} from "../../../src/PriceTrust";
 import { type MockPool, setupCommon } from "../Pool/common";
 
 describe("SuperchainLeafVoter Events", () => {
@@ -341,6 +345,125 @@ describe("SuperchainLeafVoter Events", () => {
             mockEvent.block.timestamp * 1000,
           );
         });
+      });
+    });
+
+    describe("priceTrust recomputation on existing tokens (issue #761)", () => {
+      it("flips UNTRUSTED/NON_WL to TRUSTED/WL when WhitelistToken(true) lands", async () => {
+        const whitelistEvent =
+          SuperchainLeafVoter.WhitelistToken.createMockEvent({
+            token: tokenAddress,
+            _bool: true,
+            mockEventData: {
+              block: {
+                number: 123456,
+                timestamp: 1000000,
+                hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
+              },
+              chainId,
+              logIndex: 1,
+            },
+          });
+        const existing = {
+          id: TokenId(chainId, tokenAddress),
+          address: tokenAddress,
+          symbol: "TEST",
+          name: "TEST",
+          chainId,
+          decimals: BigInt(18),
+          pricePerUSDNew: BigInt(10000000),
+          isWhitelisted: false,
+          priceTrustOutcome: PRICE_TRUST_OUTCOME.UNTRUSTED,
+          priceTrustReason: PRICE_TRUST_REASON.NON_WL,
+        } as Token;
+        const db = mockDb.entities.Token.set(existing);
+
+        const result = await db.processEvents([whitelistEvent]);
+        const token = result.entities.Token.get(TokenId(chainId, tokenAddress));
+
+        expect(token?.isWhitelisted).toBe(true);
+        expect(token?.priceTrustOutcome).toBe(PRICE_TRUST_OUTCOME.TRUSTED);
+        expect(token?.priceTrustReason).toBe(PRICE_TRUST_REASON.WL);
+      });
+
+      it("flips TRUSTED/WL to UNTRUSTED/NON_WL when WhitelistToken(false) lands", async () => {
+        const dewhitelistEvent =
+          SuperchainLeafVoter.WhitelistToken.createMockEvent({
+            token: tokenAddress,
+            _bool: false,
+            mockEventData: {
+              block: {
+                number: 123456,
+                timestamp: 1000000,
+                hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
+              },
+              chainId,
+              logIndex: 1,
+            },
+          });
+        const existing = {
+          id: TokenId(chainId, tokenAddress),
+          address: tokenAddress,
+          symbol: "TEST",
+          name: "TEST",
+          chainId,
+          decimals: BigInt(18),
+          pricePerUSDNew: BigInt(10000000),
+          isWhitelisted: true,
+          priceTrustOutcome: PRICE_TRUST_OUTCOME.TRUSTED,
+          priceTrustReason: PRICE_TRUST_REASON.WL,
+        } as Token;
+        const db = mockDb.entities.Token.set(existing);
+
+        const result = await db.processEvents([dewhitelistEvent]);
+        const token = result.entities.Token.get(TokenId(chainId, tokenAddress));
+
+        expect(token?.isWhitelisted).toBe(false);
+        expect(token?.priceTrustOutcome).toBe(PRICE_TRUST_OUTCOME.UNTRUSTED);
+        expect(token?.priceTrustReason).toBe(PRICE_TRUST_REASON.NON_WL);
+      });
+
+      it("flags an existing blacklisted token UNTRUSTED/BLACKLISTED on WhitelistToken(true)", async () => {
+        // $Manatee on Optimism — present in src/PriceOverrides.ts BLACKLIST
+        const blacklistedAddress = toChecksumAddress(
+          "0x7909Bda52eAf7C3cc12745E727Eb527a485241D8",
+        );
+        const whitelistEvent =
+          SuperchainLeafVoter.WhitelistToken.createMockEvent({
+            token: blacklistedAddress,
+            _bool: true,
+            mockEventData: {
+              block: {
+                number: 123456,
+                timestamp: 1000000,
+                hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
+              },
+              chainId,
+              logIndex: 1,
+            },
+          });
+        const existing = {
+          id: TokenId(chainId, blacklistedAddress),
+          address: blacklistedAddress,
+          symbol: "MANATEE",
+          name: "MANATEE",
+          chainId,
+          decimals: BigInt(18),
+          pricePerUSDNew: 0n,
+          isWhitelisted: false,
+          priceTrustOutcome: PRICE_TRUST_OUTCOME.UNTRUSTED,
+          priceTrustReason: PRICE_TRUST_REASON.NON_WL,
+        } as Token;
+        const db = mockDb.entities.Token.set(existing);
+
+        const result = await db.processEvents([whitelistEvent]);
+        const token = result.entities.Token.get(
+          TokenId(chainId, blacklistedAddress),
+        );
+
+        expect(token?.isWhitelisted).toBe(true);
+        expect(token?.priceTrustOutcome).toBe(PRICE_TRUST_OUTCOME.UNTRUSTED);
+        expect(token?.priceTrustReason).toBe(PRICE_TRUST_REASON.BLACKLISTED);
       });
     });
   });

--- a/test/EventHandlers/Voter/Voter.test.ts
+++ b/test/EventHandlers/Voter/Voter.test.ts
@@ -22,6 +22,10 @@ import {
   toChecksumAddress,
 } from "../../../src/Constants";
 import { getTokensDeposited } from "../../../src/Effects/Voter";
+import {
+  PRICE_TRUST_OUTCOME,
+  PRICE_TRUST_REASON,
+} from "../../../src/PriceTrust";
 import { type MockPool, setupCommon } from "../Pool/common";
 
 type MockUserStatsPerPool = ReturnType<
@@ -2100,6 +2104,117 @@ describe("Voter Events", () => {
         expect(token?.lastUpdatedTimestamp?.getTime()).toBe(
           mockEvent.block.timestamp * 1000,
         );
+      });
+    });
+
+    describe("priceTrust recomputation on existing tokens (issue #761)", () => {
+      it("flips UNTRUSTED/NON_WL to TRUSTED/WL when WhitelistToken(true) lands", async () => {
+        const existing = {
+          id: TokenId(10, tokenAddress),
+          address: tokenAddress,
+          symbol: "TEST",
+          name: "TEST",
+          chainId: 10,
+          decimals: BigInt(18),
+          pricePerUSDNew: BigInt(10000000),
+          isWhitelisted: false,
+          priceTrustOutcome: PRICE_TRUST_OUTCOME.UNTRUSTED,
+          priceTrustReason: PRICE_TRUST_REASON.NON_WL,
+        } as Token;
+        const db = mockDb.entities.Token.set(existing);
+
+        const result = await db.processEvents([mockEvent]);
+        const token = result.entities.Token.get(TokenId(10, tokenAddress));
+
+        expect(token?.isWhitelisted).toBe(true);
+        expect(token?.priceTrustOutcome).toBe(PRICE_TRUST_OUTCOME.TRUSTED);
+        expect(token?.priceTrustReason).toBe(PRICE_TRUST_REASON.WL);
+      });
+
+      it("flips TRUSTED/WL to UNTRUSTED/NON_WL when WhitelistToken(false) lands", async () => {
+        const existing = {
+          id: TokenId(10, tokenAddress),
+          address: tokenAddress,
+          symbol: "TEST",
+          name: "TEST",
+          chainId: 10,
+          decimals: BigInt(18),
+          pricePerUSDNew: BigInt(10000000),
+          isWhitelisted: true,
+          priceTrustOutcome: PRICE_TRUST_OUTCOME.TRUSTED,
+          priceTrustReason: PRICE_TRUST_REASON.WL,
+        } as Token;
+        const db = mockDb.entities.Token.set(existing);
+
+        const dewhitelistEvent = Voter.WhitelistToken.createMockEvent({
+          whitelister: toChecksumAddress(
+            "0x1111111111111111111111111111111111111111",
+          ),
+          token: tokenAddress,
+          _bool: false,
+          mockEventData: {
+            block: {
+              number: 123456,
+              timestamp: 1000000,
+              hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
+            },
+            chainId: 10,
+            logIndex: 1,
+          },
+        });
+
+        const result = await db.processEvents([dewhitelistEvent]);
+        const token = result.entities.Token.get(TokenId(10, tokenAddress));
+
+        expect(token?.isWhitelisted).toBe(false);
+        expect(token?.priceTrustOutcome).toBe(PRICE_TRUST_OUTCOME.UNTRUSTED);
+        expect(token?.priceTrustReason).toBe(PRICE_TRUST_REASON.NON_WL);
+      });
+
+      it("flags an existing blacklisted token UNTRUSTED/BLACKLISTED on WhitelistToken(true)", async () => {
+        // $Manatee on Optimism — present in src/PriceOverrides.ts BLACKLIST
+        const blacklistedAddress = toChecksumAddress(
+          "0x7909Bda52eAf7C3cc12745E727Eb527a485241D8",
+        );
+        const existing = {
+          id: TokenId(10, blacklistedAddress),
+          address: blacklistedAddress,
+          symbol: "MANATEE",
+          name: "MANATEE",
+          chainId: 10,
+          decimals: BigInt(18),
+          pricePerUSDNew: 0n,
+          isWhitelisted: false,
+          priceTrustOutcome: PRICE_TRUST_OUTCOME.UNTRUSTED,
+          priceTrustReason: PRICE_TRUST_REASON.NON_WL,
+        } as Token;
+        const db = mockDb.entities.Token.set(existing);
+
+        const whitelistEvent = Voter.WhitelistToken.createMockEvent({
+          whitelister: toChecksumAddress(
+            "0x1111111111111111111111111111111111111111",
+          ),
+          token: blacklistedAddress,
+          _bool: true,
+          mockEventData: {
+            block: {
+              number: 123456,
+              timestamp: 1000000,
+              hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
+            },
+            chainId: 10,
+            logIndex: 1,
+          },
+        });
+
+        const result = await db.processEvents([whitelistEvent]);
+        const token = result.entities.Token.get(
+          TokenId(10, blacklistedAddress),
+        );
+
+        expect(token?.isWhitelisted).toBe(true);
+        expect(token?.priceTrustOutcome).toBe(PRICE_TRUST_OUTCOME.UNTRUSTED);
+        expect(token?.priceTrustReason).toBe(PRICE_TRUST_REASON.BLACKLISTED);
       });
     });
   });


### PR DESCRIPTION
## Summary
- `Voter.WhitelistToken` and `SuperchainLeafVoter.WhitelistToken` updated `isWhitelisted` via spread but left `priceTrustOutcome` / `priceTrustReason` stale — tokens first observed via a pool event before their `WhitelistToken` event landed got stuck `UNTRUSTED/NON_WL` forever, gating their USD contribution to `0n`. Deployed-indexer impact: 9 of 12 chains showed 0% trusted tokens; Base/OP had ~75% / ~58% stuck.
- Fix routes the existing-token branch in both handlers through `getGateDecisionFromSignals(chainId, address, newWLBool)` so the persisted gate decision moves in lockstep with `isWhitelisted`. Symmetric to the existing create-new-token branches (which already called the gate correctly).
- `BLACKLIST` precedence preserved — a token in `PriceOverrides.BLACKLIST` whitelisted by the Voter still resolves to `UNTRUSTED/BLACKLISTED` per the gate's existing reason hierarchy.

Closes #761.

## Test plan
- [x] `Voter.WhitelistToken` existing-token branch persists fresh `priceTrustOutcome` + `priceTrustReason` alongside `isWhitelisted` (`src/EventHandlers/Voter/Voter.ts:420-430`)
- [x] `SuperchainLeafVoter.WhitelistToken` existing-token branch does the same (`src/EventHandlers/Voter/SuperchainLeafVoter.ts:134-150`)
- [x] Existing Token `UNTRUSTED/NON_WL` → after `WhitelistToken(true)` becomes `TRUSTED/WL` (Voter.test.ts + SuperchainLeafVoter.test.ts: `flips UNTRUSTED/NON_WL to TRUSTED/WL when WhitelistToken(true) lands`)
- [x] Existing Token `TRUSTED/WL` → after `WhitelistToken(false)` becomes `UNTRUSTED/NON_WL` (Voter.test.ts + SuperchainLeafVoter.test.ts: `flips TRUSTED/WL to UNTRUSTED/NON_WL when WhitelistToken(false) lands`)
- [x] Existing Token on `BLACKLIST` → after `WhitelistToken(true)` becomes `UNTRUSTED/BLACKLISTED` — uses `$Manatee/Optimism` from `PriceOverrides.BLACKLIST` (Voter.test.ts + SuperchainLeafVoter.test.ts: `flags an existing blacklisted token UNTRUSTED/BLACKLISTED on WhitelistToken(true)`)
- [x] `pnpm qa --write` + `pnpm test` pass (1360/1360 vitest pass, 33 skipped, 0 failed; `tsc --noEmit` clean)

## Deployment notes
The fix touches no `createEffect` definitions or effect inputs. Envio's effect cache (`getTokenPrice`, `getTokenDetails`, `hasContractBytecode`) and the HyperSync raw-event cache remain valid through redeploy — replay cost is handler CPU only, no RPC. Stored `Token.pricePerUSDNew` values are unaffected (the oracle was never trust-gated), so USD aggregates self-heal as soon as the trust state is corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)