### PR TITLE
fix(staked-counter): mirror NFPM liquidityDelta onto currentLiquidityStaked (closes #780)

### DIFF
--- a/src/EventHandlers/NFPM/NFPMCommonLogic.ts
+++ b/src/EventHandlers/NFPM/NFPMCommonLogic.ts
@@ -112,6 +112,9 @@ export async function attributeLiquidityChangeToUserStatsPerPool(
  * @param timestamp - Block timestamp
  * @param chainId - Chain ID
  * @param blockNumber - Block number
+ * @returns Promise that resolves once the pool's staked-tick edges, derived
+ *   stakedLiquidityInRange, staked reserves, and currentLiquidityStaked
+ *   counter are staged, alongside the staker's UserStatsPerPool counter.
  */
 export async function updateStakedPositionLiquidity(
   position: NonFungiblePosition,

--- a/src/EventHandlers/NFPM/NFPMCommonLogic.ts
+++ b/src/EventHandlers/NFPM/NFPMCommonLogic.ts
@@ -90,6 +90,21 @@ export async function attributeLiquidityChangeToUserStatsPerPool(
  * Updates the aggregator's staked-tick edge list and pool staked reserves when
  * a staked position's liquidity changes (IncreaseLiquidity or DecreaseLiquidity).
  *
+ * Also mirrors `liquidityDelta` onto the running `currentLiquidityStaked`
+ * counter on Pool and the staker's UserStatsPerPool (issue #780). Without
+ * this, the next gauge Withdraw arrives with `liquidityToStake =
+ * position.liquidity` reflecting in-flight Increase/Decrease deltas, while the
+ * indexer's running counter only received the original Deposit amount; the
+ * Withdraw guard at `GaugeSharedLogic.ts:419` then underflows and the edges
+ * decrement is dropped, leaving phantom positive residue in
+ * `stakedTickEdges`/`stakedTickEdgeNets` that swap re-derives forever.
+ *
+ * Position.owner is the real staker, not the gauge: `handleRegularTransfer`
+ * skips owner updates on gauge stake/unstake transfers (see
+ * `NFPMTransferLogic.ts:300-318`), so `loadOrCreateUserData(position.owner)`
+ * resolves the UserStatsPerPool that `processGaugeDeposit` originally
+ * incremented.
+ *
  * @param position - The NonFungiblePosition being modified
  * @param poolData - Pool data with liquidityPoolAggregator and token instances
  * @param liquidityDelta - Positive for increase, negative for decrease
@@ -145,6 +160,22 @@ export async function updateStakedPositionLiquidity(
     stakedTickEdgeNets,
   );
 
+  // Issue #780: load and update the staker's UserStatsPerPool in parallel
+  // with the pool update so the gauge Withdraw guard's user-side check stays
+  // in sync. `position.owner` is the staker (not the gauge) because
+  // handleRegularTransfer skips owner updates on stake/unstake transfers.
+  const stakerUserData = await loadOrCreateUserData(
+    position.owner,
+    position.pool,
+    chainId,
+    context,
+    timestamp,
+  );
+  const userDiff = {
+    incrementalCurrentLiquidityStaked: liquidityDelta,
+    lastActivityTimestamp: timestamp,
+  };
+
   if (sqrtPriceX96 === 0n) {
     // Defensive fallback: since velodrome-finance/indexer#654 wired
     // CLPool.Initialize to populate sqrtPriceX96/tick on the aggregator, a
@@ -153,19 +184,29 @@ export async function updateStakedPositionLiquidity(
     // the edge-list update so the swap path has correct state once a price is
     // established, but skip the amount math that would otherwise produce
     // garbage from sqrtPriceX96=0.
-    await updatePool(
-      {
-        stakedTickEdges,
-        stakedTickEdgeNets,
-        stakedLiquidityInRange,
-        hasStakes,
-      },
-      liquidityPoolAggregator,
-      timestamp,
-      context,
-      chainId,
-      blockNumber,
-    );
+    await Promise.all([
+      updatePool(
+        {
+          incrementalCurrentLiquidityStaked: liquidityDelta,
+          stakedTickEdges,
+          stakedTickEdgeNets,
+          stakedLiquidityInRange,
+          hasStakes,
+        },
+        liquidityPoolAggregator,
+        timestamp,
+        context,
+        chainId,
+        blockNumber,
+      ),
+      updateUserStatsPerPool(
+        userDiff,
+        stakerUserData,
+        context,
+        timestamp,
+        poolData,
+      ),
+    ]);
     return;
   }
 
@@ -182,6 +223,7 @@ export async function updateStakedPositionLiquidity(
   const direction = liquidityDelta > 0n ? 1n : -1n;
 
   const stakedDiff = {
+    incrementalCurrentLiquidityStaked: liquidityDelta,
     stakedLiquidityInRange,
     incrementalStakedReserve0: direction * amount0,
     incrementalStakedReserve1: direction * amount1,
@@ -190,12 +232,21 @@ export async function updateStakedPositionLiquidity(
     hasStakes,
   };
 
-  await updatePool(
-    stakedDiff,
-    liquidityPoolAggregator,
-    timestamp,
-    context,
-    chainId,
-    blockNumber,
-  );
+  await Promise.all([
+    updatePool(
+      stakedDiff,
+      liquidityPoolAggregator,
+      timestamp,
+      context,
+      chainId,
+      blockNumber,
+    ),
+    updateUserStatsPerPool(
+      userDiff,
+      stakerUserData,
+      context,
+      timestamp,
+      poolData,
+    ),
+  ]);
 }

--- a/test/Aggregators/CLStakedLiquidityEdgeSanity.test.ts
+++ b/test/Aggregators/CLStakedLiquidityEdgeSanity.test.ts
@@ -1,5 +1,5 @@
 import type { Token, handlerContext } from "generated";
-import { CLGauge, MockDb } from "../../generated/src/TestHelpers.gen";
+import { CLGauge, MockDb, NFPM } from "../../generated/src/TestHelpers.gen";
 import {
   applyStakedPositionToEdges,
   deriveStakedLiquidityInRange,
@@ -511,10 +511,22 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
       // delegates to for staked positions, and bypassing the full event chain
       // keeps the test focused on the counter-update path the issue exposes.
       const setSpy = vi.fn();
+      // Issue #780: updateStakedPositionLiquidity now also touches the staker's
+      // UserStatsPerPool (Pool + user must move in lockstep for the gauge
+      // Withdraw guard). Mock the user-side entities so the path completes.
       const mockContext = {
         Pool: { set: setSpy },
         PoolSnapshot: { set: vi.fn() },
         Token: { get: vi.fn().mockResolvedValue(undefined) },
+        UserStatsPerPool: {
+          get: vi.fn().mockResolvedValue(undefined),
+          set: vi.fn(),
+        },
+        UserStatsPerPoolSnapshot: {
+          get: vi.fn().mockResolvedValue(undefined),
+          set: vi.fn(),
+          getWhere: vi.fn().mockResolvedValue([]),
+        },
         log: {
           error: vi.fn(),
           warn: vi.fn(),
@@ -675,6 +687,147 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
           postWithdraw.stakedTickEdgeNets,
         ),
       );
+      expect(postWithdraw.stakedLiquidityInRange).toBe(0n);
+    });
+
+    it("(g) [#780] Deposit + IncreaseLiquidity-while-staked + Withdraw round-trips counter and edges to zero", async () => {
+      // Reproduces the exact #780 mechanism from issue body:
+      // - Deposit at liquidity L0 → pool.currentLiquidityStaked = L0
+      // - NFPM.IncreaseLiquidity while staked bumps position.liquidity to L0+ΔL
+      // - Withdraw arrives with liquidityToStake = L0+ΔL (matches chain liquidity)
+      // - Pre-fix: pool.currentLiquidityStaked - (L0+ΔL) = -ΔL < 0n → guard fires,
+      //   edges decrement is dropped, stakedTickEdges/Nets pollute → stakedReserve0/1
+      //   leak forever (phantom positive residue scaling with ΔL).
+      // - Post-fix: updateStakedPositionLiquidity mirrors ΔL onto the counter so
+      //   the Withdraw guard passes and the round-trip balances to 0n.
+      let mockDb = MockDb.createMockDb();
+      const liquidityPool = createMockPool({
+        isCL: true,
+        gaugeAddress,
+        sqrtPriceX96: sqrtAt(0n),
+        tick: 0n,
+        hasStakes: false,
+        nfpmAddress: defaultNfpmAddress,
+      });
+      mockDb = mockDb.entities.Pool.set(liquidityPool);
+      mockDb = mockDb.entities.Token.set(mockToken0Data as Token);
+      mockDb = mockDb.entities.Token.set(mockToken1Data as Token);
+
+      const tickLower = -100n;
+      const tickUpper = 100n;
+      const initialLiquidity = 19_203_953_530_494n; // L0 from issue body's USDC/mooBIFI example
+      const increaseDelta = 141_500_788_681_522_563n; // ΔL from issue body
+      const tokenId = 31357n; // matches the issue body's example
+      mockDb = mockDb.entities.NonFungiblePosition.set(
+        createMockNonFungiblePosition({
+          tokenId,
+          nfpmAddress: defaultNfpmAddress,
+          pool: liquidityPool.poolAddress,
+          owner: userAddress,
+          tickLower,
+          tickUpper,
+          liquidity: initialLiquidity,
+          isStakedInGauge: false,
+        }),
+      );
+
+      // 1) Gauge Deposit at L0.
+      const depositEvent = CLGauge.Deposit.createMockEvent({
+        user: userAddress,
+        tokenId,
+        liquidityToStake: initialLiquidity,
+        mockEventData: {
+          srcAddress: gaugeAddress,
+          chainId,
+          block: {
+            number: 1,
+            timestamp: 1_700_000_000,
+            hash: `0x${"a".repeat(64)}`,
+          },
+        },
+      });
+      let resultDb = await mockDb.processEvents([depositEvent]);
+
+      const postDeposit = resultDb.entities.Pool.get(
+        PoolId(chainId, liquidityPool.poolAddress),
+      );
+      expect(postDeposit).toBeDefined();
+      if (!postDeposit) return;
+      expect(postDeposit.currentLiquidityStaked).toBe(initialLiquidity);
+
+      // 2) NFPM.IncreaseLiquidity while position is staked. Mirror the chain
+      // by bumping position.liquidity AND firing the IncreaseLiquidity event.
+      const positionAfterDeposit = resultDb.entities.NonFungiblePosition.get(
+        NonFungiblePositionId(chainId, defaultNfpmAddress, tokenId),
+      );
+      if (!positionAfterDeposit) throw new Error("position vanished");
+      // Gauge Deposit sets isStakedInGauge=true via NFPMTransfer in the real
+      // pipeline; here we set it explicitly to mirror that state.
+      resultDb = resultDb.entities.NonFungiblePosition.set({
+        ...positionAfterDeposit,
+        isStakedInGauge: true,
+      });
+
+      const increaseEvent = NFPM.IncreaseLiquidity.createMockEvent({
+        tokenId,
+        liquidity: increaseDelta,
+        amount0: 0n,
+        amount1: 0n,
+        mockEventData: {
+          srcAddress: defaultNfpmAddress,
+          chainId,
+          block: {
+            number: 2,
+            timestamp: 1_700_010_000,
+            hash: `0x${"c".repeat(64)}`,
+          },
+        },
+      });
+      resultDb = await resultDb.processEvents([increaseEvent]);
+
+      const postIncrease = resultDb.entities.Pool.get(
+        PoolId(chainId, liquidityPool.poolAddress),
+      );
+      expect(postIncrease).toBeDefined();
+      if (!postIncrease) return;
+      // The #780 fix: pool counter MUST track in-flight liquidity changes
+      // so the next Withdraw guard does not underflow.
+      expect(postIncrease.currentLiquidityStaked).toBe(
+        initialLiquidity + increaseDelta,
+      );
+
+      // 3) Withdraw arrives with liquidityToStake = position.liquidity =
+      // initialLiquidity + increaseDelta (mirroring how the gauge contract
+      // emits Withdraw with the chain-truth liquidity).
+      const withdrawEvent = CLGauge.Withdraw.createMockEvent({
+        user: userAddress,
+        tokenId,
+        liquidityToStake: initialLiquidity + increaseDelta,
+        mockEventData: {
+          srcAddress: gaugeAddress,
+          chainId,
+          block: {
+            number: 3,
+            timestamp: 1_700_100_000,
+            hash: `0x${"b".repeat(64)}`,
+          },
+        },
+      });
+      resultDb = await resultDb.processEvents([withdrawEvent]);
+
+      const postWithdraw = resultDb.entities.Pool.get(
+        PoolId(chainId, liquidityPool.poolAddress),
+      );
+      expect(postWithdraw).toBeDefined();
+      if (!postWithdraw) return;
+
+      // The round-trip must balance: counter = 0, edges empty, derive
+      // invariant holds. Pre-#780 this would leave the edge nets at +(L0+ΔL)
+      // and the counter at "L0 - (L0+ΔL) = guard fires, no decrement applied",
+      // leaving phantom edges and a stale counter forever.
+      expect(postWithdraw.currentLiquidityStaked).toBe(0n);
+      expect(postWithdraw.stakedTickEdges).toEqual([]);
+      expect(postWithdraw.stakedTickEdgeNets).toEqual([]);
       expect(postWithdraw.stakedLiquidityInRange).toBe(0n);
     });
   });

--- a/test/EventHandlers/NFPM/NFPMCommonLogic.test.ts
+++ b/test/EventHandlers/NFPM/NFPMCommonLogic.test.ts
@@ -353,6 +353,11 @@ describe("NFPMCommonLogic", () => {
       );
       expect(updatePool).toHaveBeenCalledWith(
         {
+          // Issue #780: NFPM-mediated liquidity changes on a staked position
+          // must mirror onto the running currentLiquidityStaked counter so the
+          // gauge Withdraw guard's underflow check does not fire spuriously
+          // when Withdraw arrives with position.liquidity = Deposit + delta.
+          incrementalCurrentLiquidityStaked: 5000n,
           stakedLiquidityInRange: 6000n, // pinned by the derive mock
           incrementalStakedReserve0: 100n, // direction=+1 * 100
           incrementalStakedReserve1: 200n, // direction=+1 * 200
@@ -366,6 +371,52 @@ describe("NFPMCommonLogic", () => {
         chainId,
         blockNumber,
       );
+    });
+
+    it("[#780] should also mirror liquidityDelta onto the staker's UserStatsPerPool.currentLiquidityStaked", async () => {
+      // Issue #780: the gauge Withdraw guard at GaugeSharedLogic.ts:419
+      // checks BOTH pool and user newStake >= 0. Without the user-side
+      // mirror, an NFPM IncreaseLiquidity while staked would leave the
+      // user's currentLiquidityStaked at Deposit's amount while
+      // position.liquidity grew, and the subsequent Withdraw's guard would
+      // trip on the user side too. Position.owner is the real staker, not
+      // the gauge, because handleRegularTransfer skips owner updates on
+      // gauge stake/unstake transfers (see NFPMTransferLogic.ts:300-318).
+      vi.mocked(deriveStakedLiquidityInRange).mockReturnValue(6000n);
+      vi.mocked(loadOrCreateUserData).mockReset();
+      vi.mocked(updateUserStatsPerPool).mockReset();
+      const mockUserData = {
+        userAddress: stakedPosition.owner,
+        poolAddress,
+        chainId,
+        currentLiquidityStaked: 0n,
+      };
+      // biome-ignore lint/suspicious/noExplicitAny: minimal user-data shape for the mock
+      vi.mocked(loadOrCreateUserData).mockResolvedValue(mockUserData as any);
+
+      await updateStakedPositionLiquidity(
+        stakedPosition,
+        poolData,
+        5000n,
+        mockContext,
+        timestamp,
+        chainId,
+        blockNumber,
+      );
+
+      expect(loadOrCreateUserData).toHaveBeenCalledWith(
+        stakedPosition.owner,
+        stakedPosition.pool,
+        chainId,
+        mockContext,
+        timestamp,
+      );
+      expect(updateUserStatsPerPool).toHaveBeenCalledTimes(1);
+      const [userDiff] = vi.mocked(updateUserStatsPerPool).mock.calls[0];
+      expect(userDiff).toMatchObject({
+        incrementalCurrentLiquidityStaked: 5000n,
+        lastActivityTimestamp: timestamp,
+      });
     });
 
     it("should use negative direction for decrease (negative liquidityDelta)", async () => {
@@ -390,6 +441,10 @@ describe("NFPMCommonLogic", () => {
       );
       expect(updatePool).toHaveBeenCalledWith(
         {
+          // Issue #780: negative liquidityDelta must also flow through the
+          // running counter so DecreaseLiquidity-while-staked → Withdraw
+          // cycles balance the books on Pool + UserStatsPerPool too.
+          incrementalCurrentLiquidityStaked: -3000n,
           stakedLiquidityInRange: -2000n, // pinned by the derive mock (clamped at the aggregator)
           incrementalStakedReserve0: -100n, // direction=-1 * 100
           incrementalStakedReserve1: -200n, // direction=-1 * 200
@@ -429,6 +484,7 @@ describe("NFPMCommonLogic", () => {
       );
       expect(updatePool).toHaveBeenCalledWith(
         {
+          incrementalCurrentLiquidityStaked: 5000n, // #780: mirrored to counter
           stakedLiquidityInRange: 0n, // derived, not undefined
           incrementalStakedReserve0: 100n,
           incrementalStakedReserve1: 200n,
@@ -448,6 +504,9 @@ describe("NFPMCommonLogic", () => {
       // Pre-#719 the sqrt=0 path skipped the counter update entirely (so
       // pre-Initialize deposits drifted). Now the counter is derived even on
       // the sqrt=0 early-exit path so the aggregator stays consistent.
+      // Issue #780 also requires incrementalCurrentLiquidityStaked on this
+      // path so the Withdraw guard balances even if the pool was never
+      // Initialize'd in the indexed range.
       vi.mocked(deriveStakedLiquidityInRange).mockReturnValue(42n);
 
       const poolDataZeroPrice: PoolData = {
@@ -473,6 +532,7 @@ describe("NFPMCommonLogic", () => {
       // state once the pool is initialized.
       expect(updatePool).toHaveBeenCalledWith(
         {
+          incrementalCurrentLiquidityStaked: 5000n, // #780: mirrored on sqrt=0 path too
           stakedTickEdges: [-200n, 200n],
           stakedTickEdgeNets: [5000n, -5000n],
           stakedLiquidityInRange: 42n, // derived even on sqrt=0 path (issue #719)

--- a/test/EventHandlers/NFPM/NFPMCommonLogic.test.ts
+++ b/test/EventHandlers/NFPM/NFPMCommonLogic.test.ts
@@ -252,8 +252,12 @@ describe("NFPMCommonLogic", () => {
   });
 
   describe("updateStakedPositionLiquidity", () => {
-    const { mockLiquidityPoolData, mockToken0Data, mockToken1Data } =
-      setupCommon();
+    const {
+      createMockUserStatsPerPool,
+      mockLiquidityPoolData,
+      mockToken0Data,
+      mockToken1Data,
+    } = setupCommon();
 
     const stakedPosition: NonFungiblePosition = {
       ...mockPosition,
@@ -385,14 +389,13 @@ describe("NFPMCommonLogic", () => {
       vi.mocked(deriveStakedLiquidityInRange).mockReturnValue(6000n);
       vi.mocked(loadOrCreateUserData).mockReset();
       vi.mocked(updateUserStatsPerPool).mockReset();
-      const mockUserData = {
+      const mockUserData = createMockUserStatsPerPool({
         userAddress: stakedPosition.owner,
-        poolAddress,
+        poolAddress: stakedPosition.pool,
         chainId,
         currentLiquidityStaked: 0n,
-      };
-      // biome-ignore lint/suspicious/noExplicitAny: minimal user-data shape for the mock
-      vi.mocked(loadOrCreateUserData).mockResolvedValue(mockUserData as any);
+      });
+      vi.mocked(loadOrCreateUserData).mockResolvedValue(mockUserData);
 
       await updateStakedPositionLiquidity(
         stakedPosition,


### PR DESCRIPTION
## Summary

Fixes #780. `updateStakedPositionLiquidity` (the function `NFPM.IncreaseLiquidity` / `DecreaseLiquidity` delegates to for staked positions) now mirrors `liquidityDelta` onto the running `currentLiquidityStaked` counter on **both** `Pool` and the staker's `UserStatsPerPool`, in **both** code paths (normal and the `sqrtPriceX96 === 0n` early-exit). The pre-fix gap let the next gauge `Withdraw` arrive with `liquidityToStake = position.liquidity` (reflecting in-flight Increase/Decrease deltas) while the indexer's counter only had the original `Deposit` amount; the guard at [`GaugeSharedLogic.ts:419`](src/EventHandlers/Gauges/GaugeSharedLogic.ts#L419) underflowed and `processGaugeWithdraw` returned early, stranding contributions in `stakedTickEdges`/`stakedTickEdgeNets` and producing phantom positive `stakedReserve0/1` residue that swap re-derived forever.

`position.owner` is the real staker because `handleRegularTransfer` skips owner updates on gauge stake/unstake transfers (see [`NFPMTransferLogic.ts:300-318`](src/EventHandlers/NFPM/NFPMTransferLogic.ts#L300-L318)), so `loadOrCreateUserData(position.owner)` resolves the same `UserStatsPerPool` that `processGaugeDeposit` originally incremented.

**Separate from and complementary to PR #773** (merged): #773 clamps wei-scale rounding drift in `segmentStakedReserveDelta` (`NEG_STAKED_RESERVE_GUARD`); this PR is the systemic mechanism behind the millions-of-dollars-of-tokens-of-phantom-residue per pool that #773's clamp was masking rather than fixing.

## Changes

- `src/EventHandlers/NFPM/NFPMCommonLogic.ts` — `updateStakedPositionLiquidity` now (a) adds `incrementalCurrentLiquidityStaked: liquidityDelta` to the pool diff in both paths and (b) loads + updates the staker's `UserStatsPerPool` in parallel with `updatePool` via `Promise.all`.
- `test/EventHandlers/NFPM/NFPMCommonLogic.test.ts` — 5 new/extended assertions covering both pool-side and user-side wiring in both code paths.
- `test/Aggregators/CLStakedLiquidityEdgeSanity.test.ts` — new test `(g) [#780]` reproduces the full **Mint → Deposit → IncreaseLiquidity-while-staked → Withdraw** cycle using the USDC/mooBIFI tokenId 31357 numbers from the issue body (`L0 = 19,203,953,530,494`, `ΔL = 141,500,788,681,522,563`) and asserts the round-trip lands `currentLiquidityStaked`, `stakedTickEdges`, `stakedTickEdgeNets`, and `stakedLiquidityInRange` all at zero. Pre-fix, `postIncrease.currentLiquidityStaked === L0 + ΔL` fails and the Withdraw guard fires.

## Acceptance criteria (#780)

- [x] `updateStakedPositionLiquidity` updates `currentLiquidityStaked` on both Pool and UserStatsPerPool by `liquidityDelta`, in both code paths — verified in `src/EventHandlers/NFPM/NFPMCommonLogic.ts`
- [x] Regression test reproduces the bug on pre-fix code and passes after the fix — see `(g) [#780]` in `test/Aggregators/CLStakedLiquidityEdgeSanity.test.ts`
- [x] Zero `withdraw exceeds current stake` log errors on OP 117,044,072 → 125,000,000 — **pre-validated** in worktree `.claude/worktrees/debug-staked-reserve-trace` (1,419 → 0 per issue body)
- [x] 11 pools in `clamp_pools.json` land within wei-scale of on-chain ground truth — **pre-validated** in same debug worktree (USDC/mooBIFI post-fix `stakedReserve0 = -516`, `stakedReserve1 = -247`; max abs diff 25,161 wei on USDC/sUSD; residue absorbed by #773's `NEG_STAKED_RESERVE_GUARD`)

## Test plan

- [x] `pnpm test` — 1430 passed / 33 skipped (no regressions)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `biome check --write` — clean (one formatting fix to the test import line)
- [ ] Optional re-validation: re-run the trimmed OP-only config in `.claude/worktrees/debug-staked-reserve-trace` (start_block 117,044,072 → 125,000,000) and confirm `withdraw exceeds current stake` count is 0 and `clamp_pools.json` chain-truth diffs stay < 100k wei

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure staked liquidity deltas are mirrored into both pool and user staked-liquidity counters and updated concurrently, keeping pool/user counters aligned (including early-exit pricing path).

* **Tests**
  * Expanded regression and unit tests to cover NFPM-mediated staked liquidity changes, counter mirroring, concurrency paths, and edge-case scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/velodrome-finance/indexer/pull/781?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->