### PR TITLE
feat(price-trust): heal stale priceTrust* fields on read in getGateDecision (closes #762)

### DIFF
--- a/src/PriceTrust.ts
+++ b/src/PriceTrust.ts
@@ -1,4 +1,4 @@
-import type { Token } from "generated";
+import type { Token, handlerContext } from "generated";
 import { calculateTokenAmountUSD } from "./Helpers";
 import { isBlacklistedToken } from "./PriceOverrides";
 
@@ -121,15 +121,31 @@ export function getGateDecisionFromSignals(
 }
 
 /**
- * Gate decision from a Token entity. Thin wrapper over
- * {@link getGateDecisionFromSignals} for callers that already have a Token
- * loaded (typically aggregator paths in slice 3+).
+ * Gate decision from a Token entity, with an optional defensive heal-on-read
+ * (#762). Thin wrapper over {@link getGateDecisionFromSignals} for callers
+ * that already have a Token loaded.
+ *
+ * When `context` is provided and the Token's stored
+ * `priceTrustOutcome` / `priceTrustReason` disagree with the freshly-computed
+ * decision, the corrected entity is persisted via `context.Token.set`. This
+ * self-heals tokens stuck in the desync state described in #761 on the
+ * current deployment without requiring a re-replay. When `context` is
+ * omitted, the function is pure-read — useful for aggregator unit tests and
+ * any caller that does not want the implicit Token.set side effect.
+ *
+ * Idempotent: a token whose stored fields already match live signals
+ * triggers no write.
  *
  * @param token - Token entity. Undefined is reported as `NON_WL` (no
- *   whitelist attestation exists).
- * @returns `{ trusted, reason }` decision
+ *   whitelist attestation exists) and never triggers a heal write.
+ * @param context - Optional handler context. When provided, drift detected
+ *   between stored and freshly-computed gate fields is corrected in-place.
+ * @returns `{ trusted, outcome, reason }` decision derived from live signals
  */
-export function getGateDecision(token: Token | undefined): PriceTrustDecision {
+export function getGateDecision(
+  token: Token | undefined,
+  context?: handlerContext,
+): PriceTrustDecision {
   if (!token) {
     return {
       trusted: false,
@@ -137,9 +153,21 @@ export function getGateDecision(token: Token | undefined): PriceTrustDecision {
       reason: PRICE_TRUST_REASON.NON_WL,
     };
   }
-  return getGateDecisionFromSignals(
+  const fresh = getGateDecisionFromSignals(
     token.chainId,
     token.address,
     token.isWhitelisted,
   );
+  if (
+    context &&
+    (token.priceTrustOutcome !== fresh.outcome ||
+      token.priceTrustReason !== fresh.reason)
+  ) {
+    context.Token.set({
+      ...token,
+      priceTrustOutcome: fresh.outcome,
+      priceTrustReason: fresh.reason,
+    });
+  }
+  return fresh;
 }

--- a/test/PriceTrust.test.ts
+++ b/test/PriceTrust.test.ts
@@ -1,4 +1,4 @@
-import type { Token } from "generated";
+import type { Token, handlerContext } from "generated";
 import { TEN_TO_THE_18_BI, TokenId, toChecksumAddress } from "../src/Constants";
 import {
   PRICE_TRUST_OUTCOME,
@@ -8,6 +8,27 @@ import {
   getTrustedUSD,
   isTrusted,
 } from "../src/PriceTrust";
+
+/**
+ * Minimal mock for the slice of {@link handlerContext} that
+ * {@link getGateDecision}'s heal-on-read path touches. Records `Token.set`
+ * calls in `writes` so tests can assert exact entity payloads and whether
+ * any write fired at all.
+ */
+function makeMockContext(): {
+  context: handlerContext;
+  writes: Token[];
+} {
+  const writes: Token[] = [];
+  const context = {
+    Token: {
+      set: (token: Token) => {
+        writes.push(token);
+      },
+    },
+  } as unknown as handlerContext;
+  return { context, writes };
+}
 
 // Real BLACKLIST entries (from src/PriceOverrides.ts) used to exercise the
 // blacklist override path without rebuilding the override fixture.
@@ -129,6 +150,116 @@ describe("PriceTrust", () => {
         outcome: PRICE_TRUST_OUTCOME.UNTRUSTED,
         reason: PRICE_TRUST_REASON.NON_WL,
       });
+    });
+  });
+
+  // Defensive shim (#762): when called with a handler context, getGateDecision
+  // recomputes the decision from live signals and persists a corrected Token
+  // entity via context.Token.set whenever the stored priceTrust* fields
+  // disagree with what getGateDecisionFromSignals would produce now. This
+  // self-heals tokens stuck in the Issue B desync state (#761) on the current
+  // deployment without requiring a re-replay.
+  describe("getGateDecision heal-on-read", () => {
+    it("heals stuck UNTRUSTED token (WL=true, stored UNTRUSTED/NON_WL) → returns TRUSTED/WL and writes correction", () => {
+      const { context, writes } = makeMockContext();
+      const stuck = makeToken({
+        isWhitelisted: true,
+        priceTrustOutcome: PRICE_TRUST_OUTCOME.UNTRUSTED,
+        priceTrustReason: PRICE_TRUST_REASON.NON_WL,
+      });
+
+      const decision = getGateDecision(stuck, context);
+
+      expect(decision).toEqual({
+        trusted: true,
+        outcome: PRICE_TRUST_OUTCOME.TRUSTED,
+        reason: PRICE_TRUST_REASON.WL,
+      });
+      expect(writes).toHaveLength(1);
+      expect(writes[0]).toEqual({
+        ...stuck,
+        priceTrustOutcome: PRICE_TRUST_OUTCOME.TRUSTED,
+        priceTrustReason: PRICE_TRUST_REASON.WL,
+      });
+    });
+
+    it("downgrades stored-TRUSTED token (WL=false, stored TRUSTED/WL) → returns UNTRUSTED/NON_WL and writes correction", () => {
+      const { context, writes } = makeMockContext();
+      const stale = makeToken({
+        isWhitelisted: false,
+        priceTrustOutcome: PRICE_TRUST_OUTCOME.TRUSTED,
+        priceTrustReason: PRICE_TRUST_REASON.WL,
+      });
+
+      const decision = getGateDecision(stale, context);
+
+      expect(decision).toEqual({
+        trusted: false,
+        outcome: PRICE_TRUST_OUTCOME.UNTRUSTED,
+        reason: PRICE_TRUST_REASON.NON_WL,
+      });
+      expect(writes).toHaveLength(1);
+      expect(writes[0]).toEqual({
+        ...stale,
+        priceTrustOutcome: PRICE_TRUST_OUTCOME.UNTRUSTED,
+        priceTrustReason: PRICE_TRUST_REASON.NON_WL,
+      });
+    });
+
+    it("is idempotent for an already-consistent token (no spurious Token.set)", () => {
+      const { context, writes } = makeMockContext();
+      // makeToken() derives stored fields from signals, so this is consistent.
+      const consistent = makeToken({ isWhitelisted: true });
+
+      const decision = getGateDecision(consistent, context);
+
+      expect(decision.trusted).toBe(true);
+      expect(decision.outcome).toBe(PRICE_TRUST_OUTCOME.TRUSTED);
+      expect(decision.reason).toBe(PRICE_TRUST_REASON.WL);
+      expect(writes).toHaveLength(0);
+    });
+
+    it("heals a BLACKLISTED address with WL=true to UNTRUSTED/BLACKLISTED (precedence preserved)", () => {
+      const { context, writes } = makeMockContext();
+      // Token sat in DB with stale TRUSTED/WL fields but address is in BLACKLIST.
+      const blacklisted = makeToken({
+        chainId: 1135,
+        address: ION_LISK,
+        isWhitelisted: true,
+        priceTrustOutcome: PRICE_TRUST_OUTCOME.TRUSTED,
+        priceTrustReason: PRICE_TRUST_REASON.WL,
+      });
+
+      const decision = getGateDecision(blacklisted, context);
+
+      expect(decision).toEqual({
+        trusted: false,
+        outcome: PRICE_TRUST_OUTCOME.UNTRUSTED,
+        reason: PRICE_TRUST_REASON.BLACKLISTED,
+      });
+      expect(writes).toHaveLength(1);
+      expect(writes[0]).toEqual({
+        ...blacklisted,
+        priceTrustOutcome: PRICE_TRUST_OUTCOME.UNTRUSTED,
+        priceTrustReason: PRICE_TRUST_REASON.BLACKLISTED,
+      });
+    });
+
+    it("does not write when called without a context (pure-read mode)", () => {
+      // Stuck token but no context provided — heal must not throw and must not
+      // attempt any persistence path. Behaviour matches the legacy
+      // single-argument call shape that aggregator unit tests still use.
+      const stuck = makeToken({
+        isWhitelisted: true,
+        priceTrustOutcome: PRICE_TRUST_OUTCOME.UNTRUSTED,
+        priceTrustReason: PRICE_TRUST_REASON.NON_WL,
+      });
+
+      expect(() => getGateDecision(stuck)).not.toThrow();
+      const decision = getGateDecision(stuck);
+      expect(decision.trusted).toBe(true);
+      expect(decision.outcome).toBe(PRICE_TRUST_OUTCOME.TRUSTED);
+      expect(decision.reason).toBe(PRICE_TRUST_REASON.WL);
     });
   });
 


### PR DESCRIPTION
## Summary

- Adds an optional `context: handlerContext` parameter to `PriceTrust.getGateDecision` that detects drift between a Token's stored `priceTrustOutcome` / `priceTrustReason` and the freshly-computed decision from live signals, and persists the correction via `context.Token.set`.
- Idempotent for consistent tokens — no spurious writes.
- Backwards-compatible: callers that omit `context` get the pure-read behavior the function had before (used by existing aggregator unit tests).
- Pairs with #761 (which fixes the source bug in `WhitelistToken` handlers); this shim self-corrects already-stuck tokens on the current deployment as pool traffic consults the gate, without requiring a full re-replay.

## Test plan

- [x] Test: stuck token (`isWhitelisted=true`, stored `UNTRUSTED/NON_WL`) → returns `TRUSTED/WL` and `context.Token.set` is called with corrected entity
- [x] Test: stale token (`isWhitelisted=false`, stored `TRUSTED/WL`) → returns `UNTRUSTED/NON_WL` and entity is corrected
- [x] Test: consistent token → no `Token.set` call (idempotent)
- [x] Test: `isWhitelisted=true` + BLACKLISTED address → heals to `UNTRUSTED/BLACKLISTED` (precedence preserved)
- [x] Test: no-context call shape preserved — pure-read, no throw
- [x] `pnpm qa --write` clean (no fixes applied)
- [x] `pnpm test` — 1359 passed / 33 skipped / 0 failed

## Notes

- Out of scope for this slice: threading `context` through downstream callers (`getTrustedUSD`, `calculateTotalUSD`, and the ~13 production sites of `calculateTotalUSD`). The shim only fires when a caller opts in by passing `context` to `getGateDecision`. Wiring it through aggregator paths so heal actually triggers in production is a candidate follow-up — happy to spin a separate issue if the maintainer wants it now or to keep it bundled.
- `isTrusted` and `getTrustedUSD` are intentionally unchanged. They remain pure read-only and continue to compute trust from live signals, so neither needs the heal seam to stay correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)