### PR TITLE
Extend last-known-price fallback to V1/V2 oracle generations

### DIFF
--- a/src/PriceOracle.ts
+++ b/src/PriceOracle.ts
@@ -1,12 +1,6 @@
 import type { Token, handlerContext } from "generated";
 import { estimateBlockAtTimestamp } from "./ChainBlockTime";
-import {
-  CHAIN_CONSTANTS,
-  MS_IN_AN_HOUR,
-  PriceOracleType,
-  TEN_TO_THE_18_BI,
-  TokenId,
-} from "./Constants";
+import { MS_IN_AN_HOUR, TEN_TO_THE_18_BI, TokenId } from "./Constants";
 import {
   getTokenDetails,
   getTokenPrice,
@@ -117,9 +111,10 @@ export async function createTokenEntity(
  *   event for stuck tokens.
  * - `lastSuccessfulPriceTimestamp` advances ONLY when a non-zero price is
  *   persisted (main oracle write or rebind with a priced source). It drives
- *   the 7-day staleness window guarding the V3 last-known-price fallback —
+ *   the 7-day staleness window guarding the last-known-price fallback —
  *   so once a token enters fallback, the window can actually expire even
- *   with hourly retries.
+ *   with hourly retries. The fallback covers every oracle generation
+ *   (#775 extended it from V3-only to V1/V2 too).
  *
  * @param token - The token entity to refresh.
  * @param blockNumber - Block at which to fetch price (rounded to an hourly bucket for cache hits).
@@ -328,15 +323,14 @@ export async function refreshTokenPrice(
       blockTimestampMs - healed.lastSuccessfulPriceTimestamp.getTime() <
         7 * 24 * 60 * 60 * 1000;
 
-    // V3 last-known-price fallback: V3 is the modern, mostly-reliable oracle,
-    // but does throw transient $0 reads. Earlier V1/V2 windows are short and
-    // unreliable enough that fallback there would mask real failures, so we
-    // only trust the stored price as a substitute when V3 is the active oracle.
-    if (
-      shouldUseLastKnownPrice &&
-      CHAIN_CONSTANTS[chainId].oracle.getType(blockNumber) ===
-        PriceOracleType.V3
-    ) {
+    // Last-known-price fallback: every oracle generation throws transient $0
+    // reads (V3 from on-chain reverts; V1/V2 additionally when the RpcGateway
+    // returns its `{pricePerUSDNew: 0n, usedDefault: true}` fallback constant
+    // on RPC outage). Preserve a fresh anchor across any of those cases. The
+    // 7-day window on `lastSuccessfulPriceTimestamp` (#694) still bounds how
+    // long we'll pin a stale value. Originally gated to V3 only (#694); the
+    // V1/V2 exposure was confirmed in #775 (~$250M of Optimism volume zeroed).
+    if (shouldUseLastKnownPrice) {
       const updatedToken: Token = {
         ...healed,
         lastUpdatedTimestamp: new Date(blockTimestampMs),

--- a/test/PriceOracle.test.ts
+++ b/test/PriceOracle.test.ts
@@ -1666,6 +1666,168 @@ describe("PriceOracle", () => {
       });
     });
 
+    // Issue #775: extending the #694 fallback to V1/V2. Before the fix, the
+    // V3-only gate let a transient gateway-fallback {pricePerUSDNew: 0n,
+    // usedDefault: true} overwrite a valid non-zero anchor on any V1/V2 block
+    // (Optimism V1/V2 ran from ~block 107.6M to ~125.5M — several months of
+    // exposure). Five canonical home-chain tokens (WETH-Base, WETH-OP,
+    // AERO-Base, VELO-OP, OP-OP) ended at $0 with isWhitelisted=true,
+    // poisoning ~$250M of cumulative volume in downstream USD aggregates.
+    // Same 7-day staleness window from #694 still bounds how stale we'll
+    // preserve.
+    describe("V1/V2 fallback staleness (issue #775)", () => {
+      // Optimism V1 oracle covers blocks ≤ 124076662 (see Constants.ts). Pick
+      // a block in the middle of the V1 window to exercise the V1 path.
+      const v1Block = 115_000_000;
+      // Optimism V2 oracle covers 124076662 < block ≤ 125484892.
+      const v2Block = 125_000_000;
+      const oneHourOneMinuteAgo = () =>
+        new Date(blockDatetime.getTime() - 61 * 60 * 1000);
+
+      beforeEach(() => {
+        vi.mocked(mockContext.Token?.set)?.mockClear();
+        vi.mocked(mockContext.TokenPriceSnapshot?.set)?.mockClear();
+      });
+
+      it("applies the fallback on a V1 block when the last successful price is recent (<7d)", async () => {
+        const anchorPrice = 2_500n * 10n ** 18n; // WETH-OP shape
+        const recentSuccess = new Date(
+          blockDatetime.getTime() - 2 * 24 * 60 * 60 * 1000,
+        );
+        vi.mocked(mockContext.effect)?.mockImplementation(async (effect) => {
+          if ((effect as { name?: string }).name === "getTokenPrice") {
+            // Gateway-fallback shape: usedDefault=true → pricePerUSDNew=0n.
+            return { pricePerUSDNew: 0n };
+          }
+          return {};
+        });
+
+        const fetchedToken = {
+          ...mockToken0Data,
+          pricePerUSDNew: anchorPrice,
+          lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+          lastSuccessfulPriceTimestamp: recentSuccess,
+        };
+
+        await PriceOracle.refreshTokenPrice(
+          fetchedToken,
+          v1Block,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        // Anchor preserved — this is the #775 regression check.
+        expect(updatedToken.pricePerUSDNew).toBe(anchorPrice);
+        // Throttle clock advances on every attempt (existing #694 behavior)
+        expect(updatedToken.lastUpdatedTimestamp.getTime()).toBe(
+          blockDatetime.getTime(),
+        );
+        // Last successful timestamp must NOT advance on a fallback write
+        expect(updatedToken.lastSuccessfulPriceTimestamp?.getTime()).toBe(
+          recentSuccess.getTime(),
+        );
+      });
+
+      it("applies the fallback on a V2 block when the last successful price is recent (<7d)", async () => {
+        const anchorPrice = 2_500n * 10n ** 18n;
+        const recentSuccess = new Date(
+          blockDatetime.getTime() - 2 * 24 * 60 * 60 * 1000,
+        );
+        vi.mocked(mockContext.effect)?.mockImplementation(async (effect) => {
+          if ((effect as { name?: string }).name === "getTokenPrice") {
+            return { pricePerUSDNew: 0n };
+          }
+          return {};
+        });
+
+        const fetchedToken = {
+          ...mockToken0Data,
+          pricePerUSDNew: anchorPrice,
+          lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+          lastSuccessfulPriceTimestamp: recentSuccess,
+        };
+
+        await PriceOracle.refreshTokenPrice(
+          fetchedToken,
+          v2Block,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        expect(updatedToken.pricePerUSDNew).toBe(anchorPrice);
+      });
+
+      it("stops re-pinning on a V1 block once the last successful price is older than 7 days", async () => {
+        const anchorPrice = 2_500n * 10n ** 18n;
+        const eightDaysAgo = new Date(
+          blockDatetime.getTime() - 8 * 24 * 60 * 60 * 1000,
+        );
+        vi.mocked(mockContext.effect)?.mockImplementation(async (effect) => {
+          if ((effect as { name?: string }).name === "getTokenPrice") {
+            return { pricePerUSDNew: 0n };
+          }
+          return {};
+        });
+
+        const fetchedToken = {
+          ...mockToken0Data,
+          pricePerUSDNew: anchorPrice,
+          lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+          lastSuccessfulPriceTimestamp: eightDaysAgo,
+        };
+
+        await PriceOracle.refreshTokenPrice(
+          fetchedToken,
+          v1Block,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        // 7-day window has expired — fallback must NOT apply. Write 0.
+        expect(updatedToken.pricePerUSDNew).toBe(0n);
+      });
+
+      it("preserves 0n on a V1 block when there is no prior anchor (no spurious fallback)", async () => {
+        vi.mocked(mockContext.effect)?.mockImplementation(async (effect) => {
+          if ((effect as { name?: string }).name === "getTokenPrice") {
+            return { pricePerUSDNew: 0n };
+          }
+          return {};
+        });
+
+        const fetchedToken = {
+          ...mockToken0Data,
+          pricePerUSDNew: 0n,
+          lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+          lastSuccessfulPriceTimestamp: undefined,
+        };
+
+        await PriceOracle.refreshTokenPrice(
+          fetchedToken,
+          v1Block,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        // shouldUseLastKnownPrice requires anchor > 0n, so fallback is skipped
+        // — fall through to the normal write of 0n. No spurious value invented.
+        expect(updatedToken.pricePerUSDNew).toBe(0n);
+        expect(updatedToken.lastSuccessfulPriceTimestamp).toBeUndefined();
+      });
+    });
+
     describe("when price fetch fails", () => {
       let originalToken: Token;
       beforeEach(async () => {


### PR DESCRIPTION
Closes #775.

## Summary
- Drop the `=== PriceOracleType.V3` guard in `refreshTokenPrice` so the #694 last-known-price fallback applies to V1/V2 too. Before this, any transient gateway-fallback `{pricePerUSDNew: 0n, usedDefault: true}` on a V1/V2 block wrote `0n` straight over a valid non-zero anchor — affecting five canonical home-chain tokens (WETH-Base, WETH-OP, AERO-Base, VELO-OP, OP-OP) and zeroing ~\$250M of cumulative Optimism volume in USD aggregates.
- The 7-day staleness window on `lastSuccessfulPriceTimestamp` (introduced by #694) still bounds how long we'll pin a stale value, so no risk of preserving arbitrarily old prices.
- Add four V1/V2 unit tests mirroring the existing V3 fallback tests (recent V1 anchor preserved, recent V2 anchor preserved, V1 8-day-old anchor zeroed, V1 no-prior-anchor preserved at 0n).
- Update the JSDoc on `refreshTokenPrice` and the inline comment on the fallback branch to reflect the V1/V2 extension.

## Worked examples

All three scenarios use the same token (WETH-OP, Optimism, V1 oracle window — blocks ≤ 124_076_662) so a first reader can see exactly what changes and what doesn't.

### Setup
- Token: WETH-OP (`0x4200…0006`)
- Stored Token entity at the start: `pricePerUSDNew = 2_479_960_000_000_000_000_000` (\$2,479.96), `lastSuccessfulPriceTimestamp = T-2 days`, `lastUpdatedTimestamp = T-1 hour`

### Scenario A — transient RPC failure (the case this PR fixes)

At block 115_000_000 (V1 era) the RpcGateway can't reach the oracle and returns its fallback constant: `{ pricePerUSDNew: 0n, usedDefault: true }`.

**Before this PR:**

```
oracle.getType(115_000_000) → V1
shouldUseLastKnownPrice = (0n === 0n)
                       && (2479.96e18 > 0n)
                       && (T-2d age < 7d)
                       = true
V3 gate: V1 !== V3 → fallback SKIPPED
Falls through to the regular write: pricePerUSDNew = 0n
→ WETH-OP anchor poisoned to \$0
```

**After this PR:**

```
shouldUseLastKnownPrice = true (same as above)
Fallback branch fires unconditionally → preserves \$2,479.96
lastUpdatedTimestamp bumps to T (throttle ticks forward)
lastSuccessfulPriceTimestamp stays at T-2d (not a fresh success)
→ Anchor survives. Next hourly refresh retries the oracle.
```

### Scenario B — an inflated read tries to slip in (spike guard unchanged)

One hour later, at block 115_000_300, the oracle has recovered but returns a glitch value of `50_000e18` (\$50,000).

```
anchorPrice = 2_479.96e18 (preserved by Scenario A)
currentPrice = 50_000e18
ratio = 50000 / 2479.96 ≈ 20× → ≥ 10× threshold
anchorAgeMs = 1 hour < 14 days → spike guard active
upwardSpike rejected → early return, anchor unchanged
```

`shouldUseLastKnownPrice` is never reached — it requires `currentPrice === 0n`, but here `currentPrice > 0n`. The spike guard (#668/#730) and the fallback branch are **mutually exclusive** on the value of `currentPrice`. This PR doesn't touch the spike guard.

### Scenario C — a fresh, never-priced token tries to anchor at \$50K (FIRST_FETCH_CAP unchanged)

Different token, first-sight on a V1 block. Stored anchor is `0n` (never priced). The oracle returns `50_000e18`.

```
healed.pricePerUSDNew === 0n   ← first fetch
currentPrice (50_000e18) > FIRST_FETCH_CAP (10_000e18)
symbol "VELO" does not contain "BTC"
→ capped: writes pricePerUSDNew = 0n, return
```

The cap rejects the inflated value before it can become the anchor. The fallback in this PR can't preserve a poisonous value here because `shouldUseLastKnownPrice` requires `healed.pricePerUSDNew > 0n`, which FIRST_FETCH_CAP (#728) denies on first fetch.

### Net effect on the gating story

Every existing guard around `refreshTokenPrice` remains in place and continues to fire in the same order:

1. **Blacklist** (#669/#701/#722/#731) — forces 0n and skips the oracle entirely.
2. **Rebind** (#669/#721) — redirects to a canonical source's Token entity.
3. **FIRST_FETCH_CAP** (#728) — rejects first non-zero anchor > \$10K for non-BTC symbols.
4. **Spike guard** (#668/#730) — rejects upward refreshes ≥10× a still-fresh (<14d) anchor.
5. **PriceTrust two-tier gate** (#755/#761/#762) — downstream USD math reads via `getTrustedUSD`.
6. **7-day staleness window** (#694, now V1/V2 too) — bounds how long the fallback can preserve a stale value.

The only behavioral delta is the single Scenario-A path: on V1/V2, a transient gateway `usedDefault: true → 0n` no longer overwrites a previously-accepted anchor. Every path *into* the anchor is unchanged, so there is no new poisoning entry surface.

## Test plan
- [x] `pnpm qa --write` passes (biome: no fixes applied, 263 files checked)
- [x] `tsc --noEmit` passes (no errors after `pnpm envio codegen`)
- [x] `pnpm exec vitest run` passes (1358 PASS / 0 FAIL)
- [x] New tests in `test/PriceOracle.test.ts` ("V1/V2 fallback staleness (issue #775)") fail before the gate is dropped and pass after
- [x] Existing #694 V3 fallback tests still pass (no regression)
- [ ] Integration check: WETH-OP `pricePerUSDNew` resolves to a non-zero value when re-indexed past the V1 range *(needs human — deferred to the planned re-index from genesis for #769; per the issue's operational note, this heals automatically)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)