### PR TITLE
fix(user-stats): populate V2 LPs' raw added/removed token0/1 (closes #810)

### DIFF
--- a/src/EventHandlers/Pool/PoolBurnAndMintLogic.ts
+++ b/src/EventHandlers/Pool/PoolBurnAndMintLogic.ts
@@ -12,6 +12,10 @@ import { calculateTotalUSD } from "../../Helpers";
 export interface AttributionResult {
   recipient: string | undefined;
   totalLiquidityUSD: bigint;
+  /** Raw token0 amount from the Mint/Burn event (#810). */
+  amount0: bigint;
+  /** Raw token1 amount from the Mint/Burn event (#810). */
+  amount1: bigint;
 }
 
 /**
@@ -167,7 +171,7 @@ export function extractRecipientAddress(
  * @param token0Instance - Token0 instance
  * @param token1Instance - Token1 instance
  * @param context - Handler context
- * @returns User address and total liquidity USD, or undefined if no match found
+ * @returns User address, total liquidity USD, and the raw token0/token1 event amounts, or undefined if no match found
  */
 export async function findTransferAndAttribute(
   event: EvmEvent<"Pool", "Mint"> | EvmEvent<"Pool", "Burn">,
@@ -238,6 +242,8 @@ export async function findTransferAndAttribute(
   return {
     recipient,
     totalLiquidityUSD,
+    amount0: event.params.amount0,
+    amount1: event.params.amount1,
   };
 }
 
@@ -297,8 +303,10 @@ export async function processPoolLiquidityEvent(
     blockNumber,
   );
 
-  // Update user stats (actual user, not router) if we found a match
-  // This is the ONLY place where incrementalTotalLiquidityAddedUSD/RemovedUSD is set
+  // Update user stats (actual user, not router) if we found a match.
+  // This is the ONLY place the V2 per-LP liquidity deltas are set:
+  // incrementalTotalLiquidityAdded/RemovedUSD plus the raw added/removed
+  // token0/1 amounts (#810), mirroring the CL/NFPM path in NFPMCommonLogic.
   if (attributionResult?.recipient) {
     const userData = await loadOrCreateUserData(
       attributionResult.recipient,
@@ -312,11 +320,15 @@ export async function processPoolLiquidityEvent(
       ? {
           incrementalTotalLiquidityAddedUSD:
             attributionResult.totalLiquidityUSD,
+          incrementalTotalLiquidityAddedToken0: attributionResult.amount0,
+          incrementalTotalLiquidityAddedToken1: attributionResult.amount1,
           lastActivityTimestamp: timestamp,
         }
       : {
           incrementalTotalLiquidityRemovedUSD:
             attributionResult.totalLiquidityUSD,
+          incrementalTotalLiquidityRemovedToken0: attributionResult.amount0,
+          incrementalTotalLiquidityRemovedToken1: attributionResult.amount1,
           lastActivityTimestamp: timestamp,
         };
 

--- a/test/EventHandlers/Pool/PoolBurnAndMintLogic.test.ts
+++ b/test/EventHandlers/Pool/PoolBurnAndMintLogic.test.ts
@@ -3,10 +3,12 @@ import type {
   PoolTransferInTx,
   Token,
   TxPoolTransferRegistry,
+  UserStatsPerPool,
 } from "envio";
 import {
   PoolTransferInTxId,
   TxPoolTransferRegistryId,
+  UserStatsPerPoolId,
   ZERO_ADDRESS,
   toChecksumAddress,
 } from "../../../src/Constants";
@@ -1065,6 +1067,80 @@ describe("PoolBurnAndMintLogic", () => {
       expect(mockContext.PoolTransferInTx.deleteUnsafe).toHaveBeenCalledWith(
         userMintTransfer.id,
       );
+    });
+
+    it("V2 Mint then Burn credits the user's raw added/removed token0/1 on UserStatsPerPool (issue #810)", async () => {
+      // Stateful UserStatsPerPool so the same user entity persists across the
+      // Mint and the Burn. The default mock's get() returns undefined, which
+      // would mint a fresh zeroed entity on each call and hide accumulation.
+      const userStore = new Map<string, UserStatsPerPool>();
+      // Back the UserStatsPerPool store with userStore. mockContext's property
+      // is read-only, so spread a new context rather than reassigning it; the
+      // PoolTransferInTx/registry mocks carry over and stay stateful.
+      const statefulContext = {
+        ...mockContext,
+        UserStatsPerPool: {
+          get: vi.fn(async (id: string) => userStore.get(id)),
+          set: vi.fn((entity: UserStatsPerPool) => {
+            userStore.set(entity.id, entity);
+          }),
+        },
+      } as unknown as handlerContext;
+
+      // One tx carrying both LP Transfers: a mint Transfer (to USER) at
+      // logIndex 1 and a burn Transfer (from USER) at logIndex 3. The lazy
+      // registry seeder covers both; each event consumes its own.
+      mockPoolTransferInTx = [
+        createMockTransfer(
+          1,
+          ZERO_ADDRESS,
+          USER_ADDRESS,
+          LP_VALUE,
+          true,
+          false,
+        ),
+        createMockTransfer(
+          3,
+          USER_ADDRESS,
+          ZERO_ADDRESS,
+          LP_VALUE,
+          false,
+          true,
+        ),
+      ];
+
+      await processPoolLiquidityEvent(
+        createMockMintEvent(2),
+        mockPoolData,
+        POOL_ADDRESS,
+        CHAIN_ID,
+        statefulContext,
+        TIMESTAMP_DATE,
+        BLOCK_NUMBER,
+        true,
+      );
+      await processPoolLiquidityEvent(
+        createMockBurnEvent(4),
+        mockPoolData,
+        POOL_ADDRESS,
+        CHAIN_ID,
+        statefulContext,
+        TIMESTAMP_DATE,
+        BLOCK_NUMBER,
+        false,
+      );
+
+      const stats = userStore.get(
+        UserStatsPerPoolId(CHAIN_ID, USER_ADDRESS, POOL_ADDRESS),
+      );
+      expect(stats).toBeDefined();
+      // The raw token amounts must thread through the V2 attribution path the
+      // same way the CL/NFPM path sets them (NFPMCommonLogic.ts). Before the
+      // fix the V2 userDiff set only the USD keys, so these stayed at 0n.
+      expect(stats?.totalLiquidityAddedToken0).toBe(AMOUNT0);
+      expect(stats?.totalLiquidityAddedToken1).toBe(AMOUNT1);
+      expect(stats?.totalLiquidityRemovedToken0).toBe(AMOUNT0);
+      expect(stats?.totalLiquidityRemovedToken1).toBe(AMOUNT1);
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #810. V2 (non-CL) liquidity providers had `UserStatsPerPool.totalLiquidityAddedToken0/1` and `totalLiquidityRemovedToken0/1` stuck at `0n`. The V2 Mint/Burn attribution path computed `totalLiquidityUSD` from `event.params.amount0/1` and then **discarded** the raw amounts, so only the USD keys were ever written — while the CL/NFPM path (`NFPMCommonLogic.ts`) already set the raw per-token keys.

The fix threads the raw amounts through the existing V2 attribution path (`src/EventHandlers/Pool/PoolBurnAndMintLogic.ts`, 3 edits):

- `AttributionResult` gains `amount0` / `amount1`.
- `findTransferAndAttribute` returns `event.params.amount0/1`.
- `processPoolLiquidityEvent`'s `userDiff` sets `incrementalTotalLiquidityAddedToken0/1` (mint) and `incrementalTotalLiquidityRemovedToken0/1` (burn).

The `UserStatsPerPool` accumulator already handled these keys (gated on `!== undefined`), so no aggregator change was needed.

### Acceptance criteria
- [x] V2 Mint credits `totalLiquidityAddedToken0/1` with the raw token amounts — `PoolBurnAndMintLogic.ts:323-324`
- [x] V2 Burn credits `totalLiquidityRemovedToken0/1` — `PoolBurnAndMintLogic.ts:330-331`
- [x] CL/NFPM behaviour unchanged — diff touches only `PoolBurnAndMintLogic.ts` + its test; `NFPMCommonLogic.ts` untouched
- [x] Test: a V2 Mint then Burn leaves non-zero raw added/removed token0/1 on the user's `UserStatsPerPool`

Unifying the V2 and CL attribution into one shared helper is a deliberate out-of-scope follow-up — this PR keeps CL/NFPM behaviour unchanged per the issue.

## Test plan
- [x] New test "V2 Mint then Burn credits the user's raw added/removed token0/1 on UserStatsPerPool (issue #810)" — RED (`0n`) before the fix, GREEN after
- [x] `vitest run test/EventHandlers/Pool/` green (13 files, 113 tests)
- [x] `tsc --noEmit` clean
- [x] `biome check` clean
- [ ] Full `pnpm test` not run *(v3.0.2 suite hits live RPC on ~40 unrelated files; this change is additive, gated on `!== undefined`, and isolated to V2 `UserStatsPerPool` raw-token fields)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)