### PR TITLE
Attribute direct (non-NFPM) CL Mint/Burn flows to owner stats

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -244,12 +244,12 @@ type UserStatsPerPool {
 
   # Liquidity metrics
   lpBalance: BigInt! @config(precision: 76) # user's LP token balance (tracked from Transfer events)
-  totalLiquidityAddedUSD: BigInt! @config(precision: 76) # cumulative USD value of liquidity added (from IncreaseLiquidity events and Transfer ADD attribution)
-  totalLiquidityAddedToken0: BigInt! @config(precision: 76) # cumulative raw token0 amount added (sum of event.params.amount0 from IncreaseLiquidity + Transfer ADD). May differ from removed due to price movement between deposit and withdrawal
-  totalLiquidityAddedToken1: BigInt! @config(precision: 76) # cumulative raw token1 amount added (sum of event.params.amount1 from IncreaseLiquidity + Transfer ADD). May differ from removed due to price movement between deposit and withdrawal
-  totalLiquidityRemovedUSD: BigInt! @config(precision: 76) # cumulative USD value of liquidity removed (from DecreaseLiquidity events and Transfer REMOVE attribution)
-  totalLiquidityRemovedToken0: BigInt! @config(precision: 76) # cumulative raw token0 amount removed (sum of event.params.amount0 from DecreaseLiquidity + Transfer REMOVE). Can exceed totalLiquidityAddedToken0 due to price movement (impermanent loss rebalancing)
-  totalLiquidityRemovedToken1: BigInt! @config(precision: 76) # cumulative raw token1 amount removed (sum of event.params.amount1 from DecreaseLiquidity + Transfer REMOVE). Can exceed totalLiquidityAddedToken1 due to price movement (impermanent loss rebalancing)
+  totalLiquidityAddedUSD: BigInt! @config(precision: 76) # cumulative USD value of liquidity added (from IncreaseLiquidity events, Transfer ADD attribution, and direct non-NFPM CLPool.Mint)
+  totalLiquidityAddedToken0: BigInt! @config(precision: 76) # cumulative raw token0 amount added (sum of event.params.amount0 from IncreaseLiquidity + Transfer ADD + direct non-NFPM CLPool.Mint). May differ from removed due to price movement between deposit and withdrawal
+  totalLiquidityAddedToken1: BigInt! @config(precision: 76) # cumulative raw token1 amount added (sum of event.params.amount1 from IncreaseLiquidity + Transfer ADD + direct non-NFPM CLPool.Mint). May differ from removed due to price movement between deposit and withdrawal
+  totalLiquidityRemovedUSD: BigInt! @config(precision: 76) # cumulative USD value of liquidity removed (from DecreaseLiquidity events, Transfer REMOVE attribution, and direct non-NFPM CLPool.Burn)
+  totalLiquidityRemovedToken0: BigInt! @config(precision: 76) # cumulative raw token0 amount removed (sum of event.params.amount0 from DecreaseLiquidity + Transfer REMOVE + direct non-NFPM CLPool.Burn). Can exceed totalLiquidityAddedToken0 due to price movement (impermanent loss rebalancing)
+  totalLiquidityRemovedToken1: BigInt! @config(precision: 76) # cumulative raw token1 amount removed (sum of event.params.amount1 from DecreaseLiquidity + Transfer REMOVE + direct non-NFPM CLPool.Burn). Can exceed totalLiquidityAddedToken1 due to price movement (impermanent loss rebalancing)
 
   # Swap metrics
   numberOfSwaps: BigInt! @config(precision: 76) # number of swaps in this pool

--- a/src/EventHandlers/CLPool.ts
+++ b/src/EventHandlers/CLPool.ts
@@ -14,9 +14,11 @@ import {
 import { processCLPoolBurn } from "./CLPool/CLPoolBurnLogic";
 import { processCLPoolCollectFees } from "./CLPool/CLPoolCollectFeesLogic";
 import { processCLPoolCollect } from "./CLPool/CLPoolCollectLogic";
+import { attributeDirectCLLiquidityChange } from "./CLPool/CLPoolDirectLiquidityLogic";
 import { processCLPoolFlash } from "./CLPool/CLPoolFlashLogic";
 import { processCLPoolMint } from "./CLPool/CLPoolMintLogic";
 import { processCLPoolSwap } from "./CLPool/CLPoolSwapLogic";
+import { LiquidityChangeType } from "./NFPM/NFPMCommonLogic";
 
 /**
  * Updates the liquidity-related metrics for a Concentrated Liquidity Pool.
@@ -36,7 +38,9 @@ import { processCLPoolSwap } from "./CLPool/CLPoolSwapLogic";
  */
 
 CLPool.Burn.handler(async ({ event, context }) => {
-  // Pool-only update; user liquidity removed is attributed from NFPM.DecreaseLiquidity
+  // Updates pool reserves; NFPM-routed burns are attributed to the holder via
+  // NFPM.DecreaseLiquidity, while direct (non-NFPM) burns are attributed to the
+  // owner below via attributeDirectCLLiquidityChange (#790).
   const poolData = await loadPoolData(
     event.srcAddress,
     event.chainId,
@@ -67,6 +71,17 @@ CLPool.Burn.handler(async ({ event, context }) => {
     context,
     event.chainId,
     event.block.number,
+  );
+
+  await attributeDirectCLLiquidityChange(
+    event.params.owner,
+    event.srcAddress,
+    poolData,
+    context,
+    event.params.amount0,
+    event.params.amount1,
+    event.block.timestamp,
+    LiquidityChangeType.REMOVE,
   );
 });
 
@@ -289,7 +304,9 @@ CLPool.Initialize.handler(async ({ event, context }) => {
 });
 
 CLPool.Mint.handler(async ({ event, context }) => {
-  // Pool-only update; user liquidity added is attributed from NFPM.Transfer (mint) and NFPM.IncreaseLiquidity
+  // Updates pool reserves; NFPM-routed mints are attributed to the holder via
+  // NFPM.Transfer (mint) and NFPM.IncreaseLiquidity, while direct (non-NFPM)
+  // mints are attributed to the owner below via attributeDirectCLLiquidityChange (#790).
   const poolData = await loadPoolData(
     event.srcAddress,
     event.chainId,
@@ -319,6 +336,17 @@ CLPool.Mint.handler(async ({ event, context }) => {
     context,
     event.chainId,
     event.block.number,
+  );
+
+  await attributeDirectCLLiquidityChange(
+    event.params.owner,
+    event.srcAddress,
+    poolData,
+    context,
+    event.params.amount0,
+    event.params.amount1,
+    event.block.timestamp,
+    LiquidityChangeType.ADD,
   );
 
   // Store CLPool.Mint data for NFPM.Transfer (mint) to consume and attribute UserStatsPerPool to event.params.to

--- a/src/EventHandlers/CLPool/CLPoolDirectLiquidityLogic.ts
+++ b/src/EventHandlers/CLPool/CLPoolDirectLiquidityLogic.ts
@@ -1,0 +1,64 @@
+import type { handlerContext } from "generated";
+import type { PoolData } from "../../Aggregators/Pool";
+import {
+  type LiquidityChangeType,
+  attributeLiquidityChangeToUserStatsPerPool,
+} from "../NFPM/NFPMCommonLogic";
+
+/**
+ * Attributes a direct (non-NFPM) CLPool Mint/Burn liquidity flow to the owner's
+ * UserStatsPerPool, gated on the owner NOT being the pool's NFPM contract.
+ *
+ * CLPool.mint()/burn() are permissionless: vaults and strategies call them
+ * directly, emitting no NFPM events, so their flows would otherwise never reach
+ * any UserStatsPerPool. NFPM-routed positions also surface here with
+ * `owner === pool.nfpmAddress`, but those are already credited to the real
+ * holder via NFPM.Transfer/IncreaseLiquidity. Attributing them again here would
+ * both create a bogus row keyed on the NFPM contract address and double-count
+ * the flow (issue #790), so the NFPM-owned case is skipped.
+ *
+ * Centralising the gate here keeps the Mint and Burn handlers from drifting on
+ * the discriminator that AC#2 depends on.
+ *
+ * When `nfpmAddress` is null — the two CL factories not yet mapped to an NFPM in
+ * Constants.ts — a direct mint is indistinguishable from an NFPM-routed one, so
+ * the gate conservatively skips rather than risk mis-crediting an NFPM-routed
+ * flow. This self-heals once the factory→NFPM mapping is added.
+ *
+ * @param owner - The CLPool Mint/Burn `owner` param (EIP-55 checksummed).
+ * @param poolAddress - The pool's address (`event.srcAddress`).
+ * @param poolData - Pool data carrying the aggregator (for `nfpmAddress`) and
+ *   the token instances used to value the flow.
+ * @param context - Handler context for entity access.
+ * @param amount0 - Raw token0 amount from the event.
+ * @param amount1 - Raw token1 amount from the event.
+ * @param blockTimestamp - Block timestamp in seconds.
+ * @param changeType - `ADD` for Mint, `REMOVE` for Burn.
+ * @returns Promise that resolves once the owner's UserStatsPerPool flow has been
+ *   staged, or immediately when the flow is NFPM-routed (skipped).
+ */
+export async function attributeDirectCLLiquidityChange(
+  owner: string,
+  poolAddress: string,
+  poolData: PoolData,
+  context: handlerContext,
+  amount0: bigint,
+  amount1: bigint,
+  blockTimestamp: number,
+  changeType: LiquidityChangeType,
+): Promise<void> {
+  const nfpmAddress = poolData.liquidityPoolAggregator.nfpmAddress;
+  if (nfpmAddress == null || owner === nfpmAddress) {
+    return;
+  }
+  await attributeLiquidityChangeToUserStatsPerPool(
+    owner,
+    poolAddress,
+    poolData,
+    context,
+    amount0,
+    amount1,
+    blockTimestamp,
+    changeType,
+  );
+}

--- a/test/EventHandlers/CLPool/CLPoolDirectLiquidity.test.ts
+++ b/test/EventHandlers/CLPool/CLPoolDirectLiquidity.test.ts
@@ -1,0 +1,188 @@
+import type { Token } from "generated";
+import { CLPool, MockDb } from "../../../generated/src/TestHelpers.gen";
+import {
+  TEN_TO_THE_6_BI,
+  TEN_TO_THE_18_BI,
+  UserStatsPerPoolId,
+  toChecksumAddress,
+} from "../../../src/Constants";
+import { setupCommon } from "../Pool/common";
+
+// Issue #790: direct (non-NFPM) CLPool.Mint/Burn flows must be attributed to the
+// minting owner's UserStatsPerPool, while NFPM-routed mints (owner === pool.nfpmAddress)
+// stay untouched — they are credited to the real holder via NFPM.Transfer/IncreaseLiquidity.
+describe("CLPool direct (non-NFPM) liquidity attribution (#790)", () => {
+  const { mockToken0Data, mockToken1Data, createMockPool, defaultNfpmAddress } =
+    setupCommon();
+
+  const chainId = 10;
+  // A vault/strategy that calls CLPool.mint() directly (the issue's real example owner).
+  const vaultOwner = toChecksumAddress(
+    "0xa0f688905ef05ea853c35131b4899a613b4ba644",
+  );
+  const txHash =
+    "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
+  const blockHash =
+    "0x1234567890123456789012345678901234567890123456789012345678901234";
+
+  // token0 has 18 decimals @ $1, token1 has 6 decimals @ $1 (see common.ts).
+  const amount0 = 500n * TEN_TO_THE_18_BI;
+  const amount1 = 300n * TEN_TO_THE_6_BI;
+  // Trust-gated USD: normalize each leg to 1e18-base @ $1 → 500e18 + 300e18.
+  const expectedUSD = 800n * TEN_TO_THE_18_BI;
+
+  let mockDb: ReturnType<typeof MockDb.createMockDb>;
+  let pool: ReturnType<typeof createMockPool>;
+
+  beforeEach(() => {
+    mockDb = MockDb.createMockDb();
+    // CL pool → createMockPool defaults nfpmAddress to defaultNfpmAddress.
+    pool = createMockPool({ isCL: true });
+    mockDb = mockDb.entities.Pool.set(pool);
+    mockDb = mockDb.entities.Token.set(mockToken0Data as Token);
+    mockDb = mockDb.entities.Token.set(mockToken1Data as Token);
+  });
+
+  it("attributes a direct Mint to the owner's UserStatsPerPool added-flow", async () => {
+    const mintEvent = CLPool.Mint.createMockEvent({
+      owner: vaultOwner,
+      tickLower: -100000n,
+      tickUpper: 100000n,
+      amount: 1000000n,
+      amount0,
+      amount1,
+      mockEventData: {
+        block: { timestamp: 1000000, number: 123456, hash: blockHash },
+        chainId,
+        logIndex: 1,
+        srcAddress: pool.poolAddress as `0x${string}`,
+        transaction: { hash: txHash },
+      },
+    });
+
+    const result = await mockDb.processEvents([mintEvent]);
+
+    const stats = result.entities.UserStatsPerPool.get(
+      UserStatsPerPoolId(chainId, vaultOwner, pool.poolAddress),
+    );
+    expect(stats).toBeDefined();
+    expect(stats?.totalLiquidityAddedToken0).toBe(amount0);
+    expect(stats?.totalLiquidityAddedToken1).toBe(amount1);
+    expect(stats?.totalLiquidityAddedUSD).toBe(expectedUSD);
+
+    // AC#3: pool reserves/TVL behavior is unchanged — reserves still increment.
+    const updatedPool = result.entities.Pool.get(pool.id);
+    expect(updatedPool?.reserve0).toBe(pool.reserve0 + amount0);
+    expect(updatedPool?.reserve1).toBe(pool.reserve1 + amount1);
+  });
+
+  it("does NOT attribute an NFPM-routed Mint to the NFPM address (no double-count)", async () => {
+    // owner === pool.nfpmAddress → this mint is the NFPM's, already credited to
+    // the real holder via NFPM.Transfer/IncreaseLiquidity. Attributing here would
+    // create a bogus row on the NFPM contract and double-count the flow.
+    const mintEvent = CLPool.Mint.createMockEvent({
+      owner: defaultNfpmAddress,
+      tickLower: -100000n,
+      tickUpper: 100000n,
+      amount: 1000000n,
+      amount0,
+      amount1,
+      mockEventData: {
+        block: { timestamp: 1000000, number: 123456, hash: blockHash },
+        chainId,
+        logIndex: 1,
+        srcAddress: pool.poolAddress as `0x${string}`,
+        transaction: { hash: txHash },
+      },
+    });
+
+    const result = await mockDb.processEvents([mintEvent]);
+
+    const nfpmStats = result.entities.UserStatsPerPool.get(
+      UserStatsPerPoolId(chainId, defaultNfpmAddress, pool.poolAddress),
+    );
+    expect(nfpmStats).toBeUndefined();
+  });
+
+  it("attributes a direct mint-then-burn to matching added/removed flows", async () => {
+    // AC#4: a direct (owner ∉ NFPM) mint followed by a burn of the same size by
+    // the same owner produces equal added and removed flows.
+    const mintEvent = CLPool.Mint.createMockEvent({
+      owner: vaultOwner,
+      tickLower: -100000n,
+      tickUpper: 100000n,
+      amount: 1000000n,
+      amount0,
+      amount1,
+      mockEventData: {
+        block: { timestamp: 1000000, number: 123456, hash: blockHash },
+        chainId,
+        logIndex: 1,
+        srcAddress: pool.poolAddress as `0x${string}`,
+        transaction: { hash: txHash },
+      },
+    });
+    const burnEvent = CLPool.Burn.createMockEvent({
+      owner: vaultOwner,
+      tickLower: -100000n,
+      tickUpper: 100000n,
+      amount: 1000000n,
+      amount0,
+      amount1,
+      mockEventData: {
+        block: { timestamp: 1000100, number: 123457, hash: blockHash },
+        chainId,
+        logIndex: 2,
+        srcAddress: pool.poolAddress as `0x${string}`,
+        transaction: { hash: txHash },
+      },
+    });
+
+    const result = await mockDb.processEvents([mintEvent, burnEvent]);
+
+    const stats = result.entities.UserStatsPerPool.get(
+      UserStatsPerPoolId(chainId, vaultOwner, pool.poolAddress),
+    );
+    expect(stats).toBeDefined();
+    expect(stats?.totalLiquidityAddedToken0).toBe(amount0);
+    expect(stats?.totalLiquidityAddedToken1).toBe(amount1);
+    expect(stats?.totalLiquidityAddedUSD).toBe(expectedUSD);
+    // Burn flow mirrors the mint flow → added === removed.
+    expect(stats?.totalLiquidityRemovedToken0).toBe(amount0);
+    expect(stats?.totalLiquidityRemovedToken1).toBe(amount1);
+    expect(stats?.totalLiquidityRemovedUSD).toBe(expectedUSD);
+  });
+
+  it("skips attribution when the pool's nfpmAddress is unmapped (null)", async () => {
+    // Two CL factories are not yet mapped to an NFPM in Constants.ts, so their
+    // pools carry a null nfpmAddress. We then cannot tell a direct mint from an
+    // NFPM-routed one, so the gate conservatively skips attribution rather than
+    // risk crediting an NFPM-routed flow to the wrong row (AC#2). Self-heals
+    // once the factory→NFPM mapping is added.
+    const unmappedPool = { ...pool, nfpmAddress: undefined };
+    mockDb = mockDb.entities.Pool.set(unmappedPool);
+
+    const mintEvent = CLPool.Mint.createMockEvent({
+      owner: vaultOwner,
+      tickLower: -100000n,
+      tickUpper: 100000n,
+      amount: 1000000n,
+      amount0,
+      amount1,
+      mockEventData: {
+        block: { timestamp: 1000000, number: 123456, hash: blockHash },
+        chainId,
+        logIndex: 1,
+        srcAddress: pool.poolAddress as `0x${string}`,
+        transaction: { hash: txHash },
+      },
+    });
+
+    const result = await mockDb.processEvents([mintEvent]);
+
+    const stats = result.entities.UserStatsPerPool.get(
+      UserStatsPerPoolId(chainId, vaultOwner, pool.poolAddress),
+    );
+    expect(stats).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Direct (non-NFPM) `CLPool.Mint`/`Burn` flows — from vaults and strategies that call `mint()`/`burn()` directly, bypassing the NonFungiblePositionManager — are now attributed to the owner's `UserStatsPerPool` (`totalLiquidityAdded/Removed{Token0,Token1,USD}`). Previously these landed in pool reserves (TVL correct) but were attributed to no one, leaving all-zero rows for direct providers.
- New gated helper `attributeDirectCLLiquidityChange` (`src/EventHandlers/CLPool/CLPoolDirectLiquidityLogic.ts`), called from both the Mint and Burn handlers, skips attribution when `owner === pool.nfpmAddress` (NFPM-routed mints are already credited via `NFPM.Transfer`/`IncreaseLiquidity` — this avoids double-counting and a bogus row keyed on the NFPM contract address) or when `nfpmAddress` is unmapped/null (conservative skip for the two CL factories not yet mapped to an NFPM; self-heals once mapped).
- Flow-only attribution — no new current-position field. Pool reserves/TVL behavior is untouched; USD uses the existing trust-gated path (`getTrustedUSD` via `calculateTotalUSD`).
- `UserStatsPerPool.totalLiquidityAdded/Removed*` schema doc-comments updated to record direct CLPool.Mint/Burn as a new attribution source.

Closes #790.

## Test plan
- [x] New `test/EventHandlers/CLPool/CLPoolDirectLiquidity.test.ts` — 4 tests: direct Mint attribution (incl. reserves still increment, AC#3); NFPM-routed mint produces no row on the NFPM address (AC#2); direct mint→burn matching added/removed flows (AC#4); null-`nfpmAddress` conservative skip
- [x] `pnpm test` — full suite green (1434 passed, 33 skipped, 0 failed)
- [x] `tsc --noEmit` — no errors
- [x] `pnpm qa` (biome check) on changed files — clean, no fixes applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tracking for direct pool liquidity changes to user statistics, capturing both direct and protocol-mediated interactions.

* **Documentation**
  * Updated cumulative liquidity field descriptions to reflect inclusion of direct pool contributions in user statistics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/velodrome-finance/indexer/pull/793?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->