### PR TITLE
fix(staked-reserves): wire all 7 CLFactories into VOTER_CLPOOLS_FACTORY_LIST (#769)

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -45,10 +45,19 @@ export const toChecksumAddress = (address: string): `0x${string}` =>
   Web3.utils.toChecksumAddress(address) as `0x${string}`;
 
 // Note:
-// These pools factories addresses are hardcoded since we can't check the pool type from the Voter contract
+// These pools factories addresses are hardcoded since we can't check the pool type from the Voter contract.
+// MUST stay in sync with every CLFactory address listed under chains[id=8453|10].contracts.CLFactory.address
+// in config.yaml — see test/Constants.test.ts ("VOTER_CLPOOLS_FACTORY_LIST (#769)").
 export const VOTER_CLPOOLS_FACTORY_LIST: string[] = [
-  "0x5e7BB104d84c7CB9B682AaC2F3d509f5F406809A", // base
-  "0xCc0bDDB707055e04e497aB22a59c2aF4391cd12F", // optimism
+  // base
+  "0x5e7BB104d84c7CB9B682AaC2F3d509f5F406809A",
+  "0xaDe65c38CD4849aDBA595a4323a8C7DdfE89716a",
+  "0x9592CD9B267748cbfBDe90Ac9F7DF3c437A6d51B",
+  "0xf8f2eB4940CFE7d13603DDDD87f123820Fc061Ef",
+  // optimism
+  "0x548118C7E0B865C2CfA94D15EC86B666468ac758",
+  "0xCc0bDDB707055e04e497aB22a59c2aF4391cd12F",
+  "0xe13Dd1fbA721Aa81a1826D9523AC9BC7d260c879",
 ].map((x) => toChecksumAddress(x));
 
 export const VOTER_NONCL_POOLS_FACTORY_LIST: string[] = [

--- a/test/Constants.test.ts
+++ b/test/Constants.test.ts
@@ -1,6 +1,9 @@
+import fs from "node:fs";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   CHAIN_CONSTANTS,
+  VOTER_CLPOOLS_FACTORY_LIST,
   nfpmForCLPool,
   toChecksumAddress,
 } from "../src/Constants";
@@ -143,4 +146,60 @@ describe("oracle.v1v2ConnectorBlacklist (#688)", () => {
       }
     }
   });
+});
+
+describe("VOTER_CLPOOLS_FACTORY_LIST (#769)", () => {
+  // Voter.GaugeCreated branches on whether the emitting poolFactory is in
+  // VOTER_CLPOOLS_FACTORY_LIST. Any CLFactory wired into config.yaml but
+  // missing here causes the indexer to silently drop CLGauge Deposit/Withdraw
+  // events and drift stakedReserve0/1 negative — see issue #769.
+  function clFactoryAddressesFromConfigYaml(chainId: number): string[] {
+    const configPath = path.resolve(__dirname, "..", "config.yaml");
+    const lines = fs.readFileSync(configPath, "utf8").split("\n");
+
+    const chainHeaderRe = /^ {2}- id:\s*(\d+)/;
+    const contractNameRe = /^ {6}- name:\s*(\S+)/;
+    const bulletRe = /^ {10}- (0x[0-9a-fA-F]+)/;
+
+    let inChain = false;
+    let inCLFactory = false;
+    const collected: string[] = [];
+
+    for (const line of lines) {
+      const chainMatch = line.match(chainHeaderRe);
+      if (chainMatch) {
+        inChain = Number(chainMatch[1]) === chainId;
+        inCLFactory = false;
+        continue;
+      }
+      if (!inChain) continue;
+
+      const nameMatch = line.match(contractNameRe);
+      if (nameMatch) {
+        inCLFactory = nameMatch[1] === "CLFactory";
+        continue;
+      }
+
+      if (inCLFactory) {
+        const addrMatch = line.match(bulletRe);
+        if (addrMatch) collected.push(toChecksumAddress(addrMatch[1]));
+      }
+    }
+
+    return collected;
+  }
+
+  it.each([
+    [10, "Optimism"],
+    [8453, "Base"],
+  ])(
+    "covers every CLFactory address from config.yaml chain %s (%s)",
+    (chainId) => {
+      const expected = clFactoryAddressesFromConfigYaml(chainId as number);
+      expect(expected.length).toBeGreaterThan(0);
+      for (const address of expected) {
+        expect(VOTER_CLPOOLS_FACTORY_LIST).toContain(address);
+      }
+    },
+  );
 });


### PR DESCRIPTION
## Summary

Closes #769.

`VOTER_CLPOOLS_FACTORY_LIST` in `src/Constants.ts` was missing 2 of 3 Optimism CLFactories and 3 of 4 Base CLFactories. When `Voter.GaugeCreated` fired for a pool created by an unlisted factory, the `contractRegister` branch at `src/EventHandlers/Voter/Voter.ts:42-47` skipped `context.addCLGauge(...)` — the gauge was never dynamically registered, its `Deposit`/`Withdraw` events were silently dropped, and the indexer's `stakedReserve0/1` accumulator drifted macroscopically negative (one-legged NFPM accounting subtracted on `Burn`/`Transfer-out-of-gauge` with no matching add-side from `CLGauge.Deposit`).

- Adds the 2 missing Optimism + 3 missing Base CLFactory addresses to `VOTER_CLPOOLS_FACTORY_LIST`
- Adds `test/Constants.test.ts` coverage check that parses `config.yaml` and asserts every CLFactory under `chains[id=10|8453].contracts.CLFactory.address` is present in the constant — so future CLFactory additions can't silently regress this

## ⚠️ Operational re-index required

Existing prod data has the drift baked in. **Recovery requires a re-index from genesis with the patched constant in place — there is no in-place reconciliation path.** Deployers must wipe state before redeploying.

## Test plan

- [x] `pnpm qa --write` — clean
- [x] `tsc --noEmit` — no errors
- [x] `pnpm test` — 1356 passed, 33 skipped
- [x] New test fails before the fix (verified by running the test against the 2-entry list), passes after
- [x] Issue body documents local re-index verification: 4 target Optimism pools (USDC/OP, USDC/WETH, USDC/sUSD, wstETH/WETH) flipped from deep negatives to clean positives

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the list of supported concentrated liquidity pool factories to enable access to additional pool instances and improve market coverage.

* **Tests**
  * Added validation tests to verify that all configured pool factory addresses remain properly synchronized and supported throughout the system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/velodrome-finance/indexer/pull/772?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->