### PR TITLE
fix(storage): delete matched Hyperlane correlators on SuperSwap creation (part of #817)

### DIFF
--- a/src/EventHandlers/SuperswapsHyperlane/SuperSwapLogic.ts
+++ b/src/EventHandlers/SuperswapsHyperlane/SuperSwapLogic.ts
@@ -239,6 +239,42 @@ export async function createSuperSwapEntity(
 }
 
 /**
+ * Deletes the matched DispatchId_event / ProcessId_event correlator pair for a
+ * messageId whose SuperSwap has been confirmed created (or already exists).
+ *
+ * Only the matched pair is removed — other (unmatched) messageIds dispatched in
+ * the same source transaction are retained for their own not-yet-created
+ * SuperSwaps. Deletion is idempotent (deleteUnsafe on an already-removed id is a
+ * no-op), so a backfill / reorg re-apply that re-reaches this point is safe.
+ * This stops the Mailbox scratch tables from growing without bound (#817 Part B),
+ * mirroring the delete-on-consume pattern used for PoolTransferInTx (#629).
+ *
+ * @param matchingMessageId - The messageId whose SuperSwap was just created
+ * @param sourceChainMessageIdEntities - DispatchId events from the source transaction
+ * @param messageIdToProcessId - Map from messageId to its ProcessId event
+ * @param context - Handler context for entity operations
+ * @returns Nothing; stages the matched pair's deletion
+ */
+function deleteConsumedMailboxPair(
+  matchingMessageId: string,
+  sourceChainMessageIdEntities: DispatchId_event[],
+  messageIdToProcessId: Map<string, ProcessId_event>,
+  context: handlerContext,
+): void {
+  const dispatchEntity = sourceChainMessageIdEntities.find(
+    (entity) => entity.messageId === matchingMessageId,
+  );
+  if (dispatchEntity) {
+    context.DispatchId_event.deleteUnsafe(dispatchEntity.id);
+  }
+
+  const processEntity = messageIdToProcessId.get(matchingMessageId);
+  if (processEntity) {
+    context.ProcessId_event.deleteUnsafe(processEntity.id);
+  }
+}
+
+/**
  * Processes cross-chain swap events to create SuperSwap entities.
  * Maps DispatchId events to ProcessId events, loads swap data, and creates SuperSwap entities.
  *
@@ -308,6 +344,18 @@ export async function processCrossChainSwap(
     destinationSwapData.destinationChainToken,
     destinationSwapData.destinationChainTokenAmountSwapped,
     blockTimestamp,
+    context,
+  );
+
+  // The SuperSwap for matchingMessageId is now confirmed to exist (just created
+  // or idempotently pre-existing), so its DispatchId/ProcessId correlators are
+  // consumed and can be deleted to stop the Mailbox scratch tables from growing.
+  // Only the matched pair is removed; unmatched messageIds in this source tx are
+  // retained for their own not-yet-created SuperSwaps (#817 Part B).
+  deleteConsumedMailboxPair(
+    destinationSwapData.matchingMessageId,
+    sourceChainMessageIdEntities,
+    messageIdToProcessId,
     context,
   );
 }

--- a/test/EventHandlers/SuperswapsHyperlane/Mailbox.test.ts
+++ b/test/EventHandlers/SuperswapsHyperlane/Mailbox.test.ts
@@ -605,7 +605,9 @@ describe("Mailbox Events", () => {
         },
       });
 
-      // Assert: ProcessId_event was created
+      // Assert: once the SuperSwap is created, the matched DispatchId_event /
+      // ProcessId_event correlators are consumed and hard-deleted (#817 Part B),
+      // so they no longer linger in the scratch tables.
       const processIdEntityId = MailboxMessageId(
         destinationTransactionHash,
         destinationChainId,
@@ -613,8 +615,16 @@ describe("Mailbox Events", () => {
       );
       const processIdEntity =
         await indexer.ProcessId_event.get(processIdEntityId);
-      expect(processIdEntity).toBeDefined();
-      expect(processIdEntity?.messageId).toBe(testMessageId);
+      expect(processIdEntity).toBeUndefined();
+
+      const dispatchIdEntityId = MailboxMessageId(
+        sourceTransactionHash,
+        sourceChainId,
+        testMessageId,
+      );
+      const dispatchIdEntity =
+        await indexer.DispatchId_event.get(dispatchIdEntityId);
+      expect(dispatchIdEntity).toBeUndefined();
 
       // Assert: SuperSwap was created
       const superSwapsRaw = await indexer.SuperSwap.getAll();

--- a/test/EventHandlers/SuperswapsHyperlane/SuperSwapLogic.test.ts
+++ b/test/EventHandlers/SuperswapsHyperlane/SuperSwapLogic.test.ts
@@ -126,6 +126,8 @@ describe("SuperSwapLogic", () => {
     const swapMap = new Map<string, OUSDTSwaps[]>();
     const logWarnings: string[] = [];
     const superSwaps = new Map<string, SuperSwap>();
+    const deletedDispatchIds = new Set<string>();
+    const deletedProcessIds = new Set<string>();
 
     // Group ProcessId events by messageId
     for (const event of processIdEvents) {
@@ -140,12 +142,20 @@ describe("SuperSwapLogic", () => {
     }
 
     return {
+      DispatchId_event: {
+        deleteUnsafe: (id: string) => {
+          deletedDispatchIds.add(id);
+        },
+      },
       ProcessId_event: {
         // biome-ignore lint/suspicious/noExplicitAny: test mock context needs flexibility
         getWhere: async (params: any) => {
           if (params.messageId?._eq)
             return processIdMap.get(params.messageId._eq) || [];
           return [];
+        },
+        deleteUnsafe: (id: string) => {
+          deletedProcessIds.add(id);
         },
       },
       OUSDTSwaps: {
@@ -174,6 +184,8 @@ describe("SuperSwapLogic", () => {
       },
       getWarnings: () => logWarnings,
       getSuperSwaps: () => superSwaps,
+      getDeletedDispatchIds: () => deletedDispatchIds,
+      getDeletedProcessIds: () => deletedProcessIds,
       // biome-ignore lint/suspicious/noExplicitAny: test mock context needs flexibility
     } as any;
   };
@@ -245,6 +257,205 @@ describe("SuperSwapLogic", () => {
       expect(superSwap.destinationChainToken).toBe(tokenOutAddress);
       expect(superSwap.destinationChainTokenAmountSwapped).toBe(950n);
       expect(superSwap.timestamp).toEqual(new Date(blockTimestamp * 1000));
+    });
+
+    it("should delete the matched DispatchId/ProcessId pair once the SuperSwap is created (#817 Part B)", async () => {
+      const sourceChainMessageIdEntities: DispatchId_event[] = [
+        createDispatchIdEvent(transactionHash, chainId, messageId1),
+      ];
+      const processIdResults: ProcessId_event[][] = [
+        [
+          createProcessIdEvent(
+            destinationTxHash,
+            Number(destinationDomain),
+            messageId1,
+          ),
+        ],
+      ];
+      const sourceSwap = createOUSDTSwap(
+        transactionHash,
+        chainId,
+        tokenInAddress,
+        1000n,
+        oUSDTAddress,
+        oUSDTAmount,
+      );
+      const destinationSwap = createOUSDTSwap(
+        destinationTxHash,
+        Number(destinationDomain),
+        oUSDTAddress,
+        oUSDTAmount,
+        tokenOutAddress,
+        950n,
+      );
+      const context = createMockContext(processIdResults.flat(), [
+        sourceSwap,
+        destinationSwap,
+      ]);
+
+      await processCrossChainSwap(
+        sourceChainMessageIdEntities,
+        processIdResults,
+        mockBridgedTransaction,
+        transactionHash,
+        chainId,
+        destinationDomain,
+        blockTimestamp,
+        context,
+      );
+
+      // SuperSwap created → its DispatchId/ProcessId correlators are consumed
+      // and hard-deleted so the Mailbox scratch tables stop growing (#817 Part B).
+      expect(context.getSuperSwaps().size).toBe(1);
+      expect([...context.getDeletedDispatchIds()]).toEqual([
+        MailboxMessageId(transactionHash, chainId, messageId1),
+      ]);
+      expect([...context.getDeletedProcessIds()]).toEqual([
+        MailboxMessageId(
+          destinationTxHash,
+          Number(destinationDomain),
+          messageId1,
+        ),
+      ]);
+    });
+
+    it("should retain unmatched DispatchId rows for other messageIds in the same source tx (#817 Part B)", async () => {
+      // Two messageIds dispatched in one source tx; only messageId1 has a
+      // matching ProcessId + destination swap, so only its pair is deleted.
+      const sourceChainMessageIdEntities: DispatchId_event[] = [
+        createDispatchIdEvent(transactionHash, chainId, messageId1),
+        createDispatchIdEvent(transactionHash, chainId, messageId2),
+      ];
+      const processIdResults: ProcessId_event[][] = [
+        [
+          createProcessIdEvent(
+            destinationTxHash,
+            Number(destinationDomain),
+            messageId1,
+          ),
+        ],
+        [],
+      ];
+      const sourceSwap = createOUSDTSwap(
+        transactionHash,
+        chainId,
+        tokenInAddress,
+        1000n,
+        oUSDTAddress,
+        oUSDTAmount,
+      );
+      const destinationSwap = createOUSDTSwap(
+        destinationTxHash,
+        Number(destinationDomain),
+        oUSDTAddress,
+        oUSDTAmount,
+        tokenOutAddress,
+        950n,
+      );
+      const context = createMockContext(processIdResults.flat(), [
+        sourceSwap,
+        destinationSwap,
+      ]);
+
+      await processCrossChainSwap(
+        sourceChainMessageIdEntities,
+        processIdResults,
+        mockBridgedTransaction,
+        transactionHash,
+        chainId,
+        destinationDomain,
+        blockTimestamp,
+        context,
+      );
+
+      expect(context.getSuperSwaps().size).toBe(1);
+      const deletedDispatch = context.getDeletedDispatchIds();
+      expect(
+        deletedDispatch.has(
+          MailboxMessageId(transactionHash, chainId, messageId1),
+        ),
+      ).toBe(true);
+      expect(
+        deletedDispatch.has(
+          MailboxMessageId(transactionHash, chainId, messageId2),
+        ),
+      ).toBe(false);
+    });
+
+    it("should stay idempotent when re-processed after the pair was deleted (#817 Part B backfill/replay)", async () => {
+      const sourceChainMessageIdEntities: DispatchId_event[] = [
+        createDispatchIdEvent(transactionHash, chainId, messageId1),
+      ];
+      const processIdResults: ProcessId_event[][] = [
+        [
+          createProcessIdEvent(
+            destinationTxHash,
+            Number(destinationDomain),
+            messageId1,
+          ),
+        ],
+      ];
+      const sourceSwap = createOUSDTSwap(
+        transactionHash,
+        chainId,
+        tokenInAddress,
+        1000n,
+        oUSDTAddress,
+        oUSDTAmount,
+      );
+      const destinationSwap = createOUSDTSwap(
+        destinationTxHash,
+        Number(destinationDomain),
+        oUSDTAddress,
+        oUSDTAmount,
+        tokenOutAddress,
+        950n,
+      );
+      const context = createMockContext(processIdResults.flat(), [
+        sourceSwap,
+        destinationSwap,
+      ]);
+
+      // Process the same events twice (simulates a backfill / reorg re-apply).
+      // The second pass must not create a duplicate SuperSwap and must not throw.
+      await processCrossChainSwap(
+        sourceChainMessageIdEntities,
+        processIdResults,
+        mockBridgedTransaction,
+        transactionHash,
+        chainId,
+        destinationDomain,
+        blockTimestamp,
+        context,
+      );
+      await processCrossChainSwap(
+        sourceChainMessageIdEntities,
+        processIdResults,
+        mockBridgedTransaction,
+        transactionHash,
+        chainId,
+        destinationDomain,
+        blockTimestamp,
+        context,
+      );
+
+      expect(context.getSuperSwaps().size).toBe(1);
+      expect(
+        context
+          .getDeletedDispatchIds()
+          .has(MailboxMessageId(transactionHash, chainId, messageId1)),
+      ).toBe(true);
+      expect(
+        context
+          .getDeletedProcessIds()
+          .has(
+            MailboxMessageId(
+              destinationTxHash,
+              Number(destinationDomain),
+              messageId1,
+            ),
+          ),
+      ).toBe(true);
     });
 
     it("should create single SuperSwap when multiple destination swaps exist but only one has oUSDT", async () => {
@@ -1576,6 +1787,8 @@ describe("SuperSwapLogic", () => {
       const logWarnings: string[] = [];
       const logErrors: Array<{ message: string; error?: unknown }> = [];
       const superSwaps = new Map<string, SuperSwap>();
+      const deletedDispatchIds = new Set<string>();
+      const deletedProcessIds = new Set<string>();
 
       for (const event of dispatchIdEvents) {
         const existing = dispatchIdByTxHash.get(event.transactionHash) || [];
@@ -1605,6 +1818,17 @@ describe("SuperSwapLogic", () => {
               return dispatchIdByTxHash.get(params.transactionHash._eq) || [];
             return [];
           },
+          // Mutates the map so a subsequent getWhere reflects the deletion,
+          // modeling the real in-memory store's in-batch delete semantics.
+          deleteUnsafe: (id: string) => {
+            deletedDispatchIds.add(id);
+            for (const [txHash, events] of dispatchIdByTxHash) {
+              dispatchIdByTxHash.set(
+                txHash,
+                events.filter((event) => event.id !== id),
+              );
+            }
+          },
         },
         ProcessId_event: {
           // biome-ignore lint/suspicious/noExplicitAny: test mock context needs flexibility
@@ -1612,6 +1836,15 @@ describe("SuperSwapLogic", () => {
             if (params.messageId?._eq)
               return processIdMap.get(params.messageId._eq) || [];
             return [];
+          },
+          deleteUnsafe: (id: string) => {
+            deletedProcessIds.add(id);
+            for (const [mid, events] of processIdMap) {
+              processIdMap.set(
+                mid,
+                events.filter((event) => event.id !== id),
+              );
+            }
           },
         },
         OUSDTBridgedTransaction: {
@@ -1649,6 +1882,8 @@ describe("SuperSwapLogic", () => {
         getWarnings: () => logWarnings,
         getErrors: () => logErrors,
         getSuperSwaps: () => superSwaps,
+        getDeletedDispatchIds: () => deletedDispatchIds,
+        getDeletedProcessIds: () => deletedProcessIds,
         // biome-ignore lint/suspicious/noExplicitAny: test mock context needs flexibility
       } as any;
     };
@@ -1704,6 +1939,89 @@ describe("SuperSwapLogic", () => {
       expect(superSwap.oUSDTamount).toBe(oUSDTAmount);
       expect(superSwap.sourceChainToken).toBe(tokenInAddress);
       expect(superSwap.destinationChainToken).toBe(tokenOutAddress);
+      expect(context.getErrors()).toHaveLength(0);
+      expect(context.getWarnings()).toHaveLength(0);
+    });
+
+    it("should keep cross-chain stitching intact after the matched pair is deleted, on backfill/replay (#817 Part B, AC3)", async () => {
+      // NOTE: the v3 createTestIndexer harness cannot simulate a true block-level
+      // reorg, so this exercises the handler-observable behaviour a reorg/backfill
+      // produces — the same CrossChainSwap is processed again after its
+      // DispatchId/ProcessId pair was already consumed and deleted. The mock's
+      // deleteUnsafe removes the rows from the getWhere-backing maps (mirroring
+      // the real in-memory store), so the replay sees them gone. Stitching must
+      // survive: no duplicate SuperSwap, no error/warning, deleted rows stay gone.
+      const dispatchIdEvent = createDispatchIdEvent(
+        transactionHash,
+        chainId,
+        messageId1,
+      );
+      const processIdEvent = createProcessIdEvent(
+        destinationTxHash,
+        Number(destinationDomain),
+        messageId1,
+      );
+      const sourceSwap = createOUSDTSwap(
+        transactionHash,
+        chainId,
+        tokenInAddress,
+        1000n,
+        oUSDTAddress,
+        oUSDTAmount,
+      );
+      const destinationSwap = createOUSDTSwap(
+        destinationTxHash,
+        Number(destinationDomain),
+        oUSDTAddress,
+        oUSDTAmount,
+        tokenOutAddress,
+        950n,
+      );
+      const context = createHandlerMockContext(
+        [dispatchIdEvent],
+        [processIdEvent],
+        [mockBridgedTransaction],
+        [sourceSwap, destinationSwap],
+      );
+
+      // First pass: SuperSwap stitched + matched pair consumed/deleted.
+      await handleCrossChainSwapEvent(
+        transactionHash,
+        chainId,
+        destinationDomain,
+        blockTimestamp,
+        context,
+      );
+      expect(context.getSuperSwaps().size).toBe(1);
+      expect(
+        context
+          .getDeletedDispatchIds()
+          .has(MailboxMessageId(transactionHash, chainId, messageId1)),
+      ).toBe(true);
+      expect(
+        context
+          .getDeletedProcessIds()
+          .has(
+            MailboxMessageId(
+              destinationTxHash,
+              Number(destinationDomain),
+              messageId1,
+            ),
+          ),
+      ).toBe(true);
+
+      // Backfill / reorg re-apply: reprocess the same source event. The DispatchId
+      // correlator was deleted, so the handler finds nothing to stitch and safely
+      // no-ops — the existing SuperSwap is preserved, with no duplicate and no
+      // error/warning.
+      await handleCrossChainSwapEvent(
+        transactionHash,
+        chainId,
+        destinationDomain,
+        blockTimestamp,
+        context,
+      );
+      expect(context.getSuperSwaps().size).toBe(1);
       expect(context.getErrors()).toHaveLength(0);
       expect(context.getWarnings()).toHaveLength(0);
     });


### PR DESCRIPTION
## What

Part B of #817 (Part A: #836). `DispatchId_event` / `ProcessId_event` are the Hyperlane cross-chain correlators used to stitch a `SuperSwap` from its source `CrossChainSwap` and destination `ProcessId`. They were **never deleted**, so the Mailbox scratch tables grew without bound — the cross-chain analogue of the ALM leak fixed in Part A.

`processCrossChainSwap` now deletes the matched `DispatchId_event` + `ProcessId_event` pair once their `SuperSwap` is confirmed created (or already exists). The delete lives at the single creation chokepoint, so it covers both creation paths (`CrossChainSwap`-first via `handleCrossChainSwapEvent` and `ProcessId`-first via `attemptSuperSwapCreationFromProcessId`). `createSuperSwapEntity` is left pure.

## Why it's safe

- **Only the matched pair is deleted.** A source tx can dispatch multiple `messageId`s; only the one whose `SuperSwap` was just created is removed. Other (unmatched) `messageId`s are retained for their own not-yet-created SuperSwaps.
- **Data-loss-safe.** A correlator is only deleted once its `SuperSwap` exists, i.e. the correlation is complete and future reads short-circuit on the existing `SuperSwap`.
- **Idempotent.** `deleteUnsafe` on an already-removed id is a no-op, so a backfill / reorg re-apply that re-reaches the create step is safe.

## Scope

- ✅ **AC2** — matched pair deleted on confirmed create; unmatched rows retained.
- ✅ **AC3** — cross-chain stitching still works after deletion (see test plan + caveat).
- ✅ AC1 / AC4 — Part A (#836).

## Test plan

- [x] **Unit** (`processCrossChainSwap`): matched pair deleted; unmatched `messageId` retained; idempotent on replay (no duplicate SuperSwap, pair re-cleaned).
- [x] **Integration** (`Mailbox.ProcessId` handler via `createTestIndexer`, real in-memory store): end-to-end — `SuperSwap` is stitched **and** both correlators are deleted.
- [x] **Backfill/replay** (`handleCrossChainSwapEvent`): after deletion, reprocessing the source event is a safe no-op — `SuperSwap` preserved, no duplicate, no error/warning.
- [x] `tsc --noEmit` clean (project-wide); full `pnpm test` green; `biome check` clean.

## Notes for review (this was the `ready-for-human` half of #817)

- **AC3 harness limitation:** the v3 `createTestIndexer` has no true block-level reorg API, so AC3 is realized as the **backfill/replay** behavior a reorg produces at the handler level, plus the real-harness integration assertion. If a truer reorg simulation is wanted, flag it.
- **Known residual leak (left in deliberately):** a `ProcessId` re-delivered *after* its `DispatchId` was already cross-chain-deleted (a narrow reorg interleaving) re-leaks its row, because `attemptSuperSwapCreationFromProcessId` short-circuits on the missing `DispatchId` before reaching the delete. It is **bounded and non-corrupting** (SuperSwap data stays correct). An orphan mop-up was left out to avoid a `SuperSwap.get` on the normal `Process`-before-`Dispatch` ordering — happy to add it if preferred.

## Closing

References #817 without auto-close so the issue doesn't close prematurely on whichever of #836 / this PR merges first. Close #817 once both land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
