### PR TITLE
Derive token0Price/token1Price from pool state, not the price oracle

### DIFF
--- a/src/EventHandlers/CLPool/CLPoolSwapLogic.ts
+++ b/src/EventHandlers/CLPool/CLPoolSwapLogic.ts
@@ -10,6 +10,7 @@ import {
   pickTrustedSwapVolumeUSD,
 } from "../../Helpers";
 import { abs } from "../../Maths";
+import { deriveCLPriceRatios, pickPriceRatios } from "../../PoolPriceRatio";
 import { getTrustedUSD } from "../../PriceTrust";
 
 // Issue #733 / regression of #670: fees USD must respect the fundamental AMM
@@ -298,6 +299,22 @@ export async function processCLPoolSwap(
       liquidityPoolAggregator.stakedTickEdgeNets,
     );
 
+  // token0Price/token1Price are the pool-internal exchange rate, derived from
+  // the swap's post-trade sqrtPriceX96 — NOT from token oracle prices. This
+  // keeps the ratio oracle-independent so a mispriced token (e.g. a non-WL
+  // scam token) can no longer inflate it without bound (#783). pickPriceRatios
+  // falls back to the last-known ratio per leg when decimals are unavailable.
+  const priceRatios = pickPriceRatios(
+    token0Instance && token1Instance
+      ? deriveCLPriceRatios(
+          event.params.sqrtPriceX96,
+          token0Instance.decimals,
+          token1Instance.decimals,
+        )
+      : { token0Price: 0n, token1Price: 0n },
+    liquidityPoolAggregator,
+  );
+
   // Build complete liquidity pool aggregator diff
   const liquidityPoolDiff = {
     incrementalTotalVolume0: abs(event.params.amount0),
@@ -306,14 +323,8 @@ export async function processCLPoolSwap(
     incrementalTotalFeesGenerated0: swapFeesInToken0,
     incrementalTotalFeesGenerated1: swapFeesInToken1,
     incrementalTotalFeesGeneratedUSD: swapFeesInUSD,
-    // Token-price snapshots record observed state at this event, not a USD
-    // aggregate, so they are intentionally NOT routed through the #755 trust
-    // gate (see PriceTrust.ts). The downstream aggregate sites — volumeUSD,
-    // feesUSD, emissionsUSD, votesDepositedUSD, totalLiquidityUSD — are gated.
-    token0Price:
-      token0Instance?.pricePerUSDNew ?? liquidityPoolAggregator.token0Price,
-    token1Price:
-      token1Instance?.pricePerUSDNew ?? liquidityPoolAggregator.token1Price,
+    token0Price: priceRatios.token0Price,
+    token1Price: priceRatios.token1Price,
     incrementalNumberOfSwaps: 1n,
     incrementalReserve0: reserveDelta0,
     incrementalReserve1: reserveDelta1,

--- a/src/EventHandlers/Pool/PoolBurnAndMintLogic.ts
+++ b/src/EventHandlers/Pool/PoolBurnAndMintLogic.ts
@@ -281,17 +281,12 @@ export async function processPoolLiquidityEvent(
     context,
   );
 
-  // Update pool metrics (token prices only)
-  // DO NOT update totalLiquidityUSD here - TVL is computed from reserves in Sync handler
-  // No updates to reserves are needed - Sync events handle reserve updates
-  // Mint and burn functions always call _update method on the contract which always emits Sync event
+  // Mint and burn always call _update on the contract, which emits a Sync event
+  // in the same tx. Sync owns reserves, totalLiquidityUSD (computed from those
+  // reserves), AND the pool-internal price ratio (token0Price/token1Price,
+  // derived from reserves — #783). So this handler only bumps the activity
+  // timestamp; it must not echo token oracle prices into the ratio.
   const poolDiff = {
-    // Token-price snapshots record observed state at this event, not a USD
-    // aggregate, so they are intentionally NOT routed through the #755 trust
-    // gate (see PriceTrust.ts). The downstream aggregate sites — volumeUSD,
-    // feesUSD, emissionsUSD, votesDepositedUSD, totalLiquidityUSD — are gated.
-    token0Price: token0Instance.pricePerUSDNew,
-    token1Price: token1Instance.pricePerUSDNew,
     lastUpdatedTimestamp: timestamp,
   };
 

--- a/src/EventHandlers/Pool/PoolSwapLogic.ts
+++ b/src/EventHandlers/Pool/PoolSwapLogic.ts
@@ -30,17 +30,17 @@ export function processPoolSwap(
 
   const volumeInUSD = pickTrustedSwapVolumeUSD(token0UsdValue, token1UsdValue);
 
-  // Create liquidity pool diff
+  // Create liquidity pool diff.
+  //
+  // token0Price/token1Price (the pool-internal exchange rate) are intentionally
+  // NOT written here. A V2 swap always calls _update → emits Sync in the same
+  // tx, and processPoolSync derives the ratio from reserves (#783). Echoing the
+  // token oracle prices here would re-inflate the ratio whenever a token is
+  // mispriced — exactly the bug #783 fixes — so the field is left to Sync.
   const liquidityPoolDiff = {
     incrementalTotalVolume0: netAmount0,
     incrementalTotalVolume1: netAmount1,
     incrementalTotalVolumeUSD: volumeInUSD,
-    // Token-price snapshots record observed state at this event, not a USD
-    // aggregate, so they are intentionally NOT routed through the #755 trust
-    // gate (see PriceTrust.ts). The downstream aggregate sites — volumeUSD,
-    // feesUSD, emissionsUSD, votesDepositedUSD, totalLiquidityUSD — are gated.
-    token0Price: token0Instance.pricePerUSDNew,
-    token1Price: token1Instance.pricePerUSDNew,
     incrementalNumberOfSwaps: 1n,
     lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
   };

--- a/src/EventHandlers/Pool/PoolSyncLogic.ts
+++ b/src/EventHandlers/Pool/PoolSyncLogic.ts
@@ -2,6 +2,7 @@ import type { Pool_Sync_event, Token } from "generated";
 import type { PoolDiff } from "../../Aggregators/Pool";
 import type { Pool } from "../../EntityTypes";
 import { calculateTotalUSD } from "../../Helpers";
+import { deriveV2PriceRatios, pickPriceRatios } from "../../PoolPriceRatio";
 
 export interface PoolSyncResult {
   liquidityPoolDiff: Partial<PoolDiff>;
@@ -55,18 +56,29 @@ export function processPoolSync(
     );
   }
 
+  // token0Price/token1Price are the pool-internal exchange rate, derived from
+  // the synced reserves — NOT from token oracle prices. This keeps the ratio
+  // oracle-independent so a mispriced token (e.g. a non-WL scam token) can no
+  // longer inflate it without bound (#783). pickPriceRatios falls back to the
+  // last-known ratio per leg when decimals are unavailable or reserves are zero.
+  const priceRatios = pickPriceRatios(
+    token0Instance && token1Instance
+      ? deriveV2PriceRatios(
+          event.params.reserve0,
+          event.params.reserve1,
+          token0Instance.decimals,
+          token1Instance.decimals,
+        )
+      : { token0Price: 0n, token1Price: 0n },
+    liquidityPoolAggregator,
+  );
+
   const liquidityPoolDiff = {
     incrementalReserve0: reserve0Change,
     incrementalReserve1: reserve1Change,
     currentTotalLiquidityUSD,
-    // Token-price snapshots record observed state at this event, not a USD
-    // aggregate, so they are intentionally NOT routed through the #755 trust
-    // gate (see PriceTrust.ts). The downstream aggregate sites — volumeUSD,
-    // feesUSD, emissionsUSD, votesDepositedUSD, totalLiquidityUSD — are gated.
-    token0Price:
-      token0Instance?.pricePerUSDNew ?? liquidityPoolAggregator.token0Price,
-    token1Price:
-      token1Instance?.pricePerUSDNew ?? liquidityPoolAggregator.token1Price,
+    token0Price: priceRatios.token0Price,
+    token1Price: priceRatios.token1Price,
     lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
   };
 

--- a/src/PoolPriceRatio.ts
+++ b/src/PoolPriceRatio.ts
@@ -1,0 +1,118 @@
+import { TEN_TO_THE_18_BI } from "./Constants";
+
+/** 2^192 — denominator of `(sqrtPriceX96 / 2^96)^2` once the square is taken. */
+const Q192 = 2n ** 192n;
+
+/**
+ * A pool's internal exchange-rate pair, both as 1e18 fixed-point BigInts.
+ *
+ * These are derived purely from the pool's own state (reserves for V2,
+ * `sqrtPriceX96` for CL) and are therefore independent of the token price
+ * oracle. The field semantics match `Pool.token0Price` / `Pool.token1Price`
+ * in schema.graphql.
+ */
+export interface PoolPriceRatios {
+  /** Price of token0 denominated in token1 (whole token1 per whole token0), 1e18-scaled. */
+  token0Price: bigint;
+  /** Price of token1 denominated in token0 (whole token0 per whole token1), 1e18-scaled. */
+  token1Price: bigint;
+}
+
+/**
+ * Derives a V2 (constant-product) pool's internal price ratios from its reserves.
+ *
+ * The marginal price of token0 in token1 units is `reserve1 / reserve0`,
+ * decimal-adjusted to whole-token units and scaled to 1e18 fixed point.
+ * `token1Price` is the exact reciprocal ratio (computed independently from the
+ * same reserves rather than from `token0Price`, to avoid compounding rounding).
+ *
+ * All multiplications are applied before the single trailing division so the
+ * result keeps maximum integer precision (no intermediate truncation).
+ *
+ * @param reserve0 - Reserve of token0 in raw token units
+ * @param reserve1 - Reserve of token1 in raw token units
+ * @param decimals0 - Decimals of token0
+ * @param decimals1 - Decimals of token1
+ * @returns The 1e18-scaled ratio pair, or `{0n, 0n}` when either reserve is
+ *   non-positive (an empty pool has no defined price).
+ */
+export function deriveV2PriceRatios(
+  reserve0: bigint,
+  reserve1: bigint,
+  decimals0: bigint,
+  decimals1: bigint,
+): PoolPriceRatios {
+  if (reserve0 <= 0n || reserve1 <= 0n) {
+    return { token0Price: 0n, token1Price: 0n };
+  }
+  const scale0 = 10n ** decimals0;
+  const scale1 = 10n ** decimals1;
+  const token0Price =
+    (reserve1 * scale0 * TEN_TO_THE_18_BI) / (reserve0 * scale1);
+  const token1Price =
+    (reserve0 * scale1 * TEN_TO_THE_18_BI) / (reserve1 * scale0);
+  return { token0Price, token1Price };
+}
+
+/**
+ * Derives a CL (Uniswap-v3-style) pool's internal price ratios from `sqrtPriceX96`.
+ *
+ * The raw on-chain price (token1 per token0, in smallest units) is
+ * `(sqrtPriceX96 / 2^96)^2`; decimal-adjusting to whole-token units and scaling
+ * to 1e18 fixed point gives `token0Price`. `token1Price` is the reciprocal
+ * ratio, computed independently from the same `sqrtPriceX96`.
+ *
+ * Squaring is done before dividing by `2^192` (and all decimal/scale factors
+ * are folded into the numerator) so the single trailing division keeps maximum
+ * integer precision.
+ *
+ * @param sqrtPriceX96 - Current pool sqrt price as Q64.96 fixed point
+ * @param decimals0 - Decimals of token0
+ * @param decimals1 - Decimals of token1
+ * @returns The 1e18-scaled ratio pair, or `{0n, 0n}` when `sqrtPriceX96` is
+ *   non-positive (an uninitialised pool has no defined price).
+ */
+export function deriveCLPriceRatios(
+  sqrtPriceX96: bigint,
+  decimals0: bigint,
+  decimals1: bigint,
+): PoolPriceRatios {
+  if (sqrtPriceX96 <= 0n) {
+    return { token0Price: 0n, token1Price: 0n };
+  }
+  const scale0 = 10n ** decimals0;
+  const scale1 = 10n ** decimals1;
+  const priceX192 = sqrtPriceX96 * sqrtPriceX96;
+  const token0Price = (priceX192 * scale0 * TEN_TO_THE_18_BI) / (Q192 * scale1);
+  const token1Price = (Q192 * scale1 * TEN_TO_THE_18_BI) / (priceX192 * scale0);
+  return { token0Price, token1Price };
+}
+
+/**
+ * Merges freshly derived ratios with the pool's last-known ratios, keeping the
+ * last-known value for any leg that derives to a non-positive (0n) price.
+ *
+ * Both the CL Swap and V2 Sync writers compute ratios from live pool state, but
+ * that state is momentarily undefined for an empty/uninitialised pool (zero
+ * reserves or `sqrtPriceX96`) or when token decimals are unavailable — cases
+ * where the derive functions return `0n`. Writing `0n` would clobber a
+ * previously valid ratio with a meaningless zero, so each non-positive leg
+ * falls back to its last-known value instead. Centralizing the rule here keeps
+ * it identical across both writers (#783).
+ *
+ * @param derived - Ratios computed from current pool state (legs may be 0n)
+ * @param lastKnown - The pool's previously stored ratios to fall back on
+ * @returns The 1e18-scaled ratio pair with each non-positive leg replaced by
+ *   its last-known value.
+ */
+export function pickPriceRatios(
+  derived: PoolPriceRatios,
+  lastKnown: PoolPriceRatios,
+): PoolPriceRatios {
+  return {
+    token0Price:
+      derived.token0Price > 0n ? derived.token0Price : lastKnown.token0Price,
+    token1Price:
+      derived.token1Price > 0n ? derived.token1Price : lastKnown.token1Price,
+  };
+}

--- a/test/EventHandlers/CLPool/CLPoolSwapLogic.test.ts
+++ b/test/EventHandlers/CLPool/CLPoolSwapLogic.test.ts
@@ -7,6 +7,7 @@ import {
   calculateSwapVolume,
   processCLPoolSwap,
 } from "../../../src/EventHandlers/CLPool/CLPoolSwapLogic";
+import { deriveCLPriceRatios } from "../../../src/PoolPriceRatio";
 import { setupCommon } from "../Pool/common";
 
 describe("CLPoolSwapLogic", () => {
@@ -665,26 +666,46 @@ describe("CLPoolSwapLogic", () => {
       );
     });
 
-    it("should use updated token prices when available", async () => {
-      const token0WithNewPrice: Token = {
-        ...mockToken0,
-        pricePerUSDNew: 1500000000000000000n,
-      };
-      const token1WithNewPrice: Token = {
-        ...mockToken1,
-        pricePerUSDNew: 2500000000000000000n,
-      };
+    it("derives token0Price/token1Price from sqrtPriceX96, ignoring token oracle prices (#783)", async () => {
+      // The ratios must equal the pure derivation from the swap's sqrtPriceX96,
+      // not either token's oracle price.
+      const expected = deriveCLPriceRatios(
+        mockEvent.params.sqrtPriceX96,
+        mockToken0.decimals,
+        mockToken1.decimals,
+      );
 
-      const result = await processCLPoolSwap(
+      const baseline = await processCLPoolSwap(
         mockEvent,
         mockPool,
-        token0WithNewPrice,
-        token1WithNewPrice,
+        mockToken0,
+        mockToken1,
         mockContext,
       );
 
-      expect(result.liquidityPoolDiff.token0Price).toBe(1500000000000000000n);
-      expect(result.liquidityPoolDiff.token1Price).toBe(2500000000000000000n);
+      expect(baseline.liquidityPoolDiff.token0Price).toBe(expected.token0Price);
+      expect(baseline.liquidityPoolDiff.token1Price).toBe(expected.token1Price);
+
+      // An arbitrarily mispriced token (EARN-style oracle inflation) must not
+      // move the pool-internal ratio.
+      const mispricedToken0: Token = {
+        ...mockToken0,
+        pricePerUSDNew: 10n ** 40n,
+      };
+      const mispricedResult = await processCLPoolSwap(
+        mockEvent,
+        mockPool,
+        mispricedToken0,
+        mockToken1,
+        mockContext,
+      );
+
+      expect(mispricedResult.liquidityPoolDiff.token0Price).toBe(
+        expected.token0Price,
+      );
+      expect(mispricedResult.liquidityPoolDiff.token1Price).toBe(
+        expected.token1Price,
+      );
     });
 
     it("should set correct timestamps", async () => {

--- a/test/EventHandlers/Pool/PoolSwapLogic.test.ts
+++ b/test/EventHandlers/Pool/PoolSwapLogic.test.ts
@@ -65,13 +65,13 @@ describe("PoolSwapLogic", () => {
         lastActivityTimestamp: new Date(1000000 * 1000),
       });
 
-      // Verify liquidity pool diff content
+      // Verify liquidity pool diff content. token0Price/token1Price are NOT
+      // asserted here: the Swap handler no longer writes the pool-internal ratio
+      // (Sync owns it, derived from reserves — #783).
       expect(result.liquidityPoolDiff).toMatchObject({
         incrementalTotalVolume0: 1000n, // netAmount0 (diff) - amount0In + amount0Out = 1000 + 0
         incrementalTotalVolume1: 500n, // netAmount1 (diff) - amount1In + amount1Out = 0 + 500
         incrementalNumberOfSwaps: 1n, // diff
-        token0Price: 1000000000000000000n, // from mockToken0.pricePerUSDNew
-        token1Price: 1000000000000000000n, // from mockToken1.pricePerUSDNew
       });
 
       // Check timestamp separately
@@ -145,20 +145,20 @@ describe("PoolSwapLogic", () => {
       // "Any whitelisted" rule — consistent with calculateWhitelistedFeesUSD
     });
 
-    it("should update token prices correctly", () => {
-      const updatedToken0 = {
+    it("does not write token0Price/token1Price — the pool-internal ratio is owned by the Sync handler (#783)", () => {
+      // A V2 swap always triggers _update → Sync in the same tx, and Sync
+      // derives the ratio from reserves. The Swap handler must NOT echo token
+      // oracle prices into the ratio, or an arbitrarily mispriced token would
+      // re-inflate it (the #783 bug). Even a 1e35 oracle price is ignored.
+      const corruptedToken0 = {
         ...mockToken0,
-        pricePerUSDNew: 2000000000000000000n,
-      }; // 2 USD
-      const updatedToken1 = {
-        ...mockToken1,
-        pricePerUSDNew: 3000000000000000000n,
-      }; // 3 USD
+        pricePerUSDNew: 100000000000000000000000000000000000n, // 1e35
+      };
 
-      const result = processPoolSwap(mockEvent, updatedToken0, updatedToken1);
+      const result = processPoolSwap(mockEvent, corruptedToken0, mockToken1);
 
-      expect(result.liquidityPoolDiff?.token0Price).toBe(2000000000000000000n);
-      expect(result.liquidityPoolDiff?.token1Price).toBe(3000000000000000000n);
+      expect(result.liquidityPoolDiff).not.toHaveProperty("token0Price");
+      expect(result.liquidityPoolDiff).not.toHaveProperty("token1Price");
     });
   });
 

--- a/test/EventHandlers/Pool/PoolSyncLogic.test.ts
+++ b/test/EventHandlers/Pool/PoolSyncLogic.test.ts
@@ -2,6 +2,7 @@ import type { Pool_Sync_event, Token, handlerContext } from "generated";
 import { toChecksumAddress } from "../../../src/Constants";
 import type { Pool } from "../../../src/EntityTypes";
 import { processPoolSync } from "../../../src/EventHandlers/Pool/PoolSyncLogic";
+import { deriveV2PriceRatios } from "../../../src/PoolPriceRatio";
 import { setupCommon } from "./common";
 
 describe("PoolSyncLogic", () => {
@@ -96,8 +97,9 @@ describe("PoolSyncLogic", () => {
       expect(result.liquidityPoolDiff).toMatchObject({
         incrementalReserve0: 500n, // 1000n - 500n (incremental change)
         incrementalReserve1: 1000n, // 2000n - 1000n (incremental change)
-        token0Price: 1000000000000000000n,
-        token1Price: 2000000000000000000n,
+        // Derived from reserves (reserve0=1000 @6dp, reserve1=2000 @18dp), #783.
+        token0Price: 2000000n,
+        token1Price: 500000000000000000000000000000n,
       });
       expect(result.liquidityPoolDiff?.lastUpdatedTimestamp).toEqual(
         new Date(1000000 * 1000),
@@ -201,28 +203,39 @@ describe("PoolSyncLogic", () => {
       });
     });
 
-    it("should update token prices correctly", () => {
-      const mockToken0WithNewPrice = {
-        ...mockToken0,
-        pricePerUSDNew: 1500000000000000000n, // 1.5 USD
-      };
-
-      const mockToken1WithNewPrice = {
-        ...mockToken1,
-        pricePerUSDNew: 2500000000000000000n, // 2.5 USD
-      };
-
-      const result = processPoolSync(
-        mockEvent,
-        mockPool,
-        mockToken0WithNewPrice,
-        mockToken1WithNewPrice,
+    it("derives token0Price/token1Price from reserves, ignoring token oracle prices (#783)", () => {
+      // The ratios must equal the pure derivation from the synced reserves,
+      // not either token's oracle price.
+      const expected = deriveV2PriceRatios(
+        mockEvent.params.reserve0,
+        mockEvent.params.reserve1,
+        mockToken0.decimals,
+        mockToken1.decimals,
       );
 
-      expect(result.liquidityPoolDiff).toMatchObject({
-        token0Price: 1500000000000000000n,
-        token1Price: 2500000000000000000n,
-      });
+      const baseline = processPoolSync(
+        mockEvent,
+        mockPool,
+        mockToken0,
+        mockToken1,
+      );
+      expect(baseline.liquidityPoolDiff.token0Price).toBe(expected.token0Price);
+      expect(baseline.liquidityPoolDiff.token1Price).toBe(expected.token1Price);
+
+      // An arbitrarily mispriced token (EARN-style oracle inflation) must not
+      // move the pool-internal ratio.
+      const mispricedResult = processPoolSync(
+        mockEvent,
+        mockPool,
+        { ...mockToken0, pricePerUSDNew: 10n ** 40n },
+        mockToken1,
+      );
+      expect(mispricedResult.liquidityPoolDiff.token0Price).toBe(
+        expected.token0Price,
+      );
+      expect(mispricedResult.liquidityPoolDiff.token1Price).toBe(
+        expected.token1Price,
+      );
     });
   });
 });

--- a/test/PoolPriceRatio.test.ts
+++ b/test/PoolPriceRatio.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveCLPriceRatios,
+  deriveV2PriceRatios,
+  pickPriceRatios,
+} from "../src/PoolPriceRatio";
+
+const TEN_TO_THE_18 = 10n ** 18n;
+const Q96 = 2n ** 96n;
+
+describe("deriveV2PriceRatios", () => {
+  it("derives token0Price = reserve1/reserve0 for equal-decimal tokens", () => {
+    // 1000 token0, 2000 token1 (both 18 decimals): 1 token0 == 2 token1.
+    const { token0Price, token1Price } = deriveV2PriceRatios(
+      1000n * TEN_TO_THE_18,
+      2000n * TEN_TO_THE_18,
+      18n,
+      18n,
+    );
+
+    // token0Price = price of token0 in token1 units = 2.0
+    expect(token0Price).toBe(2n * TEN_TO_THE_18);
+    // token1Price = price of token1 in token0 units = 0.5
+    expect(token1Price).toBe(TEN_TO_THE_18 / 2n);
+  });
+
+  it("decimal-adjusts across tokens of different decimals", () => {
+    // token0 = USDC (6 dec), 2000 USDC; token1 = WETH (18 dec), 1 WETH.
+    // 1 WETH == 2000 USDC, so 1 USDC == 0.0005 WETH.
+    const { token0Price, token1Price } = deriveV2PriceRatios(
+      2000n * 10n ** 6n,
+      1n * TEN_TO_THE_18,
+      6n,
+      18n,
+    );
+
+    // token0Price = price of one USDC in WETH = 0.0005
+    expect(token0Price).toBe(5n * 10n ** 14n);
+    // token1Price = price of one WETH in USDC = 2000
+    expect(token1Price).toBe(2000n * TEN_TO_THE_18);
+  });
+
+  it("returns {0n, 0n} for an empty pool (zero reserve)", () => {
+    expect(deriveV2PriceRatios(0n, 1n * TEN_TO_THE_18, 18n, 18n)).toEqual({
+      token0Price: 0n,
+      token1Price: 0n,
+    });
+    expect(deriveV2PriceRatios(1n * TEN_TO_THE_18, 0n, 18n, 18n)).toEqual({
+      token0Price: 0n,
+      token1Price: 0n,
+    });
+  });
+});
+
+describe("deriveCLPriceRatios", () => {
+  it("derives a price of 1.0 when sqrtPriceX96 = 2^96 and decimals match", () => {
+    // (sqrtPriceX96 / 2^96)^2 = 1 → 1 token0 == 1 token1.
+    const { token0Price, token1Price } = deriveCLPriceRatios(Q96, 18n, 18n);
+
+    expect(token0Price).toBe(TEN_TO_THE_18);
+    expect(token1Price).toBe(TEN_TO_THE_18);
+  });
+
+  it("decimal-adjusts across tokens of different decimals", () => {
+    // rawPrice = 1 (sqrtPriceX96 = 2^96), token0 = 18 dec, token1 = 6 dec.
+    // 1 raw token1 per 1 raw token0 → 1 whole token0 (1e18 raw) buys 1e12 whole token1.
+    const { token0Price, token1Price } = deriveCLPriceRatios(Q96, 18n, 6n);
+
+    expect(token0Price).toBe(10n ** 30n); // 1e12 whole token1, 1e18-scaled
+    expect(token1Price).toBe(10n ** 6n); // 1e-12 whole token0, 1e18-scaled
+  });
+
+  it("returns {0n, 0n} for an uninitialised pool (sqrtPriceX96 = 0)", () => {
+    expect(deriveCLPriceRatios(0n, 18n, 18n)).toEqual({
+      token0Price: 0n,
+      token1Price: 0n,
+    });
+  });
+});
+
+describe("pickPriceRatios", () => {
+  const lastKnown = { token0Price: 100n, token1Price: 200n };
+
+  it("keeps the derived ratios when both legs are positive", () => {
+    const derived = { token0Price: 3n, token1Price: 7n };
+    expect(pickPriceRatios(derived, lastKnown)).toEqual(derived);
+  });
+
+  it("falls back to the last-known value only for the leg that derives to 0n", () => {
+    expect(
+      pickPriceRatios({ token0Price: 0n, token1Price: 7n }, lastKnown),
+    ).toEqual({ token0Price: 100n, token1Price: 7n });
+  });
+
+  it("returns the last-known ratios when the derivation is fully undefined (both 0n)", () => {
+    expect(
+      pickPriceRatios({ token0Price: 0n, token1Price: 0n }, lastKnown),
+    ).toEqual(lastKnown);
+  });
+});


### PR DESCRIPTION
## Summary
- `token0Price`/`token1Price` (the pool-internal exchange rate) now derive from the pool's **own** state — `sqrtPriceX96` for CL pools, `reserve1/reserve0` for V2 — instead of echoing token oracle USD prices. The ratio is now oracle-independent, so a mispriced token (e.g. non-whitelisted EARN on Base, `0x803b629C…`) can no longer inflate it to quadrillion scale (#783).
- New pure module `src/PoolPriceRatio.ts`: `deriveV2PriceRatios`, `deriveCLPriceRatios`, and a `pickPriceRatios` helper that keeps the last-known ratio per leg when the pool is empty/uninitialised (derivation returns `0n`).
- V2 **Sync** is now the sole V2 ratio writer (every reserve change emits a Sync event in the same tx); the redundant oracle-echo writes in V2 **Swap** and **Mint/Burn** are dropped — keeping them would re-inflate the ratio.
- No new data or RPC: `sqrtPriceX96`/reserves are already persisted on the `Pool` entity, so this is a pure refactor of the derivation.

## Test plan
- [x] `pnpm test` — full suite green (1439 passed, 33 skipped)
- [x] `tsc --noEmit` — no type errors
- [x] `pnpm qa` (biome) — clean, no fixes
- [x] Unit tests pin the derivation math and assert a 1e35–1e40 mispriced token leaves the ratio unchanged: `test/PoolPriceRatio.test.ts`, `PoolSyncLogic.test.ts:206`, `CLPoolSwapLogic.test.ts:669`, `PoolSwapLogic.test.ts:148`
- [ ] Confirm EARN pools (WETH/EARN, EARN/FDX, EARN/GRASS) show plausible ratios after a re-index against Base *(needs human — runtime/data check against mainnet)*

Closes #783

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Pool internal price ratios for V2 and Concentrated Liquidity pools are now derived directly from pool reserves and liquidity state, rather than external oracle sources, reducing dependency on external price feeds and improving resilience to price feed errors.

* **Tests**
  * Added comprehensive tests for price ratio derivation logic and updated existing tests to verify the new behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/velodrome-finance/indexer/pull/794?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->