### PR TITLE
Fill TokenPriceSnapshot gaps on reject/fallback/override ticks

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -408,6 +408,20 @@ type TokenPriceSnapshot {
   chainId: Int! # chain id
   isWhitelisted: Boolean! # whether the token is whitelisted
   lastUpdatedTimestamp: Timestamp! @index # Timestamp of the last update
+  # Issue #822: provenance of pricePerUSDNew for this tick — which branch of
+  # refreshTokenPrice produced it: `fresh` (oracle read accepted as-is),
+  # `pool-implied` (first-fetch anchored to the pool-implied hint, not the raw
+  # read), `rebind` (cross-chain copy), `override` (blacklist → 0), or `carried`
+  # (prior price kept on a reject/fallback/error tick).
+  # NOTE for consumers: a row now exists for EVERY non-throttle tick, so the
+  # series includes carried and zeroed prices (override / cold rebind / capped
+  # first-fetch all write 0) that previously left gaps — filter to
+  # `fresh`/`pool-implied`/`rebind` (or pricePerUSDNew > 0) to recover only
+  # freshly-accepted prices.
+  # Nullable: rows written before this field existed have no source. Stored as
+  # String (not an enum) so the set can extend without an Envio schema migration;
+  # the value set is pinned by PRICE_SOURCE in src/Snapshots/TokenPriceSnapshot.ts.
+  priceSource: String
 }
 
 # Tracks relevant data for each NFT minted: each NFT represents a concentrated position in a pool

--- a/src/PriceOracle.ts
+++ b/src/PriceOracle.ts
@@ -11,7 +11,11 @@ import { getRehydrated } from "./EntityTimestamps";
 import type { handlerContext } from "./EntityTypes";
 import { getRebindTarget, isBlacklistedToken } from "./PriceOverrides";
 import { getGateDecisionFromSignals } from "./PriceTrust";
-import { setTokenPriceSnapshot } from "./Snapshots/TokenPriceSnapshot";
+import {
+  PRICE_SOURCE,
+  type PriceSource,
+  setTokenPriceSnapshot,
+} from "./Snapshots/TokenPriceSnapshot";
 export interface TokenPriceData {
   pricePerUSDNew: bigint;
   decimals: bigint;
@@ -201,6 +205,27 @@ export async function refreshTokenPrice(
     return healed;
   }
 
+  // Issue #822: every non-throttle exit below records a per-block
+  // TokenPriceSnapshot so the series has no holes on reject/fallback/override
+  // ticks (the throttle return above is the sole snapshot-free exit — no tick
+  // occurred). `priceSource` tags which branch produced the price; the
+  // carried/zeroed/fresh price is passed per call. Any future early-return
+  // added below must call this too.
+  const snapshotTokenPrice = (
+    pricePerUSDNew: bigint,
+    priceSource: PriceSource,
+  ): void =>
+    setTokenPriceSnapshot(
+      healed.address,
+      chainId,
+      blockNumber,
+      new Date(blockTimestampMs),
+      pricePerUSDNew,
+      healed.isWhitelisted,
+      priceSource,
+      context,
+    );
+
   // Issue #669: blacklist + canonical rebind override the oracle for known-bad
   // (chain, token) pairs. See src/PriceOverrides.ts for rationale per token.
   if (isBlacklistedToken(chainId, healed.address)) {
@@ -210,6 +235,7 @@ export async function refreshTokenPrice(
       lastUpdatedTimestamp: new Date(blockTimestampMs),
     };
     context.Token.set(updated);
+    snapshotTokenPrice(0n, PRICE_SOURCE.OVERRIDE);
     return updated;
   }
 
@@ -263,17 +289,9 @@ export async function refreshTokenPrice(
           : healed.lastSuccessfulPriceTimestamp,
     };
     context.Token.set(updated);
-    if (sourcePrice > 0n) {
-      setTokenPriceSnapshot(
-        healed.address,
-        chainId,
-        blockNumber,
-        new Date(blockTimestampMs),
-        sourcePrice,
-        healed.isWhitelisted,
-        context,
-      );
-    }
+    // Issue #822: snapshot every rebind tick, including sourcePrice === 0n
+    // (previously gated on > 0n), so a cold-sync rebind isn't a hole.
+    snapshotTokenPrice(sourcePrice, PRICE_SOURCE.REBIND);
     return updated;
   }
 
@@ -301,7 +319,8 @@ export async function refreshTokenPrice(
     // follow-up read is validated against the (still-fresh) anchor instead of
     // slipping through the stale-anchor exemption — e.g. BPX's $7.17e18 read is
     // rejected here, and the $40,766 read three hours later is then caught by
-    // the spike guard rather than accepted. No snapshot is written.
+    // the spike guard rather than accepted. Issue #822: a `carried` snapshot of
+    // the preserved anchor is still written so the rejected tick isn't a hole.
     if (currentPrice > MAX_ACCEPTED_PRICE) {
       context.log.info(
         `[MAX_PRICE_CEILING] chain=${chainId} address=${healed.address} symbol=${healed.symbol} proposed=${currentPrice} ceiling=${MAX_ACCEPTED_PRICE} — rejecting absurd read, keeping price=${healed.pricePerUSDNew}`,
@@ -311,6 +330,7 @@ export async function refreshTokenPrice(
         lastUpdatedTimestamp: new Date(blockTimestampMs),
       };
       context.Token.set(capped);
+      snapshotTokenPrice(healed.pricePerUSDNew, PRICE_SOURCE.CARRIED);
       return capped;
     }
 
@@ -345,15 +365,11 @@ export async function refreshTokenPrice(
         lastSuccessfulPriceTimestamp: new Date(blockTimestampMs),
       };
       context.Token.set(anchored);
-      setTokenPriceSnapshot(
-        healed.address,
-        chainId,
-        blockNumber,
-        new Date(blockTimestampMs),
-        hint,
-        healed.isWhitelisted,
-        context,
-      );
+      // Issue #822: a pool-implied first-fetch anchors to the hint rather than
+      // the raw oracle read, so it carries its own `pool-implied` tag — still a
+      // successful write (it bumps lastSuccessfulPriceTimestamp), but one a
+      // consumer can distinguish from a straight-from-oracle `fresh` read.
+      snapshotTokenPrice(hint, PRICE_SOURCE.POOL_IMPLIED);
       return anchored;
     }
 
@@ -377,6 +393,7 @@ export async function refreshTokenPrice(
         lastUpdatedTimestamp: new Date(blockTimestampMs),
       };
       context.Token.set(capped);
+      snapshotTokenPrice(0n, PRICE_SOURCE.CARRIED);
       return capped;
     }
 
@@ -423,6 +440,10 @@ export async function refreshTokenPrice(
         context.log.warn(
           `[priceSpikeRejected] ${healed.address} chain=${chainId} anchor=${anchorPrice} candidate=${currentPrice}`,
         );
+        // Issue #822: snapshot the carried anchor (token returned unchanged —
+        // #730 keeps lastUpdatedTimestamp pinned) so the rejected tick isn't a
+        // hole in the per-block series.
+        snapshotTokenPrice(healed.pricePerUSDNew, PRICE_SOURCE.CARRIED);
         return healed;
       }
       context.log.info(
@@ -467,6 +488,7 @@ export async function refreshTokenPrice(
         // doesn't represent a fresh oracle success (#694).
       };
       context.Token.set(updatedToken);
+      snapshotTokenPrice(healed.pricePerUSDNew, PRICE_SOURCE.CARRIED);
       return updatedToken;
     }
 
@@ -480,21 +502,15 @@ export async function refreshTokenPrice(
           : healed.lastSuccessfulPriceTimestamp,
     };
     context.Token.set(updatedToken);
-
-    setTokenPriceSnapshot(
-      healed.address,
-      chainId,
-      blockNumber,
-      new Date(blockTimestampMs),
-      currentPrice,
-      healed.isWhitelisted,
-      context,
-    );
+    snapshotTokenPrice(currentPrice, PRICE_SOURCE.FRESH);
     return updatedToken;
   } catch (error) {
     context.log.error(
       `Error refreshing token price for ${healed.address} on chain ${chainId}: ${error}`,
     );
+    // Issue #822: even on a transient error the tick happened, so snapshot the
+    // carried price (healed token returned unchanged), tagged `carried`.
+    snapshotTokenPrice(healed.pricePerUSDNew, PRICE_SOURCE.CARRIED);
     // Return healed token if price refresh fails — metadata heal still applies.
     return healed;
   }

--- a/src/Snapshots/TokenPriceSnapshot.ts
+++ b/src/Snapshots/TokenPriceSnapshot.ts
@@ -10,6 +10,32 @@ import {
 } from "./Shared";
 
 /**
+ * Provenance tags for a {@link TokenPriceSnapshot}'s `pricePerUSDNew`, recording
+ * which branch of `refreshTokenPrice` produced the price (issue #822). Stored as
+ * a String column rather than a GraphQL enum so the set can extend without an
+ * Envio schema migration — the same convention as `priceTrustOutcome`. Call
+ * sites should reference these constants rather than bare string literals.
+ *
+ * - `fresh`        — a freshly fetched oracle price accepted as-is
+ * - `pool-implied` — a first-fetch anchored to the pool-implied hint rather than
+ *                    the raw oracle read (#784/#785); a successful write whose
+ *                    value a consumer can still tell apart from a `fresh` read
+ * - `rebind`       — copied from a canonical token's price on another chain
+ * - `override`     — forced by a hard override (blacklist → 0)
+ * - `carried`      — the prior price kept unchanged on a reject / fallback / error tick
+ */
+export const PRICE_SOURCE = {
+  FRESH: "fresh",
+  POOL_IMPLIED: "pool-implied",
+  REBIND: "rebind",
+  OVERRIDE: "override",
+  CARRIED: "carried",
+} as const;
+
+/** One of the {@link PRICE_SOURCE} provenance tags. */
+export type PriceSource = (typeof PRICE_SOURCE)[keyof typeof PRICE_SOURCE];
+
+/**
  * Creates a TokenPriceSnapshot (per-event, no epoch alignment; no persistence).
  * @param address - Token address
  * @param chainId - Chain ID
@@ -17,6 +43,7 @@ import {
  * @param lastUpdatedTimestamp - Timestamp of the last update
  * @param pricePerUSDNew - Price per USD
  * @param isWhitelisted - Whether the token is whitelisted
+ * @param priceSource - Provenance tag for the price (see {@link PRICE_SOURCE})
  * @returns TokenPriceSnapshot
  */
 export function createTokenPriceSnapshot(
@@ -26,6 +53,7 @@ export function createTokenPriceSnapshot(
   lastUpdatedTimestamp: Date,
   pricePerUSDNew: bigint,
   isWhitelisted: boolean,
+  priceSource: PriceSource,
 ): TokenPriceSnapshot {
   const snapshotId = TokenIdByBlock(chainId, address, blockNumber);
   return {
@@ -35,6 +63,7 @@ export function createTokenPriceSnapshot(
     pricePerUSDNew,
     isWhitelisted,
     lastUpdatedTimestamp,
+    priceSource,
   };
 }
 
@@ -46,6 +75,7 @@ export function createTokenPriceSnapshot(
  * @param lastUpdatedTimestamp - Timestamp of the last update
  * @param pricePerUSDNew - Price per USD
  * @param isWhitelisted - Whether the token is whitelisted
+ * @param priceSource - Provenance tag for the price (see {@link PRICE_SOURCE})
  * @param context - Handler context
  * @returns void
  */
@@ -56,6 +86,7 @@ export function setTokenPriceSnapshot(
   lastUpdatedTimestamp: Date,
   pricePerUSDNew: bigint,
   isWhitelisted: boolean,
+  priceSource: PriceSource,
   context: handlerContext,
 ): void {
   const snapshotForPersist: SnapshotForPersist = {
@@ -67,6 +98,7 @@ export function setTokenPriceSnapshot(
       lastUpdatedTimestamp,
       pricePerUSDNew,
       isWhitelisted,
+      priceSource,
     ),
   };
   persistSnapshot(snapshotForPersist, context);

--- a/test/PriceOracle.test.ts
+++ b/test/PriceOracle.test.ts
@@ -196,6 +196,8 @@ describe("PriceOracle", () => {
           testLastUpdated.getTime(),
         );
         expect(tokenPrice?.isWhitelisted).toBe(mockToken0Data.isWhitelisted);
+        // Issue #822: a fresh oracle success is tagged `fresh`.
+        expect(tokenPrice?.priceSource).toBe("fresh");
       });
     });
 
@@ -405,9 +407,12 @@ describe("PriceOracle", () => {
 
         expect(result.pricePerUSDNew).toBe(0n);
         expect(vi.mocked(mockContext.effect)).not.toHaveBeenCalled();
-        expect(
-          vi.mocked(mockContext.TokenPriceSnapshot?.set),
-        ).not.toHaveBeenCalled();
+        // Issue #822: the blacklist tick must still leave a snapshot, tagged
+        // `override`, recording the forced $0 price — no hole in the series.
+        const snapshot = vi.mocked(mockContext.TokenPriceSnapshot?.set)?.mock
+          .lastCall?.[0];
+        expect(snapshot?.priceSource).toBe("override");
+        expect(snapshot?.pricePerUSDNew).toBe(0n);
       });
 
       it("rebind: copies price from the source chain's Token entity", async () => {
@@ -553,9 +558,12 @@ describe("PriceOracle", () => {
           expect.objectContaining({ name: "getTokenPrice" }),
           expect.objectContaining({ chainId: 10 }),
         );
-        expect(
-          vi.mocked(mockContext.TokenPriceSnapshot?.set),
-        ).not.toHaveBeenCalled();
+        // Issue #822: a rebind that resolves to 0 still leaves a snapshot,
+        // tagged `rebind` — the tick happened, so it isn't a hole.
+        const snapshot = vi.mocked(mockContext.TokenPriceSnapshot?.set)?.mock
+          .lastCall?.[0];
+        expect(snapshot?.priceSource).toBe("rebind");
+        expect(snapshot?.pricePerUSDNew).toBe(0n);
       });
     });
 
@@ -1043,6 +1051,38 @@ describe("PriceOracle", () => {
         expect(warnCall?.[0]).toContain("[priceSpikeRejected]");
       });
 
+      it("still emits a TokenPriceSnapshot tagged 'carried' on a spike-rejected tick (issue #822)", async () => {
+        // Issue #822: a rejected refresh must still leave a per-block snapshot,
+        // tagged `carried`, holding the anchor price it kept — otherwise the
+        // exact volatile hours one wants to inspect have holes in the series.
+        const anchorPrice = 1n * 10n ** 18n;
+        const spikePrice = 100n * 10n ** 18n;
+
+        vi.mocked(mockContext.effect)?.mockImplementation(async (effect) => {
+          if ((effect as { name?: string }).name === "getTokenPrice") {
+            return { pricePerUSDNew: spikePrice };
+          }
+          return {};
+        });
+
+        await PriceOracle.refreshTokenPrice(
+          {
+            ...mockToken0Data,
+            pricePerUSDNew: anchorPrice,
+            lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+          },
+          blockNumber,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        const snapshot = vi.mocked(mockContext.TokenPriceSnapshot?.set)?.mock
+          .lastCall?.[0];
+        expect(snapshot?.priceSource).toBe("carried");
+        expect(snapshot?.pricePerUSDNew).toBe(anchorPrice);
+      });
+
       it("preserves lastUpdatedTimestamp on rejection so the 14-day staleness exit can fire", async () => {
         // Issue #730: prior to the fix, the rejection branch bumped
         // `lastUpdatedTimestamp` on every rejected refresh, which reset the
@@ -1336,9 +1376,12 @@ describe("PriceOracle", () => {
         const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
           .lastCall?.[0] as Token;
         expect(updatedToken.pricePerUSDNew).toBe(0n);
-        expect(
-          vi.mocked(mockContext.TokenPriceSnapshot?.set),
-        ).not.toHaveBeenCalled();
+        // Issue #822: a capped first-fetch still leaves a snapshot, tagged
+        // `carried`, holding the kept $0 anchor.
+        const snapshot = vi.mocked(mockContext.TokenPriceSnapshot?.set)?.mock
+          .lastCall?.[0];
+        expect(snapshot?.priceSource).toBe("carried");
+        expect(snapshot?.pricePerUSDNew).toBe(0n);
         const warnCall = vi.mocked(mockContext.log?.warn)?.mock.lastCall;
         expect(warnCall?.[0]).toContain("[FIRST_FETCH_CAP]");
       });
@@ -1548,12 +1591,15 @@ describe("PriceOracle", () => {
           mockContext as handlerContext,
         );
 
-        // Anchor preserved, timestamp re-armed to now, no snapshot.
+        // Anchor preserved, timestamp re-armed to now.
         expect(result.pricePerUSDNew).toBe(anchorPrice);
         expect(result.lastUpdatedTimestamp).toEqual(blockDatetime);
-        expect(
-          vi.mocked(mockContext.TokenPriceSnapshot?.set),
-        ).not.toHaveBeenCalled();
+        // Issue #822: the rejected tick still leaves a snapshot, tagged
+        // `carried`, holding the preserved anchor price.
+        const snapshot = vi.mocked(mockContext.TokenPriceSnapshot?.set)?.mock
+          .lastCall?.[0];
+        expect(snapshot?.priceSource).toBe("carried");
+        expect(snapshot?.pricePerUSDNew).toBe(anchorPrice);
         const infoCall = vi.mocked(mockContext.log?.info)?.mock.lastCall;
         expect(infoCall?.[0]).toContain("[MAX_PRICE_CEILING]");
       });
@@ -1765,6 +1811,69 @@ describe("PriceOracle", () => {
         expect(updatedToken.lastSuccessfulPriceTimestamp?.getTime()).toBe(
           recentSuccess.getTime(),
         );
+      });
+
+      it("still emits a snapshot tagged 'carried' on a last-known-price fallback tick (issue #822)", async () => {
+        // Issue #822 AC: a fallback tick (oracle 0, recent anchor reused) must
+        // leave a per-block snapshot holding the carried anchor.
+        const anchorPrice = 2n * 10n ** 18n;
+        const recentSuccess = new Date(
+          blockDatetime.getTime() - 2 * 24 * 60 * 60 * 1000,
+        );
+        vi.mocked(mockContext.effect)?.mockImplementation(async (effect) => {
+          if ((effect as { name?: string }).name === "getTokenPrice") {
+            return { pricePerUSDNew: 0n };
+          }
+          return {};
+        });
+
+        await PriceOracle.refreshTokenPrice(
+          {
+            ...mockToken0Data,
+            pricePerUSDNew: anchorPrice,
+            lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+            lastSuccessfulPriceTimestamp: recentSuccess,
+          },
+          v3Block,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        const snapshot = vi.mocked(mockContext.TokenPriceSnapshot?.set)?.mock
+          .lastCall?.[0];
+        expect(snapshot?.priceSource).toBe("carried");
+        expect(snapshot?.pricePerUSDNew).toBe(anchorPrice);
+      });
+
+      it("still emits a snapshot tagged 'carried' when the oracle effect throws (issue #822)", async () => {
+        // Issue #822: the catch path (transient RPC error) returns the healed
+        // token unchanged but must still record a per-block snapshot of the
+        // price the token carries, so error ticks aren't holes.
+        const anchorPrice = 2n * 10n ** 18n;
+        vi.mocked(mockContext.effect)?.mockImplementation(async (effect) => {
+          if ((effect as { name?: string }).name === "getTokenPrice") {
+            throw new Error("RPC exploded");
+          }
+          return {};
+        });
+
+        await PriceOracle.refreshTokenPrice(
+          {
+            ...mockToken0Data,
+            pricePerUSDNew: anchorPrice,
+            lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+          },
+          blockNumber,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        const snapshot = vi.mocked(mockContext.TokenPriceSnapshot?.set)?.mock
+          .lastCall?.[0];
+        expect(snapshot?.priceSource).toBe("carried");
+        expect(snapshot?.pricePerUSDNew).toBe(anchorPrice);
       });
 
       it("stops re-pinning once last successful price is older than 7 days, even with hourly retries (regression)", async () => {
@@ -2266,6 +2375,13 @@ describe("PriceOracle", () => {
         const written = vi.mocked(mockContext.Token?.set)?.mock
           .lastCall?.[0] as Token;
         expect(written?.pricePerUSDNew).toBe(hint);
+        // Issue #822: anchoring to the hint is tagged `pool-implied`, distinct
+        // from a straight-from-oracle `fresh` read, so a consumer can tell a
+        // pool-derived anchor apart from a raw oracle price.
+        const snapshot = vi.mocked(mockContext.TokenPriceSnapshot?.set)?.mock
+          .lastCall?.[0];
+        expect(snapshot?.priceSource).toBe("pool-implied");
+        expect(snapshot?.pricePerUSDNew).toBe(hint);
       });
 
       it("#785: replaces a too-high first read with the hint (supersedes FIRST_FETCH_CAP)", async () => {
@@ -2352,6 +2468,249 @@ describe("PriceOracle", () => {
         // instead of writing a >$1M anchor from a glitched ratio.
         expect(written?.pricePerUSDNew).toBe(read);
       });
+    });
+
+    // Issue #822: the provenance invariant, in one place. Every NON-throttle
+    // return of refreshTokenPrice must emit exactly one TokenPriceSnapshot,
+    // tagged by the branch that produced the price. This is the machine-enforced
+    // form of the "Any future early-return added below must call this too"
+    // comment in src/PriceOracle.ts: a new return that forgets to snapshot drops
+    // a row (count 0) and a stray double-snapshot adds one (count 2) — either
+    // fails here. The throttle early-return is the sole snapshot-free exit and is
+    // covered separately above ("does not refresh while inside the 1-hour
+    // throttle window").
+    describe("Issue #822: every non-throttle return emits exactly one tagged snapshot", () => {
+      const usd = (n: number) => BigInt(Math.round(n * 1e6)) * 10n ** 12n;
+      const blockTimestamp = blockDatetime.getTime() / 1000;
+      const oneHourOneMinuteAgo = () =>
+        new Date(blockDatetime.getTime() - 61 * 60 * 1000);
+
+      // Real override-table entries (mirroring the blacklist/rebind tests above)
+      // so the two pre-oracle branches are driven through the same overrides
+      // production uses, not a hand-mocked predicate.
+      const MANATEE_OP = toChecksumAddress(
+        "0x7909Bda52eAf7C3cc12745E727Eb527a485241D8",
+      );
+      const RSETH_SWELL = toChecksumAddress(
+        "0xc3eaCf0612346366Db554c991D7858716db09f58",
+      );
+      const WRSETH_BASE = toChecksumAddress(
+        "0xEDfa23602D0EC14714057867A78d01e94176BEA0",
+      );
+      const rebindSourcePrice = 2_443n * 10n ** 18n;
+
+      const setOracleRead = (read: bigint) =>
+        vi.mocked(mockContext.effect)?.mockImplementation(async (effect) => {
+          if ((effect as { name?: string }).name === "getTokenPrice") {
+            return { pricePerUSDNew: read };
+          }
+          return {};
+        });
+
+      beforeEach(() => {
+        vi.mocked(mockContext.Token?.set)?.mockClear();
+        vi.mocked(mockContext.TokenPriceSnapshot?.set)?.mockClear();
+        vi.mocked(mockContext.Token?.get)?.mockReset();
+        vi.mocked(mockContext.Token?.get)?.mockResolvedValue(undefined);
+      });
+
+      // Each scenario wires the inputs that route refreshTokenPrice to exactly
+      // one non-throttle return, then declares the price + tag that return must
+      // snapshot.
+      const scenarios: {
+        name: string;
+        prepare: () => { token: Token; chainId: number; hint?: bigint };
+        expectedTag: string;
+        expectedPrice: bigint;
+      }[] = [
+        {
+          name: "blacklist → override (0)",
+          prepare: () => ({
+            token: {
+              ...mockToken0Data,
+              address: MANATEE_OP,
+              pricePerUSDNew: 388_328n * 10n ** 18n,
+              lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+            },
+            chainId: 10, // Optimism, where $Manatee is blacklisted
+          }),
+          expectedTag: "override",
+          expectedPrice: 0n,
+        },
+        {
+          name: "rebind → rebind (source price)",
+          prepare: () => {
+            vi.mocked(mockContext.Token?.get)?.mockImplementation(async (id) =>
+              id === `8453-${WRSETH_BASE}`
+                ? ({ pricePerUSDNew: rebindSourcePrice } as Token)
+                : undefined,
+            );
+            return {
+              token: {
+                ...mockToken0Data,
+                address: RSETH_SWELL,
+                pricePerUSDNew: 3_620_000n * 10n ** 18n,
+                lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+              },
+              chainId: 1923, // Swell, where rsETH rebinds to wrsETH/Base
+            };
+          },
+          expectedTag: "rebind",
+          expectedPrice: rebindSourcePrice,
+        },
+        {
+          name: "absolute ceiling → carried (anchor)",
+          prepare: () => {
+            setOracleRead(10n ** 30n); // far above the $1M ceiling
+            return {
+              token: {
+                ...mockToken0Data,
+                symbol: "BPX",
+                pricePerUSDNew: 137n * 10n ** 12n, // $0.000137 anchor
+                lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+              },
+              chainId: 10,
+            };
+          },
+          expectedTag: "carried",
+          expectedPrice: 137n * 10n ** 12n,
+        },
+        {
+          name: "pool-implied first-fetch → pool-implied (hint)",
+          prepare: () => {
+            setOracleRead(usd(0.0014)); // too-low first read, out of band
+            return {
+              token: {
+                ...mockToken0Data,
+                pricePerUSDNew: 0n,
+                lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+              },
+              chainId: 10,
+              hint: usd(0.25),
+            };
+          },
+          expectedTag: "pool-implied",
+          expectedPrice: usd(0.25),
+        },
+        {
+          name: "first-fetch cap → carried (0)",
+          prepare: () => {
+            setOracleRead(50_000n * 10n ** 18n); // > FIRST_FETCH_CAP, < ceiling
+            return {
+              token: {
+                ...mockToken0Data,
+                symbol: "USDT", // non-BTC
+                pricePerUSDNew: 0n,
+                lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+              },
+              chainId: 10, // no hint → not the pool-implied path
+            };
+          },
+          expectedTag: "carried",
+          expectedPrice: 0n,
+        },
+        {
+          name: "spike rejection → carried (anchor)",
+          prepare: () => {
+            setOracleRead(100n * 10n ** 18n); // 100× the still-fresh anchor
+            return {
+              token: {
+                ...mockToken0Data,
+                pricePerUSDNew: 1n * 10n ** 18n,
+                lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+                lastSuccessfulPriceTimestamp: oneHourOneMinuteAgo(),
+              },
+              chainId: 10,
+            };
+          },
+          expectedTag: "carried",
+          expectedPrice: 1n * 10n ** 18n,
+        },
+        {
+          name: "last-known fallback → carried (anchor)",
+          prepare: () => {
+            setOracleRead(0n); // transient $0 read
+            return {
+              token: {
+                ...mockToken0Data,
+                pricePerUSDNew: 2n * 10n ** 18n,
+                lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+                lastSuccessfulPriceTimestamp: new Date(
+                  blockDatetime.getTime() - 24 * 60 * 60 * 1000, // 1d ago (<7d)
+                ),
+              },
+              chainId: 10,
+            };
+          },
+          expectedTag: "carried",
+          expectedPrice: 2n * 10n ** 18n,
+        },
+        {
+          name: "oracle success → fresh (read)",
+          prepare: () => {
+            setOracleRead(3n * 10n ** 18n); // 1.5× anchor: accepted, not a spike
+            return {
+              token: {
+                ...mockToken0Data,
+                pricePerUSDNew: 2n * 10n ** 18n,
+                lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+                lastSuccessfulPriceTimestamp: oneHourOneMinuteAgo(),
+              },
+              chainId: 10,
+            };
+          },
+          expectedTag: "fresh",
+          expectedPrice: 3n * 10n ** 18n,
+        },
+        {
+          name: "oracle throws → carried (anchor)",
+          prepare: () => {
+            vi.mocked(mockContext.effect)?.mockImplementation(
+              async (effect) => {
+                if ((effect as { name?: string }).name === "getTokenPrice") {
+                  throw new Error("transient RPC failure");
+                }
+                return {};
+              },
+            );
+            return {
+              token: {
+                ...mockToken0Data,
+                pricePerUSDNew: 2n * 10n ** 18n,
+                lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+              },
+              chainId: 10,
+            };
+          },
+          expectedTag: "carried",
+          expectedPrice: 2n * 10n ** 18n,
+        },
+      ];
+
+      it.each(scenarios)(
+        "$name",
+        async ({ prepare, expectedTag, expectedPrice }) => {
+          const { token, chainId: scenarioChainId, hint } = prepare();
+
+          await PriceOracle.refreshTokenPrice(
+            token,
+            blockNumber,
+            blockTimestamp,
+            scenarioChainId,
+            mockContext as handlerContext,
+            hint,
+          );
+
+          // The invariant: exactly one snapshot per non-throttle return.
+          expect(
+            vi.mocked(mockContext.TokenPriceSnapshot?.set),
+          ).toHaveBeenCalledTimes(1);
+          const snapshot = vi.mocked(mockContext.TokenPriceSnapshot?.set)?.mock
+            .lastCall?.[0];
+          expect(snapshot?.priceSource).toBe(expectedTag);
+          expect(snapshot?.pricePerUSDNew).toBe(expectedPrice);
+        },
+      );
     });
   });
 });

--- a/test/Snapshots/Shared.test.ts
+++ b/test/Snapshots/Shared.test.ts
@@ -12,7 +12,10 @@ import {
   persistSnapshot,
   shouldSnapshot,
 } from "../../src/Snapshots/Shared";
-import { createTokenPriceSnapshot } from "../../src/Snapshots/TokenPriceSnapshot";
+import {
+  PRICE_SOURCE,
+  createTokenPriceSnapshot,
+} from "../../src/Snapshots/TokenPriceSnapshot";
 import { createUserStatsPerPoolSnapshot } from "../../src/Snapshots/UserStatsPerPoolSnapshot";
 import { createVeNFTPoolVoteSnapshot } from "../../src/Snapshots/VeNFTPoolVoteSnapshot";
 import { createVeNFTStateSnapshot } from "../../src/Snapshots/VeNFTStateSnapshot";
@@ -210,6 +213,7 @@ describe("Snapshots Shared", () => {
         lastUpdatedTimestamp,
         pricePerUSDNew,
         isWhitelisted,
+        PRICE_SOURCE.FRESH,
       );
 
       persistSnapshot({ type: SnapshotType.TokenPrice, snapshot }, context);

--- a/test/Snapshots/TokenPriceSnapshot.test.ts
+++ b/test/Snapshots/TokenPriceSnapshot.test.ts
@@ -1,5 +1,6 @@
 import { TokenIdByBlock, toChecksumAddress } from "../../src/Constants";
 import {
+  PRICE_SOURCE,
   createTokenPriceSnapshot,
   setTokenPriceSnapshot,
 } from "../../src/Snapshots/TokenPriceSnapshot";
@@ -15,6 +16,7 @@ describe("TokenPriceSnapshot", () => {
   const lastUpdatedTimestamp = new Date(1000000 * 1000);
   const pricePerUSDNew = 1000000000000000000n;
   const isWhitelisted = true;
+  const priceSource = PRICE_SOURCE.FRESH;
 
   beforeEach(() => {
     common = setupCommon();
@@ -30,6 +32,7 @@ describe("TokenPriceSnapshot", () => {
         lastUpdatedTimestamp,
         pricePerUSDNew,
         isWhitelisted,
+        priceSource,
       );
 
       expect(snapshot.id).toBe(TokenIdByBlock(chainId, address, blockNumber));
@@ -43,6 +46,7 @@ describe("TokenPriceSnapshot", () => {
         lastUpdatedTimestamp,
         pricePerUSDNew,
         isWhitelisted,
+        priceSource,
       );
 
       expect(snapshot.address).toBe(address);
@@ -50,6 +54,7 @@ describe("TokenPriceSnapshot", () => {
       expect(snapshot.pricePerUSDNew).toBe(pricePerUSDNew);
       expect(snapshot.isWhitelisted).toBe(isWhitelisted);
       expect(snapshot.lastUpdatedTimestamp).toBe(lastUpdatedTimestamp);
+      expect(snapshot.priceSource).toBe(priceSource);
     });
 
     it("should handle isWhitelisted false", () => {
@@ -60,9 +65,24 @@ describe("TokenPriceSnapshot", () => {
         lastUpdatedTimestamp,
         pricePerUSDNew,
         false,
+        priceSource,
       );
 
       expect(snapshot.isWhitelisted).toBe(false);
+    });
+
+    it("should carry the provenance tag it is given", () => {
+      const snapshot = createTokenPriceSnapshot(
+        address,
+        chainId,
+        blockNumber,
+        lastUpdatedTimestamp,
+        pricePerUSDNew,
+        isWhitelisted,
+        PRICE_SOURCE.CARRIED,
+      );
+
+      expect(snapshot.priceSource).toBe("carried");
     });
   });
 
@@ -78,6 +98,7 @@ describe("TokenPriceSnapshot", () => {
       lastUpdatedTimestamp,
       pricePerUSDNew,
       isWhitelisted,
+      priceSource,
       context,
     );
 
@@ -101,6 +122,7 @@ describe("TokenPriceSnapshot", () => {
       lastUpdatedTimestamp,
       pricePerUSDNew,
       isWhitelisted,
+      priceSource,
       context,
     );
 
@@ -112,6 +134,7 @@ describe("TokenPriceSnapshot", () => {
         pricePerUSDNew,
         isWhitelisted,
         lastUpdatedTimestamp,
+        priceSource,
       }),
     );
   });
@@ -128,6 +151,7 @@ describe("TokenPriceSnapshot", () => {
       lastUpdatedTimestamp,
       pricePerUSDNew,
       false,
+      priceSource,
       context,
     );
 


### PR DESCRIPTION
## Summary
- `refreshTokenPrice` wrote a `TokenPriceSnapshot` only on its two fresh-success branches, so reject / fallback / override / rebind-zero / catch ticks left per-block holes in the series — exactly the volatile hours worth inspecting.
- Every **non-throttle** return now snapshots the price the token ends up with, tagged by provenance via a new nullable `priceSource` field: `fresh` (oracle read accepted as-is), `pool-implied` (first-fetch anchored to the pool-implied hint, not the raw read), `rebind` (cross-chain copy), `override` (blacklist → 0), `carried` (prior price kept on a reject/fallback/error tick).
- The throttle early-return stays snapshot-free (no tick occurred).
- `priceSource` is nullable (no migration of old rows) and stored as `String`, not an enum, so the set extends without an Envio schema migration; values are pinned by `PRICE_SOURCE` in `src/Snapshots/TokenPriceSnapshot.ts`.
- A local `snapshotTokenPrice(price, tag)` closure keeps the call sites to one line each.
- **Consumer note (schema comment):** a row now exists for every non-throttle tick, so the series includes carried/zeroed prices (override / cold rebind / capped first-fetch all write 0) that previously left gaps — filter on `priceSource` (`fresh`/`pool-implied`/`rebind`) or `pricePerUSDNew > 0` to recover only freshly-accepted prices.
- **Invariant guard:** a parametrized test drives all nine non-throttle branches and asserts each emits exactly one correctly-tagged snapshot, so a future early-return that forgets to snapshot (count 0) or double-snapshots (count 2) turns the suite red.

Closes #822

## Test plan
- [x] `pnpm envio codegen` — `priceSource` present on the `TokenPriceSnapshot` type (field type unchanged: still `String`)
- [x] `tsc --noEmit` — no errors
- [x] `pnpm qa` (biome) — clean
- [x] `pnpm test` — full suite green (1502 pass / 0 fail); the invariant `it.each` covers `override` (blacklist), `rebind` (sourcePrice=0), `carried` (ceiling / first-fetch-cap / spike-reject / fallback / catch), `pool-implied` (first-fetch hint), and `fresh` (oracle success); the throttle's snapshot-free return is covered separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)