### PR TITLE
fix(venft): infer isPermanent on Deposit when locktime=0 (closes #776)

### DIFF
--- a/src/Aggregators/VeNFTState.ts
+++ b/src/Aggregators/VeNFTState.ts
@@ -74,5 +74,19 @@ export async function updateVeNFTState(
     };
   }
 
+  // Defensive invariant guard: by VotingEscrow semantics, locktime=0 is only
+  // valid for permanent locks. An alive non-permanent lock must have
+  // locktime > now. If we ever land in the impossible state, surface it so
+  // monitoring catches future regressions (see #776).
+  if (
+    veNFTState.locktime === 0n &&
+    !veNFTState.isPermanent &&
+    veNFTState.isAlive
+  ) {
+    context.log.warn(
+      `[VENFT_LOCKSTATE_INVARIANT] VeNFTState ${veNFTState.id} ended with locktime=0, isPermanent=false, isAlive=true`,
+    );
+  }
+
   context.VeNFTState.set(veNFTState);
 }

--- a/src/EventHandlers/VeNFT/VeNFTLogic.ts
+++ b/src/EventHandlers/VeNFT/VeNFTLogic.ts
@@ -29,6 +29,14 @@ import {
  * Processes a VeNFT Deposit event: updates the VeNFTState with the new locktime,
  * adds the deposited value to totalValueLocked, sets isAlive to true, and refreshes lastUpdatedTimestamp.
  *
+ * When `event.params.locktime === 0n`, the deposit is a permanent-lock create or an
+ * increase_amount on an already-permanent lock — by `VotingEscrow` semantics
+ * `end = 0` is only valid for permanent locks. We infer `isPermanent: true` so
+ * the one-shot `Transfer` + `Deposit(locktime=0)` flow (no separate `LockPermanent`)
+ * does not leave the entity in the impossible `locktime=0 ∧ !isPermanent ∧ isAlive`
+ * state. For `locktime > 0n` we leave the field undefined so the aggregator
+ * preserves the existing value.
+ *
  * @param event - The VeNFT Deposit event payload (locktime, value).
  * @param currentVeNFTState - The existing VeNFTState entity for this token.
  * @param context - Handler context for storage and logging.
@@ -45,6 +53,7 @@ export async function processVeNFTDeposit(
     locktime: event.params.locktime,
     incrementalTotalValueLocked: event.params.value,
     isAlive: true,
+    isPermanent: event.params.locktime === 0n ? true : undefined,
     lastUpdatedTimestamp: timestamp,
   };
 

--- a/test/Aggregators/VeNFTState.test.ts
+++ b/test/Aggregators/VeNFTState.test.ts
@@ -260,6 +260,73 @@ describe("VeNFTState", () => {
       });
     });
 
+    describe("locktime=0 ∧ !isPermanent ∧ isAlive invariant guard", () => {
+      it("warns when the final state violates the permanent-lock invariant", async () => {
+        const freshState: VeNFTState = {
+          ...mockVeNFTState,
+          locktime: 0n,
+          isPermanent: false,
+          isAlive: true,
+        };
+        const violatingDiff = {
+          // Mirrors the pre-fix one-shot permanent-create pathology: a Deposit
+          // landing locktime=0 without inferring isPermanent.
+          locktime: 0n,
+          incrementalTotalValueLocked: 100n,
+          isAlive: true,
+        };
+
+        await updateVeNFTState(
+          violatingDiff,
+          freshState,
+          timestamp,
+          mockContext as handlerContext,
+        );
+
+        expect(mockContext.log?.warn).toHaveBeenCalledWith(
+          expect.stringContaining("[VENFT_LOCKSTATE_INVARIANT]"),
+        );
+      });
+
+      it("does not warn when the lock is a valid permanent (locktime=0 ∧ isPermanent)", async () => {
+        const permanentState: VeNFTState = {
+          ...mockVeNFTState,
+          locktime: 0n,
+          isPermanent: true,
+          isAlive: true,
+        };
+        const incrementOnly = { incrementalTotalValueLocked: 5n };
+
+        await updateVeNFTState(
+          incrementOnly,
+          permanentState,
+          timestamp,
+          mockContext as handlerContext,
+        );
+
+        expect(mockContext.log?.warn).not.toHaveBeenCalled();
+      });
+
+      it("does not warn when the lock is dead (locktime=0 ∧ !isAlive)", async () => {
+        const burnedState: VeNFTState = {
+          ...mockVeNFTState,
+          locktime: 0n,
+          isPermanent: false,
+          isAlive: false,
+        };
+        const noopDiff = {};
+
+        await updateVeNFTState(
+          noopDiff,
+          burnedState,
+          timestamp,
+          mockContext as handlerContext,
+        );
+
+        expect(mockContext.log?.warn).not.toHaveBeenCalled();
+      });
+    });
+
     describe("when updating with burn diff", () => {
       let result: VeNFTState;
       beforeEach(async () => {

--- a/test/EventHandlers/VeNFT/VeNFTLogic.test.ts
+++ b/test/EventHandlers/VeNFT/VeNFTLogic.test.ts
@@ -109,9 +109,80 @@ describe("VeNFTLogic", () => {
           locktime: 200n,
           incrementalTotalValueLocked: 50n,
           isAlive: true,
+          isPermanent: undefined,
           lastUpdatedTimestamp: timestamp,
         },
         mockVeNFTState,
+        timestamp,
+        mockContext,
+      );
+    });
+
+    it("infers isPermanent=true on permanent-create (locktime=0) for a fresh entity", async () => {
+      const event = {
+        ...createMockDepositEvent(),
+        params: {
+          ...createMockDepositEvent().params,
+          locktime: 0n,
+        },
+      } as VeNFT_Deposit_event;
+      const timestamp = new Date(event.block.timestamp * 1000);
+      const freshState: VeNFTState = {
+        ...mockVeNFTState,
+        locktime: 0n,
+        isPermanent: false,
+        totalValueLocked: 0n,
+      };
+      const updateSpy = vi
+        .spyOn(VeNFTStateAggregator, "updateVeNFTState")
+        .mockResolvedValue(undefined);
+
+      await VeNFTLogic.processVeNFTDeposit(event, freshState, mockContext);
+
+      expect(updateSpy).toHaveBeenCalledWith(
+        {
+          locktime: 0n,
+          incrementalTotalValueLocked: 50n,
+          isAlive: true,
+          isPermanent: true,
+          lastUpdatedTimestamp: timestamp,
+        },
+        freshState,
+        timestamp,
+        mockContext,
+      );
+    });
+
+    it("keeps isPermanent=true when an increase_amount Deposit fires on an already-permanent lock", async () => {
+      const event = {
+        ...createMockDepositEvent(),
+        params: {
+          ...createMockDepositEvent().params,
+          locktime: 0n,
+          value: 25n,
+        },
+      } as VeNFT_Deposit_event;
+      const timestamp = new Date(event.block.timestamp * 1000);
+      const permanentState: VeNFTState = {
+        ...mockVeNFTState,
+        locktime: 0n,
+        isPermanent: true,
+      };
+      const updateSpy = vi
+        .spyOn(VeNFTStateAggregator, "updateVeNFTState")
+        .mockResolvedValue(undefined);
+
+      await VeNFTLogic.processVeNFTDeposit(event, permanentState, mockContext);
+
+      expect(updateSpy).toHaveBeenCalledWith(
+        {
+          locktime: 0n,
+          incrementalTotalValueLocked: 25n,
+          isAlive: true,
+          isPermanent: true,
+          lastUpdatedTimestamp: timestamp,
+        },
+        permanentState,
         timestamp,
         mockContext,
       );


### PR DESCRIPTION
## Summary

- `processVeNFTDeposit` now infers `isPermanent: true` when `event.params.locktime === 0n`, plugging the one-shot permanent-create path (`Transfer` + `Deposit(locktime=0)` with no separate `LockPermanent`) that left 56 alive entities (30 OP + 26 Base) in the impossible state `locktime=0 ∧ !isPermanent ∧ isAlive`.
- Adds a defensive `[VENFT_LOCKSTATE_INVARIANT]` warn log in `updateVeNFTState` so future regressions of the same shape surface in monitoring.
- The 56 stuck entities heal automatically on the planned re-index — no migration script.

Closes #776.

## Test plan

- [x] Unit test (`VeNFTLogic.test.ts`): timed-lock Deposit (`locktime > 0n`) leaves `isPermanent` undefined in the diff, so the aggregator preserves `current.isPermanent`.
- [x] Unit test: permanent-create Deposit (`locktime = 0n`) on a freshly-minted entity → diff has `isPermanent: true`.
- [x] Unit test: increase_amount Deposit (`locktime = 0n`) on an already-permanent lock → diff has `isPermanent: true`, no flip back.
- [x] Unit test (`VeNFTState.test.ts`): final state violating `locktime=0 ∧ !isPermanent ∧ isAlive` triggers `[VENFT_LOCKSTATE_INVARIANT]` warn.
- [x] Unit test: valid permanent state (`locktime=0 ∧ isPermanent`) does not warn.
- [x] Unit test: dead state (`locktime=0 ∧ !isAlive`) does not warn.
- [x] `pnpm qa --write` clean.
- [x] `pnpm test` — 1359 pass, 33 skipped, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)