### PR TITLE
fix(superswap): map Hyperlane domain to chainId for destinationChainId (closes #811)

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -609,7 +609,7 @@ type PoolLauncherConfig {
 type SuperSwap {
   id: ID! # Format: {messageId} — globally unique Hyperlane message identifier
   originChainId: BigInt! @config(precision: 24) # Chain ID where the swap originated
-  destinationChainId: BigInt! @config(precision: 24) # Chain ID of the swap target/recipient
+  destinationChainId: BigInt! @config(precision: 24) # Resolved EVM chain ID of the swap target/recipient (mapped from the Hyperlane domain via domainToChainId)
   sender: String! # Original sender address initiating the swap
   recipient: String! # The recipient address on the destination chain
   oUSDTamount: BigInt! @config(precision: 76) # Amount of oUSDT swapped (already normalized to token decimals)
@@ -624,7 +624,7 @@ type OUSDTBridgedTransaction {
   id: ID! # Format: transaction hash (unique per bridge tx)
   transactionHash: String! @index # Transaction hash
   originChainId: BigInt! @config(precision: 24) # Chain ID where the bridge transaction originated
-  destinationChainId: BigInt! @config(precision: 24) # Chain ID where the bridge transaction is destined
+  destinationChainId: BigInt! @config(precision: 24) # Resolved EVM chain ID the bridge transaction is destined for (mapped from the Hyperlane domain via domainToChainId)
   sender: String! # Address that initiated the bridge transaction
   recipient: String! # Address that will receive the bridged tokens
   amount: BigInt! @config(precision: 76) # Amount of oUSDT tokens being bridged

--- a/src/EventHandlers/SuperswapsHyperlane/HyperlaneDomain.ts
+++ b/src/EventHandlers/SuperswapsHyperlane/HyperlaneDomain.ts
@@ -1,0 +1,36 @@
+/**
+ * Hyperlane domain IDs whose value diverges from the chain's EVM chainId.
+ *
+ * Hyperlane identifies a destination chain by a uint32 "domain". For almost
+ * every chain Velodrome/Aerodrome indexes, the domain is numerically identical
+ * to the EVM chainId, so historically the two were used interchangeably. A few
+ * chains diverge; this table maps those domains back to their canonical chainId.
+ *
+ * As of this writing the only divergence across the 12 indexed chains is Metal
+ * (domain 1000001750 -> chainId 1750), verified against the Hyperlane registry
+ * (chains/metal/metadata.yaml: chainId 1750, domainId 1000001750). All other
+ * indexed chains (Optimism, Base, Celo, Soneium, Ink, Mode, Lisk, Unichain,
+ * Fraxtal, Superseed, Swell) have domainId === chainId.
+ *
+ * Keyed by the decimal string form of the domain, since bigint cannot be used
+ * as an object key directly.
+ */
+const DOMAIN_TO_CHAIN_ID: Record<string, bigint> = {
+  "1000001750": 1750n, // Metal
+};
+
+/**
+ * Resolves a Hyperlane destination domain ID to its EVM chainId.
+ *
+ * Divergent domains listed in {@link DOMAIN_TO_CHAIN_ID} are mapped to their
+ * chainId; every other domain is returned unchanged, since domain === chainId
+ * for those chains. An unlisted divergent domain therefore passes through as-is
+ * (the pre-fix behavior), so any future chain whose domainId differs from its
+ * chainId must be added to the table above to be stored correctly.
+ *
+ * @param domain - The Hyperlane uint32 domain ID as emitted on-chain.
+ * @returns The resolved EVM chainId — mapped when divergent, identity otherwise.
+ */
+export function domainToChainId(domain: bigint): bigint {
+  return DOMAIN_TO_CHAIN_ID[domain.toString()] ?? domain;
+}

--- a/src/EventHandlers/SuperswapsHyperlane/VelodromeUniversalRouter.ts
+++ b/src/EventHandlers/SuperswapsHyperlane/VelodromeUniversalRouter.ts
@@ -1,6 +1,7 @@
 import { indexer } from "envio";
 import type { OUSDTBridgedTransaction } from "envio";
 import { OUSDT_ADDRESS } from "../../Constants";
+import { domainToChainId } from "./HyperlaneDomain";
 import { handleCrossChainSwapEvent } from "./SuperSwapLogic";
 
 indexer.onEvent(
@@ -15,7 +16,7 @@ indexer.onEvent(
       id: event.transaction.hash,
       transactionHash: event.transaction.hash,
       originChainId: BigInt(event.chainId),
-      destinationChainId: event.params.domain,
+      destinationChainId: domainToChainId(event.params.domain),
       sender: event.params.sender,
       recipient: event.params.recipient,
       amount: event.params.amount,
@@ -31,7 +32,7 @@ indexer.onEvent(
     await handleCrossChainSwapEvent(
       event.transaction.hash,
       event.chainId,
-      event.params.destinationDomain,
+      domainToChainId(event.params.destinationDomain),
       event.block.timestamp,
       context,
     );

--- a/test/EventHandlers/SuperswapsHyperlane/HyperlaneDomain.test.ts
+++ b/test/EventHandlers/SuperswapsHyperlane/HyperlaneDomain.test.ts
@@ -1,0 +1,19 @@
+import { domainToChainId } from "../../../src/EventHandlers/SuperswapsHyperlane/HyperlaneDomain";
+
+describe("domainToChainId", () => {
+  it("maps Metal's Hyperlane domain (1000001750) to its chainId (1750)", () => {
+    expect(domainToChainId(1000001750n)).toBe(1750n);
+  });
+
+  it("returns the value unchanged for chains where domain === chainId", () => {
+    // All 11 other indexed chains have domainId === chainId (identity).
+    expect(domainToChainId(10n)).toBe(10n); // Optimism
+    expect(domainToChainId(8453n)).toBe(8453n); // Base
+    expect(domainToChainId(1135n)).toBe(1135n); // Lisk
+    expect(domainToChainId(1923n)).toBe(1923n); // Swell
+  });
+
+  it("passes an unknown/unlisted domain through as-is", () => {
+    expect(domainToChainId(999999n)).toBe(999999n);
+  });
+});

--- a/test/EventHandlers/SuperswapsHyperlane/VelodromeUniversalRouter.test.ts
+++ b/test/EventHandlers/SuperswapsHyperlane/VelodromeUniversalRouter.test.ts
@@ -78,6 +78,48 @@ describe("VelodromeUniversalRouter Event Handlers", () => {
       expect(bridgedTransaction?.amount).toBe(1000n * 10n ** 6n); // Raw amount: 1000 tokens with 6 decimals
     });
 
+    it("should resolve a divergent Hyperlane domain to its chainId (Metal 1000001750 -> 1750)", async () => {
+      const indexer = createTestIndexer();
+      const metalHyperlaneDomain = 1000001750n; // Metal's Hyperlane domainId
+      const metalChainId = 1750n; // Metal's EVM chainId
+
+      await indexer.process({
+        chains: {
+          [chainId]: {
+            simulate: [
+              {
+                contract: "VelodromeUniversalRouter",
+                event: "UniversalRouterBridge",
+                logIndex: 1,
+                block: {
+                  timestamp: blockTimestamp,
+                  number: 123456,
+                  hash: transactionHash,
+                },
+                transaction: {
+                  hash: transactionHash,
+                },
+                params: {
+                  token: OUSDT_ADDRESS,
+                  domain: metalHyperlaneDomain,
+                  sender: senderAddress,
+                  recipient: recipientAddress,
+                  amount: tokenAmount,
+                },
+              },
+            ],
+          },
+        },
+      });
+
+      const bridgedTransaction =
+        await indexer.OUSDTBridgedTransaction.get(transactionHash);
+
+      expect(bridgedTransaction).toBeDefined();
+      // Must store the resolved chainId (1750), not the raw Hyperlane domain (1000001750).
+      expect(bridgedTransaction?.destinationChainId).toBe(metalChainId);
+    });
+
     it("should not create entity when token is not oUSDT", async () => {
       const indexer = createTestIndexer();
       const otherTokenAddress = toChecksumAddress(
@@ -286,6 +328,107 @@ describe("VelodromeUniversalRouter Event Handlers", () => {
       expect(superSwap?.destinationChainToken).toBe(tokenOutAddress);
       expect(superSwap?.destinationChainTokenAmountSwapped).toBe(950n);
       expect(superSwap?.timestamp).toEqual(new Date(blockTimestamp * 1000));
+    });
+
+    it("should store the resolved chainId on SuperSwap for a Metal-destined CrossChainSwap (domain 1000001750 -> 1750)", async () => {
+      const indexer = createTestIndexer();
+      const metalHyperlaneDomain = 1000001750n; // Metal's Hyperlane domainId
+      const metalChainId = 1750; // Metal's EVM chainId
+
+      // Bridged transaction already carries the resolved chainId (post-fix producer).
+      const existingBridgedTransaction: OUSDTBridgedTransaction = {
+        id: transactionHash,
+        transactionHash: transactionHash,
+        originChainId: BigInt(chainId),
+        destinationChainId: BigInt(metalChainId),
+        sender: senderAddress.toLowerCase(),
+        recipient: recipientAddress.toLowerCase(),
+        amount: 18116811000000000000n,
+      };
+
+      const dispatchIdEvent: DispatchId_event = {
+        id: MailboxMessageId(transactionHash, chainId, messageId),
+        chainId: chainId,
+        transactionHash: transactionHash,
+        messageId: messageId,
+      };
+
+      const processIdEvent: ProcessId_event = {
+        id: MailboxMessageId(destinationTxHash, metalChainId, messageId),
+        chainId: metalChainId,
+        transactionHash: destinationTxHash,
+        messageId: messageId,
+      };
+
+      const sourceSwapEvent: OUSDTSwaps = {
+        id: OUSDTSwapsId(
+          transactionHash,
+          chainId,
+          tokenInAddress,
+          1000n,
+          OUSDT_ADDRESS,
+          existingBridgedTransaction.amount,
+        ),
+        transactionHash: transactionHash,
+        tokenInPool: tokenInAddress,
+        tokenOutPool: OUSDT_ADDRESS,
+        amountIn: 1000n,
+        amountOut: existingBridgedTransaction.amount,
+      };
+
+      const destinationSwapEvent: OUSDTSwaps = {
+        id: OUSDTSwapsId(
+          destinationTxHash,
+          metalChainId,
+          OUSDT_ADDRESS,
+          existingBridgedTransaction.amount,
+          tokenOutAddress,
+          950n,
+        ),
+        transactionHash: destinationTxHash,
+        tokenInPool: OUSDT_ADDRESS,
+        tokenOutPool: tokenOutAddress,
+        amountIn: existingBridgedTransaction.amount,
+        amountOut: 950n,
+      };
+
+      indexer.OUSDTBridgedTransaction.set(existingBridgedTransaction);
+      indexer.DispatchId_event.set(dispatchIdEvent);
+      indexer.ProcessId_event.set(processIdEvent);
+      indexer.OUSDTSwaps.set(sourceSwapEvent);
+      indexer.OUSDTSwaps.set(destinationSwapEvent);
+
+      await indexer.process({
+        chains: {
+          [chainId]: {
+            simulate: [
+              {
+                contract: "VelodromeUniversalRouter",
+                event: "CrossChainSwap",
+                logIndex: 2,
+                block: {
+                  timestamp: blockTimestamp,
+                  number: 123457,
+                  hash: transactionHash,
+                },
+                transaction: {
+                  hash: transactionHash,
+                },
+                params: {
+                  destinationDomain: metalHyperlaneDomain,
+                },
+              },
+            ],
+          },
+        },
+      });
+
+      const superSwap = await indexer.SuperSwap.get(SuperSwapId(messageId));
+
+      expect(superSwap).toBeDefined();
+      expect(superSwap?.originChainId).toBe(BigInt(chainId));
+      // SuperSwap must store the resolved chainId, not the raw Hyperlane domain.
+      expect(superSwap?.destinationChainId).toBe(BigInt(metalChainId));
     });
 
     it("should not create SuperSwap when no OUSDTBridgedTransaction exists", async () => {


### PR DESCRIPTION
Closes #811

## What & why

`SuperSwap.destinationChainId` and `OUSDTBridgedTransaction.destinationChainId` stored the raw Hyperlane `uint32` domain verbatim. For 11 of the 12 indexed chains the Hyperlane domain equals the EVM chainId, so the value was correct *by coincidence* — but **Metal** (chainId `1750`, Hyperlane domain `1000001750`) stored the wrong value.

## Decision (issue was HITL: rename vs map)

Chose **(b) map domain→chainId**, not rename. The field is named `destinationChainId`, documented as "Chain ID", and sits beside a genuine `originChainId` (`BigInt(event.chainId)`); mapping keeps that contract and is non-breaking for downstream consumers (dashboards/API), whereas a rename would break them and leave the entity asymmetric (origin=chainId, destination=domain).

## Verification that "only Metal diverges"

Checked all 12 indexed chains against the Hyperlane registry `metadata.yaml`: only Metal's `domainId` (1000001750) differs from its `chainId` (1750). The other 11 — Optimism, Base, Celo, Soneium, Ink, Mode, Lisk, Unichain, Fraxtal, Superseed, Swell — have `domainId === chainId`.

## Change

- New `src/EventHandlers/SuperswapsHyperlane/HyperlaneDomain.ts`: `domainToChainId(domain)` — `1000001750n → 1750n`, identity otherwise, with a documented, extensible lookup table.
- Applied at the **two raw-event boundaries** in `VelodromeUniversalRouter.ts`: the `OUSDTBridgedTransaction` producer and the `CrossChainSwap → SuperSwap` path.
- `SuperSwapLogic.ts:453` (late-ProcessId path) reads back the already-mapped `OUSDTBridgedTransaction.destinationChainId`, so it **inherits** the fix — the read-back coupling stays consistent (no double-mapping).
- `schema.graphql`: comments on both `destinationChainId` fields updated to note the value is the resolved chainId, mapped from the Hyperlane domain. Comment-only (fields stay `BigInt!`), so no codegen/type change.

## Test plan

- [x] `domainToChainId` unit tests: Metal → 1750; identity for Optimism/Base/Lisk/Swell; unknown domain passes through (`HyperlaneDomain.test.ts`).
- [x] Metal-destination `OUSDTBridgedTransaction` stores `1750` (`VelodromeUniversalRouter.test.ts`).
- [x] Metal-destination `SuperSwap` stores `1750` via the CrossChainSwap path (`VelodromeUniversalRouter.test.ts`).
- [x] Existing identity-domain tests (Base 8453, Lisk 252) and the Mailbox ProcessId→SuperSwap integration test stay green — full SuperswapsHyperlane suite 55/55.
- [x] `tsc --noEmit` clean; `biome` clean.

## Note

`SuperSwapLogic`'s `destinationDomain` params now carry resolved chainIds; left unrenamed to keep the diff surgical (could be tidied in a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)