### PR TITLE
fix(storage): hard-delete consumed ALMLPWrapperTransferInTx scratch (part of #817)

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -842,7 +842,6 @@ type ALMLPWrapperTransferInTx {
   to: String! # recipient address (0x0 for burns)
   value: BigInt! @config(precision: 76) # LP token amount transferred
   isBurn: Boolean! # to == 0x0
-  consumedByLogIndex: Int # logIndex of the Withdraw event that consumed this transfer (undefined if unused)
   timestamp: Timestamp! # block timestamp of the transfer
 }
 

--- a/src/EventHandlers/ALM/LPWrapperLogic.ts
+++ b/src/EventHandlers/ALM/LPWrapperLogic.ts
@@ -203,8 +203,7 @@ export async function getMatchingBurnTransferInTx(
       t.wrapperAddress === wrapperAddress &&
       t.from === sender &&
       t.isBurn === true &&
-      t.logIndex < withdrawLogIndex &&
-      (t.consumedByLogIndex === null || t.consumedByLogIndex === undefined),
+      t.logIndex < withdrawLogIndex,
   );
 
   if (matchingBurns.length === 0) {
@@ -258,18 +257,13 @@ async function getActualLpAmountForV1(
     // Use the actual burned amount from Transfer event
     const actualLpAmount = matchingBurn.value;
 
-    // Mark the transfer as consumed
-    const transferEntity = await getRehydrated(
-      (context as handlerContext).ALMLPWrapperTransferInTx,
-      "ALMLPWrapperTransferInTx",
-      matchingBurn.id,
-    );
-    if (transferEntity) {
-      (context as handlerContext).ALMLPWrapperTransferInTx.set({
-        ...transferEntity,
-        consumedByLogIndex: logIndex,
-      });
-    }
+    // Hard-delete the matched burn on consumption. This handler is the sole
+    // reader of ALMLPWrapperTransferInTx, so deleting both prevents the burn
+    // from being re-matched by a later Withdraw in the same tx (the deleted
+    // row drops out of the subsequent getWhere) and stops the scratch table
+    // from growing without bound — mirroring the PoolTransferInTx (#629) /
+    // CLPositionPendingPrincipal (#789) delete-on-consume pattern.
+    context.ALMLPWrapperTransferInTx.deleteUnsafe(matchingBurn.id);
 
     return actualLpAmount;
   }
@@ -514,7 +508,6 @@ function storeBurnTransferForMatching(
     to: to,
     value: value,
     isBurn: true, // Only storing burns
-    consumedByLogIndex: undefined, // Initially unused
     timestamp: timestamp,
   });
 }

--- a/test/EventHandlers/ALM/LPWrapperLogic.test.ts
+++ b/test/EventHandlers/ALM/LPWrapperLogic.test.ts
@@ -986,7 +986,6 @@ describe("LPWrapperLogic", () => {
       expect(storedTransfer.to).toBe(ZERO_ADDRESS);
       expect(storedTransfer.value).toBe(burnValue);
       expect(storedTransfer.isBurn).toBe(true);
-      expect(storedTransfer.consumedByLogIndex).toBeUndefined();
     });
 
     it("should not store burn Transfer event for V2 wrapper", async () => {
@@ -1045,7 +1044,6 @@ describe("LPWrapperLogic", () => {
         isBurn: true,
         logIndex: 50,
         value: 1000n * TEN_TO_THE_18_BI,
-        consumedByLogIndex: undefined,
       };
 
       const otherBurn = {
@@ -1056,7 +1054,6 @@ describe("LPWrapperLogic", () => {
         isBurn: true,
         logIndex: 60,
         value: 2000n * TEN_TO_THE_18_BI,
-        consumedByLogIndex: undefined,
       };
 
       const nonMatchingBurn = {
@@ -1067,7 +1064,6 @@ describe("LPWrapperLogic", () => {
         isBurn: true,
         logIndex: 80,
         value: 3000n * TEN_TO_THE_18_BI,
-        consumedByLogIndex: undefined,
       };
 
       vi.mocked(
@@ -1110,34 +1106,6 @@ describe("LPWrapperLogic", () => {
       expect(result).toBeUndefined();
     });
 
-    it("should filter out consumed transfers", async () => {
-      const consumedBurn = {
-        id: ALMLPWrapperTransferInTxId(chainId, txHash, srcAddress, 50),
-        chainId: chainId,
-        wrapperAddress: srcAddress,
-        from: sender,
-        isBurn: true,
-        logIndex: 50,
-        value: 1000n * TEN_TO_THE_18_BI,
-        consumedByLogIndex: 90, // Already consumed
-      };
-
-      vi.mocked(
-        mockContext.ALMLPWrapperTransferInTx?.getWhere,
-      ).mockResolvedValue([consumedBurn] as ALMLPWrapperTransferInTx[]);
-
-      const result = await getMatchingBurnTransferInTx(
-        txHash,
-        sender,
-        chainId,
-        srcAddress,
-        withdrawLogIndex,
-        mockContext,
-      );
-
-      expect(result).toBeUndefined();
-    });
-
     it("should filter out transfers with logIndex >= withdrawLogIndex", async () => {
       const futureBurn = {
         id: ALMLPWrapperTransferInTxId(chainId, txHash, srcAddress, 150),
@@ -1147,7 +1115,6 @@ describe("LPWrapperLogic", () => {
         isBurn: true,
         logIndex: 150, // After withdraw event
         value: 1000n * TEN_TO_THE_18_BI,
-        consumedByLogIndex: undefined,
       };
 
       vi.mocked(
@@ -1175,7 +1142,6 @@ describe("LPWrapperLogic", () => {
         isBurn: true,
         logIndex: 30,
         value: 1000n * TEN_TO_THE_18_BI,
-        consumedByLogIndex: undefined,
       };
 
       const burn2 = {
@@ -1186,7 +1152,6 @@ describe("LPWrapperLogic", () => {
         isBurn: true,
         logIndex: 70,
         value: 2000n * TEN_TO_THE_18_BI,
-        consumedByLogIndex: undefined,
       };
 
       const burn3 = {
@@ -1197,7 +1162,6 @@ describe("LPWrapperLogic", () => {
         isBurn: true,
         logIndex: 90,
         value: 3000n * TEN_TO_THE_18_BI,
-        consumedByLogIndex: undefined,
       };
 
       vi.mocked(
@@ -1231,7 +1195,6 @@ describe("LPWrapperLogic", () => {
         isBurn: true,
         logIndex: 50,
         value: 1000n * TEN_TO_THE_18_BI,
-        consumedByLogIndex: undefined,
       };
 
       vi.mocked(
@@ -1285,6 +1248,7 @@ describe("LPWrapperLogic", () => {
           getWhere: vi.fn().mockResolvedValue([]),
           get: vi.fn(),
           set: vi.fn(),
+          deleteUnsafe: vi.fn(),
         },
         log: {
           warn: vi.fn(),
@@ -1324,7 +1288,6 @@ describe("LPWrapperLogic", () => {
         isBurn: true,
         logIndex: transferLogIndex,
         value: actualBurnedAmount,
-        consumedByLogIndex: undefined,
       };
 
       const transferEntity = {
@@ -1386,14 +1349,19 @@ describe("LPWrapperLogic", () => {
           : 0n;
       expect(wrapperUpdate.liquidity).toBe(expectedLiquidity);
 
-      // Verify Transfer event was marked as consumed
+      // Verify the matched burn Transfer was hard-deleted on consumption,
+      // replacing the old soft-consume marker so the scratch row does not leak
+      // (mirrors PoolTransferInTx / CLPositionPendingPrincipal).
+      expect(
+        vi.mocked(mockContext.ALMLPWrapperTransferInTx?.deleteUnsafe),
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        vi.mocked(mockContext.ALMLPWrapperTransferInTx?.deleteUnsafe),
+      ).toHaveBeenCalledWith(matchingBurn.id);
+      // It must replace, not supplement, the marker: no soft-consume set remains.
       expect(
         vi.mocked(mockContext.ALMLPWrapperTransferInTx?.set),
-      ).toHaveBeenCalledTimes(1);
-      const consumedTransfer = vi.mocked(
-        mockContext.ALMLPWrapperTransferInTx?.set,
-      ).mock.calls[0][0];
-      expect(consumedTransfer.consumedByLogIndex).toBe(withdrawLogIndex);
+      ).not.toHaveBeenCalled();
     });
 
     it("should use 0n for V1 withdraw when no matching burn found", async () => {

--- a/test/EventHandlers/ALM/LPWrapperV1.test.ts
+++ b/test/EventHandlers/ALM/LPWrapperV1.test.ts
@@ -62,7 +62,6 @@ describe("ALMLPWrapperV1 Events", () => {
       to: zeroAddress,
       value: actualBurnedAmount,
       isBurn: true,
-      consumedByLogIndex: undefined,
       timestamp: new Date(blockTimestamp * 1000),
     });
   }


### PR DESCRIPTION
## What

Part A of #817. `ALMLPWrapperTransferInTx` burns were only *soft*-consumed (a `consumedByLogIndex` marker) and never deleted, so the scratch table grew without bound — unlike `PoolTransferInTx` (#629) and `CLPositionPendingPrincipal` (#789), which delete on consume.

`getActualLpAmountForV1` now `deleteUnsafe`s the matched burn instead of marking it, and the now-vestigial `consumedByLogIndex` field is removed from the schema, the producer, and the reader filter.

## Why it's safe

This handler is the **sole reader** of `ALMLPWrapperTransferInTx`, so deleting the matched burn:

- **Preserves the within-tx double-match guard** — a later `Withdraw` in the same tx re-queries via `getWhere`, and the deleted row drops out. This is the *same* in-batch visibility the old soft-consume marker already relied on; `#629` (a perf-only refactor: "replace `PoolTransferInTx.getWhere` with registry PK lookup") proved the pre-registry `getWhere` path was already correct, so this introduces no new dependency.
- **Frees storage** — the whole point of the issue.

No `PoolTransferInTx`-style registry is added: that's a perf optimization for high-volume tables, and ALM V1 burn-transfer volume doesn't warrant it.

## Scope

- ✅ **AC1** — `ALMLPWrapperTransferInTx` is `deleteUnsafe`d on consumption (soft-consume marker removed).
- ✅ **AC4** — `PoolTransferInTx` left unchanged.
- ⬜ **AC2 / AC3** — Part B (Hyperlane `DispatchId_event` / `ProcessId_event` matched-pair deletion + reorg/backfill test) is **not** in this PR. It is cross-chain, idempotent-retry, and needs a reorg test, so it stays `ready-for-human` and lands separately. This PR **references** #817 but does **not** close it.

## Test plan

- [x] TDD: red (assert `deleteUnsafe` called → fails against soft-consume) → green.
- [x] Consume test asserts `deleteUnsafe(matchingBurn.id)` and that no soft-consume `set` remains; obsolete "filter out consumed transfers" test removed.
- [x] `tsc --noEmit` clean (project-wide).
- [x] Full `pnpm test` green; `biome check` clean.
- [x] `SchemaParity` / `EntityTimestamps` / `IdNormalization` unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
