### PR TITLE
fix(price-trust): route VotingReward bootstrap through createTokenEntity (closes #815)

### DIFF
--- a/src/EventHandlers/VotingReward/VotingRewardSharedLogic.ts
+++ b/src/EventHandlers/VotingReward/VotingRewardSharedLogic.ts
@@ -1,4 +1,4 @@
-import type { Token, UserStatsPerPool } from "envio";
+import type { UserStatsPerPool } from "envio";
 import {
   PoolAddressField,
   type PoolDiff,
@@ -10,17 +10,11 @@ import {
   loadOrCreateUserData,
 } from "../../Aggregators/UserStatsPerPool";
 import { TokenId } from "../../Constants";
-import {
-  getTokenDetails,
-  getTokenPrice,
-  hasContractBytecode,
-  roundBlockToInterval,
-} from "../../Effects/Index";
 import { getRehydrated } from "../../EntityTimestamps";
 import type { handlerContext } from "../../EntityTypes";
 import type { Pool } from "../../EntityTypes";
-import { refreshTokenPrice } from "../../PriceOracle";
-import { getGateDecisionFromSignals, getTrustedUSD } from "../../PriceTrust";
+import { createTokenEntity, refreshTokenPrice } from "../../PriceOracle";
+import { getTrustedUSD } from "../../PriceTrust";
 
 export interface VotingRewardEventData {
   votingRewardAddress: string;
@@ -45,14 +39,22 @@ export interface VotingRewardClaimRewardsResult {
  * VotingReward contract. Pure: returns incremental diffs to be staged by the
  * caller, no DB writes.
  *
- * Side effects: on a first-sighting reward token, runs the bytecode gate (#677)
- * to filter EOA / non-contract addresses, and otherwise stages `context.Token.set`
- * for the new token row after fetching details + price in parallel.
+ * Side effects: on a first-sighting reward token, delegates to the canonical
+ * {@link createTokenEntity}, which runs the bytecode gate (#677) to filter
+ * EOA / non-contract addresses and stages `context.Token.set` with the
+ * price-trust gate applied — `isWhitelisted` defaults to `false` (#815) rather
+ * than being hardcoded `true`, and `pricePerUSDNew` is persisted as `0n`. That
+ * `0n` + untrusted state is what makes {@link getTrustedUSD} contribute `0n` for
+ * a first-seen reward token — NOT a guarded oracle read. The bootstrap
+ * `refreshTokenPrice` below is throttled (createTokenEntity just stamped
+ * `lastUpdatedTimestamp` to this block, so `shouldRefresh` is false), so it
+ * makes no oracle call here; `FIRST_FETCH_CAP` + the spike guard first engage on
+ * a later (≥1h) claim, which owns the first actual priced read.
  *
- * When the bytecode gate rejects the reward address, zero-valued diffs are
- * returned so the pool/user entities still get a `lastUpdatedTimestamp` /
- * `lastActivityTimestamp` bump without persisting USD attribution against a
- * non-existent token.
+ * When `createTokenEntity` rejects the reward address (no deployed bytecode,
+ * returns `null`), zero-valued diffs are returned so the pool/user entities
+ * still get a `lastUpdatedTimestamp` / `lastActivityTimestamp` bump without
+ * persisting USD attribution against a non-existent token.
  *
  * @param data - The claim payload (reward token address, amount, block, chain, user).
  * @param context - The handler context (used for Token storage, effects, logging).
@@ -72,18 +74,24 @@ export async function processVotingRewardClaimRewards(
   let rewardToken = await getRehydrated(context.Token, "Token", rewardTokenId);
 
   if (!rewardToken) {
-    context.log.warn(
-      `[processVotingRewardClaimRewards] Reward token not found for ${data.reward} on chain ${data.chainId}`,
+    // First sighting: route through the canonical createTokenEntity so the
+    // reward token gets the same treatment as every other first-seen token —
+    // the #677 bytecode gate, `isWhitelisted: false` from the price-trust gate
+    // (#815, not a hardcoded `true`), and `pricePerUSDNew: 0n`. That `0n` +
+    // untrusted state is what zeros getTrustedUSD on first sight; the
+    // refreshTokenPrice call below is throttled (createTokenEntity just stamped
+    // this block), so it makes NO oracle call here — FIRST_FETCH_CAP + the spike
+    // guard first engage on a later (≥1h) claim.
+    const created = await createTokenEntity(
+      data.reward,
+      data.chainId,
+      data.blockNumber,
+      context,
+      data.timestamp,
     );
-
-    const { hasCode } = await context.effect(hasContractBytecode, {
-      address: data.reward,
-      chainId: data.chainId,
-    });
-    if (!hasCode) {
-      context.log.warn(
-        `[processVotingRewardClaimRewards] Skipping Token row and reward USD for non-contract address ${data.reward} on chain ${data.chainId} (no deployed bytecode)`,
-      );
+    if (!created) {
+      // No deployed bytecode (#677): skip USD attribution but still bump the
+      // pool/user activity timestamps.
       const zeroIncrementals = {
         incrementalTotalBribeClaimed: 0n,
         incrementalTotalBribeClaimedUSD: 0n,
@@ -101,56 +109,7 @@ export async function processVotingRewardClaimRewards(
         },
       };
     }
-
-    context.log.warn(
-      "[processVotingRewardClaimRewards] Using separate effects to get token data and then creating Token entity",
-    );
-
-    // Round block number to nearest hour interval for better cache hits
-    // Cache key is based on input parameters, so rounding must happen before effect call
-    const roundedBlockNumber = roundBlockToInterval(
-      data.blockNumber,
-      data.chainId,
-    );
-
-    // Fetch token details and price in parallel
-    const [rewardTokenDetails, priceData] = await Promise.all([
-      context.effect(getTokenDetails, {
-        contractAddress: data.reward,
-        chainId: data.chainId,
-      }),
-      context.effect(getTokenPrice, {
-        tokenAddress: data.reward,
-        chainId: data.chainId,
-        blockNumber: roundedBlockNumber, // Use rounded block for cache key
-      }),
-    ]);
-
-    const decision = getGateDecisionFromSignals(
-      data.chainId,
-      data.reward,
-      true,
-    );
-    const newToken: Token = {
-      id: TokenId(data.chainId, data.reward),
-      address: data.reward,
-      name: rewardTokenDetails.name,
-      symbol: rewardTokenDetails.symbol,
-      chainId: data.chainId,
-      decimals: BigInt(rewardTokenDetails.decimals),
-      pricePerUSDNew: priceData.pricePerUSDNew,
-      lastUpdatedTimestamp: new Date(data.timestamp * 1000),
-      lastSuccessfulPriceTimestamp:
-        priceData.pricePerUSDNew > 0n
-          ? new Date(data.timestamp * 1000)
-          : undefined,
-      isWhitelisted: true,
-      priceTrustOutcome: decision.outcome,
-      priceTrustReason: decision.reason,
-    };
-
-    context.Token.set(newToken);
-    rewardToken = newToken;
+    rewardToken = created;
   }
 
   const updatedRewardToken = await refreshTokenPrice(

--- a/test/EventHandlers/VotingReward/VotingRewardSharedLogic.test.ts
+++ b/test/EventHandlers/VotingReward/VotingRewardSharedLogic.test.ts
@@ -70,8 +70,32 @@ describe("VotingRewardSharedLogic", () => {
     };
   });
 
+  // Post-#815, first-sighting reward tokens default to isWhitelisted: false, so
+  // a trusted USD valuation requires the WhitelistToken handler to have run
+  // first. These USD-math tests pre-seed an already-whitelisted, priced token;
+  // lastUpdatedTimestamp aligned to mockTimestamp throttles refreshTokenPrice so
+  // the seeded price passes through unchanged.
+  const seedWhitelistedToken = (decimals: bigint) => {
+    mockContext.Token.set({
+      id: `${mockChainId}-${mockRewardTokenAddress}`,
+      address: mockRewardTokenAddress,
+      chainId: mockChainId,
+      symbol: "TEST",
+      name: "Test Token",
+      decimals,
+      pricePerUSDNew: 1000000000000000000n, // $1
+      isWhitelisted: true,
+      lastUpdatedTimestamp: mockTimestamp,
+      lastSuccessfulPriceTimestamp: mockTimestamp,
+      priceTrustOutcome: "TRUSTED",
+      priceTrustReason: "WL",
+    });
+  };
+
   describe("processVotingRewardClaimRewards", () => {
     it("should calculate USD values correctly for bribe rewards", async () => {
+      seedWhitelistedToken(6n);
+
       const data: VotingRewardClaimRewardsData = {
         votingRewardAddress: mockVotingRewardAddress,
         userAddress: mockUserAddress,
@@ -107,6 +131,8 @@ describe("VotingRewardSharedLogic", () => {
     });
 
     it("should distinguish between bribe and fee rewards", async () => {
+      seedWhitelistedToken(6n);
+
       const data: VotingRewardClaimRewardsData = {
         votingRewardAddress: mockVotingRewardAddress,
         userAddress: mockUserAddress,
@@ -142,27 +168,8 @@ describe("VotingRewardSharedLogic", () => {
     });
 
     it("should handle different token decimals correctly", async () => {
-      // Mock a token with 18 decimals
-      mockContext.effect = async (fn: { name: string }, params: unknown) => {
-        if (fn.name === "getTokenPrice") {
-          return {
-            pricePerUSDNew: 1000000000000000000n, // 1 USD
-            priceOracleType: "v3",
-          };
-        }
-        // Mock getTokenDetails effect for token creation
-        if (fn.name === "getTokenDetails") {
-          return {
-            name: "Test Token",
-            symbol: "TEST",
-            decimals: 18,
-          };
-        }
-        if (fn.name === "hasContractBytecode") {
-          return { hasCode: true };
-        }
-        return {};
-      };
+      // Pre-seed an 18-decimal whitelisted token.
+      seedWhitelistedToken(18n);
 
       const data: VotingRewardClaimRewardsData = {
         votingRewardAddress: mockVotingRewardAddress,
@@ -297,6 +304,61 @@ describe("VotingRewardSharedLogic", () => {
         expect(result.userDiff?.[usdKey]).toBe(0n);
       },
     );
+
+    it("first-sighting non-whitelisted reward token with an inflated price contributes 0n USD and is not whitelisted (#815)", async () => {
+      // No pre-seed: exercise the first-sighting bootstrap branch. The old code
+      // hardcoded isWhitelisted: true and persisted the raw oracle read, so an
+      // inflated price was recorded as trusted and poisoned bribe USD. The fix
+      // routes the branch through createTokenEntity (gate=false, price 0n), so
+      // the token defaults untrusted and getTrustedUSD contributes 0n.
+      //
+      // The inflated getTokenPrice mock is a deliberate poison pill: the fixed
+      // path must never fetch or persist it — createTokenEntity writes 0n and
+      // the immediately-throttled refreshTokenPrice makes no oracle call — so
+      // the assertions below stay 0n / false. If the bootstrap ever regresses
+      // to fetching + persisting the raw price, this read makes it fail loudly.
+      const INFLATED_PRICE = 1_000_000_000n * 1_000_000_000_000_000_000n; // $1e9
+      mockContext.effect = async (fn: { name: string }) => {
+        if (fn.name === "getTokenPrice") {
+          return { pricePerUSDNew: INFLATED_PRICE, priceOracleType: "v3" };
+        }
+        if (fn.name === "getTokenDetails") {
+          return { name: "Inflated", symbol: "INFL", decimals: 6 };
+        }
+        if (fn.name === "hasContractBytecode") return { hasCode: true };
+        return {};
+      };
+
+      const data: VotingRewardClaimRewardsData = {
+        votingRewardAddress: mockVotingRewardAddress,
+        userAddress: mockUserAddress,
+        chainId: mockChainId,
+        blockNumber: 12345,
+        timestamp: Math.floor(mockTimestamp.getTime() / 1000),
+        reward: mockRewardTokenAddress,
+        amount: 1000000n,
+      };
+
+      const result = await processVotingRewardClaimRewards(
+        data,
+        mockContext,
+        PoolAddressField.BRIBE_VOTING_REWARD_ADDRESS,
+      );
+
+      // Raw amount passes through; the untrusted price contributes 0n USD.
+      expect(result.poolDiff?.incrementalTotalBribeClaimed).toBe(1000000n);
+      expect(result.poolDiff?.incrementalTotalBribeClaimedUSD).toBe(0n);
+      expect(result.userDiff?.incrementalTotalBribeClaimedUSD).toBe(0n);
+
+      // The bootstrapped token defaults to NOT whitelisted (mirrors
+      // createTokenEntity); the raw inflated oracle read is never persisted.
+      const created = await mockContext.Token.get(
+        `${mockChainId}-${mockRewardTokenAddress}`,
+      );
+      expect(created?.isWhitelisted).toBe(false);
+      expect(created?.pricePerUSDNew).toBe(0n);
+      expect(created?.priceTrustOutcome).toBe("UNTRUSTED");
+    });
   });
 
   describe("loadVotingRewardData", () => {


### PR DESCRIPTION
## Summary

Fixes #815. The VotingReward reward-token bootstrap (`processVotingRewardClaimRewards`,
shared by bribe / fee / superchain-incentive `ClaimRewards`) hand-rolled a first-sighting
`Token` with `isWhitelisted: true` hardcoded and the **raw** `getTokenPrice` result
persisted, then stamped `lastUpdatedTimestamp` to the current block — throttling the
immediately-following `refreshTokenPrice` so `FIRST_FETCH_CAP` and the spike guard never
ran. A non-whitelisted reward token was therefore recorded as **trusted with an unvetted
price**, poisoning `totalBribeClaimedUSD` / `totalFeeRewardClaimedUSD`.

The fix deletes the hand-rolled block and delegates to the canonical `createTokenEntity`,
exactly as every other first-sight token creation does:
- price-trust gate with `isWhitelisted: false` (not hardcoded `true`)
- `pricePerUSDNew: 0n` (raw oracle read no longer persisted)
- the `#677` bytecode gate (EOA / non-contract addresses still skipped)

`refreshTokenPrice` now owns the first priced read — subject to `FIRST_FETCH_CAP` + the
spike guard — and `getTrustedUSD` contributes `0n` for any reward token that fails the
trust gate. The `Voter` / `SuperchainLeafVoter` `WhitelistToken` handlers still flip
genuinely-whitelisted tokens (unchanged). Side benefit: removes a redundant eager
`getTokenPrice` effect call per first sighting (previously fetched then discarded by the
throttle).

## Acceptance criteria

- [x] First-sighting reward token is not hardcoded `isWhitelisted: true`; defaults to `false` via `createTokenEntity`; `WhitelistToken` flips genuinely-whitelisted tokens
- [x] Candidate price passes through `FIRST_FETCH_CAP` + spike guard (refreshTokenPrice performs the first priced read; raw price not persisted)
- [x] Untrusted reward token contributes `0n` via `getTrustedUSD`
- [x] Test: ClaimRewards on a non-whitelisted reward token with an inflated price mock yields `incrementalTotalBribeClaimedUSD === 0n` and `isWhitelisted === false`

## Test plan

- New `#815` test in `VotingRewardSharedLogic.test.ts`: first-sighting non-whitelisted token + inflated price mock → `0n` USD, `isWhitelisted: false`, `pricePerUSDNew: 0n`, `priceTrustOutcome: UNTRUSTED`.
- Three existing first-sight USD-math tests updated to pre-seed a whitelisted token (they had encoded the old hardcoded-trust behavior).
- `vitest run test/EventHandlers/VotingReward/` → 15/15 pass · `tsc --noEmit` clean · `biome check` clean.
- Full suite: 1488/1490 pass; the 2 failures are pre-existing 120s-timeout flakes in unrelated modules (`SuperswapsHyperlane/Mailbox`, `SwapFeeModule/DynamicSwapFeeModule`) that pass in isolation — v3 worker-startup / live-RPC contention under parallel load, not this change.

## Follow-up (not in this PR)

`Voter.WhitelistToken` and `SuperchainLeafVoter.WhitelistToken` still hand-roll `Token`
creation (legitimately, from `event.params._bool` — not the #815 bug). A future cleanup
could add an optional whitelist-state arg to `createTokenEntity` and route those two sites
through it, retiring the last hand-rolled creation sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of first-time reward tokens when oracle prices are inflated; USD contributions now correctly remain zero until prices are verified as trusted.

* **Tests**
  * Added regression test for issue `#815` and improved test coverage for voting reward claim processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->