### PR TITLE
Clamp negative lpBalance, ALM lpAmount, and veNFT totalValueLocked

### DIFF
--- a/src/Aggregators/ALMLPWrapper.ts
+++ b/src/Aggregators/ALMLPWrapper.ts
@@ -25,12 +25,28 @@ export async function updateALMLPWrapper(
   timestamp: Date,
   context: handlerContext,
 ): Promise<void> {
+  // Clamp lpAmount to >= 0n on write (issue #816). The V1-withdraw fallback can
+  // subtract more than was added: a V1 `Withdraw` emits the input parameter, not
+  // the actual burned amount (see getActualLpAmountForV1 in
+  // src/EventHandlers/ALM/LPWrapperLogic.ts), so a withdraw can exceed the
+  // deposits we accumulated and drive the counter negative. Clamp-and-log mirrors
+  // [NEG_RESERVE_GUARD] in Aggregators/Pool.ts; [NEG_ALM_LP_AMOUNT_GUARD] keeps
+  // the underflow observable. Breadcrumb only — no deeper V1 fix unless a symptom
+  // is observed (issue #816 AC).
+  const lpAmountRaw =
+    diff.incrementalLpAmount !== undefined
+      ? diff.incrementalLpAmount + current.lpAmount
+      : current.lpAmount;
+  const clampedLpAmount = lpAmountRaw < 0n ? 0n : lpAmountRaw;
+  if (lpAmountRaw < 0n) {
+    context.log.warn(
+      `[NEG_ALM_LP_AMOUNT_GUARD][updateALMLPWrapper] field=lpAmount id=${current.id} priorLpAmount=${current.lpAmount} delta=${diff.incrementalLpAmount ?? 0n} clampedTo=${clampedLpAmount}`,
+    );
+  }
+
   let updated: ALM_LP_Wrapper = {
     ...current,
-    lpAmount:
-      diff.incrementalLpAmount !== undefined
-        ? diff.incrementalLpAmount + current.lpAmount
-        : current.lpAmount,
+    lpAmount: clampedLpAmount,
     tokenId: diff.tokenId !== undefined ? diff.tokenId : current.tokenId,
     liquidity:
       diff.liquidity !== undefined ? diff.liquidity : current.liquidity,

--- a/src/Aggregators/UserStatsPerPool.ts
+++ b/src/Aggregators/UserStatsPerPool.ts
@@ -200,6 +200,39 @@ export async function updateUserStatsPerPool(
   timestamp: Date,
   preloadedPoolData?: PoolData,
 ): Promise<UserStatsPerPool> {
+  // Clamp lpBalance to >= 0n on write (issue #816). A holder that existed before
+  // this chain's indexer start block surfaces first as a transfer-out: we debit
+  // an LP balance we never credited, so the running counter would go negative
+  // permanently. Clamp-and-log mirrors [NEG_RESERVE_GUARD] in Aggregators/Pool.ts;
+  // [NEG_LP_BALANCE_GUARD] keeps the underflow observable.
+  const lpBalanceRaw =
+    diff.incrementalLpBalance !== undefined
+      ? current.lpBalance + diff.incrementalLpBalance
+      : current.lpBalance;
+  const clampedLpBalance = lpBalanceRaw < 0n ? 0n : lpBalanceRaw;
+  if (lpBalanceRaw < 0n) {
+    context.log.warn(
+      `[NEG_LP_BALANCE_GUARD][updateUserStatsPerPool] field=lpBalance userAddress=${current.userAddress} poolAddress=${current.poolAddress} chainId=${current.chainId} priorLpBalance=${current.lpBalance} delta=${diff.incrementalLpBalance ?? 0n} clampedTo=${clampedLpBalance}`,
+    );
+  }
+
+  // Clamp almLpAmount to >= 0n on write (issue #816). The ALM V1-withdraw fallback
+  // can subtract more than was added: a V1 `Withdraw` emits the input parameter,
+  // not the actual burned amount (see getActualLpAmountForV1 in
+  // src/EventHandlers/ALM/LPWrapperLogic.ts), so a withdraw can exceed accumulated
+  // deposits and drive the counter negative. Breadcrumb only — no deeper V1 fix
+  // unless a symptom is observed (issue #816 AC).
+  const almLpAmountRaw =
+    diff.incrementalAlmLpAmount !== undefined
+      ? current.almLpAmount + diff.incrementalAlmLpAmount
+      : current.almLpAmount;
+  const clampedAlmLpAmount = almLpAmountRaw < 0n ? 0n : almLpAmountRaw;
+  if (almLpAmountRaw < 0n) {
+    context.log.warn(
+      `[NEG_ALM_LP_AMOUNT_GUARD][updateUserStatsPerPool] field=almLpAmount userAddress=${current.userAddress} poolAddress=${current.poolAddress} chainId=${current.chainId} priorAlmLpAmount=${current.almLpAmount} delta=${diff.incrementalAlmLpAmount ?? 0n} clampedTo=${clampedAlmLpAmount}`,
+    );
+  }
+
   let updated: UserStatsPerPool = {
     ...current,
     totalLiquidityAddedUSD:
@@ -232,10 +265,7 @@ export async function updateUserStatsPerPool(
         ? current.totalLiquidityRemovedToken1 +
           diff.incrementalTotalLiquidityRemovedToken1
         : current.totalLiquidityRemovedToken1,
-    lpBalance:
-      diff.incrementalLpBalance !== undefined
-        ? current.lpBalance + diff.incrementalLpBalance
-        : current.lpBalance,
+    lpBalance: clampedLpBalance,
 
     totalFeesContributed0:
       diff.incrementalTotalFeesContributed0 !== undefined
@@ -375,10 +405,7 @@ export async function updateUserStatsPerPool(
         : current.totalFeeRewardClaimedUSD,
 
     // ALM metrics
-    almLpAmount:
-      diff.incrementalAlmLpAmount !== undefined
-        ? current.almLpAmount + diff.incrementalAlmLpAmount
-        : current.almLpAmount,
+    almLpAmount: clampedAlmLpAmount,
     almAddress:
       diff.almAddress !== undefined ? diff.almAddress : current.almAddress,
 

--- a/src/Aggregators/VeNFTState.ts
+++ b/src/Aggregators/VeNFTState.ts
@@ -54,6 +54,22 @@ export async function updateVeNFTState(
       ? diff.lastSnapshotTimestamp
       : current.lastSnapshotTimestamp;
 
+  // Clamp totalValueLocked to >= 0n on write (issue #816). A decrement can land
+  // on a zero-initialised shell — the matching deposit that should have populated
+  // the balance was never indexed — so the raw subtraction would persist as a
+  // negative TVL. Clamp-and-log mirrors [NEG_RESERVE_GUARD] in Aggregators/Pool.ts;
+  // [NEG_VENFT_TVL_GUARD] keeps the underflow observable. Breadcrumb only — no
+  // deeper deposit-backfill fix unless a symptom is observed (issue #816 AC).
+  const totalValueLockedRaw =
+    (diff.incrementalTotalValueLocked ?? 0n) + current.totalValueLocked;
+  const clampedTotalValueLocked =
+    totalValueLockedRaw < 0n ? 0n : totalValueLockedRaw;
+  if (totalValueLockedRaw < 0n) {
+    context.log.warn(
+      `[NEG_VENFT_TVL_GUARD][updateVeNFTState] field=totalValueLocked id=${current.id} priorTVL=${current.totalValueLocked} delta=${diff.incrementalTotalValueLocked ?? 0n} clampedTo=${clampedTotalValueLocked}`,
+    );
+  }
+
   let veNFTState: VeNFTState = {
     ...current,
     id: diff.id ?? VeNFTId(current.chainId, current.tokenId),
@@ -63,8 +79,7 @@ export async function updateVeNFTState(
     locktime: diff.locktime ?? current.locktime, // lockTime of the deposit action
     isPermanent: diff.isPermanent ?? current.isPermanent,
     lastUpdatedTimestamp: timestamp,
-    totalValueLocked:
-      (diff.incrementalTotalValueLocked ?? 0n) + current.totalValueLocked,
+    totalValueLocked: clampedTotalValueLocked,
     isAlive: diff.isAlive ?? current.isAlive,
     lastSnapshotTimestamp,
   };

--- a/test/Aggregators/ALMLPWrapper.test.ts
+++ b/test/Aggregators/ALMLPWrapper.test.ts
@@ -169,13 +169,16 @@ describe("ALMLPWrapper Aggregator", () => {
         expect(result.lpAmount).toBe(1000n * TEN_TO_THE_18_BI);
       });
 
-      it("should handle withdraw correctly (negative lpAmount)", async () => {
+      it("clamps lpAmount to 0n instead of persisting a negative (issue #816)", async () => {
         const emptyWrapper: ALM_LP_Wrapper = {
           ...mockALMLPWrapperData,
           lpAmount: 0n,
           liquidity: 0n,
         };
 
+        // V1-withdraw fallback can subtract more than was added: a V1 `Withdraw`
+        // emits the input parameter, not the actual burned amount, so a withdraw
+        // can exceed accumulated deposits and drive the counter negative.
         const withdrawDiff = {
           incrementalLpAmount: -500n * TEN_TO_THE_18_BI,
           liquidity: 0n,
@@ -191,7 +194,15 @@ describe("ALMLPWrapper Aggregator", () => {
         const mockSet = vi.mocked(mockContext.ALM_LP_Wrapper?.set);
         const result = mockSet?.mock.calls[0]?.[0] as ALM_LP_Wrapper;
 
-        expect(result.lpAmount).toBe(-500n * TEN_TO_THE_18_BI); // 0 - 500
+        expect(result.lpAmount).toBe(0n); // clamped, not -500
+
+        const warn = vi.mocked(mockContext.log?.warn);
+        expect(warn).toHaveBeenCalledTimes(1);
+        const msg = warn?.mock.calls[0]?.[0] as string;
+        expect(msg).toContain("[NEG_ALM_LP_AMOUNT_GUARD]");
+        expect(msg).toContain("priorLpAmount=0");
+        expect(msg).toContain(`delta=${-500n * TEN_TO_THE_18_BI}`);
+        expect(msg).toContain("clampedTo=0");
       });
     });
 

--- a/test/Aggregators/UserStatsPerPoolLiquidity.test.ts
+++ b/test/Aggregators/UserStatsPerPoolLiquidity.test.ts
@@ -250,4 +250,77 @@ describe("UserStatsPerPool Liquidity Logic", () => {
       expect(result.totalLiquidityRemovedUSD).toBe(0n);
     });
   });
+
+  describe("Negative counter clamps (issue #816)", () => {
+    let clampContext: handlerContext;
+    let warn: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      warn = vi.fn();
+      clampContext = common.createMockContext({
+        UserStatsPerPool: { set: async () => {} },
+        UserStatsPerPoolSnapshot: { set: vi.fn() },
+        log: { error: vi.fn(), warn, info: vi.fn() },
+      });
+    });
+
+    it("clamps lpBalance to 0n instead of persisting a negative", async () => {
+      // Holder existed before this chain's indexer start block: the first event
+      // we observe is a transfer-out, debiting a balance we never credited.
+      const userStats: UserStatsPerPool = {
+        ...createMockUserStats(),
+        lpBalance: 0n,
+      };
+
+      const result = await updateUserStatsPerPool(
+        {
+          incrementalLpBalance: -50n,
+          lastActivityTimestamp: mockTimestamp,
+        },
+        userStats,
+        clampContext,
+        mockTimestamp,
+      );
+
+      expect(result.lpBalance).toBe(0n);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("[NEG_LP_BALANCE_GUARD]"),
+      );
+      const msg = warn.mock.calls
+        .map((c) => c[0] as string)
+        .find((m) => m.includes("[NEG_LP_BALANCE_GUARD]"));
+      expect(msg).toContain("priorLpBalance=0");
+      expect(msg).toContain("delta=-50");
+      expect(msg).toContain("clampedTo=0");
+    });
+
+    it("clamps almLpAmount to 0n instead of persisting a negative", async () => {
+      // ALM V1-withdraw fallback can subtract more than was added.
+      const userStats: UserStatsPerPool = {
+        ...createMockUserStats(),
+        almLpAmount: 100n,
+      };
+
+      const result = await updateUserStatsPerPool(
+        {
+          incrementalAlmLpAmount: -500n,
+          lastActivityTimestamp: mockTimestamp,
+        },
+        userStats,
+        clampContext,
+        mockTimestamp,
+      );
+
+      expect(result.almLpAmount).toBe(0n);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("[NEG_ALM_LP_AMOUNT_GUARD]"),
+      );
+      const msg = warn.mock.calls
+        .map((c) => c[0] as string)
+        .find((m) => m.includes("[NEG_ALM_LP_AMOUNT_GUARD]"));
+      expect(msg).toContain("priorAlmLpAmount=100");
+      expect(msg).toContain("delta=-500");
+      expect(msg).toContain("clampedTo=0");
+    });
+  });
 });

--- a/test/Aggregators/VeNFTState.test.ts
+++ b/test/Aggregators/VeNFTState.test.ts
@@ -167,6 +167,48 @@ describe("VeNFTState", () => {
       });
     });
 
+    describe("when a decrement drives totalValueLocked negative (issue #816)", () => {
+      let result: VeNFTState;
+      beforeEach(async () => {
+        // Zero-initialised shell: a decrement is processed against state the
+        // matching deposit never populated (e.g. the deposit was not indexed),
+        // so the raw subtraction would persist as a negative balance.
+        const zeroShell: VeNFTState = {
+          ...mockVeNFTState,
+          totalValueLocked: 0n,
+        };
+        const overdraftDiff = {
+          incrementalTotalValueLocked: -100n,
+        };
+
+        await updateVeNFTState(
+          overdraftDiff,
+          zeroShell,
+          timestamp,
+          mockContext as handlerContext,
+        );
+        const mockSet = vi.mocked(getVeNFTStateStore(mockContext).set);
+        result = mockSet?.mock.calls[0]?.[0] as VeNFTState;
+      });
+
+      it("clamps totalValueLocked to 0n instead of persisting a negative", () => {
+        expect(result.totalValueLocked).toBe(0n);
+      });
+
+      it("emits a [NEG_VENFT_TVL_GUARD] warn log with diagnostic fields", () => {
+        const warn = vi.mocked(mockContext.log?.warn);
+        expect(warn).toHaveBeenCalledWith(
+          expect.stringContaining("[NEG_VENFT_TVL_GUARD]"),
+        );
+        const msg = warn?.mock.calls
+          .map((c) => c[0] as string)
+          .find((m) => m.includes("[NEG_VENFT_TVL_GUARD]"));
+        expect(msg).toContain("priorTVL=0");
+        expect(msg).toContain("delta=-100");
+        expect(msg).toContain("clampedTo=0");
+      });
+    });
+
     describe("when updating with transfer diff", () => {
       let result: VeNFTState;
       beforeEach(async () => {

--- a/test/EventHandlers/Pool/Transfer.test.ts
+++ b/test/EventHandlers/Pool/Transfer.test.ts
@@ -144,12 +144,13 @@ describe("Pool Transfer Event", () => {
     expect(storedTransfer?.isBurn).toBe(true);
     expect(storedTransfer?.from).toBe(userAddress);
 
-    // Verify user LP balance was updated
+    // Burn from a holder we never credited (existed before the indexer start
+    // block): lpBalance clamps to 0n rather than persisting negative (issue #816).
     const userStats = await indexer.UserStatsPerPool.get(
       UserStatsPerPoolId(10, userAddress, poolAddress),
     );
     expect(userStats).toBeDefined();
-    expect(userStats?.lpBalance).toBe(-LP_VALUE);
+    expect(userStats?.lpBalance).toBe(0n);
   });
 
   it("should process regular transfer and update both user balances", async () => {
@@ -201,12 +202,13 @@ describe("Pool Transfer Event", () => {
     const storedTransfer = await indexer.PoolTransferInTx.get(transferId);
     expect(storedTransfer).toBeUndefined();
 
-    // Verify sender LP balance was decreased
+    // Sender had no credited balance (pre-indexer holder): lpBalance clamps to
+    // 0n rather than persisting negative (issue #816).
     const senderStats = await indexer.UserStatsPerPool.get(
       UserStatsPerPoolId(10, senderAddress, poolAddress),
     );
     expect(senderStats).toBeDefined();
-    expect(senderStats?.lpBalance).toBe(-LP_VALUE);
+    expect(senderStats?.lpBalance).toBe(0n);
 
     // Verify recipient LP balance was increased
     const recipientStats = await indexer.UserStatsPerPool.get(


### PR DESCRIPTION
## Summary
- Clamp three running counters that lacked the floor-to-zero guard used elsewhere (`[NEG_RESERVE_GUARD]` in `Aggregators/Pool.ts`), so none can persist a negative value:
  - **`UserStatsPerPool.lpBalance`** — a holder that existed before the chain's indexer start block surfaces first as a transfer-out, debiting a balance never credited (the live-observed negative).
  - **`ALM_LP_Wrapper.lpAmount` / `UserStatsPerPool.almLpAmount`** — the V1-withdraw fallback can subtract more than was added (a V1 `Withdraw` emits the input parameter, not the actual burned amount).
  - **`VeNFTState.totalValueLocked`** — a decrement processed against a zero-initialised shell the matching deposit never populated.
- Each write clamps to `>= 0n` and emits a `[NEG_*_GUARD]` `warn` log carrying the pre-clamp value (`prior`, `delta`, `clampedTo`), mirroring the existing reserve-guard idiom.
- Root causes captured as inline breadcrumbs only — no deeper structural fix, per the issue AC ("deeper fixes only if a symptom is observed").
- Corrects three pre-existing tests that had encoded the negative (buggy) behaviour as expected: the ALM zero-state withdraw, and two `Pool/Transfer` pre-indexer-holder cases.

Closes #816.

## Test plan
- [x] New unit test per field asserts clamp-to-`0n` + `[NEG_*_GUARD]` log contents (`UserStatsPerPoolLiquidity`, `ALMLPWrapper`, `VeNFTState` aggregator tests)
- [x] `tsc --noEmit` clean
- [x] `pnpm qa` (biome) clean — no fixes
- [x] Caller-scope regression sweep green: 46 files / 655 tests covering every handler that calls the three aggregators
- [ ] Full `pnpm test` — 104/106 files pass; 2 unrelated files (`Effects/Helpers` `sleep 0ms` timing, `SwapFeeModule` RPC test) flaked under ~30 min parallel load but **pass in isolation** and touch none of the changed files *(needs human — confirm in CI)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where certain numerical fields (liquidity balances, ALM LP amounts, and NFT total value locked) could incorrectly become negative due to transaction edge cases. These values are now clamped to zero when negative, with diagnostic warnings logged to help identify problematic transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->