### PR TITLE
fix(pool-launcher): populate PoolLauncherPool.migratedFrom on Migrate (closes #818)

### DIFF
--- a/src/EventHandlers/PoolLauncher/CLPoolLauncher.ts
+++ b/src/EventHandlers/PoolLauncher/CLPoolLauncher.ts
@@ -77,6 +77,7 @@ indexer.onEvent(
         timestamp,
         event.chainId,
         context,
+        underlyingPool, // #818: record the source pool as migratedFrom on the target
       );
 
       // Link existing Pool to PoolLauncherPool for migrated pool

--- a/src/EventHandlers/PoolLauncher/PoolLauncherLogic.ts
+++ b/src/EventHandlers/PoolLauncher/PoolLauncherLogic.ts
@@ -4,7 +4,25 @@ import { getRehydrated } from "../../EntityTimestamps";
 import type { Pool } from "../../EntityTypes";
 import type { handlerContext } from "../../EntityTypes";
 
-// Helper function to create or update PoolLauncherPool entity
+/**
+ * Creates or updates the PoolLauncherPool entity for a launched or migrated pool.
+ *
+ * On create, `migratedFrom` records the source pool when this pool is the target of a
+ * Migrate (and stays "" for Launch-created pools). On update, the existing `migratedFrom`
+ * is preserved by the spread — migration lineage is stamped only at creation, so
+ * re-processing an already-known pool never rewrites it.
+ *
+ * @param poolAddress - underlying pool address; becomes the entity's underlyingPool and (with chainId) its id
+ * @param launcherAddress - pool launcher contract that emitted the event
+ * @param creator - original launch sender (preserved across migration)
+ * @param poolLauncherToken - the launched "project" token
+ * @param pairToken - whitelisted pair token (e.g. WETH, USDC)
+ * @param createdAt - block timestamp of the triggering event
+ * @param chainId - chain the pool lives on
+ * @param context - Envio handler context used to read and stage the entity
+ * @param migratedFrom - source underlying pool when created as a Migrate target; "" for Launch
+ * @returns the created or updated PoolLauncherPool (already staged via context.PoolLauncherPool.set)
+ */
 export async function processPoolLauncherPool(
   poolAddress: string,
   launcherAddress: string,
@@ -14,6 +32,7 @@ export async function processPoolLauncherPool(
   createdAt: Date,
   chainId: number,
   context: handlerContext,
+  migratedFrom = "",
 ): Promise<PoolLauncherPool> {
   const poolId = PoolId(chainId, poolAddress);
 
@@ -36,7 +55,7 @@ export async function processPoolLauncherPool(
       createdAt,
       isEmerging: false,
       lastFlagUpdateAt: createdAt,
-      migratedFrom: "",
+      migratedFrom,
       migratedTo: "",
       oldLocker: "",
       newLocker: "",

--- a/src/EventHandlers/PoolLauncher/V2PoolLauncher.ts
+++ b/src/EventHandlers/PoolLauncher/V2PoolLauncher.ts
@@ -77,6 +77,7 @@ indexer.onEvent(
         timestamp,
         event.chainId,
         context,
+        underlyingPool, // #818: record the source pool as migratedFrom on the target
       );
 
       // Link existing Pool to PoolLauncherPool for migrated pool

--- a/test/EventHandlers/PoolLauncher/CLPoolLauncher.test.ts
+++ b/test/EventHandlers/PoolLauncher/CLPoolLauncher.test.ts
@@ -119,6 +119,8 @@ describe("CLPoolLauncher Events", () => {
       expect(poolLauncherPool?.poolLauncherToken).toBe(mockPoolLauncherToken);
       expect(poolLauncherPool?.pairToken).toBe(mockPairToken);
       expect(poolLauncherPool?.isEmerging).toBe(false);
+      // #818: Launch-created pools are not migration targets — migratedFrom stays empty.
+      expect(poolLauncherPool?.migratedFrom).toBe("");
 
       // Check that Pool was linked
       const liquidityPoolAggregator = await indexer.Pool.get(
@@ -210,6 +212,9 @@ describe("CLPoolLauncher Events", () => {
       expect(originalPoolLauncherPool?.oldLocker).toBe(oldLocker);
       expect(originalPoolLauncherPool?.newLocker).toBe(newLocker);
       expect(originalPoolLauncherPool?.lastMigratedAt).toEqual(mockTimestamp);
+      // The source is a Migrate source, not a target: its own migratedFrom
+      // stays empty (only migratedTo is set on the source).
+      expect(originalPoolLauncherPool?.migratedFrom).toBe("");
 
       // Check that new PoolLauncherPool was created
       const rawNew = await indexer.PoolLauncherPool.get(
@@ -225,6 +230,8 @@ describe("CLPoolLauncher Events", () => {
         mockPoolLauncherToken,
       );
       expect(newPoolLauncherPool?.pairToken).toBe(mockPairToken);
+      // #818: the migrated target records its source pool as migratedFrom.
+      expect(newPoolLauncherPool?.migratedFrom).toBe(underlyingPool);
     });
 
     it("should handle migration when PoolLauncherPool doesn't exist", async () => {

--- a/test/EventHandlers/PoolLauncher/PoolLauncherLogic.test.ts
+++ b/test/EventHandlers/PoolLauncher/PoolLauncherLogic.test.ts
@@ -95,6 +95,46 @@ describe("PoolLauncherLogic", () => {
       expect(savedEntity?.id).toBe(`8453-${poolAddress}`);
     });
 
+    it("should record migratedFrom when created as a Migrate target (#818)", async () => {
+      const poolAddress = toChecksumAddress(
+        "0x1234567890123456789012345678901234567890",
+      );
+      const launcherAddress = toChecksumAddress(
+        "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+      );
+      const creator = toChecksumAddress(
+        "0x1111111111111111111111111111111111111111",
+      );
+      const poolLauncherToken = toChecksumAddress(
+        "0x2222222222222222222222222222222222222222",
+      );
+      const pairToken = toChecksumAddress(
+        "0x3333333333333333333333333333333333333333",
+      );
+      const sourcePool = toChecksumAddress(
+        "0x9999999999999999999999999999999999999999",
+      );
+      const createdAt = new Date("2024-01-01T00:00:00Z");
+      const chainId = 8453;
+
+      const result = await processPoolLauncherPool(
+        poolAddress,
+        launcherAddress,
+        creator,
+        poolLauncherToken,
+        pairToken,
+        createdAt,
+        chainId,
+        mockContext,
+        sourcePool,
+      );
+
+      // The migrated target back-links to its source pool; migratedTo stays empty
+      // until this pool is itself migrated away.
+      expect(result.migratedFrom).toBe(sourcePool);
+      expect(result.migratedTo).toBe("");
+    });
+
     it("should update an existing PoolLauncherPool", async () => {
       const poolAddress = toChecksumAddress(
         "0x1234567890123456789012345678901234567890",

--- a/test/EventHandlers/PoolLauncher/V2PoolLauncher.test.ts
+++ b/test/EventHandlers/PoolLauncher/V2PoolLauncher.test.ts
@@ -118,6 +118,8 @@ describe("V2PoolLauncher Events", () => {
       expect(poolLauncherPool?.poolLauncherToken).toBe(mockPoolLauncherToken);
       expect(poolLauncherPool?.pairToken).toBe(mockPairToken);
       expect(poolLauncherPool?.isEmerging).toBe(false);
+      // #818: Launch-created pools are not migration targets — migratedFrom stays empty.
+      expect(poolLauncherPool?.migratedFrom).toBe("");
 
       // Check that Pool was linked
       const liquidityPoolAggregator = await indexer.Pool.get(
@@ -209,6 +211,9 @@ describe("V2PoolLauncher Events", () => {
       expect(originalPoolLauncherPool?.oldLocker).toBe(oldLocker);
       expect(originalPoolLauncherPool?.newLocker).toBe(newLocker);
       expect(originalPoolLauncherPool?.lastMigratedAt).toEqual(mockTimestamp);
+      // The source is a Migrate source, not a target: its own migratedFrom
+      // stays empty (only migratedTo is set on the source).
+      expect(originalPoolLauncherPool?.migratedFrom).toBe("");
 
       // Check that new PoolLauncherPool was created
       const rawNew = await indexer.PoolLauncherPool.get(
@@ -224,6 +229,8 @@ describe("V2PoolLauncher Events", () => {
         mockPoolLauncherToken,
       );
       expect(newPoolLauncherPool?.pairToken).toBe(mockPairToken);
+      // #818: the migrated target records its source pool as migratedFrom.
+      expect(newPoolLauncherPool?.migratedFrom).toBe(underlyingPool);
     });
 
     it("should handle migration when PoolLauncherPool doesn't exist", async () => {


### PR DESCRIPTION
## Problem

`PoolLauncherPool.migratedFrom` was hardcoded to `""` at the only creation site (`processPoolLauncherPool`) and never assigned — even for the pool that is the **target** of a `Migrate`, which is exactly the case the schema comment describes (`migratedFrom: "previous underlying pool (if this was target in Migrate)"`). The source pool is available on the event as `event.params.underlyingPool` but was unused for this purpose.

## Fix

- Thread an optional trailing `migratedFrom` param (default `""`) through `processPoolLauncherPool`; the create branch now uses it instead of the hardcoded `""`. The update branch is untouched — its spread already preserves any existing value, so lineage is stamped only at creation.
- Both `CLPoolLauncher.Migrate` and `V2PoolLauncher.Migrate` now pass `underlyingPool` as that arg for the newly-created target.
- Stored as the raw event param (events arrive checksummed), symmetric with how `migratedTo` records the new pool address.

Chose an optional trailing param over a mid-signature insert so the two `Launch` call sites and the existing logic-test call sites stay unchanged — only the two `Migrate` sites change.

## Acceptance criteria (#818)

- [x] On `CLPoolLauncher.Migrate` / `V2PoolLauncher.Migrate`, the newly-created target `migratedFrom` is set to `event.params.underlyingPool`
- [x] `Launch`-created pools keep `migratedFrom = ""`
- [x] The existing forward link (`source.migratedTo`) is unchanged
- [x] Test: a Migrate produces a target whose `migratedFrom` equals the source pool address

## Test plan

- `vitest run test/EventHandlers/PoolLauncher/` → **44/44 pass**. New coverage: CL & V2 Migrate tests assert the target's `migratedFrom === underlyingPool` (and that the source's own `migratedFrom` stays `""`); CL & V2 Launch tests assert `migratedFrom === ""`; a dedicated `processPoolLauncherPool` unit test exercises the new param directly.
- `tsc --noEmit` → clean (also confirms the new 9-arg signature breaks no other caller — all four call sites are in PoolLauncher).
- `biome check` → clean.
- Full `pnpm test` was not run here: the v3.0.2 suite has many files that hit live RPC and is known-flaky/slow, so `tsc` + the PoolLauncher suite give the trustworthy signal for this leaf-scoped change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
