### PR TITLE
fix(pool-launcher): stamp Pool.lastUpdatedTimestamp from block time (closes #819)

### DIFF
--- a/src/EventHandlers/PoolLauncher/CLPoolLauncher.ts
+++ b/src/EventHandlers/PoolLauncher/CLPoolLauncher.ts
@@ -31,7 +31,13 @@ indexer.onEvent(
     );
 
     // Link existing Pool to PoolLauncherPool
-    await linkPoolToPoolLauncher(poolAddress, event.chainId, context, "CL");
+    await linkPoolToPoolLauncher(
+      poolAddress,
+      event.chainId,
+      context,
+      "CL",
+      createdAt,
+    );
   },
 );
 
@@ -85,6 +91,7 @@ indexer.onEvent(
         event.chainId,
         context,
         "CL",
+        timestamp,
       );
     } else {
       context.log.warn(

--- a/src/EventHandlers/PoolLauncher/PoolLauncherLogic.ts
+++ b/src/EventHandlers/PoolLauncher/PoolLauncherLogic.ts
@@ -55,12 +55,27 @@ export async function processPoolLauncherPool(
   return poolLauncherPool;
 }
 
-// Helper function to link existing Pool to PoolLauncherPool
+/**
+ * Links an existing Pool (created by CLFactory or V2Factory) to its
+ * PoolLauncherPool by stamping `poolLauncherPoolId` onto the Pool entity.
+ *
+ * `lastUpdatedTimestamp` is taken from the caller's block-derived time rather
+ * than `new Date()`, so the field stays deterministic across re-index runs
+ * (see #819).
+ *
+ * @param poolAddress - Address of the underlying Pool to link.
+ * @param chainId - Chain the Pool lives on; combined with `poolAddress` into the entity id.
+ * @param context - Envio handler context used to read/write the Pool entity.
+ * @param factoryType - Which factory created the Pool ("CL" or "V2"); used only for the not-found warning.
+ * @param lastUpdatedTimestamp - Block-derived time (`new Date(event.block.timestamp * 1000)`) to stamp onto the Pool.
+ * @returns Promise that resolves once the linked Pool upsert is staged (no-op if the Pool does not exist yet).
+ */
 export async function linkPoolToPoolLauncher(
   poolAddress: string,
   chainId: number,
   context: handlerContext,
   factoryType: "CL" | "V2",
+  lastUpdatedTimestamp: Date,
 ): Promise<void> {
   // Load the existing Pool (created by CLFactory or V2Factory)
   const poolId = PoolId(chainId, poolAddress);
@@ -77,7 +92,7 @@ export async function linkPoolToPoolLauncher(
   const updatedPool: Pool = {
     ...existingPool,
     poolLauncherPoolId: poolId,
-    lastUpdatedTimestamp: new Date(),
+    lastUpdatedTimestamp,
   };
 
   context.Pool.set(updatedPool);

--- a/src/EventHandlers/PoolLauncher/V2PoolLauncher.ts
+++ b/src/EventHandlers/PoolLauncher/V2PoolLauncher.ts
@@ -31,7 +31,13 @@ indexer.onEvent(
     );
 
     // Link existing Pool to PoolLauncherPool
-    await linkPoolToPoolLauncher(poolAddress, event.chainId, context, "V2");
+    await linkPoolToPoolLauncher(
+      poolAddress,
+      event.chainId,
+      context,
+      "V2",
+      createdAt,
+    );
   },
 );
 
@@ -85,6 +91,7 @@ indexer.onEvent(
         event.chainId,
         context,
         "V2",
+        timestamp,
       );
     } else {
       context.log.warn(

--- a/test/EventHandlers/PoolLauncher/PoolLauncherLogic.test.ts
+++ b/test/EventHandlers/PoolLauncher/PoolLauncherLogic.test.ts
@@ -264,7 +264,14 @@ describe("PoolLauncherLogic", () => {
 
         pools.set(existingPool.id, existingPool);
 
-        await linkPoolToPoolLauncher(poolAddress, chainId, mockContext, "CL");
+        const blockTimestamp = new Date("2024-06-01T12:00:00Z");
+        await linkPoolToPoolLauncher(
+          poolAddress,
+          chainId,
+          mockContext,
+          "CL",
+          blockTimestamp,
+        );
 
         // Assert
         const updatedEntity = pools.get(PoolId(chainId, poolAddress));
@@ -272,7 +279,7 @@ describe("PoolLauncherLogic", () => {
         expect(updatedEntity?.poolLauncherPoolId).toBe(
           "8453-0x1234567890123456789012345678901234567890",
         );
-        expect(updatedEntity?.lastUpdatedTimestamp).toBeInstanceOf(Date);
+        expect(updatedEntity?.lastUpdatedTimestamp).toEqual(blockTimestamp);
 
         // Verify all other fields remain unchanged
         expect(updatedEntity?.id).toBe(PoolId(chainId, poolAddress));
@@ -306,6 +313,7 @@ describe("PoolLauncherLogic", () => {
           chainId,
           mockContextWithWarn,
           "CL",
+          new Date("2024-06-01T12:00:00Z"),
         );
 
         // Assert
@@ -331,7 +339,14 @@ describe("PoolLauncherLogic", () => {
 
         pools.set(existingPool.id, existingPool);
 
-        await linkPoolToPoolLauncher(poolAddress, chainId, mockContext, "V2");
+        const blockTimestamp = new Date("2024-06-01T12:00:00Z");
+        await linkPoolToPoolLauncher(
+          poolAddress,
+          chainId,
+          mockContext,
+          "V2",
+          blockTimestamp,
+        );
 
         // Assert
         const updatedEntity = pools.get(PoolId(chainId, poolAddress));
@@ -339,7 +354,7 @@ describe("PoolLauncherLogic", () => {
         expect(updatedEntity?.poolLauncherPoolId).toBe(
           "8453-0x1234567890123456789012345678901234567890",
         );
-        expect(updatedEntity?.lastUpdatedTimestamp).toBeInstanceOf(Date);
+        expect(updatedEntity?.lastUpdatedTimestamp).toEqual(blockTimestamp);
 
         // Verify all other fields remain unchanged
         expect(updatedEntity?.id).toBe(PoolId(chainId, poolAddress));
@@ -371,6 +386,7 @@ describe("PoolLauncherLogic", () => {
           chainId,
           mockContextWithWarn,
           "V2",
+          new Date("2024-06-01T12:00:00Z"),
         );
 
         // Assert
@@ -390,12 +406,45 @@ describe("PoolLauncherLogic", () => {
 
       pools.set(existingPool.id, existingPool);
 
-      await linkPoolToPoolLauncher(poolAddress, 10, mockContext, "CL");
+      await linkPoolToPoolLauncher(
+        poolAddress,
+        10,
+        mockContext,
+        "CL",
+        new Date("2024-06-01T12:00:00Z"),
+      );
 
       // Assert
       const updatedEntity = pools.get(PoolId(10, poolAddress));
       expect(updatedEntity).toBeDefined();
       expect(updatedEntity?.poolLauncherPoolId).toBe(PoolId(10, poolAddress));
+    });
+
+    it("stamps the block-derived lastUpdatedTimestamp it is given, not the host wall-clock (deterministic across re-index)", async () => {
+      const existingPool = createMockPool({
+        poolAddress: poolAddress,
+        chainId: chainId,
+        isCL: true,
+      });
+
+      pools.set(existingPool.id, existingPool);
+
+      // Block time of the event being (re)processed — fixed and deterministic.
+      const blockTimestamp = new Date("2024-06-01T12:00:00Z");
+
+      await linkPoolToPoolLauncher(
+        poolAddress,
+        chainId,
+        mockContext,
+        "CL",
+        blockTimestamp,
+      );
+
+      // Must equal the block-derived value passed in, proving the field is not
+      // stamped from new Date() (host clock); re-indexing the same history then
+      // yields a stable lastUpdatedTimestamp. See #819.
+      const updatedEntity = pools.get(PoolId(chainId, poolAddress));
+      expect(updatedEntity?.lastUpdatedTimestamp).toEqual(blockTimestamp);
     });
   });
 });


### PR DESCRIPTION
## Summary
- `linkPoolToPoolLauncher` stamped `lastUpdatedTimestamp` with `new Date()` (host wall-clock), making the field non-deterministic across re-index runs and able to clobber a block-derived value with a future time.
- It now takes the block-derived time as a required 5th param (`lastUpdatedTimestamp: Date`) and writes that instead. All four call sites thread the block Date already in scope — `createdAt` (CL/V2 `Launch`) and `timestamp` (CL/V2 `Migrate`), both `new Date(event.block.timestamp * 1000)`.

Closes #819.

## Acceptance criteria
- [x] `linkPoolToPoolLauncher` stamps `lastUpdatedTimestamp` from `event.block.timestamp`, threaded from the four call sites
- [x] No `new Date()` host-clock call remains in the PoolLauncher module
- [x] Re-indexing the same history yields a stable `lastUpdatedTimestamp`

## Test plan
- [x] New determinism test in `test/EventHandlers/PoolLauncher/PoolLauncherLogic.test.ts` asserts the stamped `lastUpdatedTimestamp` `toEqual` the block-derived Date — RED before the fix (stamped host clock), GREEN after. Two existing vacuous `toBeInstanceOf(Date)` assertions strengthened to `toEqual`.
- [x] `vitest run test/EventHandlers/PoolLauncher/` — 44/44 pass
- [x] `tsc --noEmit` clean (whole project)
- [x] `biome check` clean on changed files

_Built on the merged Envio v3.0.2 migration (no `generated/` dir; types via `.envio` + the `envio` package)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)