### PR TITLE
Heal frozen token metadata: decimals and off-refresh reachability

### DIFF
--- a/src/EventHandlers/Voter/SuperchainLeafVoter.ts
+++ b/src/EventHandlers/Voter/SuperchainLeafVoter.ts
@@ -9,6 +9,7 @@ import {
 } from "../../Constants";
 import { getTokenDetails, hasContractBytecode } from "../../Effects/Index";
 import { getRehydrated } from "../../EntityTimestamps";
+import { healTokenMetadata } from "../../PriceOracle";
 import { getGateDecisionFromSignals } from "../../PriceTrust";
 
 indexer.contractRegister(
@@ -143,6 +144,15 @@ indexer.onEvent(
 
     // Update the Token entity in the DB, either by updating the existing one or creating a new one
     if (token) {
+      // Issue #820: heal frozen metadata (empty symbol/name, fallback-origin
+      // decimals) for whitelisted tokens that may never hit refreshTokenPrice —
+      // a token that is never a pool or reward token never reaches the heal
+      // lifted above the throttle there. WhitelistToken is the one recurring
+      // path such tokens traverse, mirroring the #761 priceTrust recompute
+      // below. healTokenMetadata short-circuits without an RPC once symbol+name
+      // are populated, so the common (already-healed) case stays free.
+      const healed = await healTokenMetadata(token, event.chainId, context);
+
       // Recompute the price-trust gate alongside isWhitelisted so the persisted
       // priceTrustOutcome/priceTrustReason stay in lockstep with the whitelist
       // signal. Without this, tokens first observed via pool events before
@@ -153,7 +163,7 @@ indexer.onEvent(
         event.params._bool,
       );
       const updatedToken: Token = {
-        ...token,
+        ...healed,
         isWhitelisted: event.params._bool,
         priceTrustOutcome: decision.outcome,
         priceTrustReason: decision.reason,

--- a/src/EventHandlers/Voter/Voter.ts
+++ b/src/EventHandlers/Voter/Voter.ts
@@ -28,7 +28,7 @@ import {
 } from "../../Constants";
 import { getTokenDetails, hasContractBytecode } from "../../Effects/Index";
 import { getRehydrated } from "../../EntityTimestamps";
-import { refreshTokenPrice } from "../../PriceOracle";
+import { healTokenMetadata, refreshTokenPrice } from "../../PriceOracle";
 import { getGateDecisionFromSignals } from "../../PriceTrust";
 import {
   VoterEventType,
@@ -438,6 +438,15 @@ indexer.onEvent(
 
     // Update the Token entity in the DB, either by updating the existing one or creating a new one
     if (token) {
+      // Issue #820: heal frozen metadata (empty symbol/name, fallback-origin
+      // decimals) for whitelisted tokens that may never hit refreshTokenPrice —
+      // a token that is never a pool or reward token never reaches the heal
+      // lifted above the throttle there. WhitelistToken is the one recurring
+      // path such tokens traverse, mirroring the #761 priceTrust recompute
+      // below. healTokenMetadata short-circuits without an RPC once symbol+name
+      // are populated, so the common (already-healed) case stays free.
+      const healed = await healTokenMetadata(token, event.chainId, context);
+
       // Recompute the price-trust gate alongside isWhitelisted so the persisted
       // priceTrustOutcome/priceTrustReason stay in lockstep with the whitelist
       // signal. Without this, tokens first observed via pool events before
@@ -448,7 +457,7 @@ indexer.onEvent(
         event.params._bool,
       );
       const updatedToken: Token = {
-        ...token,
+        ...healed,
         isWhitelisted: event.params._bool,
         priceTrustOutcome: decision.outcome,
         priceTrustReason: decision.reason,

--- a/src/PriceOracle.ts
+++ b/src/PriceOracle.ts
@@ -506,11 +506,22 @@ export async function refreshTokenPrice(
  * once per pool's `PoolCreated` event, so a transient RPC failure persists `?`
  * (empty symbol) on the Token forever.
  *
- * Exported so callers can heal outside the price-refresh path (issue #735):
- * `refreshTokenPrice` runs this above the 1-hour throttle so the first Swap /
- * Mint / Burn / Voter event after a pool's creation clears empty metadata,
- * even when the event lands inside the throttle window. The standalone export
- * keeps the door open for non-refresh handlers to call heal directly.
+ * Also re-derives a fallback-origin `decimals` (issue #820): when the stored
+ * row carries the full TOKEN_DETAILS_FALLBACK fingerprint (empty symbol AND
+ * empty name — the only shape under which `decimals` is the stubbed 18 rather
+ * than a real read) and a genuine fresh read reports a different value, the
+ * corrected decimals is overlaid alongside symbol/name. A row missing only one
+ * of symbol/name had a real creation-time read (a failed read replaces all
+ * three fields with the fallback) so its decimals is left untouched, as is a
+ * legitimately 18-decimal token — which has a symbol and never reaches this
+ * path.
+ *
+ * Exported so callers can heal outside the price-refresh path (issues #735,
+ * #820): `refreshTokenPrice` runs this above the 1-hour throttle so the first
+ * Swap / Mint / Burn / Voter event after a pool's creation clears empty
+ * metadata even when the event lands inside the throttle window, and the
+ * `WhitelistToken` handlers call it so whitelisted tokens that never hit
+ * `refreshTokenPrice` (never a pool/reward token) still heal.
  *
  * Idempotent: once `symbol` and `name` are both populated the function
  * short-circuits without an effect call. When `getTokenDetails` legitimately
@@ -524,8 +535,9 @@ export async function refreshTokenPrice(
  * @param token - Existing Token entity (read-only).
  * @param chainId - Chain to query.
  * @param context - Envio handler context for the effect call, `Token.set`, and logging.
- * @returns The healed Token entity (with overlaid `symbol`/`name`) when fresh
- *          values were available; the original `token` reference otherwise.
+ * @returns The healed Token entity (with overlaid `symbol` / `name` and, for a
+ *          fallback-origin row, `decimals`) when fresh values were available;
+ *          the original `token` reference otherwise.
  */
 export async function healTokenMetadata(
   token: Token,
@@ -541,10 +553,40 @@ export async function healTokenMetadata(
       contractAddress: token.address,
       chainId,
     });
-    const overlay: { symbol?: string; name?: string } = {};
+    const overlay: { symbol?: string; name?: string; decimals?: bigint } = {};
     if (!token.symbol && details.symbol) overlay.symbol = details.symbol;
     if (!token.name && details.name) overlay.name = details.name;
-    if (overlay.symbol === undefined && overlay.name === undefined) {
+    // Issue #820: re-derive a fallback-origin `decimals`. It is written once at
+    // creation and was never healed, so a token created from the
+    // TOKEN_DETAILS_FALLBACK constant (transient RPC failure or full contract
+    // revert ⇒ empty symbol AND empty name AND the stubbed decimals=18) stayed
+    // mis-scaled by 10^(18-real) forever for a non-18 token (USDC=6, WBTC=8).
+    // The fingerprint is BOTH symbol and name empty — the exact fallback shape.
+    // A failed `getTokenDetails` replaces all three fields with the fallback
+    // constant, so a row missing only one of symbol/name had a real
+    // creation-time read and its decimals is trusted and left untouched; a
+    // legitimately 18-decimal token has a symbol and never reaches this heal
+    // path. A non-empty `details.symbol` marks the fresh read as genuine (a
+    // fallback read returns an empty symbol), so a differing decimals is
+    // adopted only from a real read. (Deferred edge: a token whose `decimals()`
+    // alone returns null while name/symbol succeed keeps the fetcher's
+    // substituted 18 — its symbol is non-empty so it skips this heal; catching
+    // it needs the effect to surface `usedDefault`. Out of scope for this P3
+    // fix; #736's bytecode/decimals probe filters most such tokens.)
+    const freshDecimals = BigInt(details.decimals);
+    if (
+      !token.symbol &&
+      !token.name &&
+      details.symbol &&
+      freshDecimals !== token.decimals
+    ) {
+      overlay.decimals = freshDecimals;
+    }
+    if (
+      overlay.symbol === undefined &&
+      overlay.name === undefined &&
+      overlay.decimals === undefined
+    ) {
       return token;
     }
     const updated: Token = { ...token, ...overlay };

--- a/test/PriceOracle.test.ts
+++ b/test/PriceOracle.test.ts
@@ -91,6 +91,23 @@ describe("PriceOracle", () => {
     return {};
   };
 
+  // Issue #820 test helper: install a getTokenDetails override while delegating
+  // every other effect to the default implementation, so a test only states the
+  // metadata it cares about.
+  const overrideTokenDetails = (result: {
+    name: string;
+    decimals: number;
+    symbol: string;
+  }) => {
+    vi.mocked(mockContext.effect)?.mockImplementation(
+      async (effect: unknown, input: unknown) => {
+        const name = (effect as { name?: string }).name;
+        if (name === "getTokenDetails") return result;
+        return defaultEffectImplementation(effect, input);
+      },
+    );
+  };
+
   beforeEach(() => {
     // Reset effect mock to default implementation before each test
     vi.mocked(mockContext.effect)?.mockImplementation(
@@ -991,6 +1008,120 @@ describe("PriceOracle", () => {
         expect(vi.mocked(mockContext.log?.error)).toHaveBeenCalledWith(
           expect.stringContaining("Error refreshing token metadata"),
         );
+      });
+
+      // Issue #820: a Token created from the TOKEN_DETAILS_FALLBACK constant
+      // (empty symbol + empty name + the stubbed decimals=18, written on a
+      // transient RPC failure or full contract revert at creation) used to keep
+      // the fallback 18 forever — heal overlaid only symbol/name, mis-scaling a
+      // non-18 token (USDC=6, WBTC=8) by 10^(18-real). Heal now re-derives a
+      // fallback-origin decimals in the same pass that repopulates symbol/name.
+      it("heals a fallback-origin decimals when a later read returns a different value", async () => {
+        overrideTokenDetails({ name: "USD Coin", decimals: 6, symbol: "USDC" });
+
+        const fallbackToken = {
+          ...mockToken0Data,
+          symbol: "",
+          name: "",
+          decimals: 18n,
+        };
+
+        const healed = await PriceOracle.healTokenMetadata(
+          fallbackToken,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        expect(healed.symbol).toBe("USDC");
+        expect(healed.name).toBe("USD Coin");
+        expect(healed.decimals).toBe(6n);
+        expect(vi.mocked(mockContext.Token?.set)).toHaveBeenCalledTimes(1);
+        expect(vi.mocked(mockContext.Token?.set)?.mock.lastCall?.[0]).toBe(
+          healed,
+        );
+      });
+
+      // Issue #820 fingerprint guard: a row missing ONLY the name (symbol +
+      // decimals were read successfully at creation — the fetcher is
+      // all-or-nothing) is not fallback-origin, so its decimals must stand even
+      // if a later read reports a different value. The `!token.name` half of
+      // the gate is load-bearing here; without it a stored 6 would be clobbered.
+      it("does not touch decimals for a name-only-empty row even when a later read differs", async () => {
+        overrideTokenDetails({
+          name: "USD Coin",
+          decimals: 18,
+          symbol: "USDC",
+        });
+
+        const nameOnlyEmpty = {
+          ...mockToken0Data,
+          symbol: "USDC",
+          name: "",
+          decimals: 6n,
+        };
+
+        const healed = await PriceOracle.healTokenMetadata(
+          nameOnlyEmpty,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        expect(healed.name).toBe("USD Coin");
+        expect(healed.symbol).toBe("USDC");
+        expect(healed.decimals).toBe(6n);
+      });
+
+      // Issue #820 (AC: "a frozen-name token heals on read"): a token whose
+      // name is empty but whose symbol + decimals are intact heals just the
+      // name, leaving the other fields untouched.
+      it("heals a frozen (empty) name on read without disturbing symbol or decimals", async () => {
+        overrideTokenDetails({ name: "USD Coin", decimals: 6, symbol: "USDC" });
+
+        const frozenName = {
+          ...mockToken0Data,
+          symbol: "USDC",
+          name: "",
+          decimals: 6n,
+        };
+
+        const healed = await PriceOracle.healTokenMetadata(
+          frozenName,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        expect(healed.name).toBe("USD Coin");
+        expect(healed.symbol).toBe("USDC");
+        expect(healed.decimals).toBe(6n);
+        expect(vi.mocked(mockContext.Token?.set)).toHaveBeenCalledTimes(1);
+      });
+
+      // Issue #820 difference guard: a full-fallback row whose real decimals
+      // genuinely is 18 (e.g. WETH) heals symbol/name but writes no decimals
+      // change — the `!==` check keeps the value stable rather than churning it.
+      it("leaves decimals at 18 when a fallback-origin row's real decimals is also 18", async () => {
+        overrideTokenDetails({
+          name: "Wrapped Ether",
+          decimals: 18,
+          symbol: "WETH",
+        });
+
+        const fallbackToken = {
+          ...mockToken0Data,
+          symbol: "",
+          name: "",
+          decimals: 18n,
+        };
+
+        const healed = await PriceOracle.healTokenMetadata(
+          fallbackToken,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        expect(healed.symbol).toBe("WETH");
+        expect(healed.name).toBe("Wrapped Ether");
+        expect(healed.decimals).toBe(18n);
       });
     });
 


### PR DESCRIPTION
## Summary
- `healTokenMetadata` now re-derives a **fallback-origin `decimals`**. A token created from the `TOKEN_DETAILS_FALLBACK` constant (empty symbol AND name ⇒ stubbed `decimals=18`, written on a transient RPC failure or full contract revert at creation) was mis-scaled by `10^(18 − real)` forever for a non-18 token (USDC=6, WBTC=8). It adopts a differing decimals from a genuine later read, gated on the full-fallback fingerprint so a legitimately 18-decimal token — which has a symbol and never enters the heal path — is never touched.
- **Name heal is now reachable for tokens that never hit `refreshTokenPrice`.** The `Voter` and `SuperchainLeafVoter` `WhitelistToken` handlers call `healTokenMetadata` in the existing-token branch — the one recurring path a whitelisted-but-never-pooled/rewarded token traverses. Heal short-circuits without an RPC once symbol+name are populated, so the common case stays free.
- No change to symbol heal; the decimals overlay is additive and tightly fenced.

Closes #820

## Design notes
- The "and/or avoid permanently caching empty `name()`" arm was intentionally **not** pursued: a deterministic `CONTRACT_REVERT` empty `name()` is genuinely absent and correctly cached (#692); reachability is the real fix and avoids regressing those RPC savings. The issue's "and/or" is satisfied by the reachability arm.
- Deferred edge (noted in a code comment): a token whose `decimals()` alone returns null while name/symbol succeed keeps the fetcher's substituted 18 (its symbol is non-empty, so it skips heal). Catching it needs the effect to surface `usedDefault`; out of scope for this P3, and #736's bytecode/decimals probe already filters most such tokens.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `biome check` clean
- [x] `PriceOracle.test.ts` (72), `Voter.test.ts` (47), `SuperchainLeafVoter.test.ts` (14) all pass
- [x] New unit tests: fallback `18`→`6` correction; frozen-name heal-on-read; fingerprint guards (name-only-empty must not clobber decimals; real-18 stays 18)
- [x] Full `pnpm test` — 1492/1493 pass; the sole failure is an unrelated `CLGaugeFactoryV3` 120s timeout flake that passes in isolation (documented v3-migration suite slowness)
- [ ] Confirm a real non-18 fallback-origin token corrects its decimals on a production replay *(needs human — requires live indexer replay)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)