### PR TITLE
fix(swap-fee): derive V2 Pool.Fees USD from trusted volume × rate (closes #797)

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -32,6 +32,14 @@ export const TEN_TO_THE_18_BI = BigInt(10 ** 18);
  */
 export const CL_FEE_SCALE = 1000000n;
 
+/**
+ * V2 pool fees use a 1e4 (basis-points-per-100) scale:
+ *   5 = 0.05% stable, 30 = 0.30% volatile, 100 = 1.00%
+ * Matches PoolFactory's DEFAULT_SAMM_FEE_BPS / DEFAULT_VAMM_FEE_BPS units
+ * and the `event.params.fee` passed into CustomSwapFeeModule's SetCustomFee.
+ */
+export const V2_FEE_SCALE = 10000n;
+
 export const SECONDS_IN_AN_HOUR = BigInt(3600);
 export const MS_IN_AN_HOUR = 3600 * 1000; // 3_600_000 ms
 export const SECONDS_IN_A_DAY = BigInt(86400);

--- a/src/EventHandlers/Pool.ts
+++ b/src/EventHandlers/Pool.ts
@@ -102,10 +102,10 @@ Pool.Fees.handler(async ({ event, context }) => {
     return;
   }
 
-  const { liquidityPoolAggregator, token0Instance, token1Instance } = poolData;
+  const { liquidityPoolAggregator } = poolData;
 
   // Process fees event
-  const result = processPoolFees(event, token0Instance, token1Instance);
+  const result = processPoolFees(event);
 
   const { liquidityPoolDiff, userDiff } = result;
 
@@ -156,7 +156,12 @@ Pool.Swap.handler(async ({ event, context }) => {
   const { liquidityPoolAggregator, token0Instance, token1Instance } = poolData;
 
   // Process swap event
-  const result = processPoolSwap(event, token0Instance, token1Instance);
+  const result = processPoolSwap(
+    event,
+    liquidityPoolAggregator,
+    token0Instance,
+    token1Instance,
+  );
 
   const { liquidityPoolDiff, userSwapDiff } = result;
 

--- a/src/EventHandlers/Pool/PoolFeesLogic.ts
+++ b/src/EventHandlers/Pool/PoolFeesLogic.ts
@@ -1,8 +1,6 @@
-import type { Pool_Fees_event, Token } from "generated";
+import type { Pool_Fees_event } from "generated";
 import type { PoolDiff } from "../../Aggregators/Pool";
 import type { UserStatsPerPoolDiff } from "../../Aggregators/UserStatsPerPool";
-import { pickTrustedSwapVolumeUSD } from "../../Helpers";
-import { getTrustedUSD } from "../../PriceTrust";
 
 export interface PoolFeesResult {
   liquidityPoolDiff?: Partial<PoolDiff>;
@@ -10,46 +8,32 @@ export interface PoolFeesResult {
 }
 
 /**
- * Process fees event using already-refreshed token prices from loadPoolData.
+ * Process a V2 Pool Fees event into raw token-amount diffs only.
  *
- * For regular pools (non-CL), fees are tracked as unstaked fees since regular
- * pools don't have the staked/unstaked distinction that CL pools have.
- *
- * USD fee value uses `pickTrustedSwapVolumeUSD` (smaller of the two priced legs)
- * rather than summing both legs — Velodrome V2 takes the fee from the input
- * side only, so at most one leg is non-zero per event in practice. Summing
- * inherits poisoned/scam-token prices that volume already defends against
- * (issue #733, regression of #670). Picking the trusted leg keeps the fee/volume
- * USD paths symmetric.
+ * USD fee aggregates are deliberately NOT written here. Per issue #797 they
+ * are now derived in `processPoolSwap` from trusted volume × pool fee rate
+ * (`volumeInUSD × currentFee / V2_FEE_SCALE`), mirroring CL's path
+ * (`CLPoolSwapLogic.calculateSwapFees`) and completing the #733 / regression
+ * of #670 invariant `cumulative_fees ≤ cumulative_volume × fee_ratio`. The
+ * Fees event only carries the input-side leg, so its old single-leg
+ * `pickTrustedSwapVolumeUSD` valuation had no second leg to clamp against and
+ * leaked any inflated/inconsistent input price straight into the USD
+ * aggregate (1000/1000 `[FEE_VOLUME_DIVERGENCE]` warned pools on c9b8978 were V2).
  *
  * @param event - V2 Pool Fees event
- * @param token0Instance - Token0 entity with price and decimals
- * @param token1Instance - Token1 entity with price and decimals
- * @returns Pool and user diffs with raw token-unit fees and trusted-leg USD fee
+ * @returns Pool and user diffs with raw token-unit fee amounts only
  */
-export function processPoolFees(
-  event: Pool_Fees_event,
-  token0Instance: Token | undefined,
-  token1Instance: Token | undefined,
-): PoolFeesResult {
-  // Per-leg fee USD via PriceTrust gate (issue #755): untrusted legs
-  // contribute 0n. The min pick then enforces the #733 invariant that the
-  // fee USD is bounded by the trusted (smaller) leg.
-  const token0FeeUSD = getTrustedUSD(event.params.amount0, token0Instance);
-  const token1FeeUSD = getTrustedUSD(event.params.amount1, token1Instance);
-  const totalFeesUSD = pickTrustedSwapVolumeUSD(token0FeeUSD, token1FeeUSD);
-
-  // Create liquidity pool diff
+export function processPoolFees(event: Pool_Fees_event): PoolFeesResult {
+  // Create liquidity pool diff — raw token amounts only; USD fee is written
+  // in processPoolSwap (see file-top doc / issue #797).
   const liquidityPoolDiff = {
     incrementalTotalFeesGenerated0: event.params.amount0,
     incrementalTotalFeesGenerated1: event.params.amount1,
-    incrementalTotalFeesGeneratedUSD: totalFeesUSD,
     lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
   };
 
   // Prepare user diff data
   const userDiff = {
-    incrementalTotalFeesContributedUSD: totalFeesUSD,
     incrementalTotalFeesContributed0: event.params.amount0,
     incrementalTotalFeesContributed1: event.params.amount1,
     lastActivityTimestamp: new Date(event.block.timestamp * 1000),

--- a/src/EventHandlers/Pool/PoolSwapLogic.ts
+++ b/src/EventHandlers/Pool/PoolSwapLogic.ts
@@ -1,8 +1,20 @@
 import type { Pool_Swap_event, Token } from "generated";
 import type { PoolDiff } from "../../Aggregators/Pool";
 import type { UserStatsPerPoolDiff } from "../../Aggregators/UserStatsPerPool";
+import { V2_FEE_SCALE } from "../../Constants";
+import type { Pool } from "../../EntityTypes";
 import { pickTrustedSwapVolumeUSD } from "../../Helpers";
 import { getTrustedUSD } from "../../PriceTrust";
+
+// Issue #797 (completes #733 / regression of #670): V2 fee USD must respect
+// the AMM invariant `cumulative_fees ≤ cumulative_volume × fee_ratio`. The V2
+// `Pool.Fees` event has only one non-zero leg (fee is taken on the input side),
+// so the prior single-leg `pickTrustedSwapVolumeUSD` valuation degenerated to
+// "return that one leg unclamped" and inflated/inconsistent input-leg prices
+// flowed straight into `totalFeesGeneratedUSD`. We now mirror the CL twin
+// (`CLPoolSwapLogic.calculateSwapFees`) and derive the USD fee at Swap time
+// from the already-min-protected `volumeInUSD`, multiplied by the pool's
+// current fee rate. `processPoolFees` is now USD-silent.
 
 export interface PoolSwapResult {
   liquidityPoolDiff: Partial<PoolDiff>;
@@ -10,11 +22,27 @@ export interface PoolSwapResult {
 }
 
 /**
- * Process swap event using already-refreshed token prices from loadPoolData
- * This matches CLPoolSwapLogic pattern
+ * Process a V2 Pool Swap event into pool + user diffs.
+ *
+ * Volume USD: per-leg `getTrustedUSD` then `pickTrustedSwapVolumeUSD` (min of
+ * trusted legs) — defends against scam-token / poisoned-oracle inflation
+ * (issues #699, #737, #755).
+ *
+ * Fee USD: `volumeInUSD × (currentFee ?? baseFee ?? 0n) / V2_FEE_SCALE` —
+ * inherits the volume path's min-protection by construction and tracks
+ * Custom/Dynamic fee-module changes via `currentFee` (issue #797, mirrors
+ * `CLPoolSwapLogic.calculateSwapFees`). `processPoolFees` no longer writes
+ * any USD field.
+ *
+ * @param event - V2 Pool Swap event
+ * @param liquidityPoolAggregator - Pool entity providing the fee rate
+ * @param token0Instance - Token0 entity with price + decimals + trust state
+ * @param token1Instance - Token1 entity with price + decimals + trust state
+ * @returns Pool + user diffs with raw token-unit volumes and trusted-leg USD volume + fee
  */
 export function processPoolSwap(
   event: Pool_Swap_event,
+  liquidityPoolAggregator: Pool,
   token0Instance: Token,
   token1Instance: Token,
 ): PoolSwapResult {
@@ -30,6 +58,11 @@ export function processPoolSwap(
 
   const volumeInUSD = pickTrustedSwapVolumeUSD(token0UsdValue, token1UsdValue);
 
+  // Derive fee USD from trusted volume — see file header for the #797 rationale.
+  const feeRate =
+    liquidityPoolAggregator.currentFee ?? liquidityPoolAggregator.baseFee ?? 0n;
+  const feeUSD = (volumeInUSD * feeRate) / V2_FEE_SCALE;
+
   // Create liquidity pool diff.
   //
   // token0Price/token1Price (the pool-internal exchange rate) are intentionally
@@ -41,6 +74,7 @@ export function processPoolSwap(
     incrementalTotalVolume0: netAmount0,
     incrementalTotalVolume1: netAmount1,
     incrementalTotalVolumeUSD: volumeInUSD,
+    incrementalTotalFeesGeneratedUSD: feeUSD,
     incrementalNumberOfSwaps: 1n,
     lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
   };
@@ -51,6 +85,7 @@ export function processPoolSwap(
     incrementalTotalSwapVolumeUSD: volumeInUSD,
     incrementalTotalSwapVolumeAmount0: netAmount0,
     incrementalTotalSwapVolumeAmount1: netAmount1,
+    incrementalTotalFeesContributedUSD: feeUSD,
     lastActivityTimestamp: new Date(event.block.timestamp * 1000),
   };
 

--- a/test/EventHandlers/Pool/Fees.test.ts
+++ b/test/EventHandlers/Pool/Fees.test.ts
@@ -16,7 +16,10 @@ describe("Pool Fees Event", () => {
     amount0In: 3n * 10n ** 18n,
     amount1In: 2n * 10n ** 6n,
     totalLiquidityUSD: 0n,
-    totalFeesGeneratedUSD: 0n,
+    // After issue #797: Fees no longer writes USD aggregates — they are
+    // derived in processPoolSwap from trusted volume × pool fee rate. So the
+    // pool's totalFeesGeneratedUSD is unchanged by a Fees event in isolation.
+    totalFeesGeneratedUSD: mockLiquidityPoolData.totalFeesGeneratedUSD,
   };
 
   expectations.totalLiquidityUSD =
@@ -26,27 +29,6 @@ describe("Pool Fees Event", () => {
     ((mockLiquidityPoolData.reserve1 - expectations.amount1In) *
       mockToken1Data.pricePerUSDNew) /
       10n ** mockToken1Data.decimals;
-
-  // After issue #733: totalFeesGeneratedUSD increments by the *trusted* (smaller
-  // / non-zero fallback) leg rather than the sum, mirroring the volume defense
-  // against poisoned/scam-token prices. The whitelisted variant continues to
-  // sum the whitelisted legs (separate filter, separate accumulator).
-  const token0LegUSD =
-    (expectations.amount0In / 10n ** mockToken0Data.decimals) *
-    mockToken0Data.pricePerUSDNew;
-  const token1LegUSD =
-    (expectations.amount1In / 10n ** mockToken1Data.decimals) *
-    mockToken1Data.pricePerUSDNew;
-  const trustedLegUSD =
-    token0LegUSD === 0n
-      ? token1LegUSD
-      : token1LegUSD === 0n
-        ? token0LegUSD
-        : token0LegUSD < token1LegUSD
-          ? token0LegUSD
-          : token1LegUSD;
-  expectations.totalFeesGeneratedUSD =
-    mockLiquidityPoolData.totalFeesGeneratedUSD + trustedLegUSD;
 
   let updatedPool: PoolEntity | undefined;
   let createdUserStats: UserStatsPerPool | undefined;
@@ -133,9 +115,9 @@ describe("Pool Fees Event", () => {
       expectations.amount1In,
     );
 
-    // Per issue #733, user fee USD now follows the trusted-leg pick, same as
-    // the pool's totalFeesGeneratedUSD increment.
-    expect(createdUserStats?.totalFeesContributedUSD).toBe(trustedLegUSD);
+    // Per issue #797: Fees no longer writes USD — user fee USD stays at the
+    // baseline 0n until a Swap on the same pool drives it.
+    expect(createdUserStats?.totalFeesContributedUSD).toBe(0n);
   });
 
   it("should set correct timestamps for UserStatsPerPool entity", async () => {

--- a/test/EventHandlers/Pool/PoolFeesLogic.test.ts
+++ b/test/EventHandlers/Pool/PoolFeesLogic.test.ts
@@ -1,11 +1,8 @@
-import type { Pool_Fees_event, Token, handlerContext } from "generated";
+import type { Pool_Fees_event, handlerContext } from "generated";
 import { toChecksumAddress } from "../../../src/Constants";
 import { processPoolFees } from "../../../src/EventHandlers/Pool/PoolFeesLogic";
-import { setupCommon } from "./common";
 
 describe("PoolFeesLogic", () => {
-  const { mockToken0Data, mockToken1Data } = setupCommon();
-
   const mockEvent: Pool_Fees_event = {
     chainId: 10,
     block: {
@@ -38,186 +35,63 @@ describe("PoolFeesLogic", () => {
   });
 
   describe("processPoolFees", () => {
-    describe("successful processing", () => {
-      it("should process fees and return both pool and user update data", () => {
-        const result = processPoolFees(
-          mockEvent,
-          mockToken0Data,
-          mockToken1Data,
-        );
+    it("returns pool and user diffs with raw token-amount fees only", () => {
+      const result = processPoolFees(mockEvent);
 
-        // Check liquidity pool diff
-        expect(result.liquidityPoolDiff).toBeDefined();
-        // For regular pools, fees are tracked as unstaked fees
-        expect(result.liquidityPoolDiff?.incrementalTotalFeesGenerated0).toBe(
-          mockEvent.params.amount0,
-        );
-        expect(result.liquidityPoolDiff?.incrementalTotalFeesGenerated1).toBe(
-          mockEvent.params.amount1,
-        );
-        expect(result.liquidityPoolDiff?.lastUpdatedTimestamp).toEqual(
-          new Date(mockEvent.block.timestamp * 1000),
-        );
+      expect(result.liquidityPoolDiff).toBeDefined();
+      expect(result.liquidityPoolDiff?.incrementalTotalFeesGenerated0).toBe(
+        mockEvent.params.amount0,
+      );
+      expect(result.liquidityPoolDiff?.incrementalTotalFeesGenerated1).toBe(
+        mockEvent.params.amount1,
+      );
+      expect(result.liquidityPoolDiff?.lastUpdatedTimestamp).toEqual(
+        new Date(mockEvent.block.timestamp * 1000),
+      );
 
-        // Check user diff data
-        expect(result.userDiff).toBeDefined();
-        expect(result.userDiff?.incrementalTotalFeesContributed0).toBe(
-          mockEvent.params.amount0,
-        );
-        expect(result.userDiff?.incrementalTotalFeesContributed1).toBe(
-          mockEvent.params.amount1,
-        );
-        expect(result.userDiff?.lastActivityTimestamp).toEqual(
-          new Date(mockEvent.block.timestamp * 1000),
-        );
-      });
-
-      it("should prepare user update data correctly", () => {
-        const result = processPoolFees(
-          mockEvent,
-          mockToken0Data,
-          mockToken1Data,
-        );
-
-        // Check that user diff data is prepared correctly
-        expect(result.userDiff).toBeDefined();
-        expect(result.userDiff?.incrementalTotalFeesContributed0).toBe(
-          mockEvent.params.amount0,
-        );
-        expect(result.userDiff?.incrementalTotalFeesContributed1).toBe(
-          mockEvent.params.amount1,
-        );
-        expect(result.userDiff?.lastActivityTimestamp).toEqual(
-          new Date(mockEvent.block.timestamp * 1000),
-        );
-      });
+      expect(result.userDiff).toBeDefined();
+      expect(result.userDiff?.incrementalTotalFeesContributed0).toBe(
+        mockEvent.params.amount0,
+      );
+      expect(result.userDiff?.incrementalTotalFeesContributed1).toBe(
+        mockEvent.params.amount1,
+      );
+      expect(result.userDiff?.lastActivityTimestamp).toEqual(
+        new Date(mockEvent.block.timestamp * 1000),
+      );
     });
 
-    describe("fee calculation", () => {
-      it("should pick the trusted (smaller) leg for totalFeesGeneratedUSD (issue #733)", () => {
-        const result = processPoolFees(
-          mockEvent,
-          mockToken0Data,
-          mockToken1Data,
-        );
+    // Issue #797 / completion of #733: USD aggregates are now derived in
+    // processPoolSwap from trusted volume × pool fee rate. The Fees handler
+    // must contribute the raw token amounts only — leaving the USD path
+    // single-leg-valued here is what produced 1000/1000 V2 pools warning
+    // [FEE_VOLUME_DIVERGENCE] on c9b8978.
+    it("does not write any USD fee field (issue #797)", () => {
+      const result = processPoolFees(mockEvent);
 
-        // Per-leg USD values (each priced independently):
-        //   token0: 1000n (18 decimals) * 1 USD → 1000n
-        //   token1: 2000n (6 decimals)  * 1 USD → 2_000_000_000_000_000n
-        // pickTrustedSwapVolumeUSD returns the smaller leg to defend against
-        // scam-token/poisoned-oracle inflation (issue #733).
-        const expectedToken0FeesUSD = 1000n;
-        const expectedTotalFeesUSD = expectedToken0FeesUSD;
-        // Whitelisted total still sums both whitelisted legs (whitelist filter
-        // is the existing defense for that field — separate from the #733 path).
-        const expectedToken1FeesUSD = 2000000000000000n;
-        const expectedTotalFeesUSDWhitelisted =
-          expectedToken0FeesUSD + expectedToken1FeesUSD;
-
-        expect(result.liquidityPoolDiff).toBeDefined();
-        expect(result.liquidityPoolDiff?.incrementalTotalFeesGeneratedUSD).toBe(
-          expectedTotalFeesUSD,
-        );
-      });
-
-      // Regression for issue #733: a Fees event whose only non-zero leg is on
-      // a poisoned-price token must not inflate totalFeesGeneratedUSD through
-      // the legitimately-priced counterpart. Both legs are priced independently
-      // and the trusted (smaller / non-zero fallback) leg is taken.
-      it("should not inherit a poisoned-price leg when the counterpart leg is honest (issue #733)", () => {
-        const poisonedPrice = 10n ** 35n;
-        const poisonedToken0: Token = {
-          ...mockToken0Data,
-          pricePerUSDNew: poisonedPrice,
-        };
-        // Honest fee on token1 only; token0 (poisoned) amount is 0 in this event.
-        const event: Pool_Fees_event = {
-          ...mockEvent,
-          params: { ...mockEvent.params, amount0: 0n, amount1: 2000n },
-        };
-
-        const result = processPoolFees(event, poisonedToken0, mockToken1Data);
-
-        // Only the honest leg is non-zero, so the trusted-leg pick returns it
-        // and the poisoned price never enters the computation.
-        const honestLegUSD = 2000000000000000n;
-        expect(result.liquidityPoolDiff?.incrementalTotalFeesGeneratedUSD).toBe(
-          honestLegUSD,
-        );
-        expect(
-          result.liquidityPoolDiff?.incrementalTotalFeesGeneratedUSD ?? 0n,
-        ).toBeLessThan(poisonedPrice);
-      });
-
-      it("should handle different token decimals correctly", () => {
-        // Create tokens with different decimals
-        const tokenWith6Decimals: Token = {
-          ...mockToken0Data,
-          decimals: 6n,
-          pricePerUSDNew: 1000000000000000000n, // 1 USD
-        };
-
-        const tokenWith18Decimals: Token = {
-          ...mockToken1Data,
-          decimals: 18n,
-          pricePerUSDNew: 2000000000000000000n, // 2 USD
-        };
-
-        const result = processPoolFees(
-          mockEvent,
-          tokenWith6Decimals,
-          tokenWith18Decimals,
-        );
-
-        expect(result.liquidityPoolDiff).toBeDefined();
-        expect(result.userDiff).toBeDefined();
-      });
-
-      it("should handle undefined tokens", () => {
-        const result = processPoolFees(mockEvent, undefined, undefined);
-
-        expect(result.liquidityPoolDiff).toBeDefined();
-        expect(result.userDiff).toBeDefined();
-      });
+      expect(
+        result.liquidityPoolDiff?.incrementalTotalFeesGeneratedUSD,
+      ).toBeUndefined();
+      expect(
+        result.userDiff?.incrementalTotalFeesContributedUSD,
+      ).toBeUndefined();
     });
 
-    // Regression test for issue #670: for a known token0-input swap at a
-    // realistic V2 fee tier (0.05%), fee USD must be at most 1% of volume USD.
-    describe("fee ≤ 1% of volume invariant (issue #670)", () => {
-      it("keeps fee USD within 1% of volume USD for token0-input swap at 0.05% fee", () => {
-        const usdt: Token = {
-          ...mockToken0Data,
-          decimals: 6n,
-          pricePerUSDNew: 1n * 10n ** 18n,
-        };
-        const sygx: Token = {
-          ...mockToken1Data,
-          decimals: 18n,
-          pricePerUSDNew: 1n * 10n ** 18n,
-        };
+    it("handles a single-leg fees event (amount1=0)", () => {
+      const event: Pool_Fees_event = {
+        ...mockEvent,
+        params: { ...mockEvent.params, amount0: 1000n, amount1: 0n },
+      };
 
-        const swapAmount0 = 1000n * 10n ** 6n;
-        const feeBps = 5n;
-        const feeAmount0 = (swapAmount0 * feeBps) / 10000n;
+      const result = processPoolFees(event);
 
-        const feesEvent: Pool_Fees_event = {
-          ...mockEvent,
-          params: {
-            ...mockEvent.params,
-            amount0: feeAmount0,
-            amount1: 0n,
-          },
-        };
-
-        const result = processPoolFees(feesEvent, usdt, sygx);
-
-        const volumeUSD = (swapAmount0 * 10n ** 18n) / 10n ** 6n;
-        const feesUSD =
-          result.liquidityPoolDiff?.incrementalTotalFeesGeneratedUSD ?? 0n;
-
-        expect(feesUSD * 10000n).toBe(volumeUSD * feeBps);
-        expect(feesUSD * 100n).toBeLessThanOrEqual(volumeUSD);
-      });
+      expect(result.liquidityPoolDiff?.incrementalTotalFeesGenerated0).toBe(
+        1000n,
+      );
+      expect(result.liquidityPoolDiff?.incrementalTotalFeesGenerated1).toBe(0n);
+      expect(
+        result.liquidityPoolDiff?.incrementalTotalFeesGeneratedUSD,
+      ).toBeUndefined();
     });
   });
 });

--- a/test/EventHandlers/Pool/PoolSwapLogic.test.ts
+++ b/test/EventHandlers/Pool/PoolSwapLogic.test.ts
@@ -5,8 +5,14 @@ import * as Helpers from "../../../src/Helpers";
 import { setupCommon } from "./common";
 
 describe("PoolSwapLogic", () => {
-  const { mockLiquidityPoolData, mockToken0Data, mockToken1Data } =
-    setupCommon();
+  const {
+    mockLiquidityPoolData,
+    mockToken0Data,
+    mockToken1Data,
+    createMockPool,
+  } = setupCommon();
+  // Pool with a typical V2 vAMM fee rate (30 = 0.30% on the 1e4 basis).
+  const mockPool = createMockPool({ currentFee: 30n });
   // Shared mock event for all tests
   const mockEvent: Pool_Swap_event = {
     params: {
@@ -50,7 +56,12 @@ describe("PoolSwapLogic", () => {
   describe("processPoolSwap", () => {
     it("should create entity and calculate swap updates for successful swap", () => {
       // Process the swap event
-      const result = processPoolSwap(mockEvent, mockToken0, mockToken1);
+      const result = processPoolSwap(
+        mockEvent,
+        mockPool,
+        mockToken0,
+        mockToken1,
+      );
 
       // Assertions
       expect(result.liquidityPoolDiff).toBeDefined();
@@ -92,7 +103,12 @@ describe("PoolSwapLogic", () => {
         },
       };
 
-      const result = processPoolSwap(modifiedEvent, mockToken0, mockToken1);
+      const result = processPoolSwap(
+        modifiedEvent,
+        mockPool,
+        mockToken0,
+        mockToken1,
+      );
 
       // Token0 has amount0In + amount0Out = 2n + 100n = 102n
       // Token1 has amount1In + amount1Out = 2000n + 5n = 2005n
@@ -104,6 +120,7 @@ describe("PoolSwapLogic", () => {
     it("zeros both total and whitelisted volume when neither token is whitelisted (#755 trust gate)", () => {
       const result = processPoolSwap(
         mockEvent,
+        mockPool,
         { ...mockToken0, isWhitelisted: false },
         { ...mockToken1, isWhitelisted: false },
       );
@@ -121,6 +138,7 @@ describe("PoolSwapLogic", () => {
     it("should add to whitelisted volume when both tokens are whitelisted", () => {
       const result = processPoolSwap(
         mockEvent,
+        mockPool,
         { ...mockToken0, isWhitelisted: true },
         { ...mockToken1, isWhitelisted: true },
       );
@@ -135,6 +153,7 @@ describe("PoolSwapLogic", () => {
     it("should count whitelisted volume when only one token is whitelisted", () => {
       const result = processPoolSwap(
         mockEvent,
+        mockPool,
         { ...mockToken0, isWhitelisted: true },
         { ...mockToken1, isWhitelisted: false },
       );
@@ -155,7 +174,12 @@ describe("PoolSwapLogic", () => {
         pricePerUSDNew: 100000000000000000000000000000000000n, // 1e35
       };
 
-      const result = processPoolSwap(mockEvent, corruptedToken0, mockToken1);
+      const result = processPoolSwap(
+        mockEvent,
+        mockPool,
+        corruptedToken0,
+        mockToken1,
+      );
 
       expect(result.liquidityPoolDiff).not.toHaveProperty("token0Price");
       expect(result.liquidityPoolDiff).not.toHaveProperty("token1Price");
@@ -175,7 +199,12 @@ describe("PoolSwapLogic", () => {
         },
       };
 
-      const result = processPoolSwap(swapEvent, mockToken0, mockToken1);
+      const result = processPoolSwap(
+        swapEvent,
+        mockPool,
+        mockToken0,
+        mockToken1,
+      );
 
       // Net amounts should be sum of in and out
       expect(result.liquidityPoolDiff?.incrementalTotalVolume0).toBe(800n); // 500 + 300
@@ -185,7 +214,12 @@ describe("PoolSwapLogic", () => {
     });
 
     it("should use token0 USD value when available and non-zero", () => {
-      const result = processPoolSwap(mockEvent, mockToken0, mockToken1);
+      const result = processPoolSwap(
+        mockEvent,
+        mockPool,
+        mockToken0,
+        mockToken1,
+      );
 
       expect(result.liquidityPoolDiff?.incrementalTotalVolume0).toBe(1000n);
       expect(result.liquidityPoolDiff?.incrementalTotalVolume1).toBe(500n);
@@ -206,6 +240,7 @@ describe("PoolSwapLogic", () => {
       // mockToken0/mockToken1 both default to isWhitelisted: true
       const result = processPoolSwap(
         eventWithZeroToken0,
+        mockPool,
         mockToken0,
         mockToken1,
       );
@@ -237,6 +272,7 @@ describe("PoolSwapLogic", () => {
 
       const result = processPoolSwap(
         eventWithZeroToken0,
+        mockPool,
         { ...mockToken0, isWhitelisted: false },
         { ...mockToken1, isWhitelisted: false },
       );
@@ -256,6 +292,7 @@ describe("PoolSwapLogic", () => {
 
       const result = processPoolSwap(
         mockEvent,
+        mockPool,
         { ...mockToken0, isWhitelisted: true },
         { ...mockToken1, isWhitelisted: true },
       );
@@ -296,7 +333,12 @@ describe("PoolSwapLogic", () => {
         },
       };
 
-      const result = processPoolSwap(swapEvent, corruptedToken0, healthyToken1);
+      const result = processPoolSwap(
+        swapEvent,
+        mockPool,
+        corruptedToken0,
+        healthyToken1,
+      );
 
       // token0UsdValue = (1e18 * 1e18 / 1e18) * 1e35 / 1e18 = 1e35 (corrupted)
       // token1UsdValue = (1e6 * 1e18 / 1e6) * 1e18 / 1e18 = 1e18 (honest $1)
@@ -318,6 +360,7 @@ describe("PoolSwapLogic", () => {
 
       const result = processPoolSwap(
         mockEvent,
+        mockPool,
         { ...mockToken0, isWhitelisted: true },
         { ...mockToken1, isWhitelisted: true },
       );
@@ -329,6 +372,146 @@ describe("PoolSwapLogic", () => {
       expect(result.liquidityPoolDiff?.incrementalTotalVolumeUSD).toBe(0n);
 
       calculateTokenAmountUSDSpy.mockRestore();
+    });
+  });
+
+  // Issue #797: V2 fee USD must be derived from trusted volume × currentFee /
+  // V2_FEE_SCALE at Swap time, mirroring the CL fee path (CLPoolSwapLogic).
+  // The V2 Fees event has only one non-zero leg (input side), so the old
+  // single-leg valuation flowed any poisoned/inconsistent input-leg price
+  // straight into totalFeesGeneratedUSD with no second leg to min against.
+  describe("V2 fee USD derived from trusted volume × rate (issue #797)", () => {
+    it("derives incrementalTotalFeesGeneratedUSD as volumeInUSD × currentFee / V2_FEE_SCALE", () => {
+      const pool = createMockPool({ currentFee: 30n }); // 0.30%
+      const result = processPoolSwap(mockEvent, pool, mockToken0, mockToken1);
+
+      // volumeInUSD = min(token0=1000n, token1=5e14) = 1000n (see existing tests)
+      // feeUSD = 1000 * 30 / 10000 = 3n
+      const expectedVolumeUSD = 1000n;
+      const expectedFeeUSD = (expectedVolumeUSD * 30n) / 10000n;
+      expect(result.liquidityPoolDiff?.incrementalTotalVolumeUSD).toBe(
+        expectedVolumeUSD,
+      );
+      expect(result.liquidityPoolDiff?.incrementalTotalFeesGeneratedUSD).toBe(
+        expectedFeeUSD,
+      );
+      expect(result.userSwapDiff?.incrementalTotalFeesContributedUSD).toBe(
+        expectedFeeUSD,
+      );
+    });
+
+    // Core #797 regression: an inflated/inconsistent fee-leg price must not
+    // inflate totalFeesGeneratedUSD. Because the new derivation reuses the
+    // already-min-protected volumeInUSD, the poisoned price is filtered out
+    // upstream and never reaches the fee aggregate.
+    it("ignores a poisoned fee-leg price by deriving from trusted volume", () => {
+      const poisonedPrice = 10n ** 35n; // 1e35 vs legitimate 1e18
+      const poisonedToken0: Token = {
+        ...mockToken0,
+        pricePerUSDNew: poisonedPrice,
+      };
+      const honestToken1: Token = {
+        ...mockToken1,
+        pricePerUSDNew: 1n * 10n ** 18n,
+        decimals: 6n,
+      };
+      // token0-input swap: amount0 is the fee leg. Pre-fix this leg's USD
+      // value (poisoned) would have been the fee USD; post-fix it is filtered
+      // by the volume min-pick before being multiplied by the rate.
+      const swapEvent: Pool_Swap_event = {
+        ...mockEvent,
+        params: {
+          ...mockEvent.params,
+          amount0In: 1000000000000000000n, // 1 token0 (18 decimals)
+          amount1In: 0n,
+          amount0Out: 0n,
+          amount1Out: 1000000n, // 1 USDC (6 decimals) → $1
+        },
+      };
+      const pool = createMockPool({ currentFee: 30n });
+
+      const result = processPoolSwap(
+        swapEvent,
+        pool,
+        poisonedToken0,
+        honestToken1,
+      );
+
+      // Trusted volume picks the honest $1 leg, so fee USD = $1 × 30 / 10000.
+      const expectedVolumeUSD = 1000000000000000000n; // 1e18 = $1
+      const expectedFeeUSD = (expectedVolumeUSD * 30n) / 10000n;
+      expect(result.liquidityPoolDiff?.incrementalTotalVolumeUSD).toBe(
+        expectedVolumeUSD,
+      );
+      expect(result.liquidityPoolDiff?.incrementalTotalFeesGeneratedUSD).toBe(
+        expectedFeeUSD,
+      );
+      expect(
+        result.liquidityPoolDiff?.incrementalTotalFeesGeneratedUSD ?? 0n,
+      ).toBeLessThan(poisonedPrice);
+    });
+
+    // Clean-pool sanity check: the new derivation matches what the AMM
+    // invariant says fees should be — fees = volume × rate, within bigint
+    // truncation. (This is the same shape as the existing PoolFeesLogic
+    // "fee ≤ 1% of volume invariant (#670)" test, ported to the Swap-time path.)
+    it("matches volume × rate exactly for a clean pool at 0.05% fee", () => {
+      const pool = createMockPool({ currentFee: 5n }); // 0.05% stable
+      const usdt: Token = {
+        ...mockToken0,
+        decimals: 6n,
+        pricePerUSDNew: 1n * 10n ** 18n,
+      };
+      const usdc: Token = {
+        ...mockToken1,
+        decimals: 6n,
+        pricePerUSDNew: 1n * 10n ** 18n,
+      };
+      const swapAmount0 = 1000n * 10n ** 6n; // $1000 token0-input
+      const swapEvent: Pool_Swap_event = {
+        ...mockEvent,
+        params: {
+          ...mockEvent.params,
+          amount0In: swapAmount0,
+          amount1In: 0n,
+          amount0Out: 0n,
+          amount1Out: 999n * 10n ** 6n, // ~$999 USDC out
+        },
+      };
+
+      const result = processPoolSwap(swapEvent, pool, usdt, usdc);
+
+      const volumeUSD =
+        result.liquidityPoolDiff?.incrementalTotalVolumeUSD ?? 0n;
+      const feeUSD =
+        result.liquidityPoolDiff?.incrementalTotalFeesGeneratedUSD ?? 0n;
+      expect(feeUSD).toBe((volumeUSD * 5n) / 10000n);
+      // Hard invariant: fee ≤ 1% of volume at any V2 rate up to 1%.
+      expect(feeUSD * 100n).toBeLessThanOrEqual(volumeUSD);
+    });
+
+    it("treats currentFee=0n as explicitly zero (does NOT fall back to baseFee)", () => {
+      // The `currentFee ?? baseFee` pattern (mirroring CLPoolSwapLogic) only
+      // falls through on null/undefined — 0n is a real value that a dynamic-
+      // fee module may set (e.g. promotional period). Honoring it matters
+      // because PoolFactory.SetCustomFee writes both fields in lockstep, so
+      // `baseFee=30n` here is a stale prior value, not a sensible fallback.
+      const pool = createMockPool({ currentFee: 0n, baseFee: 30n });
+      const result = processPoolSwap(mockEvent, pool, mockToken0, mockToken1);
+
+      expect(result.liquidityPoolDiff?.incrementalTotalFeesGeneratedUSD).toBe(
+        0n,
+      );
+    });
+
+    it("returns 0 fee USD when both currentFee and baseFee are 0n", () => {
+      const pool = createMockPool({ currentFee: 0n, baseFee: 0n });
+      const result = processPoolSwap(mockEvent, pool, mockToken0, mockToken1);
+
+      expect(result.liquidityPoolDiff?.incrementalTotalFeesGeneratedUSD).toBe(
+        0n,
+      );
+      expect(result.userSwapDiff?.incrementalTotalFeesContributedUSD).toBe(0n);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Mirror the CL #733 fix on V2: derive `incrementalTotalFeesGeneratedUSD` / `incrementalTotalFeesContributedUSD` at Swap time from `volumeInUSD × (currentFee ?? baseFee ?? 0n) / V2_FEE_SCALE`, inheriting the volume path's `pickTrustedSwapVolumeUSD` min-protection by construction.
- `processPoolFees` is now USD-silent — contributes only raw token-amount aggregates (`incrementalTotalFeesGenerated0/1`, `incrementalTotalFeesContributed0/1`). The single-leg `pickTrustedSwapVolumeUSD` valuation it relied on had no second leg to clamp against and leaked any inflated/inconsistent input-leg price straight into the USD aggregate (1000/1000 `[FEE_VOLUME_DIVERGENCE]` warned pools on `c9b8978` were V2).
- New `V2_FEE_SCALE = 10000n` constant in `src/Constants.ts` pins the 1e4 basis-points-per-100 scale used by `PoolFactory`'s `DEFAULT_*_FEE_BPS` and `CustomSwapFeeModule.SetCustomFee`.

## Test plan

- [x] `vitest run` — 1320/1320 pass; new `PoolSwapLogic` describe block covers volume×rate derivation, poisoned-fee-leg regression, exact-rate match on a clean 0.05% stable pool, `currentFee=0n` honored as explicit zero, both-fees-0 → 0n.
- [x] `PoolFeesLogic` tests rewritten to assert the USD fields are absent post-fix.
- [x] `Fees.test.ts` integration expectations adjusted: pool `totalFeesGeneratedUSD` + user `totalFeesContributedUSD` remain at baseline after a Fees event in isolation.
- [x] CL path (`CLPoolSwapLogic`) untouched; its tests still pass.
- [x] `pnpm qa --write` clean.
- [ ] Cannot verify locally: post-deploy re-sync — Envio re-syncs from genesis, so the 77 currently-live divergent pools' cumulative totals self-heal.

## Acceptance criteria

- [x] V2 USD-fee fields derived as `volumeInUSD × currentFee / V2_FEE_SCALE` in `processPoolSwap`; `processPoolFees` writes no USD field.
- [x] `V2_FEE_SCALE = 10000n` added.
- [x] Unit test: inflated/inconsistent fee-leg price no longer inflates `totalFeesGeneratedUSD` (poisoned-leg regression).
- [x] Unit test: clean-pool fee USD equals `volume × rate` exactly (0.05% case).
- [x] CL fee path untouched; CL tests still pass.
- [ ] Post-deploy: `[FEE_VOLUME_DIVERGENCE]` stops firing for the 77 live pools (verifiable only after re-sync).
- [x] `pnpm qa --write` + `vitest run` pass. (`tsc --noEmit` errors are pre-existing codegen-staleness issues unrelated to this change.)

## Cross-references

- Completes #733 for the V2 single-leg fee path (CL was already on the volume-derived path).
- Original divergence symptom: #670.
- Orthogonal / complementary upstream: #786 (frozen inflated PEPE/wOptiDoge prices). #786 fixes the prices; this fix makes the V2 fee path robust to any price inconsistency, current or future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed USD fee calculation to derive from trusted, min-protected volume × fee rate with proper scaling and edge-case handling.

* **Refactor**
  * Relocated USD fee aggregate computation from fee event processing to swap event processing for improved calculation consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/velodrome-finance/indexer/pull/806?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->