### PR TITLE
fix(price-oracle): pool-implied ground-truth re-anchor for poisoned anchors (closes #784, #785)

### DIFF
--- a/src/Aggregators/Pool.ts
+++ b/src/Aggregators/Pool.ts
@@ -9,7 +9,7 @@ import { getSwapFee, roundBlockToInterval } from "../Effects/Index";
 import type { Pool } from "../EntityTypes";
 import { calculateTotalUSD, generatePoolName } from "../Helpers";
 import { refreshTokenPrice } from "../PriceOracle";
-import { getTrustedUSD } from "../PriceTrust";
+import { getPoolImpliedUSD, getTrustedUSD } from "../PriceTrust";
 import {
   getSnapshotEpoch,
   setPoolSnapshot,
@@ -713,6 +713,20 @@ export async function loadPoolData(
   let updatedToken0 = token0Instance;
   let updatedToken1 = token1Instance;
   if (blockNumber !== undefined && blockTimestamp !== undefined) {
+    // Pool-implied ground-truth hints (#784/#785): each token's oracle read is
+    // cross-checked against the *other* leg's trusted USD price derived from
+    // pool state (sqrtPriceX96 / reserves via the stored token0Price /
+    // token1Price). Inert (0n) when the counterparty fails the trust gate, so
+    // pools without a trusted leg behave exactly as before.
+    const token0Hint = getPoolImpliedUSD(
+      liquidityPoolAggregator.token0Price,
+      token1Instance,
+    );
+    const token1Hint = getPoolImpliedUSD(
+      liquidityPoolAggregator.token1Price,
+      token0Instance,
+    );
+
     // Wrap each refresh in a promise that catches errors individually
     const token0Refresh = refreshTokenPrice(
       token0Instance,
@@ -720,6 +734,7 @@ export async function loadPoolData(
       blockTimestamp,
       chainId,
       context,
+      token0Hint,
     ).catch((error) => {
       context.log.error(
         `[loadPoolData] Error refreshing token0 price for ${token0Instance.address} on chain ${chainId}: ${error}`,
@@ -733,6 +748,7 @@ export async function loadPoolData(
       blockTimestamp,
       chainId,
       context,
+      token1Hint,
     ).catch((error) => {
       context.log.error(
         `[loadPoolData] Error refreshing token1 price for ${token1Instance.address} on chain ${chainId}: ${error}`,

--- a/src/PriceOracle.ts
+++ b/src/PriceOracle.ts
@@ -57,6 +57,17 @@ const FIRST_FETCH_CAP = 10_000n * TEN_TO_THE_18_BI;
 // rejected.)
 const MAX_ACCEPTED_PRICE = 1_000_000n * TEN_TO_THE_18_BI;
 
+// Two positive prices "agree" when neither exceeds the other by the spike
+// ratio (10×) — the same loose band the upward spike guard uses. Reused by the
+// pool-implied ground-truth checks (#784/#785) to ask whether an oracle read
+// and a pool-implied hint corroborate each other. Zero on either side means
+// "no usable signal" → never agrees.
+const withinRatioBand = (a: bigint, b: bigint): boolean =>
+  a > 0n &&
+  b > 0n &&
+  a <= b * PRICE_SPIKE_RATIO_THRESHOLD &&
+  b <= a * PRICE_SPIKE_RATIO_THRESHOLD;
+
 /**
  * Creates and persists a Token entity at first sight, gated on the address
  * actually being a contract on-chain.
@@ -135,11 +146,22 @@ export async function createTokenEntity(
  *   with hourly retries. The fallback covers every oracle generation
  *   (#775 extended it from V3-only to V1/V2 too).
  *
+ * When a caller supplies `impliedPriceHint` — a pool-implied USD price derived
+ * from the counterparty leg's trusted price (see {@link getPoolImpliedUSD}) —
+ * it acts as an independent ground-truth witness against a poisoned anchor:
+ * a too-low first read is replaced by the hint (#785), and a stale-low anchor
+ * is re-anchored when the incoming read corroborates the hint while the anchor
+ * contradicts it (#784). Omitting the hint (the default) leaves every code
+ * path identical to before.
+ *
  * @param token - The token entity to refresh.
  * @param blockNumber - Block at which to fetch price (rounded to an hourly bucket for cache hits).
  * @param blockTimestamp - Block timestamp in seconds.
  * @param chainId - Chain the token lives on.
  * @param context - Envio handler context.
+ * @param impliedPriceHint - Optional pool-implied USD price (1e18-base, same
+ *   scaling as `pricePerUSDNew`) used as ground truth for the #784/#785 anchor
+ *   checks. `undefined` / `0n` ⇒ no hint, behavior unchanged.
  * @returns The updated token entity (or the unchanged input when throttled).
  */
 export async function refreshTokenPrice(
@@ -148,8 +170,12 @@ export async function refreshTokenPrice(
   blockTimestamp: number,
   chainId: number,
   context: handlerContext,
+  impliedPriceHint?: bigint,
 ): Promise<Token> {
   const blockTimestampMs = blockTimestamp * 1000;
+  // Pool-implied ground truth (#784/#785); 0n / undefined ⇒ no usable hint,
+  // leaving every check below inert (behavior identical to a hint-free refresh).
+  const hint = impliedPriceHint ?? 0n;
 
   // Issue #735: heal empty symbol/name on every refresh call regardless of the
   // 1-hour price-refresh throttle. Tokens whose pool was created during a
@@ -284,6 +310,43 @@ export async function refreshTokenPrice(
       return capped;
     }
 
+    // Issue #785: FIRST_FETCH_CAP (#728) only guards a too-HIGH first read; a
+    // too-LOW first read (LIFE: $0.0014 vs true ~$0.25) is accepted as the
+    // anchor and then freezes every later correct read as an upward spike,
+    // forever. When a trusted pool-implied hint exists at first sight, validate
+    // the first nonzero read against it: if it is out of band (too-low or
+    // too-high), anchor to the hint itself so the token recovers in a single
+    // read instead of locking onto the bad value. An in-band first read falls
+    // through and is accepted normally; a $0 read is left to the existing
+    // last-known/normal path (retry next refresh) rather than eagerly anchored.
+    if (
+      healed.pricePerUSDNew === 0n &&
+      currentPrice > 0n &&
+      hint > 0n &&
+      !withinRatioBand(currentPrice, hint)
+    ) {
+      context.log.info(
+        `[poolImpliedFirstFetch] chain=${chainId} address=${healed.address} symbol=${healed.symbol} firstRead=${currentPrice} hint=${hint} — first read out of band, anchoring to pool-implied hint`,
+      );
+      const anchored: Token = {
+        ...healed,
+        pricePerUSDNew: hint,
+        lastUpdatedTimestamp: new Date(blockTimestampMs),
+        lastSuccessfulPriceTimestamp: new Date(blockTimestampMs),
+      };
+      context.Token.set(anchored);
+      setTokenPriceSnapshot(
+        healed.address,
+        chainId,
+        blockNumber,
+        new Date(blockTimestampMs),
+        hint,
+        healed.isWhitelisted,
+        context,
+      );
+      return anchored;
+    }
+
     // Issue #728: cap-reject the first non-zero anchor for non-BTC symbols.
     // The spike guard below requires anchor > 0, so without this gate a single
     // inflated read at first sight permanently poisons the anchor. Bumping
@@ -334,10 +397,27 @@ export async function refreshTokenPrice(
       anchorPrice > 0n &&
       currentPrice >= anchorPrice * PRICE_SPIKE_RATIO_THRESHOLD;
     if (upwardSpike && anchorAgeMs < PRICE_SPIKE_STALENESS_MS) {
-      context.log.warn(
-        `[priceSpikeRejected] ${healed.address} chain=${chainId} anchor=${anchorPrice} candidate=${currentPrice}`,
+      // Issue #784: a downward glitch can poison the anchor (e.g. YGG read
+      // $0.0026 vs true $0.14), after which the upward-only guard rejects
+      // every correct heal for the full staleness window. When a trusted
+      // pool-implied hint corroborates the incoming read AND contradicts the
+      // stored anchor, the *anchor* is the outlier — re-anchor to the read
+      // instead of rejecting. The pool state is an independent witness (not the
+      // oracle route that produced the bad anchor), so it distinguishes a
+      // stuck-low anchor from a genuine transient spike — the discriminator the
+      // #801 cache audit showed a time-based re-anchor lacked.
+      const poolImpliedReanchor =
+        withinRatioBand(currentPrice, hint) &&
+        !withinRatioBand(anchorPrice, hint);
+      if (!poolImpliedReanchor) {
+        context.log.warn(
+          `[priceSpikeRejected] ${healed.address} chain=${chainId} anchor=${anchorPrice} candidate=${currentPrice}`,
+        );
+        return healed;
+      }
+      context.log.info(
+        `[poolImpliedReanchor] ${healed.address} chain=${chainId} anchor=${anchorPrice} candidate=${currentPrice} hint=${hint} — re-anchoring past stuck-low anchor`,
       );
-      return healed;
     }
 
     // If price fetch returned 0, it could mean:

--- a/src/PriceOracle.ts
+++ b/src/PriceOracle.ts
@@ -319,10 +319,16 @@ export async function refreshTokenPrice(
     // read instead of locking onto the bad value. An in-band first read falls
     // through and is accepted normally; a $0 read is left to the existing
     // last-known/normal path (retry next refresh) rather than eagerly anchored.
+    //
+    // A hint above MAX_ACCEPTED_PRICE (#788) is itself the signal of a glitched
+    // pool ratio, so it is not usable ground truth: skip the override and let
+    // the read take the normal first-fetch path rather than writing a >$1M
+    // anchor that the ceiling at line 301 would reject from any other source.
     if (
       healed.pricePerUSDNew === 0n &&
       currentPrice > 0n &&
       hint > 0n &&
+      hint <= MAX_ACCEPTED_PRICE &&
       !withinRatioBand(currentPrice, hint)
     ) {
       context.log.info(

--- a/src/PriceTrust.ts
+++ b/src/PriceTrust.ts
@@ -1,5 +1,6 @@
 import type { Token, handlerContext } from "generated";
 import { calculateTokenAmountUSD } from "./Helpers";
+import { multiplyBase1e18 } from "./Maths";
 import { isBlacklistedToken } from "./PriceOverrides";
 
 /**
@@ -77,6 +78,37 @@ export function getTrustedUSD(
     Number(token.decimals),
     token.pricePerUSDNew,
   );
+}
+
+/**
+ * Pool-implied USD price (1e18-base) for one leg of a pool, derived from the
+ * pool's on-chain price ratio and the *counterparty* leg's trusted price. This
+ * is an independent ground-truth witness to the per-token oracle route: it
+ * comes from pool reserves / sqrtPriceX96, not from the route that can freeze
+ * or glitch (#784/#785).
+ *
+ * For token0 the caller passes the pool's `token0Price` (1e18-scaled
+ * token1-per-token0) and the token1 entity; for token1, `token1Price` and the
+ * token0 entity. Gated by {@link isTrusted}: an untrusted or undefined
+ * counterparty yields `0n` (no usable hint), so any consumer is inert unless
+ * the other leg is a whitelisted, non-blacklisted token whose price is
+ * reliable. A `0n` ratio (uninitialised pool) also yields `0n`.
+ *
+ * @param priceRatio1e18 - The priced token's value in counterparty units,
+ *   1e18-scaled (the pool entity's `token0Price` / `token1Price`).
+ * @param counterparty - The other token in the pool, carrying the trusted USD
+ *   price. Undefined or untrusted ⇒ `0n`.
+ * @returns USD-per-whole-token in 1e18-base (same scaling as `pricePerUSDNew`),
+ *   or `0n` when the counterparty fails the trust gate or the ratio is 0.
+ */
+export function getPoolImpliedUSD(
+  priceRatio1e18: bigint,
+  counterparty: Token | undefined,
+): bigint {
+  if (priceRatio1e18 <= 0n || !counterparty || !isTrusted(counterparty)) {
+    return 0n;
+  }
+  return multiplyBase1e18(priceRatio1e18, counterparty.pricePerUSDNew);
 }
 
 /**

--- a/test/PriceOracle.test.ts
+++ b/test/PriceOracle.test.ts
@@ -2331,6 +2331,26 @@ describe("PriceOracle", () => {
 
         expect(vi.mocked(mockContext.Token?.set)).not.toHaveBeenCalled();
       });
+
+      it("#788: a hint above MAX_ACCEPTED_PRICE is not used as an anchor; the reasonable read is accepted instead", async () => {
+        const hint = usd(2_000_000); // > MAX_ACCEPTED_PRICE ($1M): glitched pool ratio
+        const read = usd(0.25); // reasonable read, out of band vs the glitched hint
+        const fetchedToken: Token = {
+          ...mockToken0Data,
+          pricePerUSDNew: 0n, // first fetch
+          symbol: "TEST",
+          lastUpdatedTimestamp: twoHoursAgo,
+        };
+
+        await refreshWithRead(read, fetchedToken, hint);
+
+        const written = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        // Hint exceeds the absolute ceiling → not usable ground truth, so the
+        // first-fetch branch is skipped and the read is anchored normally
+        // instead of writing a >$1M anchor from a glitched ratio.
+        expect(written?.pricePerUSDNew).toBe(read);
+      });
     });
   });
 });

--- a/test/PriceOracle.test.ts
+++ b/test/PriceOracle.test.ts
@@ -2199,5 +2199,138 @@ describe("PriceOracle", () => {
         expect(detailsCall).toBeUndefined();
       });
     });
+
+    describe("pool-implied ground-truth re-anchor (#784/#785)", () => {
+      // USD price scaled by 1e18, matching `pricePerUSDNew`.
+      const usd = (n: number) => BigInt(Math.round(n * 1e6)) * 10n ** 12n;
+      const twoHoursAgo = new Date(
+        blockDatetime.getTime() - 2 * 60 * 60 * 1000,
+      );
+      const blockTimestamp = blockDatetime.getTime() / 1000;
+
+      const refreshWithRead = async (
+        read: bigint,
+        token: Token,
+        impliedPriceHint?: bigint,
+      ) => {
+        vi.mocked(mockContext.effect)?.mockImplementation(
+          async (effect: unknown) => {
+            const name = (effect as { name?: string }).name;
+            if (name === "getTokenPrice") return { pricePerUSDNew: read };
+            if (name === "getTokenDetails")
+              return { name: "Test", decimals: 18, symbol: "TEST" };
+            if (name === "hasContractBytecode") return { hasCode: true };
+            return {};
+          },
+        );
+        return PriceOracle.refreshTokenPrice(
+          token,
+          blockNumber,
+          blockTimestamp,
+          chainId,
+          mockContext as handlerContext,
+          impliedPriceHint,
+        );
+      };
+
+      it("#784: re-anchors a stuck-low anchor when the read corroborates the pool-implied hint", async () => {
+        const stuckLow = usd(0.0026); // bad downward-glitch anchor
+        const hint = usd(0.14); // pool-implied ground truth
+        const read = usd(0.14); // correct heal the upward-only guard rejects
+        const fetchedToken: Token = {
+          ...mockToken0Data,
+          pricePerUSDNew: stuckLow,
+          lastUpdatedTimestamp: twoHoursAgo, // fresh anchor → spike guard active
+          lastSuccessfulPriceTimestamp: twoHoursAgo,
+        };
+
+        await refreshWithRead(read, fetchedToken, hint);
+
+        const written = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        expect(written?.pricePerUSDNew).toBe(read);
+      });
+
+      it("#785: replaces a too-low first read with the pool-implied hint (no permanent low anchor)", async () => {
+        const hint = usd(0.25); // pool-implied true band
+        const read = usd(0.0014); // bad too-low first read
+        const fetchedToken: Token = {
+          ...mockToken0Data,
+          pricePerUSDNew: 0n, // first fetch
+          lastUpdatedTimestamp: twoHoursAgo,
+        };
+
+        await refreshWithRead(read, fetchedToken, hint);
+
+        const written = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        expect(written?.pricePerUSDNew).toBe(hint);
+      });
+
+      it("#785: replaces a too-high first read with the hint (supersedes FIRST_FETCH_CAP)", async () => {
+        const hint = usd(0.25); // pool-implied true band
+        const read = usd(50_000); // glitch-high first read, also > FIRST_FETCH_CAP
+        const fetchedToken: Token = {
+          ...mockToken0Data,
+          pricePerUSDNew: 0n, // first fetch
+          symbol: "TEST", // non-BTC: FIRST_FETCH_CAP would otherwise zero it
+          lastUpdatedTimestamp: twoHoursAgo,
+        };
+
+        await refreshWithRead(read, fetchedToken, hint);
+
+        const written = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        expect(written?.pricePerUSDNew).toBe(hint);
+      });
+
+      it("#728 intact: a too-high first read with NO hint is still rejected (kept at 0)", async () => {
+        const read = usd(50_000); // > FIRST_FETCH_CAP, non-BTC
+        const fetchedToken: Token = {
+          ...mockToken0Data,
+          pricePerUSDNew: 0n,
+          symbol: "TEST",
+          lastUpdatedTimestamp: twoHoursAgo,
+        };
+
+        await refreshWithRead(read, fetchedToken); // no hint
+
+        const written = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        expect(written?.pricePerUSDNew).toBe(0n);
+      });
+
+      it("false-positive guard: a glitch-high read is NOT re-anchored when the hint disagrees (#801 audit)", async () => {
+        const realPrice = usd(0.15); // correct, fresh anchor
+        const hint = usd(0.15); // pool-implied agrees with the anchor
+        const glitchHigh = usd(10_000); // sustained glitch-high read
+        const fetchedToken: Token = {
+          ...mockToken0Data,
+          pricePerUSDNew: realPrice,
+          lastUpdatedTimestamp: twoHoursAgo,
+          lastSuccessfulPriceTimestamp: twoHoursAgo,
+        };
+
+        await refreshWithRead(glitchHigh, fetchedToken, hint);
+
+        // Spike guard rejects → no write, correct anchor preserved.
+        expect(vi.mocked(mockContext.Token?.set)).not.toHaveBeenCalled();
+      });
+
+      it("inert without a hint: a stuck-low anchor's correct read is still rejected when no hint is supplied", async () => {
+        const stuckLow = usd(0.0026);
+        const read = usd(0.14); // correct heal, but no ground truth to corroborate
+        const fetchedToken: Token = {
+          ...mockToken0Data,
+          pricePerUSDNew: stuckLow,
+          lastUpdatedTimestamp: twoHoursAgo,
+          lastSuccessfulPriceTimestamp: twoHoursAgo,
+        };
+
+        await refreshWithRead(read, fetchedToken); // no hint → behaves as before
+
+        expect(vi.mocked(mockContext.Token?.set)).not.toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/test/PriceTrust.test.ts
+++ b/test/PriceTrust.test.ts
@@ -5,6 +5,7 @@ import {
   PRICE_TRUST_REASON,
   getGateDecision,
   getGateDecisionFromSignals,
+  getPoolImpliedUSD,
   getTrustedUSD,
   isTrusted,
 } from "../src/PriceTrust";
@@ -317,6 +318,39 @@ describe("PriceTrust", () => {
 
     it("returns 0n for an undefined token", () => {
       expect(getTrustedUSD(2n * TEN_TO_THE_18_BI, undefined)).toBe(0n);
+    });
+  });
+
+  describe("getPoolImpliedUSD", () => {
+    it("scales the pool price ratio by the counterparty's trusted USD price", () => {
+      // token0 worth 0.00005 of token1; token1 (WETH) priced $2000.
+      // implied token0 USD = 0.00005 * 2000 = $0.10.
+      const ratio1e18 = 50_000_000_000_000n; // 0.00005 * 1e18
+      const counterparty = makeToken({
+        isWhitelisted: true,
+        pricePerUSDNew: 2000n * TEN_TO_THE_18_BI,
+      });
+      expect(getPoolImpliedUSD(ratio1e18, counterparty)).toBe(
+        100_000_000_000_000_000n, // $0.10 * 1e18
+      );
+    });
+
+    it("returns 0n when the counterparty is untrusted (no ground truth)", () => {
+      const ratio1e18 = 50_000_000_000_000n;
+      const untrusted = makeToken({
+        isWhitelisted: false,
+        pricePerUSDNew: 2000n * TEN_TO_THE_18_BI,
+      });
+      expect(getPoolImpliedUSD(ratio1e18, untrusted)).toBe(0n);
+    });
+
+    it("returns 0n for a zero ratio or undefined counterparty", () => {
+      const trusted = makeToken({
+        isWhitelisted: true,
+        pricePerUSDNew: 2000n * TEN_TO_THE_18_BI,
+      });
+      expect(getPoolImpliedUSD(0n, trusted)).toBe(0n);
+      expect(getPoolImpliedUSD(50_000_000_000_000n, undefined)).toBe(0n);
     });
   });
 });


### PR DESCRIPTION
## What

Fixes two price-oracle **poison-anchor** bugs with one mechanism — a pool-implied ground-truth check.

- **#784 (YGG, Base, whitelisted):** a downward glitch ($0.0026 vs true ~$0.14) poisoned the anchor; the upward-only spike guard (#730) then rejected every correct heal for the full 14-day staleness window.
- **#785 (LIFE, Base, non-whitelisted):** a too-low first read ($0.0014 vs true ~$0.25) became a *permanent* anchor — `FIRST_FETCH_CAP` (#728) only guards too-**high** first reads.

Both are the same failure: a bad-low value the read stream alone cannot disqualify, hitting the oracle at two different points.

## How

`refreshTokenPrice` gains an optional `impliedPriceHint` — the counterparty leg's trusted price × the pool's on-chain ratio, via new `getPoolImpliedUSD` (in `PriceTrust.ts`). It is an **independent witness** to the per-token oracle route: it comes from pool reserves / `sqrtPriceX96` (the stored `token0Price`/`token1Price` from #783), not from the route that froze/glitched.

- Computed in `loadPoolData` from the already-loaded pool + token entities (no new reads).
- Gated on the **counterparty** being trusted (whitelisted, non-blacklisted) — *not* the priced token — so non-whitelisted LIFE is still covered via its trusted WETH leg.
- **First-fetch (#785):** a too-far first read (too-low *or* too-high) is replaced by the hint → recovers in one read. Supersedes `FIRST_FETCH_CAP` when a trusted hint exists; a transient $0 read is left to the existing retry path.
- **Spike-rejection (#784):** a stuck-low anchor is re-anchored to the incoming read only when the read corroborates the hint **and** the anchor contradicts it.
- **Inert without a trusted counterparty:** the 3 reward-token `refreshTokenPrice` call sites and any pool lacking a trusted leg behave exactly as before.

### Decision flow

Every read walks these checks **in order** — first match wins. `band(a,b)` = "a and b are within 10× of each other, both nonzero" (`withinRatioBand`).

```
getTokenPrice (RPC) ─► read
  │
  ├─ read > $1M ? ─────────────────────────────────► REJECT  (ceiling #788 — hint ignored)
  │
  ├─ anchor == 0   (first fetch)
  │    ├─ hint present & NOT band(read, hint) ? ────► ANCHOR TO HINT      (#785)
  │    ├─ else read > $10k & not BTC ? ─────────────► REJECT to 0         (#728)
  │    └─ else ─────────────────────────────────────► accept read
  │
  ├─ read ≥ 10× anchor & anchor younger than 14d   (upward spike)
  │    ├─ band(read, hint) & NOT band(anchor, hint)?► RE-ANCHOR to read   (#784)
  │    └─ else ─────────────────────────────────────► REJECT, keep anchor (#730)
  │
  ├─ read == 0 & anchor fresh ? ───────────────────► keep anchor (last-known #694/#775)
  │
  └─ else ──────────────────────────────────────────► accept read (normal write)
```

### Worked examples

Canonical numbers (YGG ~$0.14, LIFE ~$0.25). ✅ = fix in action · 🛡 = guard holds (no bad write) · ➖ = behavior unchanged vs pre-PR · ⚠️ = known boundary.

| # | Situation | Anchor | RPC read | Hint | Branch that fires | Outcome |
|---|-----------|-------:|---------:|-----:|-------------------|---------|
| 1 | **#785** too-low first read (LIFE/WETH) | `0` | `$0.0014` | `$0.25` | pool-implied first-fetch | ✅ anchors to **$0.25** in one read |
| 2 | **#784** stuck-low anchor (YGG/WETH) | `$0.0026` | `$0.14` | `$0.14` | spike → re-anchor | ✅ accepts **$0.14**, breaks 14-day freeze |
| 3 | glitch-high read, **pool stays low** | `$0.14` | `$10,000` | `$0.15` | spike, `read` disagrees hint | 🛡 reject, keep **$0.14** *(the #801 audit killer)* |
| 4 | too-high first read, good hint | `0` | `$50,000` | `$0.20` | pool-implied first-fetch | ✅ anchors to **$0.20** (beats old reject-to-0) |
| 5 | untrusted counterparty / reward token | any | any | — | none (hint = 0) | ➖ identical to pre-PR |
| 6 | too-high first read, **no** hint | `0` | `$50,000` | — | `FIRST_FETCH_CAP` | 🛡 reject to **0** (#728 intact) |
| 7 | genuine spike, **no** hint | `$1` | `$15` | — | spike | 🛡 reject, keep **$1** (#730 intact) |
| 8 | in-band first read | `0` | `$0.24` | `$0.25` | none (falls through) | ✅ accepts **$0.24** — hint is a no-op |
| 9 | dead `$0` read | `$0.14` | `$0` | `$0.15` | last-known fallback | ➖ keep **$0.14** (hint never *manufactures* a price) |
| 10 | 10× jump but **anchor agrees hint** | `$0.10` | `$1.50` | `$0.12` | spike, `anchor` agrees hint | 🛡 reject, keep **$0.10** (anchor is the trusted one) |
| 11 | absurd read, corroborating hint | any | `$2,000,000` | `$0.15` | ceiling (#788) | 🛡 reject — ceiling is hint-proof |
| 12 | **glitched hint** at first fetch | `0` | — | `$5,000,000` | pool-implied first-fetch | ⚠️ anchors to **$5M** — see *Known boundary* |

### Can the hint overwrite a *correct* read?

Only in two narrow, self-bounding windows — and both require the **pool state itself** to be wrong, not just the oracle (a strictly higher bar than the single-glitch this fixes):

1. **First fetch, wrong hint** — a correct read >10× off a *bad* hint (manipulated CL spot at that block, or a stale counterparty price) anchors to the hint. Self-heals: a wrong-*high* mis-anchor is fixed by the next lower read (downward reads are unguarded); a wrong-*low* one recovers via the re-anchor path once the pool ratio normalises.
2. **Re-anchor, correlated double-glitch** — a correct anchor flipped only when a glitch-high read *and* a glitch-high hint agree with each other. Needs route + pool to fail high together, most plausible when the token's only liquidity is the hint pool itself.

A *single* glitch can never flip a correct price: the surviving correct source disagrees with the glitch and the 10× band catches it. Bounded further by the counterparty trust gate and the $1M read ceiling.

## Known boundary

The first-fetch branch anchors to the hint, which — unlike the incoming read — is not bounded by `MAX_ACCEPTED_PRICE` (#788) (row 12 above). In practice the hint = a trusted counterparty price (≤ $1M by its own ceiling) × the pool ratio, and a brand-new token implying >$1M would itself signal a glitched pool ratio. Left unguarded deliberately; happy to add a `hint ≤ MAX_ACCEPTED_PRICE` clamp if preferred.

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `pnpm qa --write` — clean (biome)
- [x] `pnpm test` — **1481 passed, 33 skipped**
- [x] New `test/PriceOracle.test.ts` (6): #784 re-anchor; #785 too-low first read; #785 too-high first read (supersedes FIRST_FETCH_CAP); false-positive guard (#801 audit); #728 intact without a hint; inert without a hint
- [x] New `test/PriceTrust.test.ts` (3): `getPoolImpliedUSD` scaling + counterparty trust gate + zero/undefined guards

Closes #784, closes #785.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced token price handling with improved anchor recovery and first-fetch price determination using pool-derived pricing signals for greater accuracy.

* **Tests**
  * Added comprehensive test coverage for new price oracle scenarios including anchor recovery and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/velodrome-finance/indexer/pull/809?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
