### PR TITLE
Fix dynamic-fee CL pool reserve over-accumulation (geometry-based reserves)

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -65,7 +65,7 @@ type Pool {
   stakedReserve0: BigInt @config(precision: 76) # staked reserves in token0 raw units (running counter)
   stakedReserve1: BigInt @config(precision: 76) # staked reserves in token1 raw units (running counter)
   # True once any staked position has been recorded for this pool. Gates the
-  # per-swap staked-tick sweep in processTickCrossingsForStaked: pools that have
+  # per-swap staked-tick sweep in processTickCrossings: pools that have
   # never been staked skip the sweep entirely. Set on the first gauge Deposit.
   # One-way latch: does NOT clear if every staked position is later withdrawn.
   # A transiently-staked-then-fully-unstaked pool will keep running the sweep
@@ -80,14 +80,14 @@ type Pool {
   # allow scalars or named types — tuples don't exist at this layer.
   #
   # Maintained on gauge deposit / withdraw / NFPM staked-position liquidity
-  # changes. Consumed by processTickCrossingsForStaked via in-memory binary
+  # changes. Consumed by processTickCrossings via in-memory binary
   # search — no per-tick entity loads on the swap path, which breaks the OOM
   # chain-of-amplification from #648.
   stakedTickEdges: [BigInt!]!
   stakedTickEdgeNets: [BigInt!]!
   # Total-liquidity analog of stakedTickEdges/stakedTickEdgeNets: the pool's full
   # per-tick liquidityNet map (all positions, not just staked). Maintained on
-  # CLPool Mint/Burn; consumed by processTickCrossingsForStaked on the swap path
+  # CLPool Mint/Burn; consumed by processTickCrossings on the swap path
   # to compute the fee-free reserve delta from pool geometry (L·ΔsqrtPrice),
   # replacing the stale-fee approximation that drifts on dynamic-fee pools (#803).
   tickEdges: [BigInt!]!

--- a/schema.graphql
+++ b/schema.graphql
@@ -85,6 +85,13 @@ type Pool {
   # chain-of-amplification from #648.
   stakedTickEdges: [BigInt!]!
   stakedTickEdgeNets: [BigInt!]!
+  # Total-liquidity analog of stakedTickEdges/stakedTickEdgeNets: the pool's full
+  # per-tick liquidityNet map (all positions, not just staked). Maintained on
+  # CLPool Mint/Burn; consumed by processTickCrossingsForStaked on the swap path
+  # to compute the fee-free reserve delta from pool geometry (L·ΔsqrtPrice),
+  # replacing the stale-fee approximation that drifts on dynamic-fee pools (#803).
+  tickEdges: [BigInt!]!
+  tickEdgeNets: [BigInt!]!
   totalFlashLoanFees0: BigInt @config(precision: 76) # total flash loan fees collected in token0
   totalFlashLoanFees1: BigInt @config(precision: 76) # total flash loan fees collected in token1
   totalFlashLoanFeesUSD: BigInt @config(precision: 76) # total flash loan fees collected in USD

--- a/src/Aggregators/CLStakedLiquidity.ts
+++ b/src/Aggregators/CLStakedLiquidity.ts
@@ -46,7 +46,7 @@ export function divRoundNearest(
 /**
  * Wraps `TickMath.getSqrtRatioAtTick` to return a bigint instead of JSBI.
  * Tick is clamped to the Uniswap v3 valid range upstream by every caller
- * (`processTickCrossingsForStaked` runs the bound check before the loop;
+ * (`processTickCrossings` runs the bound check before the loop;
  * edges in `stakedTickEdges` are enforced in-range by `applyStakedPositionToEdges`),
  * so this helper trusts the input and does no validation.
  *
@@ -337,49 +337,53 @@ export function segmentStakedReserveDelta(
 }
 
 /**
- * Processes tick crossings between oldTick and newTick, returning both the
- * updated `stakedLiquidityInRange` AND the per-segment staked-reserve deltas
- * (`stakedDelta0`, `stakedDelta1`) attributable to the staked share of the
- * swap.
+ * Walks the pool's tick crossings between oldTick and newTick over a supplied
+ * per-tick liquidity map, returning the updated in-range liquidity AND the
+ * signed per-segment reserve deltas (`delta0`, `delta1`).
+ *
+ * The same walk serves two reserve computations over different edge maps: the
+ * staked share (#666/#719), over the staked-only edge map; and the total
+ * reserve (#803), over the pool's full edge map. The math is identical — only
+ * the (edges, nets) map, the seed, and the `callerLabel` differ.
  *
  * Per-segment correctness (the fix for #666):
  *   The pool's sqrt price moves through a sequence of segments separated by
- *   crossed staked-tick edges. Within each segment, staked liquidity is constant
- *   and the staked share's reserve change follows exact Uniswap v3 swap math:
- *     Δ0 = L_staked * (S_start - S_end) * Q96 / (S_start * S_end)
- *     Δ1 = L_staked * (S_end - S_start) / Q96
- *   (signed; UP swap → Δ0 negative, Δ1 positive). The L_total of the pool
- *   cancels in the staked-share formula, which is why no per-pool total-edge
- *   map is needed.
+ *   crossed tick edges. Within each segment, in-range liquidity is constant and
+ *   the reserve change follows exact Uniswap v3 swap math:
+ *     Δ0 = L * (S_start - S_end) * Q96 / (S_start * S_end)
+ *     Δ1 = L * (S_end - S_start) / Q96
+ *   (signed; UP swap → Δ0 negative, Δ1 positive). For the staked share L_total
+ *   cancels in the formula, which is why the staked caller needs no total-edge
+ *   map; the total caller passes the full map directly.
  *
- *   The previous implementation applied the *post-crossing* staked/total ratio
- *   to the entire swap's net deltas. That over- or under-credits positions
+ *   The previous staked implementation applied the *post-crossing* staked/total
+ *   ratio to the entire swap's net deltas. That over- or under-credits positions
  *   that exit (or enter) range mid-swap; over many swaps, those errors
  *   accumulated into the negative `stakedReserve0/1` drift observed on 166 CL
  *   pools (issue #666).
  *
  * Tick-crossing semantics:
  *   - UP   (newTick > oldTick): cross ticks STRICTLY above oldTick, up to and
- *     including newTick. stakedLiq += stakedTickEdgeNets[T] at each crossing.
+ *     including newTick. liq += tickEdgeNets[T] at each crossing.
  *   - DOWN (newTick < oldTick): cross ticks AT OR BELOW oldTick, strictly above
- *     newTick. stakedLiq -= stakedTickEdgeNets[T] at each crossing.
+ *     newTick. liq -= tickEdgeNets[T] at each crossing.
  *   - Single segment (no edges crossed, including oldTick === newTick within a
- *     single tick): one segment from oldSqrt to newSqrt with current stakedLiq.
+ *     single tick): one segment from oldSqrt to newSqrt with current liq.
  *
  * Structural fix for the 20GB OOM (preserved from #650/#653):
  *   - Zero `.get()` or `.getWhere()` calls. Per-edge nets are read from the
- *     in-memory `stakedTickEdgeNets` array carried on the aggregator.
+ *     in-memory `tickEdgeNets` array carried on the aggregator.
  *   - Total cost per swap: O(log E + K) where E = per-pool edge count and
  *     K = edges actually crossed (typically 0–few).
  *
  * Safety guards:
- *   - `tickSpacing === 0n` (uninitialized pool) → return current stakedLiq,
+ *   - `tickSpacing === 0n` (uninitialized pool) → return current liquidity,
  *     zero deltas. No sqrt prices to compute against.
  *   - `oldSqrtPriceX96 === 0n` || `newSqrtPriceX96 === 0n` → same. The first
  *     swap that hits a pool whose `sqrtPriceX96` was never set cannot be
  *     attributed; we accept zero deltas rather than divide by zero.
  *   - Out-of-range ticks ([TICK_MIN, TICK_MAX]) are rejected and logged with
- *     a `STAKED_TICK_DRIFT` tag. The bound check runs BEFORE the hasStakes
+ *     a `STAKED_TICK_DRIFT` tag. The bound check runs BEFORE the walkEdges
  *     short-circuit so unstaked-pool corruption is still surfaced.
  *
  * Pure in-memory computation. Uses the Envio `context` ONLY for
@@ -395,24 +399,24 @@ export function segmentStakedReserveDelta(
  * @param tickSpacing - Pool's tick spacing (used only to short-circuit when 0)
  * @param context - Envio handler context — used ONLY for context.log.error;
  *                  must not touch entity APIs (see note above)
- * @param currentStakedLiqInRange - Staked in-range liquidity before the swap.
- *   Kept for signature stability and consulted ONLY on early-exit paths
- *   (out-of-range ticks, uninitialized pool, zero sqrt prices); the normal
- *   walking path seeds itself from `deriveStakedLiquidityInRange(oldTick, ...)`
- *   so the swap heals any prior counter drift (issue #719).
- * @param hasStakes - Whether the walker should cross intermediate edges (true
- *   for the staked map when the pool has stakes; for the total map, pass
- *   `tickEdges.length > 0`). When false, only the single final segment runs.
- * @param stakedTickEdges - Sorted, dedup'd tick edges from the aggregator
- * @param stakedTickEdgeNets - Parallel nets (same index as stakedTickEdges)
+ * @param currentLiquidityInRange - In-range liquidity before the swap. Kept for
+ *   signature stability and consulted ONLY on early-exit paths (out-of-range
+ *   ticks, uninitialized pool, zero sqrt prices); the normal walking path seeds
+ *   itself from `deriveStakedLiquidityInRange(oldTick, ...)` so the swap heals
+ *   any prior counter drift (issue #719).
+ * @param walkEdges - Whether to cross intermediate edges. Pass `hasStakes` for
+ *   the staked map, `tickEdges.length > 0` for the total map. When false, only
+ *   the single final segment runs.
+ * @param tickEdges - Sorted, dedup'd tick edges from the aggregator
+ * @param tickEdgeNets - Parallel nets (same index as tickEdges)
  * @param callerLabel - Diagnostic tag for the out-of-range log so the staked
- *   (#666) and total-reserve (#803) reuses of this walk are distinguishable.
- *   Defaults to "staked" to keep existing callsites and the log string stable.
- * @returns Updated `stakedLiquidityInRange` and signed per-segment
- *          `stakedDelta0`/`stakedDelta1` (in pool-reserve sign convention:
- *          positive = added to pool, negative = removed)
+ *   (#666/#719) and total-reserve (#803) reuses of this walk are
+ *   distinguishable. Defaults to "staked" to keep the staked callsite and the
+ *   log string stable.
+ * @returns Updated in-range liquidity and signed per-segment `delta0`/`delta1`
+ *          (pool-reserve sign convention: positive = added, negative = removed)
  */
-export function processTickCrossingsForStaked(
+export function processTickCrossings(
   chainId: number,
   poolAddress: string,
   oldTick: bigint,
@@ -421,15 +425,15 @@ export function processTickCrossingsForStaked(
   newSqrtPriceX96: bigint,
   tickSpacing: bigint,
   context: handlerContext,
-  currentStakedLiqInRange: bigint,
-  hasStakes: boolean,
-  stakedTickEdges: readonly bigint[],
-  stakedTickEdgeNets: readonly bigint[],
+  currentLiquidityInRange: bigint,
+  walkEdges: boolean,
+  tickEdges: readonly bigint[],
+  tickEdgeNets: readonly bigint[],
   callerLabel = "staked",
 ): {
-  stakedLiquidityInRange: bigint;
-  stakedDelta0: bigint;
-  stakedDelta1: bigint;
+  liquidityInRange: bigint;
+  delta0: bigint;
+  delta1: bigint;
 } {
   // Bounds check runs BEFORE the zero-sqrt/tickSpacing bailout so that
   // out-of-range ticks — which indicate upstream correctness bugs (missed
@@ -444,69 +448,65 @@ export function processTickCrossingsForStaked(
     newTick > TICK_MAX
   ) {
     context.log.error(
-      `[STAKED_TICK_DRIFT][processTickCrossingsForStaked:${callerLabel}] Tick out of Uniswap v3 range for pool ${poolAddress} on chain ${chainId}: oldTick=${oldTick}, newTick=${newTick}. Skipping crossing sweep to avoid runaway loop; stakedLiquidityInRange will be stale on this pool until a subsequent stake/unstake rebuilds it.`,
+      `[STAKED_TICK_DRIFT][processTickCrossings:${callerLabel}] Tick out of Uniswap v3 range for pool ${poolAddress} on chain ${chainId}: oldTick=${oldTick}, newTick=${newTick}. Skipping crossing sweep to avoid runaway loop; in-range liquidity will be stale on this pool until a subsequent stake/unstake rebuilds it.`,
     );
     return {
-      stakedLiquidityInRange: currentStakedLiqInRange,
-      stakedDelta0: 0n,
-      stakedDelta1: 0n,
+      liquidityInRange: currentLiquidityInRange,
+      delta0: 0n,
+      delta1: 0n,
     };
   }
 
   if (tickSpacing === 0n || oldSqrtPriceX96 === 0n || newSqrtPriceX96 === 0n) {
     return {
-      stakedLiquidityInRange: currentStakedLiqInRange,
-      stakedDelta0: 0n,
-      stakedDelta1: 0n,
+      liquidityInRange: currentLiquidityInRange,
+      delta0: 0n,
+      delta1: 0n,
     };
   }
 
   // Seed the walker from canonical edge state (issue #719). The cached
-  // counter `currentStakedLiqInRange` can drift away from the truth in
+  // counter `currentLiquidityInRange` can drift away from the truth in
   // edge-merge rejection / pre-Initialize / NFPM-between-stake scenarios;
   // re-deriving from edges at oldTick ensures the per-segment attribution
-  // and the returned counter both reflect what the staked share actually is.
-  let stakedLiq = deriveStakedLiquidityInRange(
-    oldTick,
-    stakedTickEdges,
-    stakedTickEdgeNets,
-  );
+  // and the returned counter both reflect what the in-range liquidity actually is.
+  let liq = deriveStakedLiquidityInRange(oldTick, tickEdges, tickEdgeNets);
   let segStart = oldSqrtPriceX96;
-  let stakedDelta0 = 0n;
-  let stakedDelta1 = 0n;
+  let delta0 = 0n;
+  let delta1 = 0n;
 
-  // Walk staked-tick edges only when the pool actually has stakes. Unstaked
-  // pools (and pools whose stakes have all cancelled) skip the binary search
-  // and the per-edge loop entirely — the hot path remains O(1).
-  if (hasStakes && stakedTickEdges.length > 0) {
+  // Walk tick edges only when requested (staked map: pool has stakes; total
+  // map: edge list non-empty). Otherwise skip the binary search and the
+  // per-edge loop entirely — the hot path remains O(1).
+  if (walkEdges && tickEdges.length > 0) {
     if (newTick > oldTick) {
       // UP: cross strictly above oldTick, up to and including newTick.
-      const startIdx = lowerBound(stakedTickEdges, oldTick + 1n);
-      for (let i = startIdx; i < stakedTickEdges.length; i++) {
-        const edgeTick = stakedTickEdges[i];
+      const startIdx = lowerBound(tickEdges, oldTick + 1n);
+      for (let i = startIdx; i < tickEdges.length; i++) {
+        const edgeTick = tickEdges[i];
         if (edgeTick > newTick) break;
         const segEnd = sqrtRatioAtTick(edgeTick);
-        if (stakedLiq > 0n && segStart !== segEnd) {
-          const seg = segmentStakedReserveDelta(stakedLiq, segStart, segEnd);
-          stakedDelta0 += seg.stakedDelta0;
-          stakedDelta1 += seg.stakedDelta1;
+        if (liq > 0n && segStart !== segEnd) {
+          const seg = segmentStakedReserveDelta(liq, segStart, segEnd);
+          delta0 += seg.stakedDelta0;
+          delta1 += seg.stakedDelta1;
         }
-        stakedLiq += stakedTickEdgeNets[i];
+        liq += tickEdgeNets[i];
         segStart = segEnd;
       }
     } else if (newTick < oldTick) {
       // DOWN: cross at or below oldTick, strictly above newTick.
-      const endIdx = lowerBound(stakedTickEdges, oldTick + 1n) - 1;
+      const endIdx = lowerBound(tickEdges, oldTick + 1n) - 1;
       for (let i = endIdx; i >= 0; i--) {
-        const edgeTick = stakedTickEdges[i];
+        const edgeTick = tickEdges[i];
         if (edgeTick <= newTick) break;
         const segEnd = sqrtRatioAtTick(edgeTick);
-        if (stakedLiq > 0n && segStart !== segEnd) {
-          const seg = segmentStakedReserveDelta(stakedLiq, segStart, segEnd);
-          stakedDelta0 += seg.stakedDelta0;
-          stakedDelta1 += seg.stakedDelta1;
+        if (liq > 0n && segStart !== segEnd) {
+          const seg = segmentStakedReserveDelta(liq, segStart, segEnd);
+          delta0 += seg.stakedDelta0;
+          delta1 += seg.stakedDelta1;
         }
-        stakedLiq -= stakedTickEdgeNets[i];
+        liq -= tickEdgeNets[i];
         segStart = segEnd;
       }
     }
@@ -515,15 +515,15 @@ export function processTickCrossingsForStaked(
   // Final segment: from the last crossed edge (or oldSqrt if none) to newSqrt.
   // Also covers the within-a-tick case (oldTick === newTick) where no edges
   // are walked and the entire swap is a single segment.
-  if (stakedLiq > 0n && segStart !== newSqrtPriceX96) {
-    const seg = segmentStakedReserveDelta(stakedLiq, segStart, newSqrtPriceX96);
-    stakedDelta0 += seg.stakedDelta0;
-    stakedDelta1 += seg.stakedDelta1;
+  if (liq > 0n && segStart !== newSqrtPriceX96) {
+    const seg = segmentStakedReserveDelta(liq, segStart, newSqrtPriceX96);
+    delta0 += seg.stakedDelta0;
+    delta1 += seg.stakedDelta1;
   }
 
   return {
-    stakedLiquidityInRange: stakedLiq,
-    stakedDelta0,
-    stakedDelta1,
+    liquidityInRange: liq,
+    delta0,
+    delta1,
   };
 }

--- a/src/Aggregators/CLStakedLiquidity.ts
+++ b/src/Aggregators/CLStakedLiquidity.ts
@@ -47,7 +47,7 @@ export function divRoundNearest(
  * Wraps `TickMath.getSqrtRatioAtTick` to return a bigint instead of JSBI.
  * Tick is clamped to the Uniswap v3 valid range upstream by every caller
  * (`processTickCrossings` runs the bound check before the loop;
- * edges in `stakedTickEdges` are enforced in-range by `applyStakedPositionToEdges`),
+ * edges in `stakedTickEdges` are enforced in-range by `applyPositionToEdges`),
  * so this helper trusts the input and does no validation.
  *
  * @param tick - Tick index (must be within [TICK_MIN, TICK_MAX])
@@ -159,7 +159,7 @@ function applyDeltaAtTick(
     return { edges: outEdges, nets: outNets };
   }
 
-  // Not present — insert. The caller (applyStakedPositionToEdges) already
+  // Not present — insert. The caller (applyPositionToEdges) already
   // rejects delta === 0n at its top guard, so reaching this branch with a
   // zero delta is unreachable by construction.
   // Build via push to keep V8 packed-elements kind (see note above).
@@ -179,7 +179,7 @@ function applyDeltaAtTick(
 }
 
 /**
- * Reason tag emitted by `applyStakedPositionToEdges` when it refuses to apply a
+ * Reason tag emitted by `applyPositionToEdges` when it refuses to apply a
  * position. Callers use this to log the anomaly while still receiving valid
  * (unchanged) arrays to assign into the aggregator diff.
  *   - "ticks_out_of_range": at least one tick is outside [TICK_MIN, TICK_MAX].
@@ -189,19 +189,20 @@ function applyDeltaAtTick(
  * `liquidityDelta === 0n` is a legitimate no-op (e.g., the Mint-0 case from
  * NFPM) and does NOT produce a rejection tag.
  */
-export type StakedEdgesRejection = "ticks_out_of_range" | "degenerate_range";
+export type EdgesRejection = "ticks_out_of_range" | "degenerate_range";
 
 /**
- * Applies a staked-position liquidity change ([tickLower, tickUpper] × liquidityDelta)
- * to the parallel (edges, nets) arrays. In-aggregator only — the swap path never
- * needs to load a per-tick entity.
+ * Applies a position's liquidity change ([tickLower, tickUpper] × liquidityDelta)
+ * to a parallel (edges, nets) tick map. Used for both the staked-only map
+ * (stake/unstake, #666/#719) and the pool's total map (CLPool Mint/Burn, #803).
+ * In-aggregator only — the swap path never needs to load a per-tick entity.
  *
  * Convention (mirrors Uniswap v3 per-tick liquidityNet):
  *   - At tickLower: net += liquidityDelta  (positions ENTER range on upward cross)
  *   - At tickUpper: net -= liquidityDelta  (positions EXIT range on upward cross)
  *
- * On stake:   liquidityDelta = +position.liquidity
- * On unstake: liquidityDelta = -position.liquidity
+ * liquidityDelta is positive when liquidity is added (stake, Mint) and negative
+ * when removed (unstake, Burn).
  *
  * When the inputs would violate an invariant (ticks outside Uniswap v3 range,
  * or tickLower >= tickUpper), the arrays are returned unchanged and `rejected`
@@ -216,13 +217,13 @@ export type StakedEdgesRejection = "ticks_out_of_range" | "degenerate_range";
  * @returns New parallel (edges, nets) arrays; `rejected` set when an invariant
  *          violation prevented the update
  */
-export function applyStakedPositionToEdges(
+export function applyPositionToEdges(
   edges: readonly bigint[],
   nets: readonly bigint[],
   tickLower: bigint,
   tickUpper: bigint,
   liquidityDelta: bigint,
-): { edges: bigint[]; nets: bigint[]; rejected?: StakedEdgesRejection } {
+): { edges: bigint[]; nets: bigint[]; rejected?: EdgesRejection } {
   if (liquidityDelta === 0n) {
     return { edges: edges.slice(), nets: nets.slice() };
   }
@@ -256,10 +257,12 @@ export function applyStakedPositionToEdges(
 }
 
 /**
- * Derives `stakedLiquidityInRange` from the canonical edge state at a given
- * tick — replaces the running counter that drifted in issue #719.
+ * Derives in-range liquidity from the canonical edge state at a given tick —
+ * replaces the running counter that drifted in issue #719. Used for both the
+ * staked map (deriving `stakedLiquidityInRange`) and the pool's total map
+ * (seeding the #803 swap-geometry walk).
  *
- *   stakedLiquidityInRange = Σ stakedTickEdgeNets[i]  where stakedTickEdges[i] <= currentTick
+ *   liquidityInRange = Σ nets[i]  where edges[i] <= currentTick
  *
  * Equivalent to the Uniswap v3 liquidityNet sum across all ticks the pool has
  * crossed going up. Uses the same upper-exclusive convention as
@@ -268,15 +271,15 @@ export function applyStakedPositionToEdges(
  *
  * Cost: O(log E + K) — binary-search the upper bound, then sum the prefix.
  * For per-pool edge counts up to a few thousand the prefix scan is a handful
- * of microseconds; cheap enough to invoke on every staked-position write so
- * the cached counter cannot drift from the edge truth.
+ * of microseconds; cheap enough to invoke on every edge-map write so the
+ * cached counter cannot drift from the edge truth.
  *
  * @param currentTick - The pool's current tick
- * @param edges - Sorted-ascending stakedTickEdges from the aggregator
- * @param nets - Parallel stakedTickEdgeNets (same length, same index)
+ * @param edges - Sorted-ascending tick edges from the aggregator
+ * @param nets - Parallel tick-edge nets (same length, same index)
  * @returns Σ nets[i] for edges[i] <= currentTick; 0n on empty edge list
  */
-export function deriveStakedLiquidityInRange(
+export function deriveLiquidityInRange(
   currentTick: bigint,
   edges: readonly bigint[],
   nets: readonly bigint[],
@@ -292,10 +295,10 @@ export function deriveStakedLiquidityInRange(
 
 /**
  * Per-segment Uniswap v3 swap math at constant L. The pool's sqrt price moves
- * from `segStart` to `segEnd` while staked liquidity in range is `stakedLiq`.
+ * from `segStart` to `segEnd` while in-range liquidity is `liq`.
  *
- *   stakedDelta0 = stakedLiq * (segStart - segEnd) * Q96 / (segStart * segEnd)
- *   stakedDelta1 = stakedLiq * (segEnd - segStart) / Q96
+ *   delta0 = liq * (segStart - segEnd) * Q96 / (segStart * segEnd)
+ *   delta1 = liq * (segEnd - segStart) / Q96
  *
  * Both expressions are signed and direction-agnostic: when sqrt moves UP
  * (segEnd > segStart), token0 leaves the pool (delta0 negative) and token1
@@ -303,36 +306,33 @@ export function deriveStakedLiquidityInRange(
  * sign convention of `event.params.amount0/amount1` on `CLPool.Swap` (positive
  * = into pool).
  *
- * The L_total of the pool cancels out of the staked-share formula, so callers
- * only need staked-edge state — not a parallel total-liquidity edge map.
+ * For the staked share the pool's L_total cancels out of the formula, so the
+ * staked caller passes only its staked in-range liquidity (no total-edge map);
+ * the total caller (#803) passes the pool's full in-range liquidity directly.
  *
- * No-op short-circuits (segStart === segEnd, stakedLiq === 0n) are handled by
- * the caller before invocation to avoid wasted bigint multiplies on the hot
- * path.
+ * No-op short-circuits (segStart === segEnd, liq === 0n) are handled by the
+ * caller before invocation to avoid wasted bigint multiplies on the hot path.
  *
  * Per-segment rounding uses `divRoundNearest` (half-away-from-zero) rather
  * than BigInt's default truncation-toward-zero. Truncation is asymmetric on
  * signed numerators — within a single swap every segment's numerator has the
- * same sign, so per-segment errors all bias the accumulated `stakedReserve0/1`
- * in one direction and the random walk grows wei-scale across many swaps.
+ * same sign, so per-segment errors all bias the accumulated reserve in one
+ * direction and the random walk grows wei-scale across many swaps.
  * Half-away-from-zero rounding zeroes the per-segment systematic bias (#771).
  *
- * @param stakedLiq - Staked liquidity active across this segment
+ * @param liq - In-range liquidity active across this segment
  * @param segStart - sqrtPriceX96 at the start of the segment
  * @param segEnd - sqrtPriceX96 at the end of the segment
- * @returns Signed reserve deltas attributable to the staked share over this segment
+ * @returns Signed per-segment reserve deltas (delta0, delta1)
  */
-export function segmentStakedReserveDelta(
-  stakedLiq: bigint,
+export function segmentReserveDelta(
+  liq: bigint,
   segStart: bigint,
   segEnd: bigint,
-): { stakedDelta0: bigint; stakedDelta1: bigint } {
+): { delta0: bigint; delta1: bigint } {
   return {
-    stakedDelta0: divRoundNearest(
-      stakedLiq * (segStart - segEnd) * Q96,
-      segStart * segEnd,
-    ),
-    stakedDelta1: divRoundNearest(stakedLiq * (segEnd - segStart), Q96),
+    delta0: divRoundNearest(liq * (segStart - segEnd) * Q96, segStart * segEnd),
+    delta1: divRoundNearest(liq * (segEnd - segStart), Q96),
   };
 }
 
@@ -402,7 +402,7 @@ export function segmentStakedReserveDelta(
  * @param currentLiquidityInRange - In-range liquidity before the swap. Kept for
  *   signature stability and consulted ONLY on early-exit paths (out-of-range
  *   ticks, uninitialized pool, zero sqrt prices); the normal walking path seeds
- *   itself from `deriveStakedLiquidityInRange(oldTick, ...)` so the swap heals
+ *   itself from `deriveLiquidityInRange(oldTick, ...)` so the swap heals
  *   any prior counter drift (issue #719).
  * @param walkEdges - Whether to cross intermediate edges. Pass `hasStakes` for
  *   the staked map, `tickEdges.length > 0` for the total map. When false, only
@@ -470,7 +470,7 @@ export function processTickCrossings(
   // edge-merge rejection / pre-Initialize / NFPM-between-stake scenarios;
   // re-deriving from edges at oldTick ensures the per-segment attribution
   // and the returned counter both reflect what the in-range liquidity actually is.
-  let liq = deriveStakedLiquidityInRange(oldTick, tickEdges, tickEdgeNets);
+  let liq = deriveLiquidityInRange(oldTick, tickEdges, tickEdgeNets);
   let segStart = oldSqrtPriceX96;
   let delta0 = 0n;
   let delta1 = 0n;
@@ -487,9 +487,9 @@ export function processTickCrossings(
         if (edgeTick > newTick) break;
         const segEnd = sqrtRatioAtTick(edgeTick);
         if (liq > 0n && segStart !== segEnd) {
-          const seg = segmentStakedReserveDelta(liq, segStart, segEnd);
-          delta0 += seg.stakedDelta0;
-          delta1 += seg.stakedDelta1;
+          const seg = segmentReserveDelta(liq, segStart, segEnd);
+          delta0 += seg.delta0;
+          delta1 += seg.delta1;
         }
         liq += tickEdgeNets[i];
         segStart = segEnd;
@@ -502,9 +502,9 @@ export function processTickCrossings(
         if (edgeTick <= newTick) break;
         const segEnd = sqrtRatioAtTick(edgeTick);
         if (liq > 0n && segStart !== segEnd) {
-          const seg = segmentStakedReserveDelta(liq, segStart, segEnd);
-          delta0 += seg.stakedDelta0;
-          delta1 += seg.stakedDelta1;
+          const seg = segmentReserveDelta(liq, segStart, segEnd);
+          delta0 += seg.delta0;
+          delta1 += seg.delta1;
         }
         liq -= tickEdgeNets[i];
         segStart = segEnd;
@@ -516,9 +516,9 @@ export function processTickCrossings(
   // Also covers the within-a-tick case (oldTick === newTick) where no edges
   // are walked and the entire swap is a single segment.
   if (liq > 0n && segStart !== newSqrtPriceX96) {
-    const seg = segmentStakedReserveDelta(liq, segStart, newSqrtPriceX96);
-    delta0 += seg.stakedDelta0;
-    delta1 += seg.stakedDelta1;
+    const seg = segmentReserveDelta(liq, segStart, newSqrtPriceX96);
+    delta0 += seg.delta0;
+    delta1 += seg.delta1;
   }
 
   return {

--- a/src/Aggregators/CLStakedLiquidity.ts
+++ b/src/Aggregators/CLStakedLiquidity.ts
@@ -400,9 +400,14 @@ export function segmentStakedReserveDelta(
  *   (out-of-range ticks, uninitialized pool, zero sqrt prices); the normal
  *   walking path seeds itself from `deriveStakedLiquidityInRange(oldTick, ...)`
  *   so the swap heals any prior counter drift (issue #719).
- * @param hasStakes - Whether this pool has ever had a staked position
+ * @param hasStakes - Whether the walker should cross intermediate edges (true
+ *   for the staked map when the pool has stakes; for the total map, pass
+ *   `tickEdges.length > 0`). When false, only the single final segment runs.
  * @param stakedTickEdges - Sorted, dedup'd tick edges from the aggregator
  * @param stakedTickEdgeNets - Parallel nets (same index as stakedTickEdges)
+ * @param callerLabel - Diagnostic tag for the out-of-range log so the staked
+ *   (#666) and total-reserve (#803) reuses of this walk are distinguishable.
+ *   Defaults to "staked" to keep existing callsites and the log string stable.
  * @returns Updated `stakedLiquidityInRange` and signed per-segment
  *          `stakedDelta0`/`stakedDelta1` (in pool-reserve sign convention:
  *          positive = added to pool, negative = removed)
@@ -420,6 +425,7 @@ export function processTickCrossingsForStaked(
   hasStakes: boolean,
   stakedTickEdges: readonly bigint[],
   stakedTickEdgeNets: readonly bigint[],
+  callerLabel = "staked",
 ): {
   stakedLiquidityInRange: bigint;
   stakedDelta0: bigint;
@@ -438,7 +444,7 @@ export function processTickCrossingsForStaked(
     newTick > TICK_MAX
   ) {
     context.log.error(
-      `[STAKED_TICK_DRIFT][processTickCrossingsForStaked] Tick out of Uniswap v3 range for pool ${poolAddress} on chain ${chainId}: oldTick=${oldTick}, newTick=${newTick}. Skipping crossing sweep to avoid runaway loop; stakedLiquidityInRange will be stale on this pool until a subsequent stake/unstake rebuilds it.`,
+      `[STAKED_TICK_DRIFT][processTickCrossingsForStaked:${callerLabel}] Tick out of Uniswap v3 range for pool ${poolAddress} on chain ${chainId}: oldTick=${oldTick}, newTick=${newTick}. Skipping crossing sweep to avoid runaway loop; stakedLiquidityInRange will be stale on this pool until a subsequent stake/unstake rebuilds it.`,
     );
     return {
       stakedLiquidityInRange: currentStakedLiqInRange,

--- a/src/Aggregators/Pool.ts
+++ b/src/Aggregators/Pool.ts
@@ -172,6 +172,12 @@ export interface PoolDiff {
   // envio.d.ts) without a copy.
   stakedTickEdges: readonly bigint[];
   stakedTickEdgeNets: readonly bigint[];
+  // Total-liquidity edge map (all positions). Same replace semantics as the
+  // staked pair above: CLPool Mint/Burn compute the full post-edit arrays via
+  // applyStakedPositionToEdges and pass them whole. Drives the fee-free swap
+  // reserve delta (#803).
+  tickEdges: readonly bigint[];
+  tickEdgeNets: readonly bigint[];
   totalVotesDeposited: bigint;
   totalVotesDepositedUSD: bigint;
   incrementalTotalBribeClaimed: bigint;
@@ -564,6 +570,8 @@ export async function updatePool(
     // `current.stakedTickEdgeNets` and must replace both together (parallel arrays).
     stakedTickEdges: diff.stakedTickEdges ?? current.stakedTickEdges,
     stakedTickEdgeNets: diff.stakedTickEdgeNets ?? current.stakedTickEdgeNets,
+    tickEdges: diff.tickEdges ?? current.tickEdges,
+    tickEdgeNets: diff.tickEdgeNets ?? current.tickEdgeNets,
     totalVotesDeposited:
       diff.totalVotesDeposited ?? current.totalVotesDeposited,
     totalVotesDepositedUSD:
@@ -988,6 +996,8 @@ export function createPoolEntity(params: {
     hasStakes: false,
     stakedTickEdges: [],
     stakedTickEdgeNets: [],
+    tickEdges: [],
+    tickEdgeNets: [],
     totalFlashLoanFees0: 0n,
     totalFlashLoanFees1: 0n,
     totalFlashLoanFeesUSD: 0n,

--- a/src/Aggregators/Pool.ts
+++ b/src/Aggregators/Pool.ts
@@ -365,6 +365,36 @@ export async function updatePool(
     diff.stakedLiquidityInRange = undefined;
   }
 
+  // Same invariant check for the TOTAL-liquidity parallel pair (tickEdges,
+  // tickEdgeNets), added with #803. CLPool Mint/Burn always set both together
+  // via applyPositionToEdges, but — as with the staked pair above — nothing in
+  // the type system enforces that on a future caller. A presence/length
+  // mismatch would silently desync the sparse map the swap path binary-searches
+  // for the fee-free reserve geometry, so log under [TICK_EDGE_DRIFT] and drop
+  // both. Unlike the staked counter, `liquidityInRange` is NOT derived from this
+  // map (it comes straight from event.params.liquidity), so it is left untouched.
+  const totalEdgesSet = diff.tickEdges !== undefined;
+  const totalNetsSet = diff.tickEdgeNets !== undefined;
+  if (totalEdgesSet !== totalNetsSet) {
+    context.log.error(
+      `[TICK_EDGE_DRIFT][updatePool] tickEdges and tickEdgeNets must be updated together (parallel arrays) for pool ${current.poolAddress} on chain ${current.chainId}. Got edges=${totalEdgesSet ? "set" : "unset"}, nets=${totalNetsSet ? "set" : "unset"}. Dropping both from this update; aggregator retains the prior consistent pair.`,
+    );
+    diff.tickEdges = undefined;
+    diff.tickEdgeNets = undefined;
+  } else if (
+    totalEdgesSet &&
+    totalNetsSet &&
+    // biome-ignore lint/style/noNonNullAssertion: totalEdgesSet/totalNetsSet narrow above
+    diff.tickEdges!.length !== diff.tickEdgeNets!.length
+  ) {
+    context.log.error(
+      // biome-ignore lint/style/noNonNullAssertion: totalEdgesSet/totalNetsSet narrow above
+      `[TICK_EDGE_DRIFT][updatePool] tickEdges/tickEdgeNets length mismatch for pool ${current.poolAddress} on chain ${current.chainId}: edges.length=${diff.tickEdges!.length}, nets.length=${diff.tickEdgeNets!.length}. Dropping both from this update; aggregator retains the prior consistent pair.`,
+    );
+    diff.tickEdges = undefined;
+    diff.tickEdgeNets = undefined;
+  }
+
   // Clamp reserve0 / reserve1 to >= 0n at the accumulator path (issue #702).
   // Reserves are LP-deposited capital and must never go negative; a Burn
   // larger than the cumulative Mint we observed would otherwise drive the

--- a/src/Aggregators/Pool.ts
+++ b/src/Aggregators/Pool.ts
@@ -164,7 +164,7 @@ export interface PoolDiff {
   // Why replace (not incremental): the array is a sorted, dedup'd, no-zero
   // encoding of Uniswap v3's liquidityNet per tick. Splicing in a delta
   // requires a binary-search locate that only makes sense against the current
-  // state — producers already do it in applyStakedPositionToEdges, so the
+  // state — producers already do it in applyPositionToEdges, so the
   // aggregator just takes the result.
   //
   // Typed `readonly bigint[]` so callers can pass the value straight from the
@@ -174,7 +174,7 @@ export interface PoolDiff {
   stakedTickEdgeNets: readonly bigint[];
   // Total-liquidity edge map (all positions). Same replace semantics as the
   // staked pair above: CLPool Mint/Burn compute the full post-edit arrays via
-  // applyStakedPositionToEdges and pass them whole. Drives the fee-free swap
+  // applyPositionToEdges and pass them whole. Drives the fee-free swap
   // reserve delta (#803).
   tickEdges: readonly bigint[];
   tickEdgeNets: readonly bigint[];
@@ -329,7 +329,7 @@ export async function updatePool(
 ) {
   // Invariant check for the parallel-array pair (stakedTickEdges,
   // stakedTickEdgeNets). Writers are supposed to compute both together via
-  // applyStakedPositionToEdges (see src/Aggregators/CLStakedLiquidity.ts),
+  // applyPositionToEdges (see src/Aggregators/CLStakedLiquidity.ts),
   // but there's nothing in the type system that prevents a future caller
   // from setting one and forgetting the other. Diverging lengths would
   // silently desync the sparse map the swap path binary-searches, so log
@@ -407,7 +407,7 @@ export async function updatePool(
   }
 
   // Clamp stakedReserve0 / stakedReserve1 to >= 0n at the accumulator path
-  // (issue #771). Per-segment deltas computed in `segmentStakedReserveDelta`
+  // (issue #771). Per-segment deltas computed in `segmentReserveDelta`
   // are exact-when-rounded (round-half-to-nearest); the residual wei-scale
   // random walk that remains after rounding is the ONLY drift this clamp
   // catches — it is not masking real liquidity imbalance. Mirrors the

--- a/src/EventHandlers/CLPool.ts
+++ b/src/EventHandlers/CLPool.ts
@@ -1,5 +1,5 @@
 import { CLPool } from "generated";
-import { applyStakedPositionToEdges } from "../Aggregators/CLStakedLiquidity";
+import { applyPositionToEdges } from "../Aggregators/CLStakedLiquidity";
 import { createOUSDTSwapEntity } from "../Aggregators/OUSDTSwaps";
 import { loadPoolData, updatePool } from "../Aggregators/Pool";
 import {
@@ -65,7 +65,7 @@ CLPool.Burn.handler(async ({ event, context }) => {
   );
   // #803: maintain the total per-tick liquidityNet map on every Burn so the swap
   // path can integrate geometry over it. Burn removes liquidity → negative delta.
-  const burnEdges = applyStakedPositionToEdges(
+  const burnEdges = applyPositionToEdges(
     liquidityPoolAggregator.tickEdges,
     liquidityPoolAggregator.tickEdgeNets,
     event.params.tickLower,
@@ -346,7 +346,7 @@ CLPool.Mint.handler(async ({ event, context }) => {
   );
   // #803: maintain the total per-tick liquidityNet map on every Mint so the swap
   // path can integrate geometry over it. Mint adds liquidity → positive delta.
-  const mintEdges = applyStakedPositionToEdges(
+  const mintEdges = applyPositionToEdges(
     liquidityPoolAggregator.tickEdges,
     liquidityPoolAggregator.tickEdgeNets,
     event.params.tickLower,

--- a/src/EventHandlers/CLPool.ts
+++ b/src/EventHandlers/CLPool.ts
@@ -1,4 +1,5 @@
 import { CLPool } from "generated";
+import { applyStakedPositionToEdges } from "../Aggregators/CLStakedLiquidity";
 import { createOUSDTSwapEntity } from "../Aggregators/OUSDTSwaps";
 import { loadPoolData, updatePool } from "../Aggregators/Pool";
 import {
@@ -62,6 +63,22 @@ CLPool.Burn.handler(async ({ event, context }) => {
     token1Instance,
     context,
   );
+  // #803: maintain the total per-tick liquidityNet map on every Burn so the swap
+  // path can integrate geometry over it. Burn removes liquidity → negative delta.
+  const burnEdges = applyStakedPositionToEdges(
+    liquidityPoolAggregator.tickEdges,
+    liquidityPoolAggregator.tickEdgeNets,
+    event.params.tickLower,
+    event.params.tickUpper,
+    -event.params.amount,
+  );
+  if (burnEdges.rejected) {
+    context.log.error(
+      `[TICK_EDGE_DRIFT][CLPool.Burn] rejected=${burnEdges.rejected} pool=${event.srcAddress} chain=${event.chainId} tickLower=${event.params.tickLower} tickUpper=${event.params.tickUpper}`,
+    );
+  }
+  result.liquidityPoolDiff.tickEdges = burnEdges.edges;
+  result.liquidityPoolDiff.tickEdgeNets = burnEdges.nets;
   const timestamp = new Date(event.block.timestamp * 1000);
 
   await updatePool(
@@ -327,6 +344,22 @@ CLPool.Mint.handler(async ({ event, context }) => {
     token0Instance,
     token1Instance,
   );
+  // #803: maintain the total per-tick liquidityNet map on every Mint so the swap
+  // path can integrate geometry over it. Mint adds liquidity → positive delta.
+  const mintEdges = applyStakedPositionToEdges(
+    liquidityPoolAggregator.tickEdges,
+    liquidityPoolAggregator.tickEdgeNets,
+    event.params.tickLower,
+    event.params.tickUpper,
+    event.params.amount,
+  );
+  if (mintEdges.rejected) {
+    context.log.error(
+      `[TICK_EDGE_DRIFT][CLPool.Mint] rejected=${mintEdges.rejected} pool=${event.srcAddress} chain=${event.chainId} tickLower=${event.params.tickLower} tickUpper=${event.params.tickUpper}`,
+    );
+  }
+  result.liquidityPoolDiff.tickEdges = mintEdges.edges;
+  result.liquidityPoolDiff.tickEdgeNets = mintEdges.nets;
   const timestamp = new Date(event.block.timestamp * 1000);
 
   await updatePool(

--- a/src/EventHandlers/CLPool/CLPoolCollectFeesLogic.ts
+++ b/src/EventHandlers/CLPool/CLPoolCollectFeesLogic.ts
@@ -22,7 +22,8 @@ export function processCLPoolCollectFees(
     token1Instance,
   );
 
-  // TVL definition: reserves track LP-deposited capital only (see calculateSwapLiquidityChanges).
+  // TVL definition: reserves track LP-deposited capital only (see the geometry
+  // reserve-delta derivation in processCLPoolSwap).
   // Gauge fees accumulate in gaugeFees.token0/token1 during swaps but are excluded from
   // reserves at swap time. When the gauge collects them, no reserve change is needed.
   // Therefore, CollectFees events should NOT affect reserves — only track fees collected.

--- a/src/EventHandlers/CLPool/CLPoolSwapLogic.ts
+++ b/src/EventHandlers/CLPool/CLPoolSwapLogic.ts
@@ -214,6 +214,13 @@ export async function processCLPoolSwap(
   // edge map via deriveLiquidityInRange — so it stays correct even when the
   // price starts at a boundary tick where the cached liquidityInRange is 0, and
   // it walks initialized edges directly (binary search) with no per-tick step cap.
+  //
+  // Edge-map completeness: the seed comes from tickEdges (built by Mint/Burn from
+  // pool creation), NOT from the cached liquidityInRange. If the map is empty —
+  // e.g. a partial-history sync whose start block postdates the pool's Mints — the
+  // seed is 0n and swaps contribute no reserve delta. That is consistent with the
+  // reserve accumulator's full-history requirement (those pre-start Mints' principal
+  // would be absent from reserve0/1 too); a from-creation sync always has a complete map.
   const totalCrossings = processTickCrossings(
     event.chainId,
     event.srcAddress,

--- a/src/EventHandlers/CLPool/CLPoolSwapLogic.ts
+++ b/src/EventHandlers/CLPool/CLPoolSwapLogic.ts
@@ -211,7 +211,7 @@ export async function processCLPoolSwap(
   // exact principal token flow (Δ1 = L·ΔsqrtPrice/Q96, Δ0 = L·ΔsqrtPrice·Q96/
   // (S_a·S_b)); the fee never moves the price, so it is excluded by construction.
   // This is the same edge-walk as the staked share (#666), seeded from the total
-  // edge map via deriveStakedLiquidityInRange — so it stays correct even when the
+  // edge map via deriveLiquidityInRange — so it stays correct even when the
   // price starts at a boundary tick where the cached liquidityInRange is 0, and
   // it walks initialized edges directly (binary search) with no per-tick step cap.
   const totalCrossings = processTickCrossings(

--- a/src/EventHandlers/CLPool/CLPoolSwapLogic.ts
+++ b/src/EventHandlers/CLPool/CLPoolSwapLogic.ts
@@ -42,12 +42,6 @@ interface SwapVolumeAndFees {
   swapFeesInUSD: bigint;
 }
 
-interface SwapLiquidityChanges {
-  newReserve0: bigint;
-  newReserve1: bigint;
-  currentTotalLiquidityUSD: bigint;
-}
-
 /** Compute fee amount in native token units from a CL fee rate and a swap amount. */
 function computeClFeeAmount(amount: bigint, feeRate: bigint): bigint {
   return (abs(amount) * feeRate) / CL_FEE_SCALE;
@@ -194,60 +188,6 @@ function calculateSwapVolumeAndFees(
   };
 }
 
-/**
- * Calculates liquidity and reserve changes from a swap event.
- *
- * TVL definition: reserves track **LP-deposited capital only** (Mint/Burn/Swap rebalancing).
- * Swap fees are excluded because they are protocol/LP earnings, not deposited capital.
- * In the CLPool contract, swap event amounts (amount0/amount1) include fees — the fee
- * portion flows into gaugeFees or feeGrowthGlobal, not into any LP position's liquidity.
- * The fee is only charged on the **input token** (the positive amount side), confirmed by
- * SwapMath.computeSwapStep which computes feeAmount solely from amountIn.
- * We subtract the fee from the input side only so that:
- *   - Mint: reserves += deposited amounts
- *   - Burn: reserves -= withdrawn amounts (tokens stay in contract as tokensOwed until collect)
- *   - Swap: reserves += net rebalancing (input-side fee excluded, output side unchanged)
- *   - Collect/CollectFees: no reserve change (fees were never in reserves)
- *
- * Exported for testing purposes only.
- */
-export function calculateSwapLiquidityChanges(
-  event: CLPool_Swap_event,
-  liquidityPoolAggregator: Pool,
-  token0Instance: Token | undefined,
-  token1Instance: Token | undefined,
-  clFeeRate: bigint,
-): SwapLiquidityChanges {
-  // Subtract fees only from the input token (positive amount). The output token
-  // (negative amount) is not fee-charged — see SwapMath.computeSwapStep.
-  const reserveDelta0 =
-    event.params.amount0 > 0n
-      ? event.params.amount0 -
-        computeClFeeAmount(event.params.amount0, clFeeRate)
-      : event.params.amount0;
-  const reserveDelta1 =
-    event.params.amount1 > 0n
-      ? event.params.amount1 -
-        computeClFeeAmount(event.params.amount1, clFeeRate)
-      : event.params.amount1;
-
-  const newReserve0 = liquidityPoolAggregator.reserve0 + reserveDelta0;
-  const newReserve1 = liquidityPoolAggregator.reserve1 + reserveDelta1;
-
-  const currentTotalLiquidityUSD = calculateTotalUSD(
-    newReserve0,
-    newReserve1,
-    token0Instance,
-    token1Instance,
-  );
-
-  return {
-    newReserve0,
-    newReserve1,
-    currentTotalLiquidityUSD,
-  };
-}
-
 export async function processCLPoolSwap(
   event: CLPool_Swap_event,
   liquidityPoolAggregator: Pool,
@@ -265,24 +205,43 @@ export async function processCLPoolSwap(
       context,
     );
 
-  // Calculate liquidity and reserve changes (fees excluded from reserves — see function docs)
-  const clFeeRate =
-    liquidityPoolAggregator.currentFee ?? liquidityPoolAggregator.baseFee ?? 0n;
-  const { newReserve0, newReserve1, currentTotalLiquidityUSD } =
-    calculateSwapLiquidityChanges(
-      event,
-      liquidityPoolAggregator,
-      token0Instance,
-      token1Instance,
-      clFeeRate,
-    );
+  // #803: derive the swap's reserve delta from pool geometry (fee-free) rather
+  // than the stale-fee approximation `amount − currentFee·amount`. The pool's
+  // sqrtPrice move, integrated over the TOTAL per-tick liquidity map, is the
+  // exact principal token flow (Δ1 = L·ΔsqrtPrice/Q96, Δ0 = L·ΔsqrtPrice·Q96/
+  // (S_a·S_b)); the fee never moves the price, so it is excluded by construction.
+  // This is the same edge-walk as the staked share (#666), seeded from the total
+  // edge map via deriveStakedLiquidityInRange — so it stays correct even when the
+  // price starts at a boundary tick where the cached liquidityInRange is 0, and
+  // it walks initialized edges directly (binary search) with no per-tick step cap.
+  const totalCrossings = processTickCrossingsForStaked(
+    event.chainId,
+    event.srcAddress,
+    liquidityPoolAggregator.tick ?? 0n,
+    event.params.tick,
+    liquidityPoolAggregator.sqrtPriceX96 ?? 0n,
+    event.params.sqrtPriceX96,
+    liquidityPoolAggregator.tickSpacing,
+    context,
+    liquidityPoolAggregator.liquidityInRange ?? 0n,
+    liquidityPoolAggregator.tickEdges.length > 0,
+    liquidityPoolAggregator.tickEdges,
+    liquidityPoolAggregator.tickEdgeNets,
+    "total",
+  );
+  const reserveDelta0 = totalCrossings.stakedDelta0;
+  const reserveDelta1 = totalCrossings.stakedDelta1;
+  const newReserve0 = liquidityPoolAggregator.reserve0 + reserveDelta0;
+  const newReserve1 = liquidityPoolAggregator.reserve1 + reserveDelta1;
+  const currentTotalLiquidityUSD = calculateTotalUSD(
+    newReserve0,
+    newReserve1,
+    token0Instance,
+    token1Instance,
+  );
 
-  // Process tick crossings for staked liquidity tracking AND compute the
-  // per-segment staked share of the swap's reserve deltas. The walk and the
-  // attribution share the same edge sweep — see CLStakedLiquidity.ts for the
-  // per-segment Uniswap v3 math (fix for #666).
-  const reserveDelta0 = newReserve0 - liquidityPoolAggregator.reserve0;
-  const reserveDelta1 = newReserve1 - liquidityPoolAggregator.reserve1;
+  // Staked-share tracking (#666) — unchanged. Same edge-walk math, but over the
+  // staked-only edge map, producing the staked slice of the reserve deltas.
   const { stakedLiquidityInRange, stakedDelta0, stakedDelta1 } =
     processTickCrossingsForStaked(
       event.chainId,

--- a/src/EventHandlers/CLPool/CLPoolSwapLogic.ts
+++ b/src/EventHandlers/CLPool/CLPoolSwapLogic.ts
@@ -1,5 +1,5 @@
 import type { CLPool_Swap_event, Token, handlerContext } from "generated";
-import { processTickCrossingsForStaked } from "../../Aggregators/CLStakedLiquidity";
+import { processTickCrossings } from "../../Aggregators/CLStakedLiquidity";
 import type { PoolDiff } from "../../Aggregators/Pool";
 import type { UserStatsPerPoolDiff } from "../../Aggregators/UserStatsPerPool";
 import { CL_FEE_SCALE } from "../../Constants";
@@ -214,7 +214,7 @@ export async function processCLPoolSwap(
   // edge map via deriveStakedLiquidityInRange — so it stays correct even when the
   // price starts at a boundary tick where the cached liquidityInRange is 0, and
   // it walks initialized edges directly (binary search) with no per-tick step cap.
-  const totalCrossings = processTickCrossingsForStaked(
+  const totalCrossings = processTickCrossings(
     event.chainId,
     event.srcAddress,
     liquidityPoolAggregator.tick ?? 0n,
@@ -229,8 +229,8 @@ export async function processCLPoolSwap(
     liquidityPoolAggregator.tickEdgeNets,
     "total",
   );
-  const reserveDelta0 = totalCrossings.stakedDelta0;
-  const reserveDelta1 = totalCrossings.stakedDelta1;
+  const reserveDelta0 = totalCrossings.delta0;
+  const reserveDelta1 = totalCrossings.delta1;
   const newReserve0 = liquidityPoolAggregator.reserve0 + reserveDelta0;
   const newReserve1 = liquidityPoolAggregator.reserve1 + reserveDelta1;
   const currentTotalLiquidityUSD = calculateTotalUSD(
@@ -242,21 +242,24 @@ export async function processCLPoolSwap(
 
   // Staked-share tracking (#666) — unchanged. Same edge-walk math, but over the
   // staked-only edge map, producing the staked slice of the reserve deltas.
-  const { stakedLiquidityInRange, stakedDelta0, stakedDelta1 } =
-    processTickCrossingsForStaked(
-      event.chainId,
-      event.srcAddress,
-      liquidityPoolAggregator.tick ?? 0n,
-      event.params.tick,
-      liquidityPoolAggregator.sqrtPriceX96 ?? 0n,
-      event.params.sqrtPriceX96,
-      liquidityPoolAggregator.tickSpacing,
-      context,
-      liquidityPoolAggregator.stakedLiquidityInRange ?? 0n,
-      liquidityPoolAggregator.hasStakes,
-      liquidityPoolAggregator.stakedTickEdges,
-      liquidityPoolAggregator.stakedTickEdgeNets,
-    );
+  const {
+    liquidityInRange: stakedLiquidityInRange,
+    delta0: stakedDelta0,
+    delta1: stakedDelta1,
+  } = processTickCrossings(
+    event.chainId,
+    event.srcAddress,
+    liquidityPoolAggregator.tick ?? 0n,
+    event.params.tick,
+    liquidityPoolAggregator.sqrtPriceX96 ?? 0n,
+    event.params.sqrtPriceX96,
+    liquidityPoolAggregator.tickSpacing,
+    context,
+    liquidityPoolAggregator.stakedLiquidityInRange ?? 0n,
+    liquidityPoolAggregator.hasStakes,
+    liquidityPoolAggregator.stakedTickEdges,
+    liquidityPoolAggregator.stakedTickEdgeNets,
+  );
 
   // token0Price/token1Price are the pool-internal exchange rate, derived from
   // the swap's post-trade sqrtPriceX96 — NOT from token oracle prices. This

--- a/src/EventHandlers/Gauges/GaugeSharedLogic.ts
+++ b/src/EventHandlers/Gauges/GaugeSharedLogic.ts
@@ -329,7 +329,7 @@ export async function processGaugeDeposit(
     stakedTickEdges,
     stakedTickEdgeNets,
     // Flip the CL pool's hasStakes latch on the first deposit. The latch gates the
-    // per-swap staked-tick sweep in processTickCrossingsForStaked. Non-CL pools
+    // per-swap staked-tick sweep in processTickCrossings. Non-CL pools
     // and already-latched CL pools leave this field alone. Also gate on an actual
     // edge list being produced: if computeCLStakedReservesOnGaugeEvent bailed
     // early or the edge merge was rejected, latching hasStakes would mark the

--- a/src/EventHandlers/Gauges/GaugeSharedLogic.ts
+++ b/src/EventHandlers/Gauges/GaugeSharedLogic.ts
@@ -1,7 +1,7 @@
 import type { handlerContext } from "generated";
 import {
-  applyStakedPositionToEdges,
-  deriveStakedLiquidityInRange,
+  applyPositionToEdges,
+  deriveLiquidityInRange,
 } from "../../Aggregators/CLStakedLiquidity";
 import type { PoolData } from "../../Aggregators/Pool";
 import {
@@ -39,7 +39,7 @@ export interface GaugeEventData {
  * Computes the CL staked reserve deltas and updated pool staked USD when a position
  * is deposited to or withdrawn from a gauge. Applies the position's liquidity to the
  * aggregator's in-memory (stakedTickEdges, stakedTickEdgeNets) arrays via
- * applyStakedPositionToEdges and determines whether the position is in range.
+ * applyPositionToEdges and determines whether the position is in range.
  *
  * @param data - Gauge event data (must have tokenId for CL)
  * @param liquidityPoolAggregator - Current pool entity
@@ -82,7 +82,7 @@ async function computeCLStakedReservesOnGaugeEvent(
     edges: stakedTickEdges,
     nets: stakedTickEdgeNets,
     rejected: edgesRejected,
-  } = applyStakedPositionToEdges(
+  } = applyPositionToEdges(
     liquidityPoolAggregator.stakedTickEdges,
     liquidityPoolAggregator.stakedTickEdgeNets,
     position.tickLower,
@@ -91,7 +91,7 @@ async function computeCLStakedReservesOnGaugeEvent(
   );
   if (edgesRejected) {
     context.log.error(
-      `[computeCLStakedReservesOnGaugeEvent] applyStakedPositionToEdges rejected position ${data.tokenId} on pool ${liquidityPoolAggregator.poolAddress} chain ${data.chainId}: reason=${edgesRejected} tickLower=${position.tickLower} tickUpper=${position.tickUpper}. Edge list left unchanged.`,
+      `[computeCLStakedReservesOnGaugeEvent] applyPositionToEdges rejected position ${data.tokenId} on pool ${liquidityPoolAggregator.poolAddress} chain ${data.chainId}: reason=${edgesRejected} tickLower=${position.tickLower} tickUpper=${position.tickUpper}. Edge list left unchanged.`,
     );
   }
 
@@ -104,7 +104,7 @@ async function computeCLStakedReservesOnGaugeEvent(
   // write, regardless of in-range / sqrt / rejection status; if the position
   // was rejected, the unchanged arrays still produce the prior consistent
   // value.
-  const stakedLiquidityInRange = deriveStakedLiquidityInRange(
+  const stakedLiquidityInRange = deriveLiquidityInRange(
     currentTick,
     stakedTickEdges,
     stakedTickEdgeNets,

--- a/src/EventHandlers/NFPM/NFPMCommonLogic.ts
+++ b/src/EventHandlers/NFPM/NFPMCommonLogic.ts
@@ -1,7 +1,7 @@
 import type { NonFungiblePosition, handlerContext } from "generated";
 import {
-  applyStakedPositionToEdges,
-  deriveStakedLiquidityInRange,
+  applyPositionToEdges,
+  deriveLiquidityInRange,
 } from "../../Aggregators/CLStakedLiquidity";
 import type { PoolData } from "../../Aggregators/Pool";
 import { updatePool } from "../../Aggregators/Pool";
@@ -131,7 +131,7 @@ export async function updateStakedPositionLiquidity(
     edges: stakedTickEdges,
     nets: stakedTickEdgeNets,
     rejected: edgesRejected,
-  } = applyStakedPositionToEdges(
+  } = applyPositionToEdges(
     liquidityPoolAggregator.stakedTickEdges,
     liquidityPoolAggregator.stakedTickEdgeNets,
     position.tickLower,
@@ -140,7 +140,7 @@ export async function updateStakedPositionLiquidity(
   );
   if (edgesRejected) {
     context.log.error(
-      `[updateStakedPositionLiquidity] applyStakedPositionToEdges rejected position ${position.tokenId} on pool ${position.pool} chain ${chainId}: reason=${edgesRejected} tickLower=${position.tickLower} tickUpper=${position.tickUpper}. Edge list left unchanged.`,
+      `[updateStakedPositionLiquidity] applyPositionToEdges rejected position ${position.tokenId} on pool ${position.pool} chain ${chainId}: reason=${edgesRejected} tickLower=${position.tickLower} tickUpper=${position.tickUpper}. Edge list left unchanged.`,
     );
   }
 
@@ -157,7 +157,7 @@ export async function updateStakedPositionLiquidity(
   // currentTick (issue #719). Applies on both the early-exit path (sqrt=0n)
   // and the normal path, so NFPM-mediated liquidity changes between gauge
   // deposit and withdraw can't desync the counter from the edges.
-  const stakedLiquidityInRange = deriveStakedLiquidityInRange(
+  const stakedLiquidityInRange = deriveLiquidityInRange(
     currentTick,
     stakedTickEdges,
     stakedTickEdgeNets,

--- a/test/Aggregators/CLStakedLiquidity.test.ts
+++ b/test/Aggregators/CLStakedLiquidity.test.ts
@@ -1,11 +1,11 @@
 import type { handlerContext } from "generated";
 import {
-  applyStakedPositionToEdges,
-  deriveStakedLiquidityInRange,
+  applyPositionToEdges,
+  deriveLiquidityInRange,
   divRoundNearest,
   isPositionInRange,
   processTickCrossings,
-  segmentStakedReserveDelta,
+  segmentReserveDelta,
 } from "../../src/Aggregators/CLStakedLiquidity";
 import { calculatePositionAmountsFromLiquidity } from "../../src/Helpers";
 import { sqrtAt } from "./common";
@@ -60,24 +60,18 @@ describe("CLStakedLiquidity", () => {
     });
   });
 
-  describe("applyStakedPositionToEdges", () => {
+  describe("applyPositionToEdges", () => {
     it("should insert both edges with correct signs on stake", () => {
-      const { edges, nets } = applyStakedPositionToEdges(
-        [],
-        [],
-        100n,
-        200n,
-        500n,
-      );
+      const { edges, nets } = applyPositionToEdges([], [], 100n, 200n, 500n);
       expect(edges).toEqual([100n, 200n]);
       expect(nets).toEqual([500n, -500n]);
     });
 
     it("should keep the list sorted when inserting into the middle", () => {
       // Start with an existing position at [0, 400]
-      const start = applyStakedPositionToEdges([], [], 0n, 400n, 100n);
+      const start = applyPositionToEdges([], [], 0n, 400n, 100n);
       // Insert a nested position at [100, 300]
-      const { edges, nets } = applyStakedPositionToEdges(
+      const { edges, nets } = applyPositionToEdges(
         start.edges,
         start.nets,
         100n,
@@ -89,8 +83,8 @@ describe("CLStakedLiquidity", () => {
     });
 
     it("should sum nets when two positions share an edge", () => {
-      const a = applyStakedPositionToEdges([], [], 100n, 200n, 500n);
-      const b = applyStakedPositionToEdges(a.edges, a.nets, 100n, 300n, 200n);
+      const a = applyPositionToEdges([], [], 100n, 200n, 500n);
+      const b = applyPositionToEdges(a.edges, a.nets, 100n, 300n, 200n);
       // tickLower=100 contributes +500 (A) + +200 (B) = +700
       // tickUpper=200 is only A: -500
       // tickUpper=300 is only B: -200
@@ -100,18 +94,18 @@ describe("CLStakedLiquidity", () => {
 
     it("should drop an edge when its net becomes zero", () => {
       // Stake then unstake the same position
-      const a = applyStakedPositionToEdges([], [], 100n, 200n, 500n);
-      const b = applyStakedPositionToEdges(a.edges, a.nets, 100n, 200n, -500n);
+      const a = applyPositionToEdges([], [], 100n, 200n, 500n);
+      const b = applyPositionToEdges(a.edges, a.nets, 100n, 200n, -500n);
       expect(b.edges).toEqual([]);
       expect(b.nets).toEqual([]);
     });
 
     it("should keep non-zero edges when a partial unstake leaves residual net", () => {
       // Two positions sharing tickLower=100
-      const a = applyStakedPositionToEdges([], [], 100n, 200n, 500n);
-      const b = applyStakedPositionToEdges(a.edges, a.nets, 100n, 300n, 200n);
+      const a = applyPositionToEdges([], [], 100n, 200n, 500n);
+      const b = applyPositionToEdges(a.edges, a.nets, 100n, 300n, 200n);
       // Unstake only one of them
-      const c = applyStakedPositionToEdges(b.edges, b.nets, 100n, 200n, -500n);
+      const c = applyPositionToEdges(b.edges, b.nets, 100n, 200n, -500n);
       // tickLower=100: +700 - 500 = +200
       // tickUpper=200: -500 + 500 = 0 → dropped
       // tickUpper=300: -200 (unchanged)
@@ -120,7 +114,7 @@ describe("CLStakedLiquidity", () => {
     });
 
     it("should ignore out-of-range ticks and tag them 'ticks_out_of_range'", () => {
-      const result = applyStakedPositionToEdges(
+      const result = applyPositionToEdges(
         [],
         [],
         -900000n, // below TICK_MIN
@@ -133,7 +127,7 @@ describe("CLStakedLiquidity", () => {
     });
 
     it("should ignore degenerate ranges and tag them 'degenerate_range'", () => {
-      const result = applyStakedPositionToEdges([], [], 200n, 100n, 500n);
+      const result = applyPositionToEdges([], [], 200n, 100n, 500n);
       expect(result.edges).toEqual([]);
       expect(result.nets).toEqual([]);
       expect(result.rejected).toBe("degenerate_range");
@@ -142,8 +136,8 @@ describe("CLStakedLiquidity", () => {
     it("should silently no-op on liquidityDelta=0 without a rejection tag", () => {
       // Zero-delta is a legitimate NFPM Mint-0 flow, not an invariant violation.
       // It must NOT log/alert — the caller treats `rejected: undefined` as success.
-      const seed = applyStakedPositionToEdges([], [], 100n, 200n, 500n);
-      const result = applyStakedPositionToEdges(
+      const seed = applyPositionToEdges([], [], 100n, 200n, 500n);
+      const result = applyPositionToEdges(
         seed.edges,
         seed.nets,
         100n,
@@ -161,12 +155,12 @@ describe("CLStakedLiquidity", () => {
       // other as tickLower, the residual can remain negative but non-zero.
       // Invariant under test: the edge MUST be preserved (not dropped just because
       // the net is negative) and the sort order MUST hold.
-      const a = applyStakedPositionToEdges([], [], 100n, 200n, 500n);
+      const a = applyPositionToEdges([], [], 100n, 200n, 500n);
       expect(a.edges).toEqual([100n, 200n]);
       expect(a.nets).toEqual([500n, -500n]);
 
       // Second position uses 200 as tickLower, stacking onto the existing -500 net.
-      const b = applyStakedPositionToEdges(a.edges, a.nets, 200n, 300n, 300n);
+      const b = applyPositionToEdges(a.edges, a.nets, 200n, 300n, 300n);
       // tickLower=100: +500 (A)
       // tickLower=200 from B adds +300 onto -500 (A's upper) = -200 (residual NEGATIVE, not dropped)
       // tickUpper=300 from B: -300
@@ -195,14 +189,14 @@ describe("CLStakedLiquidity", () => {
         { tl: 150n, tu: 250n, liq: 700n },
       ];
       for (const p of positions) {
-        const out = applyStakedPositionToEdges(edges, nets, p.tl, p.tu, p.liq);
+        const out = applyPositionToEdges(edges, nets, p.tl, p.tu, p.liq);
         edges = out.edges;
         nets = out.nets;
       }
       expect(edges.length).toBeGreaterThan(0);
       // Unstake each in reverse order
       for (const p of positions.slice().reverse()) {
-        const out = applyStakedPositionToEdges(edges, nets, p.tl, p.tu, -p.liq);
+        const out = applyPositionToEdges(edges, nets, p.tl, p.tu, -p.liq);
         edges = out.edges;
         nets = out.nets;
       }
@@ -211,10 +205,10 @@ describe("CLStakedLiquidity", () => {
     });
 
     it("should not mutate the input arrays", () => {
-      const input = applyStakedPositionToEdges([], [], 100n, 200n, 500n);
+      const input = applyPositionToEdges([], [], 100n, 200n, 500n);
       const frozenEdges = Object.freeze([...input.edges]);
       const frozenNets = Object.freeze([...input.nets]);
-      applyStakedPositionToEdges(frozenEdges, frozenNets, 300n, 400n, 100n);
+      applyPositionToEdges(frozenEdges, frozenNets, 300n, 400n, 100n);
       // Freeze throws on mutation; absence of throw proves no mutation happened.
       expect(frozenEdges).toEqual([100n, 200n]);
       expect(frozenNets).toEqual([500n, -500n]);
@@ -229,7 +223,7 @@ describe("CLStakedLiquidity", () => {
         const tu = BigInt(i * 10 + 50);
         const liq = BigInt(100 + i);
         positions.push({ tl, tu, liq });
-        const out = applyStakedPositionToEdges(edges, nets, tl, tu, liq);
+        const out = applyPositionToEdges(edges, nets, tl, tu, liq);
         edges = out.edges;
         nets = out.nets;
         // Monotone check after every event
@@ -240,7 +234,7 @@ describe("CLStakedLiquidity", () => {
       // Unstake half of them
       for (let i = 0; i < 25; i++) {
         const p = positions[i * 2];
-        const out = applyStakedPositionToEdges(edges, nets, p.tl, p.tu, -p.liq);
+        const out = applyPositionToEdges(edges, nets, p.tl, p.tu, -p.liq);
         edges = out.edges;
         nets = out.nets;
         for (let k = 1; k < edges.length; k++) {
@@ -939,7 +933,7 @@ describe("CLStakedLiquidity", () => {
         //
         // Mirrors the production failure mode that left 30 CL pools with
         // negative stakedReserve0/1 values at snapshot epochs. After the
-        // fix (rounding inside segmentStakedReserveDelta + clamp at the
+        // fix (rounding inside segmentReserveDelta + clamp at the
         // aggregator write site) the final telescoping reserve totals must
         // be non-negative at all times.
         const L_A = 10n ** 18n;
@@ -955,7 +949,7 @@ describe("CLStakedLiquidity", () => {
         let edges: readonly bigint[] = [];
         let nets: readonly bigint[] = [];
         for (const p of positions) {
-          const applied = applyStakedPositionToEdges(
+          const applied = applyPositionToEdges(
             edges,
             nets,
             p.tickLower,
@@ -1065,7 +1059,7 @@ describe("CLStakedLiquidity", () => {
   });
 
   // Regression coverage for issue #771: per-segment BigInt division in
-  // `segmentStakedReserveDelta` truncated toward zero on signed numerators,
+  // `segmentReserveDelta` truncated toward zero on signed numerators,
   // accumulating sub-wei bias across thousands of tick-crossing segments per
   // swap. The fix routes the division through `divRoundNearest`, which rounds
   // half-away-from-zero so per-segment error has mean 0.
@@ -1111,34 +1105,34 @@ describe("CLStakedLiquidity", () => {
   // The segment formula is exact in real arithmetic — the rounding mode
   // chosen here governs the per-segment residual. Direct tests pin the
   // boundary cases that flip between truncation and round-half-to-nearest.
-  describe("segmentStakedReserveDelta (#771)", () => {
+  describe("segmentReserveDelta (#771)", () => {
     it("returns symmetric magnitudes for UP and DOWN moves at the same prices", () => {
       const L = 10n ** 18n;
       const segA = Q96;
       const segB = Q96 + Q96 / 100n;
-      const up = segmentStakedReserveDelta(L, segA, segB);
-      const down = segmentStakedReserveDelta(L, segB, segA);
-      expect(up.stakedDelta0).toBe(-down.stakedDelta0);
-      expect(up.stakedDelta1).toBe(-down.stakedDelta1);
+      const up = segmentReserveDelta(L, segA, segB);
+      const down = segmentReserveDelta(L, segB, segA);
+      expect(up.delta0).toBe(-down.delta0);
+      expect(up.delta1).toBe(-down.delta1);
     });
 
-    it("rounds half-away-from-zero on stakedDelta1 (matches the helper, not truncation)", () => {
-      // Construct an exact half-case: stakedLiq*(segEnd-segStart) = Q96/2
-      //   ⇒ stakedDelta1 = 0.5 in real arithmetic.
+    it("rounds half-away-from-zero on delta1 (matches the helper, not truncation)", () => {
+      // Construct an exact half-case: liq*(segEnd-segStart) = Q96/2
+      //   ⇒ delta1 = 0.5 in real arithmetic.
       // BigInt truncation toward zero would give 0n; the fix gives 1n.
       const stakedLiq = 1n;
       const segStart = Q96;
       const segEnd = Q96 + Q96 / 2n;
-      const seg = segmentStakedReserveDelta(stakedLiq, segStart, segEnd);
-      expect(seg.stakedDelta1).toBe(1n);
+      const seg = segmentReserveDelta(stakedLiq, segStart, segEnd);
+      expect(seg.delta1).toBe(1n);
 
-      const segDown = segmentStakedReserveDelta(stakedLiq, segEnd, segStart);
-      expect(segDown.stakedDelta1).toBe(-1n);
+      const segDown = segmentReserveDelta(stakedLiq, segEnd, segStart);
+      expect(segDown.delta1).toBe(-1n);
     });
 
-    it("rounds half-away-from-zero on stakedDelta0", () => {
-      // Construct an exact half-case on stakedDelta0:
-      //   stakedDelta0 = stakedLiq * (segStart - segEnd) * Q96 / (segStart * segEnd)
+    it("rounds half-away-from-zero on delta0", () => {
+      // Construct an exact half-case on delta0:
+      //   delta0 = liq * (segStart - segEnd) * Q96 / (segStart * segEnd)
       // Pick segStart = 2 * Q96, segEnd = 4 * Q96, stakedLiq = 1:
       //   numerator = 1 * (2Q96 - 4Q96) * Q96 = -2 * Q96^2
       //   denominator = 8 * Q96^2
@@ -1159,10 +1153,10 @@ describe("CLStakedLiquidity", () => {
       const stakedLiq = 10n ** 18n;
       const segStart = sqrtAt(0n);
       const segEnd = sqrtAt(100n);
-      const seg = segmentStakedReserveDelta(stakedLiq, segStart, segEnd);
+      const seg = segmentReserveDelta(stakedLiq, segStart, segEnd);
       // UP move ⇒ delta0 negative, delta1 positive.
-      expect(seg.stakedDelta0).toBeLessThan(0n);
-      expect(seg.stakedDelta1).toBeGreaterThan(0n);
+      expect(seg.delta0).toBeLessThan(0n);
+      expect(seg.delta1).toBeGreaterThan(0n);
     });
   });
 
@@ -1175,48 +1169,46 @@ describe("CLStakedLiquidity", () => {
   // tracked, but without any of the drift paths the counter exhibited (pre-
   // Initialize deposit, edge-merge rejection, NFPM-mediated liquidity change
   // between gauge deposit and withdraw).
-  describe("deriveStakedLiquidityInRange (#719)", () => {
+  describe("deriveLiquidityInRange (#719)", () => {
     it("returns 0n on empty edge list", () => {
-      expect(deriveStakedLiquidityInRange(0n, [], [])).toBe(0n);
+      expect(deriveLiquidityInRange(0n, [], [])).toBe(0n);
     });
 
     it("returns 0n when currentTick is below every edge", () => {
       // Position [100, 200]: edges=[100, 200], nets=[+L, -L]. currentTick=50
       // is below both — no entry crossed, so 0.
-      expect(
-        deriveStakedLiquidityInRange(50n, [100n, 200n], [500n, -500n]),
-      ).toBe(0n);
+      expect(deriveLiquidityInRange(50n, [100n, 200n], [500n, -500n])).toBe(0n);
     });
 
     it("returns liquidity when currentTick is in range (only tickLower crossed)", () => {
       // currentTick=150 ≥ 100 (entered) but < 200 (not exited yet).
-      expect(
-        deriveStakedLiquidityInRange(150n, [100n, 200n], [500n, -500n]),
-      ).toBe(500n);
+      expect(deriveLiquidityInRange(150n, [100n, 200n], [500n, -500n])).toBe(
+        500n,
+      );
     });
 
     it("returns 0n when currentTick is above every edge (entered then exited)", () => {
       // currentTick=300 ≥ 100 AND ≥ 200 ⇒ +L - L = 0.
-      expect(
-        deriveStakedLiquidityInRange(300n, [100n, 200n], [500n, -500n]),
-      ).toBe(0n);
+      expect(deriveLiquidityInRange(300n, [100n, 200n], [500n, -500n])).toBe(
+        0n,
+      );
     });
 
     it("includes an edge that equals currentTick (tickLower inclusive)", () => {
       // Uniswap v3 convention: tickLower <= currentTick < tickUpper.
-      // deriveStakedLiquidityInRange uses edges[i] <= currentTick, so the
+      // deriveLiquidityInRange uses edges[i] <= currentTick, so the
       // tickLower edge is included when currentTick === tickLower.
-      expect(
-        deriveStakedLiquidityInRange(100n, [100n, 200n], [500n, -500n]),
-      ).toBe(500n);
+      expect(deriveLiquidityInRange(100n, [100n, 200n], [500n, -500n])).toBe(
+        500n,
+      );
     });
 
     it("excludes the tickUpper edge when currentTick === tickUpper (boundary exit)", () => {
       // currentTick=200 ⇒ both edges <=200 ⇒ +L - L = 0. Matches the upper-
       // exclusive convention in isPositionInRange.
-      expect(
-        deriveStakedLiquidityInRange(200n, [100n, 200n], [500n, -500n]),
-      ).toBe(0n);
+      expect(deriveLiquidityInRange(200n, [100n, 200n], [500n, -500n])).toBe(
+        0n,
+      );
     });
 
     it("sums multiple overlapping positions", () => {
@@ -1225,7 +1217,7 @@ describe("CLStakedLiquidity", () => {
       // At currentTick=250: A is in (entered at 100, not yet exited at 300),
       // B is in (entered at 200, not yet exited at 400) ⇒ 500 + 300 = 800.
       expect(
-        deriveStakedLiquidityInRange(
+        deriveLiquidityInRange(
           250n,
           [100n, 200n, 300n, 400n],
           [500n, 300n, -500n, -300n],
@@ -1235,16 +1227,16 @@ describe("CLStakedLiquidity", () => {
 
     it("handles negative ticks", () => {
       // Position [-200, -100], L=500.
-      expect(
-        deriveStakedLiquidityInRange(-150n, [-200n, -100n], [500n, -500n]),
-      ).toBe(500n);
-      expect(
-        deriveStakedLiquidityInRange(-50n, [-200n, -100n], [500n, -500n]),
-      ).toBe(0n);
+      expect(deriveLiquidityInRange(-150n, [-200n, -100n], [500n, -500n])).toBe(
+        500n,
+      );
+      expect(deriveLiquidityInRange(-50n, [-200n, -100n], [500n, -500n])).toBe(
+        0n,
+      );
     });
 
     it("agrees with processTickCrossings walking up from the lowest edge", () => {
-      // Build a non-trivial edge set and verify deriveStakedLiquidityInRange
+      // Build a non-trivial edge set and verify deriveLiquidityInRange
       // matches what processTickCrossings produces by walking up from
       // far below to the target tick.
       const edges = [-200n, -100n, 100n, 300n];
@@ -1270,7 +1262,7 @@ describe("CLStakedLiquidity", () => {
         nets,
       );
 
-      expect(deriveStakedLiquidityInRange(target, edges, nets)).toBe(
+      expect(deriveLiquidityInRange(target, edges, nets)).toBe(
         walked.liquidityInRange,
       );
     });

--- a/test/Aggregators/CLStakedLiquidity.test.ts
+++ b/test/Aggregators/CLStakedLiquidity.test.ts
@@ -4,7 +4,7 @@ import {
   deriveStakedLiquidityInRange,
   divRoundNearest,
   isPositionInRange,
-  processTickCrossingsForStaked,
+  processTickCrossings,
   segmentStakedReserveDelta,
 } from "../../src/Aggregators/CLStakedLiquidity";
 import { calculatePositionAmountsFromLiquidity } from "../../src/Helpers";
@@ -251,7 +251,7 @@ describe("CLStakedLiquidity", () => {
     });
   });
 
-  describe("processTickCrossingsForStaked", () => {
+  describe("processTickCrossings", () => {
     let mockContext: handlerContext;
     let logErrorSpy: ReturnType<typeof vi.fn>;
 
@@ -274,7 +274,7 @@ describe("CLStakedLiquidity", () => {
       // touch. Here edges=[100, 200] with nets=[300, -300] and oldTick=100
       // ⇒ derive(100) = 300 (the tickLower at 100 is in-range, tickUpper at
       // 200 has not been crossed yet). The 500n input is intentionally stale.
-      const result = processTickCrossingsForStaked(
+      const result = processTickCrossings(
         CHAIN_ID,
         POOL_ADDRESS,
         100n,
@@ -288,14 +288,14 @@ describe("CLStakedLiquidity", () => {
         [100n, 200n],
         [300n, -300n],
       );
-      expect(result.stakedLiquidityInRange).toBe(300n);
+      expect(result.liquidityInRange).toBe(300n);
       // Same sqrt → final segment is a no-op → zero deltas
-      expect(result.stakedDelta0).toBe(0n);
-      expect(result.stakedDelta1).toBe(0n);
+      expect(result.delta0).toBe(0n);
+      expect(result.delta1).toBe(0n);
     });
 
     it("should return unchanged when tickSpacing is zero", async () => {
-      const result = processTickCrossingsForStaked(
+      const result = processTickCrossings(
         CHAIN_ID,
         POOL_ADDRESS,
         100n,
@@ -309,15 +309,15 @@ describe("CLStakedLiquidity", () => {
         [200n],
         [300n],
       );
-      expect(result.stakedLiquidityInRange).toBe(500n);
-      expect(result.stakedDelta0).toBe(0n);
-      expect(result.stakedDelta1).toBe(0n);
+      expect(result.liquidityInRange).toBe(500n);
+      expect(result.delta0).toBe(0n);
+      expect(result.delta1).toBe(0n);
     });
 
     it("should return unchanged when oldSqrtPriceX96 is zero (pre-Initialize)", async () => {
       // First swap on a pool whose sqrtPriceX96 was never set: cannot attribute,
       // accept zero deltas rather than divide by zero.
-      const result = processTickCrossingsForStaked(
+      const result = processTickCrossings(
         CHAIN_ID,
         POOL_ADDRESS,
         100n,
@@ -331,13 +331,13 @@ describe("CLStakedLiquidity", () => {
         [200n],
         [300n],
       );
-      expect(result.stakedLiquidityInRange).toBe(500n);
-      expect(result.stakedDelta0).toBe(0n);
-      expect(result.stakedDelta1).toBe(0n);
+      expect(result.liquidityInRange).toBe(500n);
+      expect(result.delta0).toBe(0n);
+      expect(result.delta1).toBe(0n);
     });
 
     it("should add stakedLiquidityNet when crossing up", async () => {
-      const result = processTickCrossingsForStaked(
+      const result = processTickCrossings(
         CHAIN_ID,
         POOL_ADDRESS,
         100n,
@@ -351,11 +351,11 @@ describe("CLStakedLiquidity", () => {
         [200n],
         [300n],
       );
-      expect(result.stakedLiquidityInRange).toBe(300n);
+      expect(result.liquidityInRange).toBe(300n);
     });
 
     it("should subtract stakedLiquidityNet when crossing down", async () => {
-      const result = processTickCrossingsForStaked(
+      const result = processTickCrossings(
         CHAIN_ID,
         POOL_ADDRESS,
         250n,
@@ -369,11 +369,11 @@ describe("CLStakedLiquidity", () => {
         [200n],
         [300n],
       );
-      expect(result.stakedLiquidityInRange).toBe(0n);
+      expect(result.liquidityInRange).toBe(0n);
     });
 
     it("should handle multiple tick crossings going up", async () => {
-      const result = processTickCrossingsForStaked(
+      const result = processTickCrossings(
         CHAIN_ID,
         POOL_ADDRESS,
         100n,
@@ -387,11 +387,11 @@ describe("CLStakedLiquidity", () => {
         [200n, 400n, 600n],
         [100n, 200n, -50n],
       );
-      expect(result.stakedLiquidityInRange).toBe(250n); // 0 + 100 + 200 - 50
+      expect(result.liquidityInRange).toBe(250n); // 0 + 100 + 200 - 50
     });
 
     it("should handle multiple tick crossings going down", async () => {
-      const result = processTickCrossingsForStaked(
+      const result = processTickCrossings(
         CHAIN_ID,
         POOL_ADDRESS,
         650n,
@@ -406,7 +406,7 @@ describe("CLStakedLiquidity", () => {
         [100n, 200n, -50n],
       );
       // 250 - (-50) - 200 - 100 = 250 + 50 - 200 - 100 = 0
-      expect(result.stakedLiquidityInRange).toBe(0n);
+      expect(result.liquidityInRange).toBe(0n);
     });
 
     it("should skip edges that fall outside the [oldTick, newTick] window", async () => {
@@ -414,7 +414,7 @@ describe("CLStakedLiquidity", () => {
       // derive(oldTick=100) = 0 (no edges <= 100); walker adds nets[200]=150
       // crossing strictly above oldTick up to newTick=300 (400 is beyond).
       // The 50n input is stale and ignored on the normal path (issue #719).
-      const result = processTickCrossingsForStaked(
+      const result = processTickCrossings(
         CHAIN_ID,
         POOL_ADDRESS,
         100n,
@@ -428,11 +428,11 @@ describe("CLStakedLiquidity", () => {
         [200n, 400n],
         [150n, -150n],
       );
-      expect(result.stakedLiquidityInRange).toBe(150n); // derive(100)=0 + 150
+      expect(result.liquidityInRange).toBe(150n); // derive(100)=0 + 150
     });
 
     it("should handle negative tick ranges", async () => {
-      const result = processTickCrossingsForStaked(
+      const result = processTickCrossings(
         CHAIN_ID,
         POOL_ADDRESS,
         -300n,
@@ -446,7 +446,7 @@ describe("CLStakedLiquidity", () => {
         [-200n],
         [500n],
       );
-      expect(result.stakedLiquidityInRange).toBe(500n);
+      expect(result.liquidityInRange).toBe(500n);
     });
 
     it("should not cross the oldTick itself when going up (strict-above semantics)", async () => {
@@ -455,7 +455,7 @@ describe("CLStakedLiquidity", () => {
       // tickLower at 200 is in-range by the upper-exclusive convention), so
       // the walker starts at 100 and crosses no further edges. The seed `0n`
       // input is stale and ignored on the normal path (issue #719).
-      const result = processTickCrossingsForStaked(
+      const result = processTickCrossings(
         CHAIN_ID,
         POOL_ADDRESS,
         200n,
@@ -469,12 +469,12 @@ describe("CLStakedLiquidity", () => {
         [200n],
         [100n],
       );
-      expect(result.stakedLiquidityInRange).toBe(100n);
+      expect(result.liquidityInRange).toBe(100n);
     });
 
     it("should include the oldTick boundary when going down (at-or-below semantics)", async () => {
       // oldTick=200, edge at 200 — going down includes it
-      const result = processTickCrossingsForStaked(
+      const result = processTickCrossings(
         CHAIN_ID,
         POOL_ADDRESS,
         200n,
@@ -488,13 +488,13 @@ describe("CLStakedLiquidity", () => {
         [200n],
         [100n],
       );
-      expect(result.stakedLiquidityInRange).toBe(0n); // 100 - 100
+      expect(result.liquidityInRange).toBe(0n); // 100 - 100
     });
 
     it("should handle tickSpacing of 1 without scanning per-tick (only edges drive the walk)", async () => {
       // Edges 101/102/103; spacing=1 means the old impl would sweep per-tick,
       // but the new impl only visits the edges that exist.
-      const result = processTickCrossingsForStaked(
+      const result = processTickCrossings(
         CHAIN_ID,
         POOL_ADDRESS,
         100n,
@@ -508,7 +508,7 @@ describe("CLStakedLiquidity", () => {
         [101n, 102n, 103n],
         [10n, 20n, -5n],
       );
-      expect(result.stakedLiquidityInRange).toBe(25n); // 0 + 10 + 20 - 5
+      expect(result.liquidityInRange).toBe(25n); // 0 + 10 + 20 - 5
     });
 
     describe("safety guards", () => {
@@ -517,7 +517,7 @@ describe("CLStakedLiquidity", () => {
         // so currentStakedLiqInRange MUST be 0n. Seed 0n to reflect that and
         // assert zero deltas — non-zero L would let the final-segment fallback
         // emit attribution despite the edge loop being skipped.
-        const result = processTickCrossingsForStaked(
+        const result = processTickCrossings(
           CHAIN_ID,
           POOL_ADDRESS,
           100n,
@@ -531,15 +531,15 @@ describe("CLStakedLiquidity", () => {
           [200n],
           [999n],
         );
-        expect(result.stakedLiquidityInRange).toBe(0n);
-        expect(result.stakedDelta0).toBe(0n);
-        expect(result.stakedDelta1).toBe(0n);
+        expect(result.liquidityInRange).toBe(0n);
+        expect(result.delta0).toBe(0n);
+        expect(result.delta1).toBe(0n);
       });
 
       it("should short-circuit when the edge list is empty (no staked positions)", async () => {
         // Precondition: empty edge list ⇒ no active staked positions ⇒
         // currentStakedLiqInRange MUST be 0n. Same reasoning as above.
-        const result = processTickCrossingsForStaked(
+        const result = processTickCrossings(
           CHAIN_ID,
           POOL_ADDRESS,
           100n,
@@ -553,15 +553,15 @@ describe("CLStakedLiquidity", () => {
           [],
           [],
         );
-        expect(result.stakedLiquidityInRange).toBe(0n);
-        expect(result.stakedDelta0).toBe(0n);
-        expect(result.stakedDelta1).toBe(0n);
+        expect(result.liquidityInRange).toBe(0n);
+        expect(result.delta0).toBe(0n);
+        expect(result.delta1).toBe(0n);
       });
 
       it("should bail and log when oldTick is below TICK_MIN", async () => {
         // oldTick out of range — pass dummy non-zero sqrt placeholders since
         // sqrtAt(out-of-range) would throw before we even reach the function.
-        const result = processTickCrossingsForStaked(
+        const result = processTickCrossings(
           CHAIN_ID,
           POOL_ADDRESS,
           -900000n,
@@ -575,9 +575,9 @@ describe("CLStakedLiquidity", () => {
           [200n],
           [300n],
         );
-        expect(result.stakedLiquidityInRange).toBe(500n);
-        expect(result.stakedDelta0).toBe(0n);
-        expect(result.stakedDelta1).toBe(0n);
+        expect(result.liquidityInRange).toBe(500n);
+        expect(result.delta0).toBe(0n);
+        expect(result.delta1).toBe(0n);
         expect(logErrorSpy).toHaveBeenCalledTimes(1);
         expect(logErrorSpy.mock.calls[0][0]).toContain(
           "out of Uniswap v3 range",
@@ -585,7 +585,7 @@ describe("CLStakedLiquidity", () => {
       });
 
       it("should bail and log when newTick is above TICK_MAX", async () => {
-        const result = processTickCrossingsForStaked(
+        const result = processTickCrossings(
           CHAIN_ID,
           POOL_ADDRESS,
           100n,
@@ -599,12 +599,12 @@ describe("CLStakedLiquidity", () => {
           [200n],
           [300n],
         );
-        expect(result.stakedLiquidityInRange).toBe(500n);
+        expect(result.liquidityInRange).toBe(500n);
         expect(logErrorSpy).toHaveBeenCalledTimes(1);
       });
 
       it("should accept boundary ticks at exactly TICK_MIN and TICK_MAX", async () => {
-        const result = processTickCrossingsForStaked(
+        const result = processTickCrossings(
           CHAIN_ID,
           POOL_ADDRESS,
           -887272n,
@@ -618,14 +618,14 @@ describe("CLStakedLiquidity", () => {
           [],
           [],
         );
-        expect(result.stakedLiquidityInRange).toBe(0n);
+        expect(result.liquidityInRange).toBe(0n);
         expect(logErrorSpy).not.toHaveBeenCalled();
       });
     });
 
     describe("per-segment reserve delta attribution (#666 fix)", () => {
       it("returns zero deltas when stakedLiq is zero throughout the swap", () => {
-        const result = processTickCrossingsForStaked(
+        const result = processTickCrossings(
           CHAIN_ID,
           POOL_ADDRESS,
           100n,
@@ -639,8 +639,8 @@ describe("CLStakedLiquidity", () => {
           [],
           [],
         );
-        expect(result.stakedDelta0).toBe(0n);
-        expect(result.stakedDelta1).toBe(0n);
+        expect(result.delta0).toBe(0n);
+        expect(result.delta1).toBe(0n);
       });
 
       it("matches calculatePositionAmountsFromLiquidity diff for an in-range single-segment swap", () => {
@@ -661,7 +661,7 @@ describe("CLStakedLiquidity", () => {
         const edges = [tickLower, tickUpper];
         const nets = [L, -L];
 
-        const result = processTickCrossingsForStaked(
+        const result = processTickCrossings(
           CHAIN_ID,
           POOL_ADDRESS,
           oldTick,
@@ -676,7 +676,7 @@ describe("CLStakedLiquidity", () => {
           nets,
         );
 
-        expect(result.stakedLiquidityInRange).toBe(L);
+        expect(result.liquidityInRange).toBe(L);
 
         const before = calculatePositionAmountsFromLiquidity(
           L,
@@ -696,14 +696,10 @@ describe("CLStakedLiquidity", () => {
         const expectedDelta0 = after.amount0 - before.amount0;
         const expectedDelta1 = after.amount1 - before.amount1;
         // Bigint truncation may differ by ≤1 wei vs the source helper.
-        expect(result.stakedDelta0 - expectedDelta0).toBeGreaterThanOrEqual(
-          -1n,
-        );
-        expect(result.stakedDelta0 - expectedDelta0).toBeLessThanOrEqual(1n);
-        expect(result.stakedDelta1 - expectedDelta1).toBeGreaterThanOrEqual(
-          -1n,
-        );
-        expect(result.stakedDelta1 - expectedDelta1).toBeLessThanOrEqual(1n);
+        expect(result.delta0 - expectedDelta0).toBeGreaterThanOrEqual(-1n);
+        expect(result.delta0 - expectedDelta0).toBeLessThanOrEqual(1n);
+        expect(result.delta1 - expectedDelta1).toBeGreaterThanOrEqual(-1n);
+        expect(result.delta1 - expectedDelta1).toBeLessThanOrEqual(1n);
       });
 
       it("attributes nothing past the boundary when the position exits range mid-swap", () => {
@@ -722,7 +718,7 @@ describe("CLStakedLiquidity", () => {
         const newSqrt = sqrtAt(newTick);
         const sqrtAtLower = sqrtAt(tickLower);
 
-        const result = processTickCrossingsForStaked(
+        const result = processTickCrossings(
           CHAIN_ID,
           POOL_ADDRESS,
           oldTick,
@@ -738,7 +734,7 @@ describe("CLStakedLiquidity", () => {
         );
 
         // Position fully exited going down → stakedLiq drops to 0
-        expect(result.stakedLiquidityInRange).toBe(0n);
+        expect(result.liquidityInRange).toBe(0n);
 
         // Expected delta = single segment from oldSqrt down to sqrtAtLower
         // with L active. Nothing attributed past the boundary.
@@ -756,14 +752,10 @@ describe("CLStakedLiquidity", () => {
         );
         const expectedDelta0 = atBoundary.amount0 - before.amount0;
         const expectedDelta1 = atBoundary.amount1 - before.amount1;
-        expect(result.stakedDelta0 - expectedDelta0).toBeGreaterThanOrEqual(
-          -1n,
-        );
-        expect(result.stakedDelta0 - expectedDelta0).toBeLessThanOrEqual(1n);
-        expect(result.stakedDelta1 - expectedDelta1).toBeGreaterThanOrEqual(
-          -1n,
-        );
-        expect(result.stakedDelta1 - expectedDelta1).toBeLessThanOrEqual(1n);
+        expect(result.delta0 - expectedDelta0).toBeGreaterThanOrEqual(-1n);
+        expect(result.delta0 - expectedDelta0).toBeLessThanOrEqual(1n);
+        expect(result.delta1 - expectedDelta1).toBeGreaterThanOrEqual(-1n);
+        expect(result.delta1 - expectedDelta1).toBeLessThanOrEqual(1n);
       });
 
       it("telescopes Deposit + swap + Withdraw to ~0 when the position exits range mid-swap (#666 invariant)", () => {
@@ -793,7 +785,7 @@ describe("CLStakedLiquidity", () => {
 
         // 2) Swap moves price down through the lower edge. Per-segment
         //    attribution credits only the in-range segment.
-        const swapResult = processTickCrossingsForStaked(
+        const swapResult = processTickCrossings(
           CHAIN_ID,
           POOL_ADDRESS,
           tickAtDeposit,
@@ -819,13 +811,9 @@ describe("CLStakedLiquidity", () => {
         );
 
         const net0 =
-          depositAmounts.amount0 +
-          swapResult.stakedDelta0 -
-          withdrawAmounts.amount0;
+          depositAmounts.amount0 + swapResult.delta0 - withdrawAmounts.amount0;
         const net1 =
-          depositAmounts.amount1 +
-          swapResult.stakedDelta1 -
-          withdrawAmounts.amount1;
+          depositAmounts.amount1 + swapResult.delta1 - withdrawAmounts.amount1;
 
         // Tolerance: a few wei from bigint truncation across the three steps.
         expect(net0).toBeGreaterThanOrEqual(-2n);
@@ -844,7 +832,7 @@ describe("CLStakedLiquidity", () => {
         const oldTick = 200n;
         const newTick = 300n;
 
-        const result = processTickCrossingsForStaked(
+        const result = processTickCrossings(
           CHAIN_ID,
           POOL_ADDRESS,
           oldTick,
@@ -859,9 +847,9 @@ describe("CLStakedLiquidity", () => {
           [L, -L],
         );
 
-        expect(result.stakedLiquidityInRange).toBe(0n);
-        expect(result.stakedDelta0).toBe(0n);
-        expect(result.stakedDelta1).toBe(0n);
+        expect(result.liquidityInRange).toBe(0n);
+        expect(result.delta0).toBe(0n);
+        expect(result.delta1).toBe(0n);
       });
 
       it("attributes only the in-range segment when the position enters range mid-swap", () => {
@@ -877,7 +865,7 @@ describe("CLStakedLiquidity", () => {
         const newSqrt = sqrtAt(newTick);
         const sqrtAtLower = sqrtAt(tickLower);
 
-        const result = processTickCrossingsForStaked(
+        const result = processTickCrossings(
           CHAIN_ID,
           POOL_ADDRESS,
           oldTick,
@@ -892,7 +880,7 @@ describe("CLStakedLiquidity", () => {
           [L, -L],
         );
 
-        expect(result.stakedLiquidityInRange).toBe(L);
+        expect(result.liquidityInRange).toBe(L);
 
         // Expected: single in-range segment from sqrtAt(-100) (boundary cross)
         // up to newSqrt. Equivalent to position-amounts diff at those prices.
@@ -910,14 +898,10 @@ describe("CLStakedLiquidity", () => {
         );
         const expectedDelta0 = after.amount0 - atBoundary.amount0;
         const expectedDelta1 = after.amount1 - atBoundary.amount1;
-        expect(result.stakedDelta0 - expectedDelta0).toBeGreaterThanOrEqual(
-          -1n,
-        );
-        expect(result.stakedDelta0 - expectedDelta0).toBeLessThanOrEqual(1n);
-        expect(result.stakedDelta1 - expectedDelta1).toBeGreaterThanOrEqual(
-          -1n,
-        );
-        expect(result.stakedDelta1 - expectedDelta1).toBeLessThanOrEqual(1n);
+        expect(result.delta0 - expectedDelta0).toBeGreaterThanOrEqual(-1n);
+        expect(result.delta0 - expectedDelta0).toBeLessThanOrEqual(1n);
+        expect(result.delta1 - expectedDelta1).toBeGreaterThanOrEqual(-1n);
+        expect(result.delta1 - expectedDelta1).toBeLessThanOrEqual(1n);
       });
 
       it("returns zero deltas when oldSqrt === newSqrt (no movement) regardless of tick", () => {
@@ -925,7 +909,7 @@ describe("CLStakedLiquidity", () => {
         // No reserve flow → no attribution.
         const L = 10n ** 18n;
         const sqrt = sqrtAt(0n);
-        const result = processTickCrossingsForStaked(
+        const result = processTickCrossings(
           CHAIN_ID,
           POOL_ADDRESS,
           -50n,
@@ -939,8 +923,8 @@ describe("CLStakedLiquidity", () => {
           [-100n, 100n],
           [L, -L],
         );
-        expect(result.stakedDelta0).toBe(0n);
-        expect(result.stakedDelta1).toBe(0n);
+        expect(result.delta0).toBe(0n);
+        expect(result.delta1).toBe(0n);
       });
     });
 
@@ -1030,7 +1014,7 @@ describe("CLStakedLiquidity", () => {
         let currentTick = startTick;
         for (let cycle = 0; cycle < 25; cycle++) {
           for (const target of trajectory) {
-            const result = processTickCrossingsForStaked(
+            const result = processTickCrossings(
               CHAIN_ID,
               POOL_ADDRESS,
               currentTick,
@@ -1044,8 +1028,8 @@ describe("CLStakedLiquidity", () => {
               edges,
               nets,
             );
-            const sum0 = stakedReserve0 + result.stakedDelta0;
-            const sum1 = stakedReserve1 + result.stakedDelta1;
+            const sum0 = stakedReserve0 + result.delta0;
+            const sum1 = stakedReserve1 + result.delta1;
             stakedReserve0 = sum0 < 0n ? 0n : sum0;
             stakedReserve1 = sum1 < 0n ? 0n : sum1;
             expect(stakedReserve0).toBeGreaterThanOrEqual(0n);
@@ -1259,9 +1243,9 @@ describe("CLStakedLiquidity", () => {
       ).toBe(0n);
     });
 
-    it("agrees with processTickCrossingsForStaked walking up from the lowest edge", () => {
+    it("agrees with processTickCrossings walking up from the lowest edge", () => {
       // Build a non-trivial edge set and verify deriveStakedLiquidityInRange
-      // matches what processTickCrossingsForStaked produces by walking up from
+      // matches what processTickCrossings produces by walking up from
       // far below to the target tick.
       const edges = [-200n, -100n, 100n, 300n];
       const nets = [400n, 200n, -100n, -500n];
@@ -1271,7 +1255,7 @@ describe("CLStakedLiquidity", () => {
         log: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
       } as unknown as handlerContext;
 
-      const walked = processTickCrossingsForStaked(
+      const walked = processTickCrossings(
         CHAIN_ID,
         POOL_ADDRESS,
         -500n,
@@ -1287,7 +1271,7 @@ describe("CLStakedLiquidity", () => {
       );
 
       expect(deriveStakedLiquidityInRange(target, edges, nets)).toBe(
-        walked.stakedLiquidityInRange,
+        walked.liquidityInRange,
       );
     });
   });

--- a/test/Aggregators/CLStakedLiquidityEdgeSanity.test.ts
+++ b/test/Aggregators/CLStakedLiquidityEdgeSanity.test.ts
@@ -1,8 +1,8 @@
 import type { Token, handlerContext } from "generated";
 import { CLGauge, MockDb, NFPM } from "../../generated/src/TestHelpers.gen";
 import {
-  applyStakedPositionToEdges,
-  deriveStakedLiquidityInRange,
+  applyPositionToEdges,
+  deriveLiquidityInRange,
   processTickCrossings,
 } from "../../src/Aggregators/CLStakedLiquidity";
 import {
@@ -206,7 +206,7 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
       );
 
       // Under test: apply to the sparse edge list.
-      const out = applyStakedPositionToEdges(
+      const out = applyPositionToEdges(
         edges,
         nets,
         tickLower,
@@ -306,7 +306,7 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
   // Regression coverage for issue #719: cover the three concrete drift paths
   // from the bug report plus the closed-system invariant. Each test pins the
   // structural property that the fix introduces:
-  //   stakedLiquidityInRange === deriveStakedLiquidityInRange(currentTick,
+  //   stakedLiquidityInRange === deriveLiquidityInRange(currentTick,
   //                                                            stakedTickEdges,
   //                                                            stakedTickEdgeNets)
   // ALWAYS. The cached running counter is replaced by derivation, so the field
@@ -371,7 +371,7 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
       expect(updated).toBeDefined();
       if (!updated) return;
 
-      // Edges populated by applyStakedPositionToEdges.
+      // Edges populated by applyPositionToEdges.
       expect(updated.stakedTickEdges).toEqual([tickLower, tickUpper]);
       expect(updated.stakedTickEdgeNets).toEqual([liquidity, -liquidity]);
       // Counter MUST equal derive(currentTick=0n, edges, nets):
@@ -379,7 +379,7 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
       //   edge  100 > 0 → excluded
       // ⇒ stakedLiquidityInRange = 500. Legacy gated path would leave 0n.
       expect(updated.stakedLiquidityInRange).toBe(
-        deriveStakedLiquidityInRange(
+        deriveLiquidityInRange(
           updated.tick ?? 0n,
           updated.stakedTickEdges,
           updated.stakedTickEdgeNets,
@@ -392,7 +392,7 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
       // Simulates the "edge map disagrees with counter" mode: the aggregator's
       // stakedLiquidityInRange is poisoned (non-zero with empty edges) from
       // prior drift, and an incoming Deposit gets rejected by
-      // applyStakedPositionToEdges (degenerate range: tickLower >= tickUpper).
+      // applyPositionToEdges (degenerate range: tickLower >= tickUpper).
       // With derivation, the rejection still triggers a heal — the counter is
       // overwritten with derive(currentTick, edges, nets), which on empty
       // edges is 0. The legacy gated path skipped the counter on rejection,
@@ -457,7 +457,7 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
       expect(updated.stakedTickEdgeNets).toEqual([]);
       // The healing invariant: counter must equal derive at the current tick.
       expect(updated.stakedLiquidityInRange).toBe(
-        deriveStakedLiquidityInRange(
+        deriveLiquidityInRange(
           updated.tick ?? 0n,
           updated.stakedTickEdges,
           updated.stakedTickEdgeNets,
@@ -471,7 +471,7 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
       // in range (counter += L). Price moves out of range. NFPM
       // IncreaseLiquidity bumps position liquidity, but the legacy gate
       // `isPositionInRange(...)` skips the counter update while the edge
-      // nets still update via applyStakedPositionToEdges. With derivation,
+      // nets still update via applyPositionToEdges. With derivation,
       // the counter is recomputed from the updated edges at the (out-of-range)
       // tick — both edges land ≤ currentTick, so the nets sum to zero and the
       // counter heals from "stale L" to "0".
@@ -555,7 +555,7 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
         tick: bigint;
       };
 
-      // Edges absorbed the +increaseDelta (consistent with applyStakedPositionToEdges).
+      // Edges absorbed the +increaseDelta (consistent with applyPositionToEdges).
       expect(written.stakedTickEdges).toEqual([tickLower, tickUpper]);
       expect(written.stakedTickEdgeNets).toEqual([
         positionLiquidity + increaseDelta,
@@ -565,7 +565,7 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
       // edges contribute → +(L+Δ) - (L+Δ) = 0. The legacy code would have
       // kept the counter at `positionLiquidity` (stale).
       expect(written.stakedLiquidityInRange).toBe(
-        deriveStakedLiquidityInRange(
+        deriveLiquidityInRange(
           written.tick ?? 0n,
           written.stakedTickEdges,
           written.stakedTickEdgeNets,
@@ -631,7 +631,7 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
       expect(postDeposit).toBeDefined();
       if (!postDeposit) return;
       expect(postDeposit.stakedLiquidityInRange).toBe(
-        deriveStakedLiquidityInRange(
+        deriveLiquidityInRange(
           postDeposit.tick ?? 0n,
           postDeposit.stakedTickEdges,
           postDeposit.stakedTickEdgeNets,
@@ -681,7 +681,7 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
       expect(postWithdraw.stakedTickEdges).toEqual([]);
       expect(postWithdraw.stakedTickEdgeNets).toEqual([]);
       expect(postWithdraw.stakedLiquidityInRange).toBe(
-        deriveStakedLiquidityInRange(
+        deriveLiquidityInRange(
           postWithdraw.tick ?? 0n,
           postWithdraw.stakedTickEdges,
           postWithdraw.stakedTickEdgeNets,

--- a/test/Aggregators/CLStakedLiquidityEdgeSanity.test.ts
+++ b/test/Aggregators/CLStakedLiquidityEdgeSanity.test.ts
@@ -3,7 +3,7 @@ import { CLGauge, MockDb, NFPM } from "../../generated/src/TestHelpers.gen";
 import {
   applyStakedPositionToEdges,
   deriveStakedLiquidityInRange,
-  processTickCrossingsForStaked,
+  processTickCrossings,
 } from "../../src/Aggregators/CLStakedLiquidity";
 import {
   NonFungiblePositionId,
@@ -15,14 +15,14 @@ import { setupCommon } from "../EventHandlers/Pool/common";
 import { sqrtAt } from "./common";
 
 /**
- * Co-located sanity test for #649: replacing `processTickCrossingsForStaked`
+ * Co-located sanity test for #649: replacing `processTickCrossings`
  * fan-out with the sparse stakedTickEdges / stakedTickEdgeNets list on
  * Pool.
  *
  * Two assertions:
  *   (a) The edge list stays sorted + monotone under arbitrary gauge
  *       deposit/withdraw ordering across ≥200 synthetic events.
- *   (b) `processTickCrossingsForStaked` returns the same staked-liq-in-range
+ *   (b) `processTickCrossings` returns the same staked-liq-in-range
  *       delta as a pure in-test baseline map for a swap window that crosses
  *       multiple edges.
  */
@@ -182,7 +182,7 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
     }
   });
 
-  it("(b) processTickCrossingsForStaked returns the same in-range delta as a pure-map baseline across a swap window crossing multiple edges", async () => {
+  it("(b) processTickCrossings returns the same in-range delta as a pure-map baseline across a swap window crossing multiple edges", async () => {
     const mockPoolAddress = toChecksumAddress(`0x${"1".repeat(40)}`);
     // Build a realistic edge set by simulating 50 stake events and walking
     // the exact same events through a pure-map baseline.
@@ -222,7 +222,7 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
     const newTick = 400n;
 
     // Baseline: walk the map directly and sum liquidityNet for ticks ≤ newTick.
-    // Post-#719, processTickCrossingsForStaked returns derive(newTick) rather
+    // Post-#719, processTickCrossings returns derive(newTick) rather
     // than (seed + delta-across-window) — the function self-heals from edge
     // state regardless of the cached seed.
     let baselineResult = 0n;
@@ -243,7 +243,7 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
       // biome-ignore lint/suspicious/noExplicitAny: test-only shape
     } as any;
 
-    const newResult = processTickCrossingsForStaked(
+    const newResult = processTickCrossings(
       chainId,
       mockPoolAddress,
       oldTick,
@@ -258,7 +258,7 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
       nets,
     );
 
-    expect(newResult.stakedLiquidityInRange).toBe(baselineResult);
+    expect(newResult.liquidityInRange).toBe(baselineResult);
 
     // Sanity: the window actually crosses multiple edges.
     const crossingCount = edges.filter(
@@ -279,7 +279,7 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
       }
     }
 
-    const downResult = processTickCrossingsForStaked(
+    const downResult = processTickCrossings(
       chainId,
       mockPoolAddress,
       oldTickDown,
@@ -294,13 +294,13 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
       nets,
     );
 
-    expect(downResult.stakedLiquidityInRange).toBe(baselineDownResult);
+    expect(downResult.liquidityInRange).toBe(baselineDownResult);
     // Sanity: the round trip exits at derive(newTickDown), which on this
     // edge set is non-zero because several positions have tickLower ≤ -400
     // (tickLowers start at -500 and step up). The walker's seed input is
     // no longer load-bearing (issue #719) — the return is purely a function
     // of (newTickDown, edges, nets).
-    expect(downResult.stakedLiquidityInRange).toBeGreaterThan(0n);
+    expect(downResult.liquidityInRange).toBeGreaterThan(0n);
   });
 
   // Regression coverage for issue #719: cover the three concrete drift paths

--- a/test/Aggregators/Pool.test.ts
+++ b/test/Aggregators/Pool.test.ts
@@ -570,7 +570,7 @@ describe("Pool Functions", () => {
     // negative. The accumulator path clamps both fields to >= 0n and emits
     // [NEG_STAKED_RESERVE_GUARD] with {poolAddress, chainId, priorStakedReserve,
     // delta, clampedTo}. Mirrors the #702 [NEG_RESERVE_GUARD] shape; the
-    // structural rounding fix in segmentStakedReserveDelta bounds the residual
+    // structural rounding fix in segmentReserveDelta bounds the residual
     // drift so the clamp catches only sub-wei truncation noise, not real
     // liquidity imbalance.
     //

--- a/test/Aggregators/Pool.test.ts
+++ b/test/Aggregators/Pool.test.ts
@@ -565,6 +565,101 @@ describe("Pool Functions", () => {
       expect(updated.stakedTickEdgeNets).toEqual([]);
     });
 
+    // Issue #803: the TOTAL-liquidity parallel pair (tickEdges, tickEdgeNets)
+    // gets the same lockstep guard the staked pair has. A presence- or
+    // length-mismatched diff would silently desync the map the swap path
+    // binary-searches for the fee-free reserve geometry, so updatePool drops
+    // both edge fields, logs [TICK_EDGE_DRIFT], and retains the prior pair.
+    // Unlike the staked guard, liquidityInRange is NOT dropped (it comes from
+    // event.params.liquidity, not from this map).
+    it("drops tickEdges/tickEdgeNets together on a presence mismatch (#803)", async () => {
+      await updatePool(
+        {
+          tickEdges: [100n, 200n, 300n],
+          // tickEdgeNets intentionally omitted — half-written diff
+        },
+        {
+          ...(liquidityPoolAggregator as Pool),
+          tickEdges: [100n, 200n],
+          tickEdgeNets: [500n, -500n],
+        },
+        timestamp,
+        mockContext as handlerContext,
+        10,
+        blockNumber,
+      );
+
+      const poolStore = mockContext.Pool;
+      if (!poolStore) {
+        throw new Error("test setup: Pool store must exist");
+      }
+      const updated = vi.mocked(poolStore.set).mock.calls.at(-1)?.[0] as Pool;
+      // Prior consistent pair retained, not the half-written diff.
+      expect(updated.tickEdges).toEqual([100n, 200n]);
+      expect(updated.tickEdgeNets).toEqual([500n, -500n]);
+      expect(vi.mocked(mockContext.log?.error)).toHaveBeenCalledWith(
+        expect.stringContaining("[TICK_EDGE_DRIFT]"),
+      );
+    });
+
+    it("drops tickEdges/tickEdgeNets together on a length mismatch (#803)", async () => {
+      await updatePool(
+        {
+          tickEdges: [100n, 200n, 300n],
+          tickEdgeNets: [500n, -500n], // length 2 ≠ 3
+        },
+        {
+          ...(liquidityPoolAggregator as Pool),
+          tickEdges: [100n, 200n],
+          tickEdgeNets: [500n, -500n],
+        },
+        timestamp,
+        mockContext as handlerContext,
+        10,
+        blockNumber,
+      );
+
+      const poolStore = mockContext.Pool;
+      if (!poolStore) {
+        throw new Error("test setup: Pool store must exist");
+      }
+      const updated = vi.mocked(poolStore.set).mock.calls.at(-1)?.[0] as Pool;
+      expect(updated.tickEdges).toEqual([100n, 200n]);
+      expect(updated.tickEdgeNets).toEqual([500n, -500n]);
+      expect(vi.mocked(mockContext.log?.error)).toHaveBeenCalledWith(
+        expect.stringContaining("[TICK_EDGE_DRIFT]"),
+      );
+    });
+
+    it("writes a consistent tickEdges/tickEdgeNets pair through unchanged (#803)", async () => {
+      await updatePool(
+        {
+          tickEdges: [100n, 200n, 300n],
+          tickEdgeNets: [500n, -200n, -300n],
+        },
+        {
+          ...(liquidityPoolAggregator as Pool),
+          tickEdges: [100n, 200n],
+          tickEdgeNets: [500n, -500n],
+        },
+        timestamp,
+        mockContext as handlerContext,
+        10,
+        blockNumber,
+      );
+
+      const poolStore = mockContext.Pool;
+      if (!poolStore) {
+        throw new Error("test setup: Pool store must exist");
+      }
+      const updated = vi.mocked(poolStore.set).mock.calls.at(-1)?.[0] as Pool;
+      expect(updated.tickEdges).toEqual([100n, 200n, 300n]);
+      expect(updated.tickEdgeNets).toEqual([500n, -200n, -300n]);
+      expect(vi.mocked(mockContext.log?.error)).not.toHaveBeenCalledWith(
+        expect.stringContaining("[TICK_EDGE_DRIFT]"),
+      );
+    });
+
     // Regression test for issue #771: stakedReserve0/stakedReserve1 are
     // running counters of staked LP-deposited capital and must never persist
     // negative. The accumulator path clamps both fields to >= 0n and emits

--- a/test/EventHandlers/CLPool/CLPoolSwapLogic.test.ts
+++ b/test/EventHandlers/CLPool/CLPoolSwapLogic.test.ts
@@ -1,9 +1,9 @@
+import { TickMath } from "@uniswap/v3-sdk";
 import type { CLPool_Swap_event, Token, handlerContext } from "generated";
 import { TEN_TO_THE_18_BI, toChecksumAddress } from "../../../src/Constants";
 import type { Pool } from "../../../src/EntityTypes";
 import {
   calculateSwapFees,
-  calculateSwapLiquidityChanges,
   calculateSwapVolume,
   processCLPoolSwap,
 } from "../../../src/EventHandlers/CLPool/CLPoolSwapLogic";
@@ -456,91 +456,6 @@ describe("CLPoolSwapLogic", () => {
     });
   });
 
-  describe("calculateSwapLiquidityChanges", () => {
-    it("should exclude fees from the input token and leave output unchanged", () => {
-      const result = calculateSwapLiquidityChanges(
-        mockEvent,
-        mockPool,
-        mockToken0,
-        mockToken1,
-        CL_FEE_30,
-      );
-      const fee0 = (1n * TEN_TO_THE_18_BI * CL_FEE_30) / 1000000n;
-      expect(result.newReserve0).toBe(
-        mockPool.reserve0 + 1n * TEN_TO_THE_18_BI - fee0,
-      );
-      expect(result.newReserve1).toBe(
-        mockPool.reserve1 - 2n * TEN_TO_THE_18_BI,
-      );
-    });
-
-    it("should not deduct fees when both amounts are negative (output)", () => {
-      const eventWithNegativeAmounts: CLPool_Swap_event = {
-        ...mockEvent,
-        params: {
-          ...mockEvent.params,
-          amount0: -5n * TEN_TO_THE_18_BI,
-          amount1: -3n * TEN_TO_THE_18_BI,
-        },
-      };
-      const result = calculateSwapLiquidityChanges(
-        eventWithNegativeAmounts,
-        mockPool,
-        mockToken0,
-        mockToken1,
-        CL_FEE_30,
-      );
-      expect(result.newReserve0).toBe(
-        mockPool.reserve0 - 5n * TEN_TO_THE_18_BI,
-      );
-      expect(result.newReserve1).toBe(
-        mockPool.reserve1 - 3n * TEN_TO_THE_18_BI,
-      );
-    });
-
-    it("should deduct fees from both sides when both amounts are positive", () => {
-      const eventWithPositiveAmounts: CLPool_Swap_event = {
-        ...mockEvent,
-        params: {
-          ...mockEvent.params,
-          amount0: 5n * TEN_TO_THE_18_BI,
-          amount1: 3n * TEN_TO_THE_18_BI,
-        },
-      };
-      const result = calculateSwapLiquidityChanges(
-        eventWithPositiveAmounts,
-        mockPool,
-        mockToken0,
-        mockToken1,
-        CL_FEE_30,
-      );
-      const fee0 = (5n * TEN_TO_THE_18_BI * CL_FEE_30) / 1000000n;
-      const fee1 = (3n * TEN_TO_THE_18_BI * CL_FEE_30) / 1000000n;
-      expect(result.newReserve0).toBe(
-        mockPool.reserve0 + 5n * TEN_TO_THE_18_BI - fee0,
-      );
-      expect(result.newReserve1).toBe(
-        mockPool.reserve1 + 3n * TEN_TO_THE_18_BI - fee1,
-      );
-    });
-
-    it("should not deduct fees when fee rate is zero", () => {
-      const result = calculateSwapLiquidityChanges(
-        mockEvent,
-        mockPool,
-        undefined,
-        undefined,
-        0n,
-      );
-      expect(result.newReserve0).toBe(
-        mockPool.reserve0 + mockEvent.params.amount0,
-      );
-      expect(result.newReserve1).toBe(
-        mockPool.reserve1 + mockEvent.params.amount1,
-      );
-    });
-  });
-
   describe("processCLPoolSwap", () => {
     // TVL routes through calculateTotalUSD which is gated on PriceTrust (#755).
     // File-level mockToken0/mockToken1 are deliberately non-WL for the #699/#737
@@ -573,11 +488,13 @@ describe("CLPoolSwapLogic", () => {
       expect(result.liquidityPoolDiff.incrementalTotalFeesGeneratedUSD).toBe(
         3000000000000000n,
       ); // 3e15
-      // TVL: reserves exclude the 0.3% fee on the input side (amount0 = +1e18)
-      // reserve0 = 10e18 + (1e18 - 3e15) = 10.997e18, reserve1 = 6e18 - 2e18 = 4e18
-      // TVL = 10.997 * $1 + 4 * $2 = $18.997
+      // Reserve deltas now derive from pool geometry, not `amount − fee` (#803).
+      // This mock has no tick-edge map (tickEdges: []), so the geometry seed is 0
+      // and the swap moves no principal → reserves stay 10e18 / 6e18.
+      // TVL = 10 * $1 + 6 * $2 = $22. (Geometry over a real edge map + price move
+      // is covered by the fee-independence test below.)
       expect(result.liquidityPoolDiff.currentTotalLiquidityUSD).toBe(
-        18997000000000000000n,
+        22n * TEN_TO_THE_18_BI,
       );
 
       expect(result.userSwapDiff.incrementalNumberOfSwaps).toBe(1n);
@@ -625,32 +542,60 @@ describe("CLPoolSwapLogic", () => {
       expect(result.liquidityPoolDiff.token1Price).toBe(mockPool.token1Price);
     });
 
-    it("should exclude fees from reserve increments (input side only)", async () => {
-      const eventWithPositiveAmounts: CLPool_Swap_event = {
+    it("derives reserve deltas from geometry, independent of the fee rate (#803)", async () => {
+      // #803: the swap reserve delta is now L·ΔsqrtPrice integrated over the tick
+      // map — fee-free by construction — replacing the old `amount − feeRate·amount`
+      // term whose stale hourly fee sample drifted on dynamic-fee pools. The
+      // defining property: changing the fee rate must NOT change the reserves.
+      const L = 1_000_000n * TEN_TO_THE_18_BI;
+      const sqrtAtTick = (t: number) =>
+        BigInt(TickMath.getSqrtRatioAtTick(t).toString());
+      // Pool at tick 0 with a single full-range position (in-range liquidity = L).
+      const geoBase: Pool = {
+        ...mockPool,
+        tick: 0n,
+        sqrtPriceX96: sqrtAtTick(0),
+        tickSpacing: 1n,
+        liquidityInRange: L,
+        tickEdges: [-887272n, 887272n],
+        tickEdgeNets: [L, -L],
+      };
+      // Swap moves the price up from tick 0 to tick 100 (stays within the range).
+      const geoEvent: CLPool_Swap_event = {
         ...mockEvent,
         params: {
           ...mockEvent.params,
-          amount0: 5n * TEN_TO_THE_18_BI,
-          amount1: 3n * TEN_TO_THE_18_BI,
+          tick: 100n,
+          sqrtPriceX96: sqrtAtTick(100),
         },
       };
 
-      const result = await processCLPoolSwap(
-        eventWithPositiveAmounts,
-        mockPool,
-        mockToken0,
-        mockToken1,
+      const hiFee = await processCLPoolSwap(
+        geoEvent,
+        { ...geoBase, currentFee: CL_FEE_100, baseFee: CL_FEE_100 },
+        wlToken0,
+        wlToken1,
+        mockContext,
+      );
+      const zeroFee = await processCLPoolSwap(
+        geoEvent,
+        { ...geoBase, currentFee: 0n, baseFee: 0n },
+        wlToken0,
+        wlToken1,
         mockContext,
       );
 
-      const fee0 = (5n * TEN_TO_THE_18_BI * CL_FEE_30) / 1000000n;
-      const fee1 = (3n * TEN_TO_THE_18_BI * CL_FEE_30) / 1000000n;
-      expect(result.liquidityPoolDiff.incrementalReserve0).toBe(
-        5n * TEN_TO_THE_18_BI - fee0,
+      // Fee-independence: identical reserve deltas at a 1% fee and at 0% fee.
+      expect(hiFee.liquidityPoolDiff.incrementalReserve0).toBe(
+        zeroFee.liquidityPoolDiff.incrementalReserve0,
       );
-      expect(result.liquidityPoolDiff.incrementalReserve1).toBe(
-        3n * TEN_TO_THE_18_BI - fee1,
+      expect(hiFee.liquidityPoolDiff.incrementalReserve1).toBe(
+        zeroFee.liquidityPoolDiff.incrementalReserve1,
       );
+      // Non-triviality: the up-move actually moved principal — token1 in (+),
+      // token0 out (−), matching the SqrtPriceMath sign convention.
+      expect(hiFee.liquidityPoolDiff.incrementalReserve1).toBeGreaterThan(0n);
+      expect(hiFee.liquidityPoolDiff.incrementalReserve0).toBeLessThan(0n);
     });
 
     it("should calculate whitelisted volume correctly", async () => {

--- a/test/EventHandlers/NFPM/NFPMCommonLogic.test.ts
+++ b/test/EventHandlers/NFPM/NFPMCommonLogic.test.ts
@@ -2,8 +2,8 @@ import { TickMath } from "@uniswap/v3-sdk";
 import type { NonFungiblePosition, handlerContext } from "generated";
 import { MockDb } from "../../../generated/src/TestHelpers.gen";
 import {
-  applyStakedPositionToEdges,
-  deriveStakedLiquidityInRange,
+  applyPositionToEdges,
+  deriveLiquidityInRange,
 } from "../../../src/Aggregators/CLStakedLiquidity";
 import { type PoolData, updatePool } from "../../../src/Aggregators/Pool";
 import {
@@ -287,7 +287,7 @@ describe("NFPMCommonLogic", () => {
     const blockNumber = 123456;
 
     beforeEach(() => {
-      vi.mocked(deriveStakedLiquidityInRange).mockReset();
+      vi.mocked(deriveLiquidityInRange).mockReset();
       vi.mocked(updatePool).mockReset();
       vi.mocked(updatePool).mockResolvedValue(undefined);
       vi.mocked(calculatePositionAmountsFromLiquidity).mockReset();
@@ -295,17 +295,17 @@ describe("NFPMCommonLogic", () => {
         amount0: 100n,
         amount1: 200n,
       });
-      // applyStakedPositionToEdges is auto-mocked by vi.mock above; return a
+      // applyPositionToEdges is auto-mocked by vi.mock above; return a
       // valid shape so NFPMCommonLogic's destructure doesn't trip.
-      vi.mocked(applyStakedPositionToEdges).mockReset();
-      vi.mocked(applyStakedPositionToEdges).mockReturnValue({
+      vi.mocked(applyPositionToEdges).mockReset();
+      vi.mocked(applyPositionToEdges).mockReturnValue({
         edges: [-200n, 200n],
         nets: [5000n, -5000n],
       });
     });
 
     it("should apply the liquidity delta to the aggregator edge list", async () => {
-      vi.mocked(deriveStakedLiquidityInRange).mockReturnValue(0n);
+      vi.mocked(deriveLiquidityInRange).mockReturnValue(0n);
 
       await updateStakedPositionLiquidity(
         stakedPosition,
@@ -317,7 +317,7 @@ describe("NFPMCommonLogic", () => {
         blockNumber,
       );
 
-      expect(applyStakedPositionToEdges).toHaveBeenCalledWith(
+      expect(applyPositionToEdges).toHaveBeenCalledWith(
         poolData.liquidityPoolAggregator.stakedTickEdges,
         poolData.liquidityPoolAggregator.stakedTickEdgeNets,
         stakedPosition.tickLower,
@@ -329,8 +329,8 @@ describe("NFPMCommonLogic", () => {
     it("should derive stakedLiquidityInRange from updated edges at the current tick", async () => {
       // Post-#719 the counter is no longer "current + delta"; it is rederived
       // from the edges on every write, so the test pins the value the
-      // (mocked) deriveStakedLiquidityInRange returns.
-      vi.mocked(deriveStakedLiquidityInRange).mockReturnValue(6000n);
+      // (mocked) deriveLiquidityInRange returns.
+      vi.mocked(deriveLiquidityInRange).mockReturnValue(6000n);
 
       await updateStakedPositionLiquidity(
         stakedPosition,
@@ -343,8 +343,8 @@ describe("NFPMCommonLogic", () => {
       );
 
       // Derivation is called with (currentTick, updatedEdges, updatedNets) —
-      // the edges/nets produced by the (mocked) applyStakedPositionToEdges.
-      expect(deriveStakedLiquidityInRange).toHaveBeenCalledWith(
+      // the edges/nets produced by the (mocked) applyPositionToEdges.
+      expect(deriveLiquidityInRange).toHaveBeenCalledWith(
         0n,
         [-200n, 200n],
         [5000n, -5000n],
@@ -386,7 +386,7 @@ describe("NFPMCommonLogic", () => {
       // trip on the user side too. Position.owner is the real staker, not
       // the gauge, because handleRegularTransfer skips owner updates on
       // gauge stake/unstake transfers (see NFPMTransferLogic.ts:300-318).
-      vi.mocked(deriveStakedLiquidityInRange).mockReturnValue(6000n);
+      vi.mocked(deriveLiquidityInRange).mockReturnValue(6000n);
       vi.mocked(loadOrCreateUserData).mockReset();
       vi.mocked(updateUserStatsPerPool).mockReset();
       const mockUserData = createMockUserStatsPerPool({
@@ -423,7 +423,7 @@ describe("NFPMCommonLogic", () => {
     });
 
     it("should use negative direction for decrease (negative liquidityDelta)", async () => {
-      vi.mocked(deriveStakedLiquidityInRange).mockReturnValue(-2000n);
+      vi.mocked(deriveLiquidityInRange).mockReturnValue(-2000n);
 
       await updateStakedPositionLiquidity(
         stakedPosition,
@@ -467,7 +467,7 @@ describe("NFPMCommonLogic", () => {
       // Derivation is structural — there is no longer an "in-range" gate.
       // The function pins the value (representing derive at an out-of-range
       // tick, which would naturally be 0n for a single-position edge set).
-      vi.mocked(deriveStakedLiquidityInRange).mockReturnValue(0n);
+      vi.mocked(deriveLiquidityInRange).mockReturnValue(0n);
 
       await updateStakedPositionLiquidity(
         stakedPosition,
@@ -510,7 +510,7 @@ describe("NFPMCommonLogic", () => {
       // Issue #780 also requires incrementalCurrentLiquidityStaked on this
       // path so the Withdraw guard balances even if the pool was never
       // Initialize'd in the indexed range.
-      vi.mocked(deriveStakedLiquidityInRange).mockReturnValue(42n);
+      vi.mocked(deriveLiquidityInRange).mockReturnValue(42n);
 
       const poolDataZeroPrice: PoolData = {
         ...poolData,

--- a/test/EventHandlers/Pool/common.ts
+++ b/test/EventHandlers/Pool/common.ts
@@ -167,6 +167,8 @@ export function setupCommon() {
     hasStakes: false,
     stakedTickEdges: [],
     stakedTickEdgeNets: [],
+    tickEdges: [],
+    tickEdgeNets: [],
     totalFlashLoanFees0: 0n,
     totalFlashLoanFees1: 0n,
     totalFlashLoanFeesUSD: 0n,
@@ -455,6 +457,10 @@ export function setupCommon() {
       stakedTickEdgeNets: [
         ...(overrides.stakedTickEdgeNets ??
           mockLiquidityPoolData.stakedTickEdgeNets),
+      ],
+      tickEdges: [...(overrides.tickEdges ?? mockLiquidityPoolData.tickEdges)],
+      tickEdgeNets: [
+        ...(overrides.tickEdgeNets ?? mockLiquidityPoolData.tickEdgeNets),
       ],
       poolAddress,
       chainId,

--- a/test/EventHandlers/PoolLauncher/PoolLauncherLogic.test.ts
+++ b/test/EventHandlers/PoolLauncher/PoolLauncherLogic.test.ts
@@ -33,6 +33,8 @@ describe("PoolLauncherLogic", () => {
             ...entity,
             stakedTickEdges: [...entity.stakedTickEdges],
             stakedTickEdgeNets: [...entity.stakedTickEdgeNets],
+            tickEdges: [...entity.tickEdges],
+            tickEdgeNets: [...entity.tickEdgeNets],
           });
         },
       },

--- a/test/Snapshots/SchemaParity.test.ts
+++ b/test/Snapshots/SchemaParity.test.ts
@@ -57,6 +57,12 @@ describe("Snapshot schema parity", () => {
         // IncreaseLiquidity/DecreaseLiquidity events.
         "stakedTickEdges",
         "stakedTickEdgeNets",
+        // Total-liquidity analog of the staked edge map (#803), consumed by the
+        // swap path to derive the fee-free reserve delta. Same reasoning as the
+        // staked pair above: derived per-tick state, not an hourly metric — the
+        // underlying position history lives in CLPool Mint/Burn events.
+        "tickEdges",
+        "tickEdgeNets",
       ],
     ],
     ["UserStatsPerPool", ["firstActivityTimestamp", "lastSnapshotTimestamp"]],

--- a/test/Snapshots/SchemaParity.test.ts
+++ b/test/Snapshots/SchemaParity.test.ts
@@ -46,12 +46,12 @@ describe("Snapshot schema parity", () => {
         // never changes — no analytical value in trending it hourly. Used only
         // to clamp roundBlockToInterval above the pool's bytecode boundary.
         "createdBlockNumber",
-        // Control-flow latch for processTickCrossingsForStaked — once true, stays
+        // Control-flow latch for processTickCrossings — once true, stays
         // true. No analytical value in trending it over time.
         "hasStakes",
         // Implementation detail of the #649 swap-path optimization: a sparse
         // in-memory liquidityNet list keyed by tick, consumed only by
-        // processTickCrossingsForStaked. Not snapshotted hourly — the arrays
+        // processTickCrossings. Not snapshotted hourly — the arrays
         // are derived state (sum-of-stakes per tick) and the per-stake history
         // is already captured by Gauge Deposit/Withdraw and NFPM
         // IncreaseLiquidity/DecreaseLiquidity events.

--- a/test/testHelpers.ts
+++ b/test/testHelpers.ts
@@ -117,6 +117,8 @@ export function setupPool(
     // Array fields: force mutable bigint[] (envio.d.ts uses readonly; set() wants mutable).
     stakedTickEdges: [...mockLiquidityPoolData.stakedTickEdges],
     stakedTickEdgeNets: [...mockLiquidityPoolData.stakedTickEdgeNets],
+    tickEdges: [...mockLiquidityPoolData.tickEdges],
+    tickEdgeNets: [...mockLiquidityPoolData.tickEdgeNets],
   };
   return mockDb.entities.Pool.set(mockPool);
 }


### PR DESCRIPTION
## Summary
- **Closes #803.** Dynamic-fee CL pools over-accumulated `reserve0/1` because the swap reserve delta used `amount − currentFee·amount`, where `currentFee` is sampled only hourly (the `getSwapFee` effect) and held constant. On dynamic-fee pools the stale sample diverges from the per-swap fee, and the error accumulates over millions of swaps — pushing reserves above true principal, even above the physical token balance (an invariant violation invisible to the negative-only `NEG_RESERVE_GUARD`).
- Replace the fee-based swap delta with **pure price geometry** (`L·ΔsqrtPrice`), integrated over a new total per-tick liquidity map (`tickEdges`/`tickEdgeNets` — the analog of the staked edge map from #666/#719). The fee never moves the price, so the geometric token flow is **fee-free by construction**.
- `CLPool.Mint`/`Burn` maintain the total edge map via `applyStakedPositionToEdges`; the swap path reuses `processTickCrossingsForStaked` over it — seeded from the edge map (so it stays correct even at boundary ticks where the cached `liquidityInRange` is 0) and walking initialized edges directly with no per-tick step cap.
- Remove the now-dead `calculateSwapLiquidityChanges` (+ its unit tests); add a fee-independence regression test for the geometry delta; add a `callerLabel` to `processTickCrossingsForStaked` so the total vs staked out-of-range diagnostic is distinguishable; allowlist `tickEdges`/`tickEdgeNets` in the snapshot-parity check (derived state, not an hourly metric).

## Local validation
Base, blocks 13.8M–17.8M, **111 nonzero-reserve CL pools**:
- **0 invariant violations** (`reserve ≤ balanceOf` everywhere), **0 over-accumulations**.
- Geometry reconstructs to true on-chain principal (`FLOW == STATE == liquidity()`) on every pool checked, including the flagged dynamic-fee WETH/USDC `0xb2cc` (now within **0.035%** of principal; old code violated the invariant by +0.58%/+0.74% at the deployed head).
- Tick-map footprint stays sparse (max **177** edges), so the option-2 storage concern from the issue (#648 OOM) does not materialize.

Full methodology in the [#803 comment](https://github.com/velodrome-finance/indexer/issues/803#issuecomment-4573856554).

## Acceptance criteria (#803)
- [x] Quantify the overcount on dynamic-fee pools, confirm absent on static-fee — done via the local run (documented in the issue comment).
- [x] Pick a fix with bounded tolerance regardless of fee regime — geometry; in fact *exact* (= true principal), not merely bounded.
- [ ] **Positive-direction detector — Partial.** The geometry makes positive drift structurally impossible (no fee term), and `[TICK_EDGE_DRIFT]` catches the new failure mode (map desync). **No standalone `reserve > balanceOf` metric was added** — flag for reviewer: add one for defence-in-depth, or accept structural prevention.
- [x] `totalLiquidityUSD` tracks the corrected reserves; the #734 `NEG_RESERVE_GUARD` clamp is retained.

## Test plan
- [x] `tsc --noEmit` — clean
- [x] `biome check` (`pnpm qa`) — clean
- [x] `pnpm test` — 105 files / 1468 passed, 33 skipped, 0 failed (post-rebase onto current main)
- [x] New regression test: reserve delta is identical at 1% vs 0% fee, and nonzero on a price move (`CLPoolSwapLogic.test.ts`)
- [ ] Full-genesis run across all chains *(needs human — local validation was Base / windowed; the structural fix should behave identically, but a full run is the final gate)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added per-tick liquidity tracking fields to enable more accurate reserve calculations.

* **Bug Fixes**
  * Improved swap reserve delta calculations by deriving values from actual pool geometry instead of fee-rate approximations, eliminating stale fee estimates.

* **Tests**
  * Updated swap tests to validate geometry-based reserve calculations; added regression tests confirming fee-rate independence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/velodrome-finance/indexer/pull/808?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->