### PR TITLE
fix(staked-usd): zero USD companion when staked units reach 0 (closes #782)

### DIFF
--- a/src/Aggregators/UserStatsPerPool.ts
+++ b/src/Aggregators/UserStatsPerPool.ts
@@ -390,11 +390,16 @@ export async function updateUserStatsPerPool(
         : current.lastActivityTimestamp,
   };
 
+  // Issue #782: lockstep invariant — zero staked liquidity cannot have USD value.
+  // Units and USD are updated by separate paths, so enforce agreement on every
+  // write rather than relying solely on snapshot-time recompute.
+  if (updated.currentLiquidityStaked === 0n) {
+    updated = { ...updated, currentLiquidityStakedUSD: 0n };
+  }
+
   if (shouldSnapshot(current.lastSnapshotTimestamp, timestamp)) {
-    // Compute staked USD for this user at snapshot time (both CL and non-CL)
-    if (updated.currentLiquidityStaked === 0n) {
-      updated = { ...updated, currentLiquidityStakedUSD: 0n };
-    } else if (updated.currentLiquidityStaked > 0n) {
+    // Recompute staked USD at snapshot time (both CL and non-CL).
+    if (updated.currentLiquidityStaked > 0n) {
       // Reuse caller-provided poolData when available (saves 3 redundant entity loads
       // per snapshot when the caller already loaded pool + token0 + token1).
       let poolEntity = preloadedPoolData?.liquidityPoolAggregator;

--- a/test/Aggregators/UserStatsPerPoolStakedUSDLockstep.test.ts
+++ b/test/Aggregators/UserStatsPerPoolStakedUSDLockstep.test.ts
@@ -1,0 +1,100 @@
+import { updateUserStatsPerPool } from "../../src/Aggregators/UserStatsPerPool";
+import { toChecksumAddress } from "../../src/Constants";
+import { setupCommon } from "../EventHandlers/Pool/common";
+
+/**
+ * Issue #782: the staked units counter (currentLiquidityStaked) and its USD
+ * companion (currentLiquidityStakedUSD) must reach 0 together on the LIVE
+ * entity, not only at snapshot boundaries. Before the fix, a full unstake
+ * between snapshots drove units -> 0 but left the USD companion sticky,
+ * producing rows with currentLiquidityStaked=0 / currentLiquidityStakedUSD>0
+ * (~$1T phantom in WETH/PEPE, amplified by the PEPE misprice).
+ *
+ * These tests exercise the NON-snapshot path: lastSnapshotTimestamp sits in the
+ * same hour-epoch as the event timestamp, so shouldSnapshot() returns false and
+ * the snapshot-time recompute block (which already zeroes USD when units hit 0)
+ * is skipped.
+ */
+describe("UserStatsPerPool staked-USD lockstep on live path (issue #782)", () => {
+  let common: ReturnType<typeof setupCommon>;
+
+  const mockChainId = 10;
+  const mockPoolAddress = toChecksumAddress(
+    "0xabcdef1234567890abcdef1234567890abcdef12",
+  );
+  const mockUserAddress = toChecksumAddress(
+    "0x1234567890123456789012345678901234567890",
+  );
+
+  // The entity was last snapshotted in this same hour-epoch, so the update
+  // below does NOT cross an epoch boundary -> no snapshot recompute fires.
+  const sameEpochTimestamp = new Date(1_000_000 * 1000);
+
+  beforeEach(() => {
+    common = setupCommon();
+  });
+
+  // Minimal context: the snapshot block is skipped, so the only context call
+  // exercised is the final UserStatsPerPool.set().
+  function buildMockContext() {
+    return common.createMockContext({
+      UserStatsPerPool: { set: async () => {} },
+      log: { error: () => {}, warn: () => {}, info: () => {} },
+    });
+  }
+
+  it("zeroes currentLiquidityStakedUSD in lockstep on a full unstake", async () => {
+    const ctx = buildMockContext();
+    const userStats = common.createMockUserStatsPerPool({
+      userAddress: mockUserAddress,
+      poolAddress: mockPoolAddress,
+      chainId: mockChainId,
+      currentLiquidityStaked: 1_000_000n,
+      currentLiquidityStakedUSD: 5_000n, // stale positive USD from a prior stake
+      lastSnapshotTimestamp: sameEpochTimestamp,
+      lastActivityTimestamp: sameEpochTimestamp,
+    });
+
+    const result = await updateUserStatsPerPool(
+      {
+        incrementalCurrentLiquidityStaked: -1_000_000n, // full unstake -> units 0
+        lastActivityTimestamp: sameEpochTimestamp,
+      },
+      userStats,
+      ctx,
+      sameEpochTimestamp,
+    );
+
+    expect(result.currentLiquidityStaked).toBe(0n);
+    expect(result.currentLiquidityStakedUSD).toBe(0n);
+  });
+
+  it("leaves currentLiquidityStakedUSD sticky on a partial unstake (units stay > 0)", async () => {
+    const ctx = buildMockContext();
+    const userStats = common.createMockUserStatsPerPool({
+      userAddress: mockUserAddress,
+      poolAddress: mockPoolAddress,
+      chainId: mockChainId,
+      currentLiquidityStaked: 1_000_000n,
+      currentLiquidityStakedUSD: 5_000n,
+      lastSnapshotTimestamp: sameEpochTimestamp,
+      lastActivityTimestamp: sameEpochTimestamp,
+    });
+
+    const result = await updateUserStatsPerPool(
+      {
+        incrementalCurrentLiquidityStaked: -400_000n, // partial -> units 600k
+        lastActivityTimestamp: sameEpochTimestamp,
+      },
+      userStats,
+      ctx,
+      sameEpochTimestamp,
+    );
+
+    expect(result.currentLiquidityStaked).toBe(600_000n);
+    // The lockstep zeroing fires only when units reach 0. While units remain
+    // positive, USD is refreshed at snapshot time, so on the live path it stays
+    // at its prior value — the fix must not over-zero or recompute here.
+    expect(result.currentLiquidityStakedUSD).toBe(5_000n);
+  });
+});

--- a/test/EventHandlers/Gauges/GaugeSharedLogic.test.ts
+++ b/test/EventHandlers/Gauges/GaugeSharedLogic.test.ts
@@ -417,11 +417,10 @@ describe("GaugeSharedLogic", () => {
       expect(updatedPool?.currentLiquidityStaked).toBe(0n);
       expect(updatedPool?.currentLiquidityStakedUSD).toBe(0n);
       expect(updatedUser?.currentLiquidityStaked).toBe(0n);
-      // User staked USD was set to 200 at deposit snapshot; withdraw is in the same
-      // epoch so no new snapshot fires — value stays at deposit-time snapshot value
-      expect(updatedUser?.currentLiquidityStakedUSD).toBe(
-        200000000000000000000n,
-      );
+      // Issue #782: a full withdraw drives user units to 0, so the staked-USD
+      // lockstep invariant zeroes currentLiquidityStakedUSD on the live entity
+      // too — even though the withdraw is in the same epoch and no snapshot fires.
+      expect(updatedUser?.currentLiquidityStakedUSD).toBe(0n);
     });
 
     it("should derive non-negative currentLiquidityStakedUSD after deposit then partial withdraw", async () => {


### PR DESCRIPTION
## Summary

`UserStatsPerPool` rows accumulated `currentLiquidityStaked = 0` while `currentLiquidityStakedUSD > 0` — a violated invariant (zero staked liquidity cannot be worth anything). The issue reports ~$1.04T phantom across the top-100 rows of the WETH/PEPE pool, amplified by the PEPE misprice. **Live table only** — `UserStatsPerPoolSnapshot` was already clean.

This is the USD-companion sibling of the #780/#781 units-counter fix.

## Root cause

`currentLiquidityStaked` (units) and `currentLiquidityStakedUSD` are maintained by separate paths inside `updateUserStatsPerPool`. The `units = 0 ⇒ USD = 0` zeroing lived **only inside the `if (shouldSnapshot(...))` block**, so a full unstake *between* snapshots drove the units counter to 0 while leaving the USD companion sticky at its prior value. Snapshots were clean precisely because the zeroing did run at snapshot boundaries.

## Fix

- Lifted the lockstep invariant out of the snapshot block in `src/Aggregators/UserStatsPerPool.ts` so `currentLiquidityStaked === 0n ⇒ currentLiquidityStakedUSD = 0n` is enforced on **every** write of the live entity.
- Collapsed the now-redundant `units === 0n` zeroing branch inside the snapshot block (single source of truth for the invariant; the snapshot block now only recomputes USD when units are positive).
- No separate backfill script exists in this repo — Envio recomputes deterministically, so the corrected handler **is** the backfill: a re-index re-zeroes every historical full-unstake's residue.

## Tests

- New `test/Aggregators/UserStatsPerPoolStakedUSDLockstep.test.ts`: full unstake on the non-snapshot path zeroes both counters together; a partial unstake (units stay > 0) leaves USD sticky (pins the invariant's scope so it can't be over-broadened into a recompute).
- Corrected `test/EventHandlers/Gauges/GaugeSharedLogic.test.ts`: its full-withdraw test had pinned the buggy residue (user USD staying at `200e18` while units hit 0) as *expected* behavior. It now asserts lockstep, making it an integration-level regression test for #782 through `processGaugeWithdraw`.
- Full suite green (1432 tests, 0 failed), `tsc --noEmit` clean, `biome check` clean.

## Test plan

- [x] No `UserStatsPerPool` row has `currentLiquidityStaked = 0` with `currentLiquidityStakedUSD != 0` — invariant enforced on every write; proven by unit + integration tests
- [x] A test covers full-unstake → both counters reach 0 together
- [ ] Backfill/replay clears existing live residue **verified against the deployed endpoint** *(needs ops — requires a redeploy/re-index, then querying the deployed GraphQL endpoint; cannot be checked from the diff. The deterministic-replay mechanism is in place.)*

## Note

`src/Aggregators/Pool.ts` (~L534) has a structurally similar snapshot-only zeroing for the **pool-level** `currentLiquidityStakedUSD`, but it is driven by `stakedReserve0/1` (a coupled mechanism) and has no observed symptom — intentionally left untouched here.

Closes #782.

🤖 Generated with [Claude Code](https://claude.com/claude-code)