### PR TITLE
feat(nfpm): map 3 unmapped CLFactories to verified NFPMs (closes #796)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -347,6 +347,7 @@ chains:
         address:
           - 0x827922686190790b37229fd06084350E74485b72
           - 0xa990C6a764b73BF43cee5Bb40339c3322FB9D55F
+          - 0xc741beb2156827704A1466575ccA1cBf726a1178 # NFPM paired with CLFactory 0x9592CD9B..d51B ("Another CL"); previously absent left these pools unindexed (#795)
           - 0xe1f8cd9AC4e4A65F54f38a5CdAfCA44f6dD68b53 # V3 NFPM (paired with newest CLFactory 0xf8f2eB..061Ef)
       - name: FactoryRegistry
         address:

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -100,45 +100,50 @@ export const ROOT_POOL_FACTORY_ADDRESS_OPTIMISM = toChecksumAddress(
  * to populate on newly created CL pools.
  */
 const CL_FACTORY_TO_NFPM: Record<string, string> = {
-  // Optimism — two NFPMs, two CLFactories. Paired by deployment order.
+  // Optimism — three NFPMs, three CLFactories. Each pairing verified on-chain
+  // via NFPM.factory().
   [`10-${toChecksumAddress("0x548118C7E0B865C2CfA94D15EC86B666468ac758")}`]:
     toChecksumAddress("0xbB5DFE1380333CEE4c2EeBd7202c80dE2256AdF4"),
   [`10-${toChecksumAddress("0xCc0bDDB707055e04e497aB22a59c2aF4391cd12F")}`]:
     toChecksumAddress("0x416b433906b1B72FA758e166e239c43d68dC6F29"),
+  // Slipstream gauge-V2 CLFactory (#727) ↔ third OP NFPM. Verified via NFPM.factory().
+  [`10-${toChecksumAddress("0xe13Dd1fbA721Aa81a1826D9523AC9BC7d260c879")}`]:
+    toChecksumAddress("0xf7f8ccce99Ca2896eC75D3A399D152dB96808399"),
 
-  // Base — three CLFactories each with a dedicated NFPM, verified on-chain via
-  // NFPM.factory(). Pools created by an unmapped factory fall through to null.
-  // TODO(nfpm): RPC-verify NFPM.factory() and add mappings for:
-  //   - 10-0xe13Dd1fbA721Aa81a1826D9523AC9BC7d260c879   (OP slipstream gauge-V2 CLFactory, likely 0xf7f8ccce…)
-  //   - 8453-0xf8f2eB4940CFE7d13603DDDD87f123820Fc061Ef (Base V3-newest CLFactory, paired NFPM in config.yaml is 0xe1f8cd9A…)
-  // Both are also whitelisted in test/Constants.test.ts "config.yaml ↔ Constants.ts
-  // factory parity (#770)" so the parity assertion passes — remove from that whitelist
-  // when the mappings land here.
+  // Base — four CLFactories each with a dedicated NFPM, verified on-chain via
+  // NFPM.factory().
   [`8453-${toChecksumAddress("0x5e7BB104d84c7CB9B682AaC2F3d509f5F406809A")}`]:
     toChecksumAddress("0x827922686190790b37229fd06084350E74485b72"),
   [`8453-${toChecksumAddress("0xaDe65c38CD4849aDBA595a4323a8C7DdfE89716a")}`]:
     toChecksumAddress("0xa990C6a764b73BF43cee5Bb40339c3322FB9D55F"),
   [`8453-${toChecksumAddress("0x9592CD9B267748cbfBDe90Ac9F7DF3c437A6d51B")}`]:
     toChecksumAddress("0xc741beb2156827704A1466575ccA1cBf726a1178"),
+  // Newest CLFactory (paired with CLGaugeFactoryV3) ↔ fourth Base NFPM. Verified.
+  [`8453-${toChecksumAddress("0xf8f2eB4940CFE7d13603DDDD87f123820Fc061Ef")}`]:
+    toChecksumAddress("0xe1f8cd9AC4e4A65F54f38a5CdAfCA44f6dD68b53"),
 };
 
 /**
- * All superchain leaf chains share the same CLFactory↔NFPM pair, so we match on
- * factory alone to avoid listing every chain ID explicitly.
+ * Every superchain leaf chain shares the same set of CLFactory↔NFPM pairs, so
+ * we match on factory alone to avoid listing every chain ID explicitly. There
+ * are currently two pairings: the original Slipstream V1 deployment, and the
+ * gauge-V2 deployment added in #727. Both verified on-chain via NFPM.factory().
  */
-const SUPERCHAIN_CL_FACTORY = toChecksumAddress(
-  "0x04625B046C69577EfC40e6c0Bb83CDBAfab5a55F",
-);
-const SUPERCHAIN_NFPM = toChecksumAddress(
-  "0x991d5546C4B442B4c5fdc4c8B8b8d131DEB24702",
-);
+const SUPERCHAIN_CL_FACTORY_TO_NFPM: Record<string, string> = {
+  [toChecksumAddress("0x04625B046C69577EfC40e6c0Bb83CDBAfab5a55F")]:
+    toChecksumAddress("0x991d5546C4B442B4c5fdc4c8B8b8d131DEB24702"),
+  [toChecksumAddress("0x718E46d0962A66942E233760a8bd6038Ce54EdCD")]:
+    toChecksumAddress("0xefD0f78F93f578036AE34D52A813a4BE7D8D2D52"),
+};
 
 /**
  * Resolve the canonical NFPM address for a CL pool from its (chainId, factoryAddress) pair.
  *
  * The NFPM contract owns position NFTs for CL pools created by its paired CLFactory.
  * On chains with a single NFPM/CLFactory this is trivially deterministic; on Optimism
- * (two NFPMs) we rely on the factory that emitted PoolCreated to pick the right one.
+ * (three NFPMs) and Base (four NFPMs) we rely on the factory that emitted PoolCreated
+ * to pick the right one. Superchain leaves share two CLFactory↔NFPM pairs matched on
+ * factory alone.
  *
  * @param chainId - Chain ID where the CL pool lives
  * @param factoryAddress - Address of the CLFactory that created the pool (event.srcAddress)
@@ -151,8 +156,7 @@ export function nfpmForCLPool(
   const checksummed = toChecksumAddress(factoryAddress);
   const explicit = CL_FACTORY_TO_NFPM[`${chainId}-${checksummed}`];
   if (explicit) return explicit;
-  if (checksummed === SUPERCHAIN_CL_FACTORY) return SUPERCHAIN_NFPM;
-  return null;
+  return SUPERCHAIN_CL_FACTORY_TO_NFPM[checksummed] ?? null;
 }
 
 export const OUSDT_ADDRESS = "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189";

--- a/test/Constants.test.ts
+++ b/test/Constants.test.ts
@@ -369,4 +369,40 @@ describe("config.yaml ↔ Constants.ts factory parity (#770, subsumes #769)", ()
       },
     );
   });
+
+  describe("config.yaml NFPM list covers every NFPM mapped from a CLFactory (#795)", () => {
+    // The factory-side parity above ensures every CLFactory in config.yaml has a
+    // paired NFPM declared in CL_FACTORY_TO_NFPM (or is explicitly whitelisted).
+    // That is necessary but not sufficient: if the mapped NFPM is itself missing
+    // from config.yaml's NFPM address list, the indexer subscribes to the CLFactory
+    // but never subscribes to the NFPM's Transfer/IncreaseLiquidity/DecreaseLiquidity
+    // events. Downstream, NonFungiblePosition rows are never created for pools that
+    // factory spawns, computeCLStakedReservesOnGaugeEvent bails at `if (!position)`,
+    // and the #780/#781 currentLiquidityStaked mirror cannot run — producing a
+    // chronic "CLGauge.Withdraw: withdraw exceeds current stake" underflow when
+    // staked liquidity grows via NFPM IncreaseLiquidity (auto-compounders).
+    //
+    // This was the failure mode behind the Base 0xc741beb2… miss that #770's
+    // factory-only parity did not catch.
+    it.each([10, 8453, ...SUPERCHAIN_LEAF_CHAIN_IDS])(
+      "every NFPM that nfpmForCLPool resolves to on chain %i is registered in config.yaml NFPM",
+      (chainId) => {
+        const factories = configByChain.get(chainId)?.get("CLFactory") ?? [];
+        const nfpms = configByChain.get(chainId)?.get("NFPM") ?? [];
+        expect(
+          nfpms.length,
+          `config.yaml has no NFPM entries for chain ${chainId} — parser broken or chain has no CL deployment`,
+        ).toBeGreaterThan(0);
+
+        for (const factory of factories) {
+          const mappedNfpm = nfpmForCLPool(chainId, factory);
+          if (mappedNfpm === null) continue;
+          expect(
+            nfpms,
+            `chain ${chainId} CLFactory ${factory} maps to NFPM ${mappedNfpm}, but that NFPM is not in config.yaml — add it to chains[id=${chainId}].contracts.NFPM.address so the indexer subscribes to its Transfer/IncreaseLiquidity/DecreaseLiquidity events`,
+          ).toContain(mappedNfpm);
+        }
+      },
+    );
+  });
 });

--- a/test/Constants.test.ts
+++ b/test/Constants.test.ts
@@ -19,11 +19,17 @@ describe("nfpmForCLPool", () => {
   const OP_CL_FACTORY_NEW = toChecksumAddress(
     "0xCc0bDDB707055e04e497aB22a59c2aF4391cd12F",
   );
+  const OP_CL_FACTORY_GAUGE_V2 = toChecksumAddress(
+    "0xe13Dd1fbA721Aa81a1826D9523AC9BC7d260c879",
+  );
   const OP_NFPM_OLD = toChecksumAddress(
     "0xbB5DFE1380333CEE4c2EeBd7202c80dE2256AdF4",
   );
   const OP_NFPM_NEW = toChecksumAddress(
     "0x416b433906b1B72FA758e166e239c43d68dC6F29",
+  );
+  const OP_NFPM_GAUGE_V2 = toChecksumAddress(
+    "0xf7f8ccce99Ca2896eC75D3A399D152dB96808399",
   );
 
   const BASE_CL_FACTORY_OLD = toChecksumAddress(
@@ -47,37 +53,47 @@ describe("nfpmForCLPool", () => {
   const BASE_NFPM_V3 = toChecksumAddress(
     "0xc741beb2156827704A1466575ccA1cBf726a1178",
   );
+  const BASE_NFPM_V3_NEWEST = toChecksumAddress(
+    "0xe1f8cd9AC4e4A65F54f38a5CdAfCA44f6dD68b53",
+  );
 
-  const SUPERCHAIN_CL_FACTORY = toChecksumAddress(
+  const SUPERCHAIN_CL_FACTORY_V1 = toChecksumAddress(
     "0x04625B046C69577EfC40e6c0Bb83CDBAfab5a55F",
   );
-  const SUPERCHAIN_NFPM = toChecksumAddress(
+  const SUPERCHAIN_NFPM_V1 = toChecksumAddress(
     "0x991d5546C4B442B4c5fdc4c8B8b8d131DEB24702",
   );
+  const SUPERCHAIN_CL_FACTORY_V2 = toChecksumAddress(
+    "0x718E46d0962A66942E233760a8bd6038Ce54EdCD",
+  );
+  const SUPERCHAIN_NFPM_V2 = toChecksumAddress(
+    "0xefD0f78F93f578036AE34D52A813a4BE7D8D2D52",
+  );
 
-  it("disambiguates Optimism's two CLFactories to distinct NFPMs", () => {
+  it("disambiguates Optimism's three CLFactories to distinct NFPMs", () => {
     expect(nfpmForCLPool(10, OP_CL_FACTORY_OLD)).toBe(OP_NFPM_OLD);
     expect(nfpmForCLPool(10, OP_CL_FACTORY_NEW)).toBe(OP_NFPM_NEW);
+    expect(nfpmForCLPool(10, OP_CL_FACTORY_GAUGE_V2)).toBe(OP_NFPM_GAUGE_V2);
   });
 
   it("pairs Base CLFactories with their respective NFPMs", () => {
     expect(nfpmForCLPool(8453, BASE_CL_FACTORY_OLD)).toBe(BASE_NFPM_OLD);
     expect(nfpmForCLPool(8453, BASE_CL_FACTORY_NEW)).toBe(BASE_NFPM_NEW);
     expect(nfpmForCLPool(8453, BASE_CL_FACTORY_V3)).toBe(BASE_NFPM_V3);
+    expect(nfpmForCLPool(8453, BASE_CL_FACTORY_V3_NEWEST)).toBe(
+      BASE_NFPM_V3_NEWEST,
+    );
   });
 
-  it("returns null for the newest Base CLFactory pending NFPM deployment", () => {
-    // 0xf8f2eB... ships without a paired NFPM yet; callers should treat null
-    // as "unknown" and skip attribution until the mapping is filled in.
-    expect(nfpmForCLPool(8453, BASE_CL_FACTORY_V3_NEWEST)).toBeNull();
-  });
-
-  // Every superchain leaf shares the same CLFactory↔NFPM pair
+  // Every superchain leaf shares the same two CLFactory↔NFPM pairs (V1 and gauge-V2)
   it.each([1135, 34443, 42220, 1868, 130, 252, 57073, 1750, 1923, 5330])(
-    "returns the superchain NFPM for leaf chain %i",
+    "returns both superchain NFPMs for leaf chain %i",
     (chainId) => {
-      expect(nfpmForCLPool(chainId, SUPERCHAIN_CL_FACTORY)).toBe(
-        SUPERCHAIN_NFPM,
+      expect(nfpmForCLPool(chainId, SUPERCHAIN_CL_FACTORY_V1)).toBe(
+        SUPERCHAIN_NFPM_V1,
+      );
+      expect(nfpmForCLPool(chainId, SUPERCHAIN_CL_FACTORY_V2)).toBe(
+        SUPERCHAIN_NFPM_V2,
       );
     },
   );
@@ -313,33 +329,14 @@ describe("config.yaml ↔ Constants.ts factory parity (#770, subsumes #769)", ()
   });
 
   describe("nfpmForCLPool covers every (chainId, CLFactory) pair", () => {
-    // Some CLFactories are wired into config.yaml but don't yet have a paired NFPM
-    // declared in CL_FACTORY_TO_NFPM. They resolve to `null` from nfpmForCLPool;
-    // callers treat null as "unknown" and skip NFPM attribution for those pools.
-    //
-    // Each entry below records *why* the gap is currently tolerated. Resolve by
-    // adding the (chainId, factory) -> NFPM mapping in src/Constants.ts and
-    // removing the entry from this allowlist.
-    const UNMAPPED_CL_FACTORIES_BY_CHAIN: Record<number, Set<string>> = {
-      // Base: newest CLFactory (paired with CLGaugeFactoryV3). The matching NFPM
-      // 0xe1f8cd9A… is in config.yaml but has not yet been declared in
-      // CL_FACTORY_TO_NFPM. See TODO(nfpm) in src/Constants.ts.
-      8453: new Set([
-        toChecksumAddress("0xf8f2eB4940CFE7d13603DDDD87f123820Fc061Ef"),
-      ]),
-      // Optimism: slipstream gauge-V2 CLFactory added in #727. Likely pairs with
-      // the third OP NFPM (0xf7f8ccce…) but the pairing has not been on-chain
-      // verified via NFPM.factory(), so it is left unmapped.
-      10: new Set([
-        toChecksumAddress("0xe13Dd1fbA721Aa81a1826D9523AC9BC7d260c879"),
-      ]),
-    };
-    // Superchain leaves: slipstream gauge-V2 CLFactory deployed at
-    // 0x718E46d… on every leaf (#727). Likely pairs with the second leaf NFPM
-    // 0xefD0f78F…; unverified, so currently unmapped.
-    const UNMAPPED_SUPERCHAIN_CL_FACTORIES = new Set<string>([
-      toChecksumAddress("0x718E46d0962A66942E233760a8bd6038Ce54EdCD"),
-    ]);
+    // Allowlists for CLFactories that are wired into config.yaml but intentionally
+    // not paired in CL_FACTORY_TO_NFPM (e.g. pending on-chain verification of the
+    // NFPM lineage). When that happens, add the factory here with a comment
+    // explaining *why* the gap is tolerated; resolve by declaring the
+    // (chainId, factory) -> NFPM mapping in src/Constants.ts and emptying the
+    // allowlist again.
+    const UNMAPPED_CL_FACTORIES_BY_CHAIN: Record<number, Set<string>> = {};
+    const UNMAPPED_SUPERCHAIN_CL_FACTORIES = new Set<string>();
 
     it.each([10, 8453, ...SUPERCHAIN_LEAF_CHAIN_IDS])(
       "every CLFactory on chain %i is either mapped or explicitly unmapped",


### PR DESCRIPTION
## Summary

Closes #796. **Stacked on top of #804** (set as base) — review/merge that one first.

Three watched CLFactories had no entry in `CL_FACTORY_TO_NFPM`, so `nfpmForCLPool()` returned `null` for any pool they create. With null `nfpmAddress`, `computeCLStakedReservesOnGaugeEvent` bails (`if (!position) return {}`), so staked-tick edges / reserves / USD on any gauged-and-staked pool would have been incomplete. Currently no pools route to these factories, so this was a latent trap — but it would spring the moment any of these factories created a gauged, staked pool.

Pairings (all four #796/#795 RPC-verified via `NFPM.factory()`):

| chain | CLFactory | `NFPM.factory()` result | mapped NFPM |
| --- | --- | --- | --- |
| Base (8453) | `0xf8f2eB…` (newest, CLGaugeFactoryV3) | `0xf8f2eb4940cfe7d13603dddd87f123820fc061ef` ✓ | `0xe1f8cd9A…` |
| Optimism (10) | `0xe13Dd1f…` (slipstream gauge-V2, #727) | `0xe13dd1fba721aa81a1826d9523ac9bc7d260c879` ✓ | `0xf7f8ccce…` |
| Superchain (Celo verified; Soneium cross-checked) | `0x718E46d…` (slipstream gauge-V2, #727) | `0x718e46d0962a66942e233760a8bd6038ce54edcd` ✓ | `0xefD0f78F…` |

Probe: raw `eth_call` against `0xc45a0155` (`factory()` selector) per chain's public RPC.

## Changes

- **`src/Constants.ts`**: add the three new pairings to `CL_FACTORY_TO_NFPM`. Refactor the two `SUPERCHAIN_CL_FACTORY` / `SUPERCHAIN_NFPM` consts into a single `SUPERCHAIN_CL_FACTORY_TO_NFPM` record so both pairings live in one place and `nfpmForCLPool` reduces to one record lookup. Remove the `TODO(nfpm)` block.
- **`test/Constants.test.ts`**: empty `UNMAPPED_CL_FACTORIES_BY_CHAIN` and `UNMAPPED_SUPERCHAIN_CL_FACTORIES` (kept as future drift escape hatch). Extend the existing `nfpmForCLPool` unit tests to cover the three new pairings; remove the "returns null for the newest Base CLFactory" test (no longer null); rename the superchain test to assert both pairings.

The mapped-NFPM-is-indexed parity assertion from #804 stays green: all three NFPMs were already in their chains' config.yaml NFPM lists.

## Test plan

- [x] `pnpm envio codegen` clean
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test` — 104/104 test files pass, 1450 passed / 33 pre-existing skipped
- [x] `pnpm qa` (biome check) clean
- [x] `nfpmForCLPool()` returns non-null for all three #796 factories (covered by extended unit tests)
- [x] `UNMAPPED_CL_FACTORIES_BY_CHAIN` and `UNMAPPED_SUPERCHAIN_CL_FACTORIES` emptied; `TODO(nfpm)` removed
- [x] Both #804's mirror parity assertion and the original factory-direction assertion stay green with the empty allowlists

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for additional Concentrated Liquidity Pool contract addresses on Base and Optimism chains, enabling proper indexing of previously unindexed pools.

* **Tests**
  * Expanded test coverage to validate contract address mappings for all supported chains and ensure configuration consistency between address lists.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/velodrome-finance/indexer/pull/805?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->