### PR TITLE
fix(price-oracle): verify Soneium oracle startBlock deploy block (closes #821)

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -651,7 +651,7 @@ const SONEIUM_CONSTANTS: chainConstants = {
     getAddress: (priceOracleType: PriceOracleType) => {
       return "0xe58920a8c684CD3d6dCaC2a41b12998e4CB17EfE";
     },
-    startBlock: 1863998, // TODO: Get start block
+    startBlock: 1863998, // #821: V3 oracle deploy block, RPC-verified (eth_getCode binary-search)
     updateDelta: 60 * 60, // 1 hour
     priceConnectors: SONEIUM_PRICE_CONNECTORS,
     v1v2ConnectorBlacklist: new Set(),

--- a/test/Constants.test.ts
+++ b/test/Constants.test.ts
@@ -177,6 +177,20 @@ describe("oracle.v1v2ConnectorBlacklist (#688)", () => {
   });
 });
 
+describe("oracle.startBlock (#821)", () => {
+  // Drift guard for the Soneium V3 oracle deploy block, mirroring the
+  // price_connectors.json createdBlock snapshot in test/PriceConnectors.test.ts
+  // (#764/#768). startBlock floors every Soneium token price to 0n below it
+  // (src/Effects/RpcGateway.ts), so a wrong value either zero-prices a real gap
+  // (too late) or triggers reverting pre-deploy RPC calls (too early). 1863998
+  // is the on-chain deploy block, RPC-verified via eth_getCode binary-search
+  // (code absent @1863997, present @1863998; deployed 2025-01-14). Any edit to
+  // the constant must update this expectation rather than regress to a TODO.
+  it("pins the Soneium oracle to its RPC-verified deploy block", () => {
+    expect(CHAIN_CONSTANTS[1868].oracle.startBlock).toBe(1863998);
+  });
+});
+
 /**
  * Parses config.yaml's `chains[]` blocks into a `chainId -> contractName -> addresses[]`
  * map of checksummed addresses. Used by the parity assertions below (#770) to detect


### PR DESCRIPTION
## Summary
- RPC-verified the Soneium V3 oracle (`0xe58920a8c684CD3d6dCaC2a41b12998e4CB17EfE`, chainId 1868) deploy block via `eth_getCode` binary-search on two independent RPCs (`rpc.soneium.org`, `soneium.drpc.org`): code **absent @1863997, present @1863998** (deployed 2025-01-14T13:52:27Z).
- The existing `startBlock: 1863998` was **already exactly the verified deploy block**, so there is **no behavioral change** — this removes the unverified `// TODO: Get start block` (replacing it with a provenance comment) and locks the value with a drift-guard test.
- Why it matters: `startBlock` hard-floors every Soneium token price to `0n` below it (`src/Effects/RpcGateway.ts:424-432`); a wrong value would either zero-price a real gap (too late) or trigger reverting pre-deploy RPC calls (too early). The #764/#768 audit fixed connector `createdBlock`s but never touched this oracle `startBlock`.

## Reviewer note
The drift guard was added to `test/Constants.test.ts` (home of the `oracle.*` describe blocks; already imports `CHAIN_CONSTANTS`) rather than literally inside `test/PriceConnectors.test.ts` — the file issue #821 calls "the #768 snapshot regression test" — because the oracle `startBlock` lives in `Constants.ts`, not `price_connectors.json`. It mirrors the #764/#768 `EXPECTED_CREATED_BLOCKS` drift-guard pattern. Easy to relocate if you'd prefer the literal #768 file.

## Test plan
- [x] `tsc --noEmit` — 0 errors (after `envio codegen` to generate the gitignored `.envio` types)
- [x] `vitest run test/Constants.test.ts` — 70/70 pass, incl. the new `oracle.startBlock (#821)` guard
- [x] Bite-check — guard goes red when the constant is set to a wrong value (non-vacuous)
- [x] `biome check` — clean
- [x] Deploy block independently confirmed on two Soneium RPCs

Closes #821

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test to verify oracle configuration is correctly pinned to the expected deployment block.

* **Documentation**
  * Updated comments clarifying the oracle deployment block verification source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->