### PR TITLE
feat(ci): assert config.yaml ↔ Constants.ts factory parity (closes #770)

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -66,9 +66,16 @@ export const VOTER_NONCL_POOLS_FACTORY_LIST: string[] = [
 ].map((x) => toChecksumAddress(x));
 
 // Note:
-// These pools factories addresses are hardcoded since we can't check the pool type from the Voter contract
+// These pools factories addresses are hardcoded since we can't check the pool type
+// from the SuperchainLeafVoter contract.
+// MUST stay in sync with every CLFactory address listed under each superchain leaf
+// chain's contracts.CLFactory.address in config.yaml — see test/Constants.test.ts
+// ("config.yaml ↔ Constants.ts factory parity (#770, subsumes #769)").
+// Missing entries cause SuperchainLeafVoter.GaugeCreated to silently drop the gauge
+// from dynamic registration (same #769-class drift that hit VOTER_CLPOOLS_FACTORY_LIST).
 export const SUPERCHAIN_LEAF_VOTER_CLPOOLS_FACTORY_LIST: string[] = [
-  "0x04625B046C69577EfC40e6c0Bb83CDBAfab5a55F", // All superchain chains have this address
+  "0x04625B046C69577EfC40e6c0Bb83CDBAfab5a55F", // Slipstream V1 — all superchain leaves
+  "0x718E46d0962A66942E233760a8bd6038Ce54EdCD", // Slipstream gauge-V2 — all superchain leaves (added in #727)
 ].map((x) => toChecksumAddress(x));
 
 export const SUPERCHAIN_LEAF_VOTER_NONCL_POOLS_FACTORY_LIST: string[] = [
@@ -100,11 +107,13 @@ const CL_FACTORY_TO_NFPM: Record<string, string> = {
     toChecksumAddress("0x416b433906b1B72FA758e166e239c43d68dC6F29"),
 
   // Base — three CLFactories each with a dedicated NFPM, verified on-chain via
-  // NFPM.factory(). The newest Base CLFactory (0xf8f2eB49...) does not yet have
-  // a paired NFPM deployed, so pools from it fall through to null — this will
-  // resolve itself once a new NFPM is deployed and added here.
-  // TODO(nfpm): add Base V3-newest NFPM for 0xf8f2eB4940CFE7d13603DDDD87f123820Fc061Ef
-  //             once that factory ships with a paired NFPM.
+  // NFPM.factory(). Pools created by an unmapped factory fall through to null.
+  // TODO(nfpm): RPC-verify NFPM.factory() and add mappings for:
+  //   - 10-0xe13Dd1fbA721Aa81a1826D9523AC9BC7d260c879   (OP slipstream gauge-V2 CLFactory, likely 0xf7f8ccce…)
+  //   - 8453-0xf8f2eB4940CFE7d13603DDDD87f123820Fc061Ef (Base V3-newest CLFactory, paired NFPM in config.yaml is 0xe1f8cd9A…)
+  // Both are also whitelisted in test/Constants.test.ts "config.yaml ↔ Constants.ts
+  // factory parity (#770)" so the parity assertion passes — remove from that whitelist
+  // when the mappings land here.
   [`8453-${toChecksumAddress("0x5e7BB104d84c7CB9B682AaC2F3d509f5F406809A")}`]:
     toChecksumAddress("0x827922686190790b37229fd06084350E74485b72"),
   [`8453-${toChecksumAddress("0xaDe65c38CD4849aDBA595a4323a8C7DdfE89716a")}`]:

--- a/test/Constants.test.ts
+++ b/test/Constants.test.ts
@@ -3,7 +3,11 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   CHAIN_CONSTANTS,
+  ROOT_POOL_FACTORY_ADDRESS_OPTIMISM,
+  SUPERCHAIN_LEAF_VOTER_CLPOOLS_FACTORY_LIST,
+  SUPERCHAIN_LEAF_VOTER_NONCL_POOLS_FACTORY_LIST,
   VOTER_CLPOOLS_FACTORY_LIST,
+  VOTER_NONCL_POOLS_FACTORY_LIST,
   nfpmForCLPool,
   toChecksumAddress,
 } from "../src/Constants";
@@ -157,58 +161,212 @@ describe("oracle.v1v2ConnectorBlacklist (#688)", () => {
   });
 });
 
-describe("VOTER_CLPOOLS_FACTORY_LIST (#769)", () => {
-  // Voter.GaugeCreated branches on whether the emitting poolFactory is in
-  // VOTER_CLPOOLS_FACTORY_LIST. Any CLFactory wired into config.yaml but
-  // missing here causes the indexer to silently drop CLGauge Deposit/Withdraw
-  // events and drift stakedReserve0/1 negative — see issue #769.
-  function clFactoryAddressesFromConfigYaml(chainId: number): string[] {
-    const configPath = path.resolve(__dirname, "..", "config.yaml");
-    const lines = fs.readFileSync(configPath, "utf8").split("\n");
+/**
+ * Parses config.yaml's `chains[]` blocks into a `chainId -> contractName -> addresses[]`
+ * map of checksummed addresses. Used by the parity assertions below (#770) to detect
+ * drift between config.yaml and address-tied constants in src/Constants.ts.
+ *
+ * Hand-rolled rather than pulling in a YAML dep because config.yaml's chain blocks
+ * use a uniform 2/6/8/10-space indentation and we only need address bullets.
+ *
+ * @returns Nested map keyed first by chain ID, then by contract name (e.g. "CLFactory")
+ */
+function parseConfigYamlAddresses(): Map<number, Map<string, string[]>> {
+  const configPath = path.resolve(__dirname, "..", "config.yaml");
+  const lines = fs.readFileSync(configPath, "utf8").split("\n");
 
-    const chainHeaderRe = /^ {2}- id:\s*(\d+)/;
-    const contractNameRe = /^ {6}- name:\s*(\S+)/;
-    const bulletRe = /^ {10}- (0x[0-9a-fA-F]+)/;
+  const chainHeaderRe = /^ {2}- id:\s*(\d+)/;
+  const contractNameRe = /^ {6}- name:\s*(\S+)/;
+  const bulletRe = /^ {10}- (0x[0-9a-fA-F]{40})/;
 
-    let inChain = false;
-    let inCLFactory = false;
-    const collected: string[] = [];
+  const result = new Map<number, Map<string, string[]>>();
+  let currentChain: Map<string, string[]> | null = null;
+  let currentContract: string | null = null;
 
-    for (const line of lines) {
-      const chainMatch = line.match(chainHeaderRe);
-      if (chainMatch) {
-        inChain = Number(chainMatch[1]) === chainId;
-        inCLFactory = false;
-        continue;
+  for (const line of lines) {
+    const chainMatch = line.match(chainHeaderRe);
+    if (chainMatch) {
+      const chainId = Number(chainMatch[1]);
+      currentChain = new Map();
+      currentContract = null;
+      result.set(chainId, currentChain);
+      continue;
+    }
+    if (!currentChain) continue;
+
+    const nameMatch = line.match(contractNameRe);
+    if (nameMatch) {
+      currentContract = nameMatch[1];
+      if (!currentChain.has(currentContract)) {
+        currentChain.set(currentContract, []);
       }
-      if (!inChain) continue;
-
-      const nameMatch = line.match(contractNameRe);
-      if (nameMatch) {
-        inCLFactory = nameMatch[1] === "CLFactory";
-        continue;
-      }
-
-      if (inCLFactory) {
-        const addrMatch = line.match(bulletRe);
-        if (addrMatch) collected.push(toChecksumAddress(addrMatch[1]));
-      }
+      continue;
     }
 
-    return collected;
+    if (currentContract) {
+      const addrMatch = line.match(bulletRe);
+      if (addrMatch) {
+        currentChain
+          .get(currentContract)
+          ?.push(toChecksumAddress(addrMatch[1]));
+      }
+    }
+  }
+
+  return result;
+}
+
+describe("config.yaml ↔ Constants.ts factory parity (#770, subsumes #769)", () => {
+  const SUPERCHAIN_LEAF_CHAIN_IDS = [
+    42220, 1868, 57073, 34443, 1135, 130, 252, 1750, 5330, 1923,
+  ] as const;
+
+  const configByChain = parseConfigYamlAddresses();
+
+  /**
+   * Asserts every config.yaml address for `(chainId, contractName)` is present in
+   * `constant`. Reports the first missing entry with the constant name, chain ID,
+   * and address so the failure message tells you exactly which list to update.
+   */
+  function assertCoverage(
+    chainId: number,
+    contractName: string,
+    constantName: string,
+    constant: readonly string[],
+    whitelist: ReadonlySet<string> = new Set(),
+  ) {
+    const expected = configByChain.get(chainId)?.get(contractName) ?? [];
+    expect(
+      expected.length,
+      `config.yaml has no ${contractName} entries for chain ${chainId} — parser broken or chain removed`,
+    ).toBeGreaterThan(0);
+    for (const address of expected) {
+      if (whitelist.has(address)) continue;
+      expect(
+        constant,
+        `missing in ${constantName}: ${address} (chain ${chainId}) — add to src/Constants.ts to keep config.yaml in sync`,
+      ).toContain(address);
+    }
   }
 
   it.each([
     [10, "Optimism"],
     [8453, "Base"],
+  ])("VOTER_CLPOOLS_FACTORY_LIST covers chain %s (%s) CLFactories", (id) => {
+    assertCoverage(
+      id as number,
+      "CLFactory",
+      "VOTER_CLPOOLS_FACTORY_LIST",
+      VOTER_CLPOOLS_FACTORY_LIST,
+    );
+  });
+
+  it.each([
+    [10, "Optimism"],
+    [8453, "Base"],
   ])(
-    "covers every CLFactory address from config.yaml chain %s (%s)",
-    (chainId) => {
-      const expected = clFactoryAddressesFromConfigYaml(chainId as number);
-      expect(expected.length).toBeGreaterThan(0);
-      for (const address of expected) {
-        expect(VOTER_CLPOOLS_FACTORY_LIST).toContain(address);
-      }
+    "VOTER_NONCL_POOLS_FACTORY_LIST covers chain %s (%s) PoolFactories",
+    (id) => {
+      assertCoverage(
+        id as number,
+        "PoolFactory",
+        "VOTER_NONCL_POOLS_FACTORY_LIST",
+        VOTER_NONCL_POOLS_FACTORY_LIST,
+      );
     },
   );
+
+  it.each(SUPERCHAIN_LEAF_CHAIN_IDS.map((id) => [id]))(
+    "SUPERCHAIN_LEAF_VOTER_CLPOOLS_FACTORY_LIST covers leaf chain %i CLFactories",
+    (id) => {
+      assertCoverage(
+        id,
+        "CLFactory",
+        "SUPERCHAIN_LEAF_VOTER_CLPOOLS_FACTORY_LIST",
+        SUPERCHAIN_LEAF_VOTER_CLPOOLS_FACTORY_LIST,
+      );
+    },
+  );
+
+  it.each(SUPERCHAIN_LEAF_CHAIN_IDS.map((id) => [id]))(
+    "SUPERCHAIN_LEAF_VOTER_NONCL_POOLS_FACTORY_LIST covers leaf chain %i PoolFactories",
+    (id) => {
+      assertCoverage(
+        id,
+        "PoolFactory",
+        "SUPERCHAIN_LEAF_VOTER_NONCL_POOLS_FACTORY_LIST",
+        SUPERCHAIN_LEAF_VOTER_NONCL_POOLS_FACTORY_LIST,
+      );
+    },
+  );
+
+  it("ROOT_POOL_FACTORY_ADDRESS_OPTIMISM stays in sync with the superchain non-CL factory", () => {
+    // The constant's name is historical; semantically it is the non-CL pool factory
+    // used in cross-chain root↔leaf V2 lookups (getRootPoolAddress in PoolFactory.ts).
+    // The same address appears as `PoolFactory.address` on every superchain leaf chain,
+    // so we assert internal consistency against SUPERCHAIN_LEAF_VOTER_NONCL_POOLS_FACTORY_LIST
+    // — that list itself is checked against config.yaml above.
+    expect(
+      SUPERCHAIN_LEAF_VOTER_NONCL_POOLS_FACTORY_LIST,
+      "ROOT_POOL_FACTORY_ADDRESS_OPTIMISM diverged from SUPERCHAIN_LEAF_VOTER_NONCL_POOLS_FACTORY_LIST",
+    ).toContain(ROOT_POOL_FACTORY_ADDRESS_OPTIMISM);
+  });
+
+  describe("nfpmForCLPool covers every (chainId, CLFactory) pair", () => {
+    // Some CLFactories are wired into config.yaml but don't yet have a paired NFPM
+    // declared in CL_FACTORY_TO_NFPM. They resolve to `null` from nfpmForCLPool;
+    // callers treat null as "unknown" and skip NFPM attribution for those pools.
+    //
+    // Each entry below records *why* the gap is currently tolerated. Resolve by
+    // adding the (chainId, factory) -> NFPM mapping in src/Constants.ts and
+    // removing the entry from this allowlist.
+    const UNMAPPED_CL_FACTORIES_BY_CHAIN: Record<number, Set<string>> = {
+      // Base: newest CLFactory (paired with CLGaugeFactoryV3). The matching NFPM
+      // 0xe1f8cd9A… is in config.yaml but has not yet been declared in
+      // CL_FACTORY_TO_NFPM. See TODO(nfpm) in src/Constants.ts.
+      8453: new Set([
+        toChecksumAddress("0xf8f2eB4940CFE7d13603DDDD87f123820Fc061Ef"),
+      ]),
+      // Optimism: slipstream gauge-V2 CLFactory added in #727. Likely pairs with
+      // the third OP NFPM (0xf7f8ccce…) but the pairing has not been on-chain
+      // verified via NFPM.factory(), so it is left unmapped.
+      10: new Set([
+        toChecksumAddress("0xe13Dd1fbA721Aa81a1826D9523AC9BC7d260c879"),
+      ]),
+    };
+    // Superchain leaves: slipstream gauge-V2 CLFactory deployed at
+    // 0x718E46d… on every leaf (#727). Likely pairs with the second leaf NFPM
+    // 0xefD0f78F…; unverified, so currently unmapped.
+    const UNMAPPED_SUPERCHAIN_CL_FACTORIES = new Set<string>([
+      toChecksumAddress("0x718E46d0962A66942E233760a8bd6038Ce54EdCD"),
+    ]);
+
+    it.each([10, 8453, ...SUPERCHAIN_LEAF_CHAIN_IDS])(
+      "every CLFactory on chain %i is either mapped or explicitly unmapped",
+      (chainId) => {
+        const factories = configByChain.get(chainId)?.get("CLFactory") ?? [];
+        expect(
+          factories.length,
+          `config.yaml has no CLFactory entries for chain ${chainId}`,
+        ).toBeGreaterThan(0);
+
+        const chainWhitelist =
+          UNMAPPED_CL_FACTORIES_BY_CHAIN[chainId] ??
+          (SUPERCHAIN_LEAF_CHAIN_IDS.includes(
+            chainId as (typeof SUPERCHAIN_LEAF_CHAIN_IDS)[number],
+          )
+            ? UNMAPPED_SUPERCHAIN_CL_FACTORIES
+            : new Set<string>());
+
+        for (const factory of factories) {
+          const mapped = nfpmForCLPool(chainId, factory);
+          if (mapped !== null) continue;
+          expect(
+            chainWhitelist,
+            `nfpmForCLPool returned null for chain ${chainId} factory ${factory} — add the (chainId, factory) -> NFPM mapping to CL_FACTORY_TO_NFPM in src/Constants.ts, or whitelist with a comment`,
+          ).toContain(factory);
+        }
+      },
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- Adds a vitest parity check that walks every chain block in `config.yaml` and verifies each CLFactory / PoolFactory address is wired into the matching trusted-list constant in `src/Constants.ts`. Failure messages name the missing address, the chain, and the constant.
- Surfaces and fixes a latent #769-class drift: the slipstream gauge-V2 CLFactory `0x718E46d…` was added to every superchain leaf in #727 but never wired into `SUPERCHAIN_LEAF_VOTER_CLPOOLS_FACTORY_LIST`, so `SuperchainLeafVoter.GaugeCreated` was silently dropping its gauges.
- Updates the `TODO(nfpm)` comment in `src/Constants.ts` to reference both unmapped CLFactories and the test whitelist that holds the gap explicit. (AC #5)

## Constants covered

| Constant | Source of truth in config.yaml |
| --- | --- |
| `VOTER_CLPOOLS_FACTORY_LIST` | every `CLFactory.address` under `chains[id=10\|8453]` |
| `VOTER_NONCL_POOLS_FACTORY_LIST` | every `PoolFactory.address` under `chains[id=10\|8453]` |
| `SUPERCHAIN_LEAF_VOTER_CLPOOLS_FACTORY_LIST` | every `CLFactory.address` on each of 10 superchain leaves |
| `SUPERCHAIN_LEAF_VOTER_NONCL_POOLS_FACTORY_LIST` | every `PoolFactory.address` on each of 10 superchain leaves |
| `ROOT_POOL_FACTORY_ADDRESS_OPTIMISM` | internal consistency against `SUPERCHAIN_LEAF_VOTER_NONCL_POOLS_FACTORY_LIST` (the constant's name is historical — it is the non-CL pool factory used in cross-chain root↔leaf V2 lookups, not `RootCLPoolFactory@10` as the issue ticket suggested) |
| `nfpmForCLPool()` / `CL_FACTORY_TO_NFPM` | every `(chainId, CLFactory)` pair in chain blocks; two unmapped factories are whitelisted with TODO references pending on-chain `NFPM.factory()` verification |

## Diagnostic example (AC #2)

Manually removed an entry from `VOTER_CLPOOLS_FACTORY_LIST` to verify the failure:

```
AssertionError: missing in VOTER_CLPOOLS_FACTORY_LIST: 0xaDe65c38CD4849aDBA595a4323a8C7DdfE89716a (chain 8453) — add to src/Constants.ts to keep config.yaml in sync
```

## Test plan

- [x] `pnpm qa` — clean (1 biome fix applied: `!` → `?.`)
- [x] `tsc --noEmit` — clean
- [x] `pnpm test` — 1391 tests pass, 33 skipped, 0 failures
- [x] Manual: yank one entry from `VOTER_CLPOOLS_FACTORY_LIST` → assertion fails with the diagnostic above
- [x] Manual: confirm assertion passes on first commit after the SUPERCHAIN_LEAF drift fix

## Notes

- Stacked on #772 (closes #769). Base = `worktree-issue-769-voter-clfactory-list`. Rebase onto main once #772 lands.
- The two unmapped CLFactories (Base `0xf8f2eB49…`, OP `0xe13Dd1f…`) are documented in both the `TODO(nfpm)` comment and the test's whitelist. Resolving them is follow-up work that needs RPC verification of `NFPM.factory()`.
- Hand-rolled YAML parser (no new dep). Indentation regex relies on the uniform 2/6/10-space chain-block formatting that `envio codegen` enforces; if anyone reindents, the "parser broken or chain removed" guard fires before any false-negative parity pass.

Closes #770.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage to validate configuration consistency and prevent silent gauge registration failures.
  * Added configuration-driven validation tests for factory address mappings across multiple chains.

* **Chores**
  * Updated factory address constants and enhanced documentation to maintain synchronization with configuration files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/velodrome-finance/indexer/pull/774?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->