### PR TITLE
fix(price-oracle): $1M absolute price ceiling + blacklist frozen-route PEPE/wOptiDoge (closes #786, #788)

### DIFF
--- a/src/PriceOracle.ts
+++ b/src/PriceOracle.ts
@@ -38,6 +38,25 @@ const PRICE_SPIKE_STALENESS_MS = 14 * 24 * 60 * 60 * 1000;
 // they routinely price in the tens of thousands.
 const FIRST_FETCH_CAP = 10_000n * TEN_TO_THE_18_BI;
 
+// Issue #788: absolute price ceiling. The spike guard only protects a FRESH
+// anchor (younger than PRICE_SPIKE_STALENESS_MS); once a token idles past that
+// window its anchor is no longer trusted, so a read of ANY magnitude is
+// accepted — BPX/BPX6900 booked a $7.17e18-per-token read after 26 days idle
+// (the highest price the indexer has ever recorded). This is a hard upper
+// bound applied to every read regardless of anchor age. $1M/token sits ~10×
+// above BTC's range (WBTC ≈ $100K) and far below the $10^28 egregious-poison
+// gate. An oracle-cache audit of the deployed indexer (commit c9b8978, 4.77M
+// nonzero reads) found every persistent read above $1M to be an oracle glitch,
+// never a legitimate price — so no real token (BTC variants included)
+// approaches it, and no symbol exemption is needed, unlike FIRST_FETCH_CAP.
+// Deliberately a loose backstop, not a tight bound: glitch plateaus in the
+// $1K–$100K band — where legitimate high-value tokens also live — are left to
+// the anchor-relative spike guard, which rejects them as ≥10× jumps against a
+// fresh anchor. (The same audit showed re-anchoring those plateaus would
+// poison ~250 tokens; see issues #784/#785 for why a mechanical re-anchor was
+// rejected.)
+const MAX_ACCEPTED_PRICE = 1_000_000n * TEN_TO_THE_18_BI;
+
 /**
  * Creates and persists a Token entity at first sight, gated on the address
  * actually being a contract on-chain.
@@ -244,6 +263,26 @@ export async function refreshTokenPrice(
       tokenDecimals: Number(healed.decimals),
     });
     const currentPrice = priceData.pricePerUSDNew;
+
+    // Issue #788: absolute ceiling — reject any read above MAX_ACCEPTED_PRICE
+    // before the anchor-relative checks below, so it fires regardless of anchor
+    // state (first-fetch, fresh, or stale). The prior anchor is preserved; we
+    // only bump `lastUpdatedTimestamp` to re-arm the spike guard, so a smaller
+    // follow-up read is validated against the (still-fresh) anchor instead of
+    // slipping through the stale-anchor exemption — e.g. BPX's $7.17e18 read is
+    // rejected here, and the $40,766 read three hours later is then caught by
+    // the spike guard rather than accepted. No snapshot is written.
+    if (currentPrice > MAX_ACCEPTED_PRICE) {
+      context.log.info(
+        `[MAX_PRICE_CEILING] chain=${chainId} address=${healed.address} symbol=${healed.symbol} proposed=${currentPrice} ceiling=${MAX_ACCEPTED_PRICE} — rejecting absurd read, keeping price=${healed.pricePerUSDNew}`,
+      );
+      const capped: Token = {
+        ...healed,
+        lastUpdatedTimestamp: new Date(blockTimestampMs),
+      };
+      context.Token.set(capped);
+      return capped;
+    }
 
     // Issue #728: cap-reject the first non-zero anchor for non-BTC symbols.
     // The spike guard below requires anchor > 0, so without this gate a single

--- a/src/PriceOverrides.ts
+++ b/src/PriceOverrides.ts
@@ -19,6 +19,11 @@ export interface RebindTarget {
  *
  *     Token(where: {pricePerUSDNew: {_gt: "10000000000000000000000000000"}})
  *
+ * Not every entry fits that enumeration: issue #786 added two WHITELISTED
+ * tokens whose oracle route froze at a wrong-high but SMALL per-token constant
+ * (well under $10^28), invisible to the sweep above — see the #786 block at the
+ * end of the list for that distinct failure mode.
+ *
  * Issue #669: $Manatee (no real market; tBTC/$Manatee pool routes price through
  * tBTC and produces $76K-$92K; alETH/$Manatee disagrees with alUSD/$Manatee by 10x).
  * Issue #669: SQUID (oracle returns 0 at every stable read; the $13B contaminated
@@ -546,6 +551,26 @@ const BLACKLIST: ReadonlySet<string> = new Set([
     8453,
     toChecksumAddress("0x23FA9a1a634222C03F3C02124242DFf56bD90787"),
   ), // BAIBAI
+  // Issue #786: frozen oracle-route constants on WHITELISTED tokens. Distinct
+  // from every entry above (which are wrong-HIGH in absolute per-token terms
+  // and surface via the `pricePerUSDNew > 10^28` enumeration). Here the route
+  // returns a flat wrong-high constant that is SMALL per-token — PEPE froze at
+  // ~$0.259302, wOptiDoge at ~$0.0515 — so it is invisible to both the >$10^28
+  // sweep and the absolute price ceiling, and the spike-guard/re-anchor logic
+  // (#784/#785) cannot see it either: the oracle keeps returning the stuck
+  // value, so every read AGREES with the bad anchor (no upward disagreement to
+  // re-anchor against). Because both tokens are protocol-whitelisted, the
+  // frozen value leaks straight into USD aggregates (#786 reports ~$238B
+  // phantom TVL across WETH/PEPE, PEPE/GIZA, VELO/wOptiDoge, WETH/wOptiDoge).
+  // Blacklisting forces price 0 → trust-gated out of USD → pool TVL routes
+  // through the counterparty leg. The root question — WHY the connector route
+  // freezes at a constant for these two — is tracked as a separate
+  // investigation (see #786 cross-reference); this is the immediate stopgap.
+  TokenId(
+    8453,
+    toChecksumAddress("0x52b492a33E447Cdb854c7FC19F1e57E8BfA1777D"),
+  ), // PEPE / Base (whitelisted; frozen route)
+  TokenId(10, toChecksumAddress("0xC26921B5b9ee80773774d36C84328ccb22c3a819")), // wOptiDoge / Optimism (whitelisted; frozen route)
 ]);
 
 /**

--- a/test/PriceOracle.test.ts
+++ b/test/PriceOracle.test.ts
@@ -1501,6 +1501,209 @@ describe("PriceOracle", () => {
       });
     });
 
+    // Issue #788: absolute price ceiling. The spike guard only protects a
+    // fresh anchor; a token idle past the staleness window has no anchor to
+    // compare against, so an arbitrarily large read used to be accepted. BPX
+    // booked a $7.17e18/token read after 26 days idle. MAX_ACCEPTED_PRICE
+    // ($1M/token) rejects any read above it regardless of anchor age.
+    describe("absolute price ceiling (issue #788)", () => {
+      const oneHourOneMinuteAgo = () =>
+        new Date(blockDatetime.getTime() - 61 * 60 * 1000);
+      const ceiling = 1_000_000n * 10n ** 18n; // $1M/token
+
+      beforeEach(() => {
+        vi.mocked(mockContext.Token?.set)?.mockClear();
+        vi.mocked(mockContext.TokenPriceSnapshot?.set)?.mockClear();
+        vi.mocked(mockContext.log?.warn)?.mockClear();
+        vi.mocked(mockContext.log?.info)?.mockClear();
+      });
+
+      it("rejects an absurd read on a stale anchor, preserves the anchor, and logs [MAX_PRICE_CEILING]", async () => {
+        // BPX/BPX6900: anchor $0.000137, idle 26 days, oracle returns
+        // $7.17e18/token (the highest price the indexer ever recorded).
+        const anchorPrice = 137n * 10n ** 12n; // $0.000137
+        const absurdPrice = 7_170_000_000_000_000_000n * 10n ** 18n; // $7.17e18
+        const twentySixDaysAgo = new Date(
+          blockDatetime.getTime() - 26 * 24 * 60 * 60 * 1000,
+        );
+
+        vi.mocked(mockContext.effect)?.mockImplementation(async (effect) => {
+          if ((effect as { name?: string }).name === "getTokenPrice") {
+            return { pricePerUSDNew: absurdPrice };
+          }
+          return {};
+        });
+
+        const result = await PriceOracle.refreshTokenPrice(
+          {
+            ...mockToken0Data,
+            symbol: "BPX",
+            pricePerUSDNew: anchorPrice,
+            lastUpdatedTimestamp: twentySixDaysAgo,
+          },
+          blockNumber,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        // Anchor preserved, timestamp re-armed to now, no snapshot.
+        expect(result.pricePerUSDNew).toBe(anchorPrice);
+        expect(result.lastUpdatedTimestamp).toEqual(blockDatetime);
+        expect(
+          vi.mocked(mockContext.TokenPriceSnapshot?.set),
+        ).not.toHaveBeenCalled();
+        const infoCall = vi.mocked(mockContext.log?.info)?.mock.lastCall;
+        expect(infoCall?.[0]).toContain("[MAX_PRICE_CEILING]");
+      });
+
+      it("rejects an absurd first-fetch (anchor 0) via the ceiling, before FIRST_FETCH_CAP", async () => {
+        const absurdPrice = 10n ** 30n; // $1e12/token — far above the ceiling
+
+        vi.mocked(mockContext.effect)?.mockImplementation(async (effect) => {
+          if ((effect as { name?: string }).name === "getTokenPrice") {
+            return { pricePerUSDNew: absurdPrice };
+          }
+          return {};
+        });
+
+        await PriceOracle.refreshTokenPrice(
+          {
+            ...mockToken0Data,
+            symbol: "USDT",
+            pricePerUSDNew: 0n,
+            lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+          },
+          blockNumber,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        expect(updatedToken.pricePerUSDNew).toBe(0n);
+        const infoCalls = vi.mocked(mockContext.log?.info)?.mock.calls ?? [];
+        const infoMessages = infoCalls.map(([msg]) => msg);
+        const warnCalls = vi.mocked(mockContext.log?.warn)?.mock.calls ?? [];
+        const warnMessages = warnCalls.map(([msg]) => msg);
+        expect(
+          infoMessages.some((m) => m?.includes("[MAX_PRICE_CEILING]")),
+        ).toBe(true);
+        expect(warnMessages.some((m) => m?.includes("[FIRST_FETCH_CAP]"))).toBe(
+          false,
+        );
+      });
+
+      it("rejects even a BTC-symbol read above the ceiling (no symbol exemption, unlike FIRST_FETCH_CAP)", async () => {
+        // FIRST_FETCH_CAP exempts BTC; the absolute ceiling does NOT — a BTC
+        // oracle glitch into the millions must still be rejected.
+        const absurdBtcPrice = ceiling + 1n;
+
+        vi.mocked(mockContext.effect)?.mockImplementation(async (effect) => {
+          if ((effect as { name?: string }).name === "getTokenPrice") {
+            return { pricePerUSDNew: absurdBtcPrice };
+          }
+          return {};
+        });
+
+        const result = await PriceOracle.refreshTokenPrice(
+          {
+            ...mockToken0Data,
+            symbol: "WBTC",
+            pricePerUSDNew: 90_000n * 10n ** 18n, // $90K anchor
+            lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+          },
+          blockNumber,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        expect(result.pricePerUSDNew).toBe(90_000n * 10n ** 18n);
+        const infoCall = vi.mocked(mockContext.log?.info)?.mock.lastCall;
+        expect(infoCall?.[0]).toContain("[MAX_PRICE_CEILING]");
+      });
+
+      it("accepts a BTC-symbol first-fetch at exactly the $1M ceiling (boundary, > not >=)", async () => {
+        vi.mocked(mockContext.effect)?.mockImplementation(async (effect) => {
+          if ((effect as { name?: string }).name === "getTokenPrice") {
+            return { pricePerUSDNew: ceiling };
+          }
+          return {};
+        });
+
+        await PriceOracle.refreshTokenPrice(
+          {
+            ...mockToken0Data,
+            symbol: "WBTC",
+            pricePerUSDNew: 0n,
+            lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+          },
+          blockNumber,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        expect(updatedToken.pricePerUSDNew).toBe(ceiling);
+      });
+
+      it("re-arms the spike guard: the smaller follow-up read after a ceiling rejection is then caught by the spike guard", async () => {
+        // BPX AC sequence: $7.17e18 rejected by the ceiling (bumps the
+        // timestamp), then $40,766 three hours later — below the ceiling but
+        // ~3e8× the $0.000137 anchor, so the now-fresh anchor lets the spike
+        // guard reject it instead of the stale-anchor exemption accepting it.
+        const anchorPrice = 137n * 10n ** 12n; // $0.000137
+        const absurdPrice = 7_170_000_000_000_000_000n * 10n ** 18n; // $7.17e18
+        const followUpPrice = 40_766n * 10n ** 18n; // $40,766
+        const twentySixDaysAgo = new Date(
+          blockDatetime.getTime() - 26 * 24 * 60 * 60 * 1000,
+        );
+
+        vi.mocked(mockContext.effect)?.mockImplementation(async (effect) => {
+          if ((effect as { name?: string }).name === "getTokenPrice") {
+            return { pricePerUSDNew: absurdPrice };
+          }
+          return {};
+        });
+        const afterCeiling = await PriceOracle.refreshTokenPrice(
+          {
+            ...mockToken0Data,
+            symbol: "BPX",
+            pricePerUSDNew: anchorPrice,
+            lastUpdatedTimestamp: twentySixDaysAgo,
+          },
+          blockNumber,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+        expect(afterCeiling.pricePerUSDNew).toBe(anchorPrice);
+
+        vi.mocked(mockContext.effect)?.mockImplementation(async (effect) => {
+          if ((effect as { name?: string }).name === "getTokenPrice") {
+            return { pricePerUSDNew: followUpPrice };
+          }
+          return {};
+        });
+        const threeHoursLater = blockDatetime.getTime() / 1000 + 3 * 60 * 60;
+        const afterFollowUp = await PriceOracle.refreshTokenPrice(
+          afterCeiling,
+          blockNumber,
+          threeHoursLater,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        // Still pinned to the sane anchor — the absurd read never poisoned it
+        // and the follow-up was rejected by the re-armed spike guard.
+        expect(afterFollowUp.pricePerUSDNew).toBe(anchorPrice);
+      });
+    });
+
     // Issue #694: V3 last-known-price fallback used `lastUpdatedTimestamp`
     // for two purposes — the 1-hour throttle and the 7-day staleness window
     // guarding the fallback. Because every refresh attempt (including those

--- a/test/PriceOverrides.test.ts
+++ b/test/PriceOverrides.test.ts
@@ -84,6 +84,36 @@ describe("PriceOverrides", () => {
       },
     );
 
+    // Issue #786: whitelisted tokens whose oracle route froze at a wrong-high
+    // but small per-token constant (invisible to the >$10^28 sweep). Blacklist
+    // is the immediate stopgap that trust-gates them out of USD aggregates.
+    it("returns true for PEPE on Base (frozen route, issue #786)", () => {
+      expect(
+        isBlacklistedToken(
+          8453,
+          toChecksumAddress("0x52b492a33E447Cdb854c7FC19F1e57E8BfA1777D"),
+        ),
+      ).toBe(true);
+    });
+
+    it("returns true for wOptiDoge on Optimism (frozen route, issue #786)", () => {
+      expect(
+        isBlacklistedToken(
+          10,
+          toChecksumAddress("0xC26921B5b9ee80773774d36C84328ccb22c3a819"),
+        ),
+      ).toBe(true);
+    });
+
+    it("scopes #786 entries by chainId (PEPE/Base not blacklisted on Optimism)", () => {
+      expect(
+        isBlacklistedToken(
+          10,
+          toChecksumAddress("0x52b492a33E447Cdb854c7FC19F1e57E8BfA1777D"),
+        ),
+      ).toBe(false);
+    });
+
     it("does not blacklist the canonical AERO on Base", () => {
       expect(
         isBlacklistedToken(


### PR DESCRIPTION
## What

Two safe price-oracle hardening fixes from the #784/#785/#786/#788 cluster. The two re-anchor issues (#784/#785) are **deferred** — an audit proved the proposed mechanism unsafe (see below).

### #788 — absolute price ceiling
The spike guard only protects a *fresh* anchor; once a token idles past the 14-day staleness window, a read of any magnitude was accepted. BPX (`0x8286D12D…`, non-WL) booked a **$7.17×10¹⁸/token** read after 26 days idle.

`MAX_ACCEPTED_PRICE = $1M/token` now rejects any read above it **regardless of anchor age**, before the anchor-relative checks. The rejection preserves the prior anchor and bumps `lastUpdatedTimestamp` to re-arm the spike guard (so a smaller follow-up read is re-validated against the now-fresh anchor instead of slipping through the stale-anchor exemption). No symbol exemption (unlike `FIRST_FETCH_CAP`): the audit below found **every** persistent read above $1M to be a glitch; WBTC (~$100K) keeps a 10× margin.

### #786 — blacklist frozen-route tokens
PEPE (Base, `0x52b4…777D`) and wOptiDoge (Optimism, `0xC269…a819`) are whitelisted tokens whose oracle **route** froze at a wrong-high constant, leaking phantom TVL into USD aggregates. They are invisible to the `>$10²⁸` enumeration sweep because the per-token value is small. Blacklisting trust-gates them out of the USD aggregates as an immediate stopgap; a follow-up issue tracks the route-level root cause.

> Note: AC #2/#3 (the 4 pools' TVL drop; downstream staked/fee USD) are satisfied by the mechanism (blacklist → price 0 → pool USD routes through the trusted counterparty leg) but the live values require a reindex to observe — same posture as prior blacklist PRs #716/#731.

### Deferred — #784/#785 (stuck-low anchor)
A mechanical re-anchor (re-accepting a price that has disagreed with a stuck-low anchor for N hours) was the planned fix. **The audit shows it would mis-fire on ~250 tokens** — so it is rejected here and the issues stay open for a ground-truth-aware fix.

## Audit (why #784/#785 are deferred)

Reconstructed every token's oracle trajectory from the effect cache (commit `c9b8978`, **4.77M nonzero reads**, 3,747 token series) and modeled exactly what a re-anchor would do. Of the **530** upward (≥10×) runs that persist ≥24h *below* the $1M ceiling — precisely the reads a re-anchor would re-accept:

| outcome | count | meaning |
|---|---|---|
| round-tripped back down | **252** | the high was a *sustained glitch*, not the real price |
| returned but stayed elevated | 24 | ambiguous |
| persisted to end | 254 | real re-pricing **or** permanent stuck (many are benign $1 stablecoin bootstraps) |

Examples a re-anchor would have locked onto for **weeks**: a token whose oracle baseline reads ~$0.15 but plateaued at **~$10K–24K for 70 days** before returning to ~$0.15; round-number oracle artifacts as the "price" (**$1,000**, **$1,024** = 2¹⁰, **$316,227** ≈ 10^5.5).

A stuck-low anchor (#784/#785) and a glitch-high plateau are **indistinguishable from the read stream alone** — the right discriminator is ground truth (whitelist / counterparty / trust gate), not elapsed time.

## Test plan

- `tsc --noEmit` ✓
- `pnpm qa --write` ✓ (biome clean)
- `pnpm test` → **1447 passed, 33 skipped** ✓
- New: 5 absolute-ceiling tests (#788), 3 blacklist tests (#786)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an absolute price ceiling to oracle price validation
  * Blacklisted PEPE (Base) and wOptiDoge (Optimism) tokens

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/velodrome-finance/indexer/pull/798?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->