### PR TITLE
fix(config): index Base NFPM 0xc741beb2 paired with CLFactory 0x9592CD9B (closes #795)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -347,6 +347,7 @@ chains:
         address:
           - 0x827922686190790b37229fd06084350E74485b72
           - 0xa990C6a764b73BF43cee5Bb40339c3322FB9D55F
+          - 0xc741beb2156827704A1466575ccA1cBf726a1178 # NFPM paired with CLFactory 0x9592CD9B..d51B ("Another CL"); previously absent left these pools unindexed (#795)
           - 0xe1f8cd9AC4e4A65F54f38a5CdAfCA44f6dD68b53 # V3 NFPM (paired with newest CLFactory 0xf8f2eB..061Ef)
       - name: FactoryRegistry
         address:

--- a/test/Constants.test.ts
+++ b/test/Constants.test.ts
@@ -369,4 +369,40 @@ describe("config.yaml ↔ Constants.ts factory parity (#770, subsumes #769)", ()
       },
     );
   });
+
+  describe("config.yaml NFPM list covers every NFPM mapped from a CLFactory (#795)", () => {
+    // The factory-side parity above ensures every CLFactory in config.yaml has a
+    // paired NFPM declared in CL_FACTORY_TO_NFPM (or is explicitly whitelisted).
+    // That is necessary but not sufficient: if the mapped NFPM is itself missing
+    // from config.yaml's NFPM address list, the indexer subscribes to the CLFactory
+    // but never subscribes to the NFPM's Transfer/IncreaseLiquidity/DecreaseLiquidity
+    // events. Downstream, NonFungiblePosition rows are never created for pools that
+    // factory spawns, computeCLStakedReservesOnGaugeEvent bails at `if (!position)`,
+    // and the #780/#781 currentLiquidityStaked mirror cannot run — producing a
+    // chronic "CLGauge.Withdraw: withdraw exceeds current stake" underflow when
+    // staked liquidity grows via NFPM IncreaseLiquidity (auto-compounders).
+    //
+    // This was the failure mode behind the Base 0xc741beb2… miss that #770's
+    // factory-only parity did not catch.
+    it.each([10, 8453, ...SUPERCHAIN_LEAF_CHAIN_IDS])(
+      "every NFPM that nfpmForCLPool resolves to on chain %i is registered in config.yaml NFPM",
+      (chainId) => {
+        const factories = configByChain.get(chainId)?.get("CLFactory") ?? [];
+        const nfpms = configByChain.get(chainId)?.get("NFPM") ?? [];
+        expect(
+          nfpms.length,
+          `config.yaml has no NFPM entries for chain ${chainId} — parser broken or chain has no CL deployment`,
+        ).toBeGreaterThan(0);
+
+        for (const factory of factories) {
+          const mappedNfpm = nfpmForCLPool(chainId, factory);
+          if (mappedNfpm === null) continue;
+          expect(
+            nfpms,
+            `chain ${chainId} CLFactory ${factory} maps to NFPM ${mappedNfpm}, but that NFPM is not in config.yaml — add it to chains[id=${chainId}].contracts.NFPM.address so the indexer subscribes to its Transfer/IncreaseLiquidity/DecreaseLiquidity events`,
+          ).toContain(mappedNfpm);
+        }
+      },
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- Registers Base NFPM `0xc741beb2156827704A1466575ccA1cBf726a1178` in `config.yaml` (Base chain `8453`). The `CL_FACTORY_TO_NFPM` map already paired this NFPM with CLFactory `0x9592CD9B…` (Base "Another CL"), but the NFPM itself was absent from `config.yaml`, so Envio never subscribed to its `Transfer`/`IncreaseLiquidity`/`DecreaseLiquidity` events. The 22 pools that factory spawned had no `NonFungiblePosition` rows, the gauge staked-reserve logic bailed at `if (!position)`, and the #780/#781 compound-mirror could not run — producing chronic `CLGauge.Withdraw: withdraw exceeds current stake` underflows whenever staked liquidity grew via NFPM `IncreaseLiquidity` (auto-compounders).
- Extends the #770 parity assertion with a mirror direction in `test/Constants.test.ts`: every NFPM that `nfpmForCLPool` resolves to from a `config.yaml` CLFactory must itself appear in that chain's `config.yaml` NFPM list. Red on the pre-fix config (failure message names `chain 8453 CLFactory 0x9592CD9B… maps to NFPM 0xc741beb2…, but that NFPM is not in config.yaml`), green after.

## Operational note (AC #5)

The fix takes effect for new events going forward as soon as the indexer redeploys with this `config.yaml`. **Repairing the already-corrupted `currentLiquidityStaked` counters on the affected pools requires a re-index from the NFPM's deploy block** so the missed `Transfer(mint)` / `IncreaseLiquidity` / `DecreaseLiquidity` events flow through `NFPMTransferLogic` and `GaugeSharedLogic.computeCLStakedReservesOnGaugeEvent`. Base `start_block` is `0` in `config.yaml`, so a full Base re-sync is needed. A redeploy without re-index will only stop the bleed; historical counters and staked reserves will remain wrong until the re-sync completes.

## Test plan

- [x] `pnpm envio codegen` clean
- [x] `tsc --noEmit` clean
- [x] `pnpm qa --write` no fixes applied
- [x] `pnpm test` — 104/104 files pass, 1451 passed / 33 skipped (pre-existing)
- [x] New parity assertion verified red on pre-fix `config.yaml`, green after fix
- [ ] Post-deploy re-index: confirm 22 Base pools on NFPM `0xc741beb2…` have `NonFungiblePosition` rows; staked subset has non-empty `stakedTickEdges` and non-zero `stakedReserve0/1` / `currentLiquidityStakedUSD` (AC #3 — requires re-sync from `start_block: 0`)
- [ ] Post-deploy log monitoring: no new `CLGauge.Withdraw: withdraw exceeds current stake` errors for these pools (AC #4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an additional NFPM contract address on the Base network, extending on-chain event handling coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/velodrome-finance/indexer/pull/804?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->