### PR TITLE
fix(fees): unify V2/CL fee-field scaling — 1e18 amounts + 1e6 FEE_SCALE (closes #812)

### DIFF
--- a/docs/adr/0001-canonical-fee-field-scaling.md
+++ b/docs/adr/0001-canonical-fee-field-scaling.md
@@ -1,0 +1,52 @@
+# ADR 0001: Canonical fee-field scaling across V2 and CL pools
+
+- **Status:** Accepted (2026-06-02)
+- **Issue:** [#812](https://github.com/velodrome-finance/indexer/issues/812)
+
+## Context
+
+The same `Pool` / `UserStatsPerPool` schema fields carried **different scales
+depending on pool type**, so any cross-pool-type aggregation or interpretation
+was wrong. Confirmed live on the deployed endpoint:
+
+- **Token-amount fee fields** (`totalFeesGenerated0/1`, `totalFeesContributed0/1`):
+  V2 (AMM) stored **raw** token units; CL stored **1e18-normalized**. A 0.50-USDC
+  fee read as `~5e5` on V2 but `~5e17` on CL.
+- **`baseFee` / `currentFee`**: V2 stored **basis points** (÷1e4, e.g. `30` = 0.30%);
+  CL stored **hundredths-of-a-basis-point** (÷1e6, e.g. `3000` = 0.30%) — off by 100×.
+  After issue #797 each path also had its own divisor (`V2_FEE_SCALE` = 1e4,
+  `CL_FEE_SCALE` = 1e6), so a stored `100` meant 1% on V2 but 0.01% on CL.
+
+## Decision
+
+Adopt CL's scales as canonical so an equivalent fee reads identically on both paths:
+
+1. **Token-amount fee fields are 1e18-normalized** on both V2 and CL. V2's
+   `Pool.Fees` amounts are normalized at write via `normalizeTokenAmountTo1e18`
+   (CL already did this). This is the house convention for cross-token comparability.
+2. **`baseFee` / `currentFee` use a single `FEE_SCALE = 1e6`** ("hundredths of a
+   basis point"), with `V2_FEE_SCALE` and `CL_FEE_SCALE` merged into it — one
+   divisor everywhere. On-chain V2 basis-point fees are lifted into `FEE_SCALE`
+   at every write site via `toCanonicalFeeScale(rawFee, isCL)` (`isCL ? raw : raw × 100`).
+
+`FEE_SCALE = 1e6` was chosen over unifying down to basis points because CL pools
+use sub-basis-point dynamic fees (e.g. `9`, `313`, `2090` = 0.0009%, 0.0313%,
+0.209% seen live) that ÷100 would truncate; 1e6 is lossless and matches both the
+CL on-chain representation and what `getSwapFee` returns.
+
+### Write-site routing
+
+- V2 `PoolFactory` (PoolCreated defaults, SetCustomFee): bps → `toCanonicalFeeScale(fee, false)` (×100).
+- `CustomSwapFeeModule.SetCustomFee`: routed through `toCanonicalFeeScale(fee, pool.isCL)` — correct whether it targets V2 or CL.
+- `DynamicSwapFeeModule.CustomFeeSet`: confirmed CL-only (all `feeCap`/`scalingFactor` pools are `isCL`), already 1e6 — left untouched.
+- CL `CLFactory` + `getSwapFee`: already 1e6 — unchanged.
+
+## Consequences
+
+- **No USD value changes.** Token-amount fields are separate from the `*USD`
+  fields; for fees, the V2 rate is ×100 *and* the divisor is ×100, so
+  `volumeUSD × fee / FEE_SCALE` is unchanged.
+- **Breaking for external consumers of V2 `baseFee`/`currentFee`:** a V2 pool's
+  served fee changes from e.g. `30`→`3000`; consumers reading it as basis points
+  must switch to ÷`FEE_SCALE` (1e6). This is the one outward-facing change.
+- Parity is pinned by `test/EventHandlers/FeeFieldScaling.test.ts`.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -52,8 +52,8 @@ Latest-state entities that hold the headline metrics most consumers query.
 | `totalVolume0` | `BigInt!` | total swap volume of token0 in token units |
 | `totalVolume1` | `BigInt!` | total swap volume of token1 in token units |
 | `totalVolumeUSD` | `BigInt!` | total swap volume of the pool in USD |
-| `totalFeesGenerated0` | `BigInt!` | total swap fees generated of token0 in token units |
-| `totalFeesGenerated1` | `BigInt!` | total swap fees generated of token1 in token units |
+| `totalFeesGenerated0` | `BigInt!` | total swap fees generated of token0, 1e18-normalized token units (same scale on V2 & CL — issue #812) |
+| `totalFeesGenerated1` | `BigInt!` | total swap fees generated of token1, 1e18-normalized token units (same scale on V2 & CL — issue #812) |
 | `totalFeesGeneratedUSD` | `BigInt!` | total swap fees of the pool in USD |
 | `totalUnstakedFeesCollected0` | `BigInt!` | total fees collected from unstaked LPs (Collect events) in token0 units |
 | `totalUnstakedFeesCollected1` | `BigInt!` | total fees collected from unstaked LPs (Collect events) in token1 units |
@@ -109,10 +109,10 @@ Latest-state entities that hold the headline metrics most consumers query.
 | `totalFeeRewardClaimed` | `BigInt!` | total fee rewards claimed by users in token units |
 | `totalFeeRewardClaimedUSD` | `BigInt!` | total fee rewards claimed by users in USD |
 | `veNFTamountStaked` | `BigInt!` | total amount of veNFT staked for this pool |
-| `baseFee` | `BigInt!` | Current base fee set for pool |
+| `baseFee` | `BigInt!` | Current base fee, FEE_SCALE 1e6 (hundredths of a basis point); single fee divisor across V2 & CL — issue #812 |
 | `feeCap` | `BigInt` | Current fee cap for pool |
 | `scalingFactor` | `BigInt` | Current scaling factor for pool |
-| `currentFee` | `BigInt!` | Current fee for pool (base + dynamic) |
+| `currentFee` | `BigInt!` | Current fee (base + dynamic), FEE_SCALE 1e6; single fee divisor across V2 & CL — issue #812 |
 | `unstakedFee` | `BigInt` | Raw customFee value last emitted by an UnstakedFeeModule for this pool (CL pools only). 0 = no override (factory default applies), 420 = explicit 0% fee (ZERO_FEE_INDICATOR), else fee rate with 6-decimal precision (e.g. 500_000 = 50%). Null = never set. |
 | `poolLauncherPoolId` | `String` | ID of the PoolLauncherPool entity if this pool was launched via Pool Launcher |
 | `factoryAddress` | `String` | Address of the factory that created this pool (e.g. CLFactory for CL pools, set from PoolCreated event) |
@@ -160,8 +160,8 @@ Entity for tracking user activity and positions in specific pools
 | `totalSwapVolumeAmount1` | `BigInt!` | swap volume denominated in token1 in this pool |
 | `totalSwapVolumeUSD` | `BigInt!` | swap volume in USD in this pool |
 | `totalFeesContributedUSD` | `BigInt!` | total fees contributed in USD (from swaps made by the user - essentially fees paid by the user in swaps) |
-| `totalFeesContributed0` | `BigInt!` | total fees contributed in token0 (from swaps made by the user - essentially fees paid by the user in swaps) |
-| `totalFeesContributed1` | `BigInt!` | total fees contributed in token1 (from swaps made by the user - essentially fees paid by the user in swaps) |
+| `totalFeesContributed0` | `BigInt!` | total fees contributed in token0, 1e18-normalized (fees paid by the user in swaps; same scale on V2 & CL — issue #812) |
+| `totalFeesContributed1` | `BigInt!` | total fees contributed in token1, 1e18-normalized (fees paid by the user in swaps; same scale on V2 & CL — issue #812) |
 | `numberOfFlashLoans` | `BigInt!` | number of flash loan swaps in this pool |
 | `totalFlashLoanVolumeUSD` | `BigInt!` | flash loan swap volume in USD in this pool |
 | `numberOfGaugeDeposits` | `BigInt!` | number of gauge deposits (staking) |
@@ -293,8 +293,8 @@ Snapshot of the LiquidityPool entity
 | `totalVolume0` | `BigInt!` | total swap volume of token0 in token units |
 | `totalVolume1` | `BigInt!` | total swap volume of token1 in token units |
 | `totalVolumeUSD` | `BigInt!` | total swap volume of the pool in USD |
-| `totalFeesGenerated0` | `BigInt!` | total swap fees generated of token0 in token units |
-| `totalFeesGenerated1` | `BigInt!` | total swap fees generated of token1 in token units |
+| `totalFeesGenerated0` | `BigInt!` | total swap fees generated of token0, 1e18-normalized token units (same scale on V2 & CL — issue #812) |
+| `totalFeesGenerated1` | `BigInt!` | total swap fees generated of token1, 1e18-normalized token units (same scale on V2 & CL — issue #812) |
 | `totalFeesGeneratedUSD` | `BigInt!` | total swap fees of the pool in USD |
 | `totalUnstakedFeesCollected0` | `BigInt!` | total fees collected from unstaked LPs (Collect events) in token0 units |
 | `totalUnstakedFeesCollected1` | `BigInt!` | total fees collected from unstaked LPs (Collect events) in token1 units |
@@ -344,10 +344,10 @@ Snapshot of the LiquidityPool entity
 | `totalFeeRewardClaimed` | `BigInt!` | total fee rewards claimed by users in token units |
 | `totalFeeRewardClaimedUSD` | `BigInt!` | total fee rewards claimed by users in USD |
 | `veNFTamountStaked` | `BigInt!` | total amount of veNFT staked for this pool |
-| `baseFee` | `BigInt!` | Current base fee set for pool |
+| `baseFee` | `BigInt!` | Current base fee, FEE_SCALE 1e6 (hundredths of a basis point); single fee divisor across V2 & CL — issue #812 |
 | `feeCap` | `BigInt` | Current fee cap for pool |
 | `scalingFactor` | `BigInt` | Current scaling factor for pool |
-| `currentFee` | `BigInt!` | Current fee for pool (base + dynamic) |
+| `currentFee` | `BigInt!` | Current fee (base + dynamic), FEE_SCALE 1e6; single fee divisor across V2 & CL — issue #812 |
 | `unstakedFee` | `BigInt` | Raw customFee value last emitted by an UnstakedFeeModule for this pool (see Pool for semantics) |
 
 ### TokenPriceSnapshot
@@ -386,8 +386,8 @@ Snapshot of UserStatsPerPool at an epoch (invariant fields + position params for
 | `totalSwapVolumeAmount1` | `BigInt!` | swap volume denominated in token1 in this pool |
 | `totalSwapVolumeUSD` | `BigInt!` | swap volume in USD in this pool |
 | `totalFeesContributedUSD` | `BigInt!` | total fees contributed in USD (fees paid by the user in swaps) |
-| `totalFeesContributed0` | `BigInt!` | total fees contributed in token0 |
-| `totalFeesContributed1` | `BigInt!` | total fees contributed in token1 |
+| `totalFeesContributed0` | `BigInt!` | total fees contributed in token0, 1e18-normalized (same scale on V2 & CL — issue #812) |
+| `totalFeesContributed1` | `BigInt!` | total fees contributed in token1, 1e18-normalized (same scale on V2 & CL — issue #812) |
 | `numberOfFlashLoans` | `BigInt!` | number of flash loan swaps in this pool |
 | `totalFlashLoanVolumeUSD` | `BigInt!` | flash loan swap volume in USD in this pool |
 | `numberOfGaugeDeposits` | `BigInt!` | number of gauge deposits (staking) |

--- a/schema.graphql
+++ b/schema.graphql
@@ -18,8 +18,8 @@ type Pool {
   totalVolume0: BigInt! @config(precision: 76) # total swap volume of token0 in token units
   totalVolume1: BigInt! @config(precision: 76) # total swap volume of token1 in token units
   totalVolumeUSD: BigInt! @config(precision: 76) # total swap volume of the pool in USD
-  totalFeesGenerated0: BigInt! @config(precision: 76) # total swap fees generated of token0 in token units
-  totalFeesGenerated1: BigInt! @config(precision: 76) # total swap fees generated of token1 in token units
+  totalFeesGenerated0: BigInt! @config(precision: 76) # total swap fees generated of token0, 1e18-normalized token units (same scale on V2 & CL — issue #812)
+  totalFeesGenerated1: BigInt! @config(precision: 76) # total swap fees generated of token1, 1e18-normalized token units (same scale on V2 & CL — issue #812)
   totalFeesGeneratedUSD: BigInt! @config(precision: 76) # total swap fees of the pool in USD
   totalUnstakedFeesCollected0: BigInt! @config(precision: 76) # total fees collected from unstaked LPs (Collect events) in token0 units
   totalUnstakedFeesCollected1: BigInt! @config(precision: 76) # total fees collected from unstaked LPs (Collect events) in token1 units
@@ -121,10 +121,10 @@ type Pool {
   veNFTamountStaked: BigInt! @config(precision: 76) # total amount of veNFT staked for this pool
 
   # Dynamic Fee fields
-  baseFee: BigInt! @config(precision: 24) # Current base fee set for pool
+  baseFee: BigInt! @config(precision: 24) # Current base fee, FEE_SCALE 1e6 (hundredths of a basis point); single fee divisor across V2 & CL — issue #812
   feeCap: BigInt @config(precision: 76) # Current fee cap for pool
   scalingFactor: BigInt @config(precision: 76) # Current scaling factor for pool
-  currentFee: BigInt! @config(precision: 76) # Current fee for pool (base + dynamic)
+  currentFee: BigInt! @config(precision: 76) # Current fee (base + dynamic), FEE_SCALE 1e6; single fee divisor across V2 & CL — issue #812
 
   # Unstaked Fee fields
   # Raw customFee value last emitted by an UnstakedFeeModule for this pool (CL pools only).
@@ -168,8 +168,8 @@ type PoolSnapshot {
   totalVolume0: BigInt! @config(precision: 76) # total swap volume of token0 in token units
   totalVolume1: BigInt! @config(precision: 76) # total swap volume of token1 in token units
   totalVolumeUSD: BigInt! @config(precision: 76) # total swap volume of the pool in USD
-  totalFeesGenerated0: BigInt! @config(precision: 76) # total swap fees generated of token0 in token units
-  totalFeesGenerated1: BigInt! @config(precision: 76) # total swap fees generated of token1 in token units
+  totalFeesGenerated0: BigInt! @config(precision: 76) # total swap fees generated of token0, 1e18-normalized token units (same scale on V2 & CL — issue #812)
+  totalFeesGenerated1: BigInt! @config(precision: 76) # total swap fees generated of token1, 1e18-normalized token units (same scale on V2 & CL — issue #812)
   totalFeesGeneratedUSD: BigInt! @config(precision: 76) # total swap fees of the pool in USD
   totalUnstakedFeesCollected0: BigInt! @config(precision: 76) # total fees collected from unstaked LPs (Collect events) in token0 units
   totalUnstakedFeesCollected1: BigInt! @config(precision: 76) # total fees collected from unstaked LPs (Collect events) in token1 units
@@ -233,10 +233,10 @@ type PoolSnapshot {
   veNFTamountStaked: BigInt! @config(precision: 76) # total amount of veNFT staked for this pool
 
   # Dynamic Fee fields
-  baseFee: BigInt! @config(precision: 24) # Current base fee set for pool
+  baseFee: BigInt! @config(precision: 24) # Current base fee, FEE_SCALE 1e6 (hundredths of a basis point); single fee divisor across V2 & CL — issue #812
   feeCap: BigInt @config(precision: 76) # Current fee cap for pool
   scalingFactor: BigInt @config(precision: 76) # Current scaling factor for pool
-  currentFee: BigInt! @config(precision: 76) # Current fee for pool (base + dynamic)
+  currentFee: BigInt! @config(precision: 76) # Current fee (base + dynamic), FEE_SCALE 1e6; single fee divisor across V2 & CL — issue #812
 
   # Unstaked Fee fields
   unstakedFee: BigInt @config(precision: 24) # Raw customFee value last emitted by an UnstakedFeeModule for this pool (see Pool for semantics)
@@ -264,8 +264,8 @@ type UserStatsPerPool {
   totalSwapVolumeAmount1: BigInt! @config(precision: 76) # swap volume denominated in token1 in this pool
   totalSwapVolumeUSD: BigInt! @config(precision: 76) # swap volume in USD in this pool
   totalFeesContributedUSD: BigInt! @config(precision: 76) # total fees contributed in USD (from swaps made by the user - essentially fees paid by the user in swaps)
-  totalFeesContributed0: BigInt! @config(precision: 76) # total fees contributed in token0 (from swaps made by the user - essentially fees paid by the user in swaps)
-  totalFeesContributed1: BigInt! @config(precision: 76) # total fees contributed in token1 (from swaps made by the user - essentially fees paid by the user in swaps)
+  totalFeesContributed0: BigInt! @config(precision: 76) # total fees contributed in token0, 1e18-normalized (fees paid by the user in swaps; same scale on V2 & CL — issue #812)
+  totalFeesContributed1: BigInt! @config(precision: 76) # total fees contributed in token1, 1e18-normalized (fees paid by the user in swaps; same scale on V2 & CL — issue #812)
 
   # Flash swap metrics
   numberOfFlashLoans: BigInt! @config(precision: 76) # number of flash loan swaps in this pool
@@ -328,8 +328,8 @@ type UserStatsPerPoolSnapshot {
   totalSwapVolumeAmount1: BigInt! @config(precision: 76) # swap volume denominated in token1 in this pool
   totalSwapVolumeUSD: BigInt! @config(precision: 76) # swap volume in USD in this pool
   totalFeesContributedUSD: BigInt! @config(precision: 76) # total fees contributed in USD (fees paid by the user in swaps)
-  totalFeesContributed0: BigInt! @config(precision: 76) # total fees contributed in token0
-  totalFeesContributed1: BigInt! @config(precision: 76) # total fees contributed in token1
+  totalFeesContributed0: BigInt! @config(precision: 76) # total fees contributed in token0, 1e18-normalized (same scale on V2 & CL — issue #812)
+  totalFeesContributed1: BigInt! @config(precision: 76) # total fees contributed in token1, 1e18-normalized (same scale on V2 & CL — issue #812)
 
   # Flash swap metrics
   numberOfFlashLoans: BigInt! @config(precision: 76) # number of flash loan swaps in this pool

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -27,18 +27,37 @@ export const TEN_TO_THE_6_BI = BigInt(10 ** 6);
 export const TEN_TO_THE_18_BI = BigInt(10 ** 18);
 
 /**
- * CL pool fees use a 1e6 scale (hundredths of a basis point):
- *   100 = 0.01%, 500 = 0.05%, 3000 = 0.30%, 10000 = 1.00%
+ * Canonical pool-fee scale: 1e6, "hundredths of a basis point".
+ *
+ * Every Pool stores `baseFee`/`currentFee` in this scale, and every fee
+ * derivation divides by it — a single divisor across V2 (AMM) and CL pools
+ * (issue #812). Examples:
+ *   100 = 0.01%, 500 = 0.05%, 3000 = 0.30%, 10000 = 1.00%, 1_000_000 = 100%
+ *
+ * On-chain, CL (Slipstream) pools already report fees in 1e6, whereas V2 pools
+ * report in basis points (1e4). {@link toCanonicalFeeScale} lifts V2 bps values
+ * into FEE_SCALE at write time so the stored field and this divisor always agree.
  */
-export const CL_FEE_SCALE = 1000000n;
+export const FEE_SCALE = 1000000n;
+
+/** Multiplier converting an on-chain V2 basis-point fee (1e4) into {@link FEE_SCALE} (1e6). */
+export const BPS_TO_FEE_SCALE = 100n;
 
 /**
- * V2 pool fees use a 1e4 (basis-points-per-100) scale:
- *   5 = 0.05% stable, 30 = 0.30% volatile, 100 = 1.00%
- * Matches PoolFactory's DEFAULT_SAMM_FEE_BPS / DEFAULT_VAMM_FEE_BPS units
- * and the `event.params.fee` passed into CustomSwapFeeModule's SetCustomFee.
+ * Normalize a raw on-chain pool fee to the canonical {@link FEE_SCALE} (1e6).
+ *
+ * CL pools already emit fees in FEE_SCALE and are returned unchanged. V2 (AMM)
+ * pools emit fees in basis points (1e4) and are multiplied by
+ * {@link BPS_TO_FEE_SCALE}. Keyed on `isCL` so a single stored scale — and a
+ * single divisor — holds across both pool types (issue #812).
+ *
+ * @param rawFee - Fee as emitted on-chain (basis points for V2, 1e6 for CL)
+ * @param isCL - Whether the owning pool is a concentrated-liquidity pool
+ * @returns The fee expressed in FEE_SCALE (1e6)
  */
-export const V2_FEE_SCALE = 10000n;
+export function toCanonicalFeeScale(rawFee: bigint, isCL: boolean): bigint {
+  return isCL ? rawFee : rawFee * BPS_TO_FEE_SCALE;
+}
 
 export const SECONDS_IN_AN_HOUR = BigInt(3600);
 export const MS_IN_AN_HOUR = 3600 * 1000; // 3_600_000 ms

--- a/src/EventHandlers/CLPool/CLPoolSwapLogic.ts
+++ b/src/EventHandlers/CLPool/CLPoolSwapLogic.ts
@@ -2,7 +2,7 @@ import type { EvmEvent, Token } from "envio";
 import { processTickCrossings } from "../../Aggregators/CLStakedLiquidity";
 import type { PoolDiff } from "../../Aggregators/Pool";
 import type { UserStatsPerPoolDiff } from "../../Aggregators/UserStatsPerPool";
-import { CL_FEE_SCALE } from "../../Constants";
+import { FEE_SCALE } from "../../Constants";
 import type { Pool, handlerContext } from "../../EntityTypes";
 import {
   calculateTotalUSD,
@@ -44,7 +44,7 @@ interface SwapVolumeAndFees {
 
 /** Compute fee amount in native token units from a CL fee rate and a swap amount. */
 function computeClFeeAmount(amount: bigint, feeRate: bigint): bigint {
-  return (abs(amount) * feeRate) / CL_FEE_SCALE;
+  return (abs(amount) * feeRate) / FEE_SCALE;
 }
 
 /**
@@ -81,7 +81,7 @@ export function calculateSwapVolume(
  * Raw fee amounts (`swapFeesInToken0`, `swapFeesInToken1`) come directly from the
  * input side of the swap and the pool's fee rate, normalized to 1e18 precision.
  * USD value (`swapFeesInUSD`) is derived from the already-trusted `volumeInUSD`
- * via `volumeInUSD × feeRate / CL_FEE_SCALE` — this enforces the AMM invariant
+ * via `volumeInUSD × feeRate / FEE_SCALE` — this enforces the AMM invariant
  * `fees ≤ volume × feeRate` by construction and inherits the volume path's
  * `pickTrustedSwapVolumeUSD` defense against poisoned-price tokens (issue #733).
  *
@@ -144,7 +144,7 @@ export function calculateSwapFees(
   );
 
   // Derive fee USD from trusted volume — see file header for the #733 rationale.
-  const swapFeesInUSD = (volumeInUSD * fee) / CL_FEE_SCALE;
+  const swapFeesInUSD = (volumeInUSD * fee) / FEE_SCALE;
 
   return {
     swapFeesInToken0,

--- a/src/EventHandlers/Pool.ts
+++ b/src/EventHandlers/Pool.ts
@@ -110,10 +110,11 @@ indexer.onEvent(
       return;
     }
 
-    const { liquidityPoolAggregator } = poolData;
+    const { liquidityPoolAggregator, token0Instance, token1Instance } =
+      poolData;
 
     // Process fees event
-    const result = processPoolFees(event);
+    const result = processPoolFees(event, token0Instance, token1Instance);
 
     const { liquidityPoolDiff, userDiff } = result;
 

--- a/src/EventHandlers/Pool/PoolFeesLogic.ts
+++ b/src/EventHandlers/Pool/PoolFeesLogic.ts
@@ -1,6 +1,7 @@
-import type { EvmEvent } from "envio";
+import type { EvmEvent, Token } from "envio";
 import type { PoolDiff } from "../../Aggregators/Pool";
 import type { UserStatsPerPoolDiff } from "../../Aggregators/UserStatsPerPool";
+import { normalizeTokenAmountTo1e18 } from "../../Helpers";
 
 export interface PoolFeesResult {
   liquidityPoolDiff?: Partial<PoolDiff>;
@@ -8,11 +9,17 @@ export interface PoolFeesResult {
 }
 
 /**
- * Process a V2 Pool Fees event into raw token-amount diffs only.
+ * Process a V2 Pool Fees event into token-amount diffs only.
+ *
+ * Token-amount fee fields (`totalFeesGenerated0/1`, `totalFeesContributed0/1`)
+ * are stored 1e18-normalized so they share one scale with the CL path
+ * (`CLPoolSwapLogic.calculateSwapFees`) — issue #812. The V2 `Pool.Fees` event
+ * reports raw token units, so each leg is normalized here using its token's
+ * decimals.
  *
  * USD fee aggregates are deliberately NOT written here. Per issue #797 they
  * are now derived in `processPoolSwap` from trusted volume × pool fee rate
- * (`volumeInUSD × currentFee / V2_FEE_SCALE`), mirroring CL's path
+ * (`volumeInUSD × currentFee / FEE_SCALE`), mirroring CL's path
  * (`CLPoolSwapLogic.calculateSwapFees`) and completing the #733 / regression
  * of #670 invariant `cumulative_fees ≤ cumulative_volume × fee_ratio`. The
  * Fees event only carries the input-side leg, so its old single-leg
@@ -21,23 +28,36 @@ export interface PoolFeesResult {
  * aggregate (1000/1000 `[FEE_VOLUME_DIVERGENCE]` warned pools on c9b8978 were V2).
  *
  * @param event - V2 Pool Fees event
- * @returns Pool and user diffs with raw token-unit fee amounts only
+ * @param token0Instance - Token0 entity (decimals used for 1e18 normalization)
+ * @param token1Instance - Token1 entity (decimals used for 1e18 normalization)
+ * @returns Pool and user diffs with 1e18-normalized token-unit fee amounts only
  */
 export function processPoolFees(
   event: EvmEvent<"Pool", "Fees">,
+  token0Instance: Token,
+  token1Instance: Token,
 ): PoolFeesResult {
-  // Create liquidity pool diff — raw token amounts only; USD fee is written
-  // in processPoolSwap (see file-top doc / issue #797).
+  // Normalize raw V2 fee amounts to a 1e18 base so V2 and CL agree (issue #812).
+  const fees0 = normalizeTokenAmountTo1e18(
+    event.params.amount0,
+    Number(token0Instance.decimals),
+  );
+  const fees1 = normalizeTokenAmountTo1e18(
+    event.params.amount1,
+    Number(token1Instance.decimals),
+  );
+
+  // Token-amount fees only; USD fee is written in processPoolSwap (issue #797).
   const liquidityPoolDiff = {
-    incrementalTotalFeesGenerated0: event.params.amount0,
-    incrementalTotalFeesGenerated1: event.params.amount1,
+    incrementalTotalFeesGenerated0: fees0,
+    incrementalTotalFeesGenerated1: fees1,
     lastUpdatedTimestamp: new Date(event.block.timestamp * 1000),
   };
 
   // Prepare user diff data
   const userDiff = {
-    incrementalTotalFeesContributed0: event.params.amount0,
-    incrementalTotalFeesContributed1: event.params.amount1,
+    incrementalTotalFeesContributed0: fees0,
+    incrementalTotalFeesContributed1: fees1,
     lastActivityTimestamp: new Date(event.block.timestamp * 1000),
   };
 

--- a/src/EventHandlers/Pool/PoolSwapLogic.ts
+++ b/src/EventHandlers/Pool/PoolSwapLogic.ts
@@ -1,7 +1,7 @@
 import type { EvmEvent, Token } from "envio";
 import type { PoolDiff } from "../../Aggregators/Pool";
 import type { UserStatsPerPoolDiff } from "../../Aggregators/UserStatsPerPool";
-import { V2_FEE_SCALE } from "../../Constants";
+import { FEE_SCALE } from "../../Constants";
 import type { Pool } from "../../EntityTypes";
 import { pickTrustedSwapVolumeUSD } from "../../Helpers";
 import { getTrustedUSD } from "../../PriceTrust";
@@ -28,7 +28,7 @@ export interface PoolSwapResult {
  * trusted legs) — defends against scam-token / poisoned-oracle inflation
  * (issues #699, #737, #755).
  *
- * Fee USD: `volumeInUSD × (currentFee ?? baseFee ?? 0n) / V2_FEE_SCALE` —
+ * Fee USD: `volumeInUSD × (currentFee ?? baseFee ?? 0n) / FEE_SCALE` —
  * inherits the volume path's min-protection by construction and tracks
  * Custom/Dynamic fee-module changes via `currentFee` (issue #797, mirrors
  * `CLPoolSwapLogic.calculateSwapFees`). `processPoolFees` no longer writes
@@ -61,7 +61,7 @@ export function processPoolSwap(
   // Derive fee USD from trusted volume — see file header for the #797 rationale.
   const feeRate =
     liquidityPoolAggregator.currentFee ?? liquidityPoolAggregator.baseFee ?? 0n;
-  const feeUSD = (volumeInUSD * feeRate) / V2_FEE_SCALE;
+  const feeUSD = (volumeInUSD * feeRate) / FEE_SCALE;
 
   // Create liquidity pool diff.
   //

--- a/src/EventHandlers/PoolFactory.ts
+++ b/src/EventHandlers/PoolFactory.ts
@@ -8,6 +8,7 @@ import {
   ROOT_POOL_FACTORY_ADDRESS_OPTIMISM,
   RootPoolLeafPoolId,
   TokenId,
+  toCanonicalFeeScale,
 } from "../Constants";
 import { getRootPoolAddress } from "../Effects/RootPool";
 import { getRehydrated } from "../EntityTimestamps";
@@ -95,9 +96,12 @@ indexer.onEvent(
       }
     }
 
-    const fee = event.params.stable
-      ? DEFAULT_SAMM_FEE_BPS
-      : DEFAULT_VAMM_FEE_BPS;
+    // V2 PoolFactory reports fees in basis points; lift to canonical FEE_SCALE
+    // (1e6) so V2 and CL share one stored scale + divisor (issue #812).
+    const fee = toCanonicalFeeScale(
+      event.params.stable ? DEFAULT_SAMM_FEE_BPS : DEFAULT_VAMM_FEE_BPS,
+      false,
+    );
 
     const pool = createPoolEntity({
       poolAddress: event.params.pool,
@@ -181,9 +185,16 @@ indexer.onEvent(
       return;
     }
 
+    // V2 SetCustomFee carries the fee in basis points; lift to FEE_SCALE (1e6).
+    // poolEntity.isCL is always false here (PoolFactory only owns V2 pools) — we
+    // still key on it so the canonical-scale rule is uniform across write sites.
+    const canonicalFee = toCanonicalFeeScale(
+      BigInt(event.params.fee),
+      poolEntity.isCL,
+    );
     const diff: Partial<Pool> = {
-      baseFee: BigInt(event.params.fee),
-      currentFee: BigInt(event.params.fee), // When custom fee is set, both baseFee and currentFee are updated
+      baseFee: canonicalFee,
+      currentFee: canonicalFee, // When custom fee is set, both baseFee and currentFee are updated
     };
 
     await updatePool(

--- a/src/EventHandlers/SwapFeeModule/CustomSwapFeeModule.ts
+++ b/src/EventHandlers/SwapFeeModule/CustomSwapFeeModule.ts
@@ -1,7 +1,7 @@
 import { indexer } from "envio";
 import type { DynamicFeeGlobalConfig } from "envio";
 import { updatePool } from "../../Aggregators/Pool";
-import { PoolId } from "../../Constants";
+import { PoolId, toCanonicalFeeScale } from "../../Constants";
 import { getRehydrated } from "../../EntityTimestamps";
 import type { Pool } from "../../EntityTypes";
 
@@ -16,9 +16,16 @@ indexer.onEvent(
       return;
     }
 
+    // Lift to canonical FEE_SCALE (1e6). Keyed on pool.isCL so the stored fee
+    // matches the single divisor regardless of which pool type the module
+    // targets (issue #812).
+    const canonicalFee = toCanonicalFeeScale(
+      BigInt(event.params.fee),
+      pool.isCL,
+    );
     const diff: Partial<Pool> = {
-      baseFee: BigInt(event.params.fee),
-      currentFee: BigInt(event.params.fee),
+      baseFee: canonicalFee,
+      currentFee: canonicalFee,
     };
 
     await updatePool(

--- a/test/EventHandlers/CLPool/CLPoolSwapLogic.test.ts
+++ b/test/EventHandlers/CLPool/CLPoolSwapLogic.test.ts
@@ -350,7 +350,7 @@ describe("CLPoolSwapLogic", () => {
         mockContext,
       );
 
-      // volumeInUSD × feeRate / CL_FEE_SCALE = 1e18 × 3000 / 1e6 = 3e15
+      // volumeInUSD × feeRate / FEE_SCALE = 1e18 × 3000 / 1e6 = 3e15
       expect(result.swapFeesInUSD).toBe(
         (trustedVolumeForMockEvent * CL_FEE_30) / 1000000n,
       );

--- a/test/EventHandlers/FeeFieldScaling.test.ts
+++ b/test/EventHandlers/FeeFieldScaling.test.ts
@@ -1,0 +1,136 @@
+import type { EvmEvent, Token } from "envio";
+import {
+  FEE_SCALE,
+  TEN_TO_THE_6_BI,
+  TEN_TO_THE_18_BI,
+  toCanonicalFeeScale,
+  toChecksumAddress,
+} from "../../src/Constants";
+import type { Pool, handlerContext } from "../../src/EntityTypes";
+import { calculateSwapFees } from "../../src/EventHandlers/CLPool/CLPoolSwapLogic";
+import { processPoolFees } from "../../src/EventHandlers/Pool/PoolFeesLogic";
+import { setupCommon } from "./Pool/common";
+
+/**
+ * Issue #812: the same schema fields carried different scales depending on pool
+ * type (V2 raw / bps vs CL 1e18-normalized / 1e6). These tests pin the unified
+ * conventions so an equivalent fee reads identically across V2 and CL:
+ *   - token-amount fee fields are 1e18-normalized on both paths
+ *   - baseFee / currentFee share a single FEE_SCALE (1e6) divisor on both paths
+ */
+describe("Issue #812: fee-field scaling parity across V2 and CL", () => {
+  const { mockToken0Data, mockToken1Data, mockLiquidityPoolData } =
+    setupCommon();
+
+  // token0 = 18 decimals, token1 = 6 decimals. Using the 6-decimal leg makes
+  // the 1e18 normalization observable (raw 1e6 base != 1e18 base).
+  const token18 = mockToken0Data as Token;
+  const token6 = mockToken1Data as Token;
+
+  const ctx = {
+    log: { error: () => undefined, warn: () => undefined },
+  } as unknown as handlerContext;
+
+  // An economically identical fee: 0.50 of the 6-decimal token.
+  const HALF_TOKEN6_RAW = 5n * (TEN_TO_THE_6_BI / 10n); // 0.50 * 1e6 = 500_000
+  const EXPECTED_1E18 = 5n * 10n ** 17n; // 0.50 normalized to a 1e18 base
+
+  const v2FeesEvent = {
+    params: { amount0: 0n, amount1: HALF_TOKEN6_RAW },
+    block: {
+      timestamp: 1_000_000,
+      number: 1,
+      hash: `0x${"0".repeat(64)}`,
+    },
+    chainId: 10,
+    srcAddress: toChecksumAddress("0x3333333333333333333333333333333333333333"),
+  } as unknown as EvmEvent<"Pool", "Fees">;
+
+  // 1000 of the 6-decimal token swapped IN at 0.05% (500 / 1e6) => 0.50 fee.
+  const clPool: Pool = {
+    ...mockLiquidityPoolData,
+    currentFee: 500n,
+    baseFee: 500n,
+  };
+  const clSwapEvent = {
+    params: {
+      amount0: -1n * TEN_TO_THE_18_BI, // output leg — not fee-charged
+      amount1: 1000n * TEN_TO_THE_6_BI, // input leg — 1000 of the 6-decimal token
+      sqrtPriceX96: 0n,
+      liquidity: 0n,
+      tick: 0n,
+      sender: toChecksumAddress("0x1111111111111111111111111111111111111111"),
+      recipient: toChecksumAddress(
+        "0x2222222222222222222222222222222222222222",
+      ),
+    },
+    block: {
+      timestamp: 1_000_000,
+      number: 1,
+      hash: `0x${"0".repeat(64)}`,
+    },
+    chainId: 10,
+    srcAddress: toChecksumAddress("0x3333333333333333333333333333333333333333"),
+  } as unknown as EvmEvent<"CLPool", "Swap">;
+
+  describe("token-amount fee fields are 1e18-normalized on both paths", () => {
+    it("V2 processPoolFees normalizes the 6-decimal leg to a 1e18 base", () => {
+      const { liquidityPoolDiff, userDiff } = processPoolFees(
+        v2FeesEvent,
+        token18,
+        token6,
+      );
+      expect(liquidityPoolDiff?.incrementalTotalFeesGenerated1).toBe(
+        EXPECTED_1E18,
+      );
+      expect(userDiff?.incrementalTotalFeesContributed1).toBe(EXPECTED_1E18);
+    });
+
+    it("CL calculateSwapFees normalizes the 6-decimal leg to a 1e18 base", () => {
+      const { swapFeesInToken1 } = calculateSwapFees(
+        clSwapEvent,
+        clPool,
+        token18,
+        token6,
+        0n,
+        ctx,
+      );
+      expect(swapFeesInToken1).toBe(EXPECTED_1E18);
+    });
+
+    it("V2 and CL store the SAME amount for an equivalent fee", () => {
+      const v2 = processPoolFees(v2FeesEvent, token18, token6).liquidityPoolDiff
+        ?.incrementalTotalFeesGenerated1;
+      const cl = calculateSwapFees(
+        clSwapEvent,
+        clPool,
+        token18,
+        token6,
+        0n,
+        ctx,
+      ).swapFeesInToken1;
+      expect(v2).toBe(cl);
+    });
+  });
+
+  describe("baseFee/currentFee share a single FEE_SCALE divisor", () => {
+    it("FEE_SCALE is the 1e6 (hundredths-of-a-bp) scale", () => {
+      expect(FEE_SCALE).toBe(1_000_000n);
+    });
+
+    it("V2 bps and CL 1e6 representations of 0.30% canonicalize equally", () => {
+      const v2_030 = toCanonicalFeeScale(30n, false); // V2 on-chain basis points
+      const cl_030 = toCanonicalFeeScale(3000n, true); // CL on-chain 1e6
+      expect(v2_030).toBe(3000n);
+      expect(cl_030).toBe(3000n);
+      expect(v2_030).toBe(cl_030);
+    });
+
+    it("the single FEE_SCALE divisor recovers identical fractions", () => {
+      // 0.30% on both => identical (value * 1e6 / FEE_SCALE) integer ratio
+      const v2 = toCanonicalFeeScale(30n, false);
+      const cl = toCanonicalFeeScale(3000n, true);
+      expect((v2 * 1_000_000n) / FEE_SCALE).toBe((cl * 1_000_000n) / FEE_SCALE);
+    });
+  });
+});

--- a/test/EventHandlers/Pool/Fees.test.ts
+++ b/test/EventHandlers/Pool/Fees.test.ts
@@ -89,7 +89,9 @@ describe("Pool Fees Event", () => {
       mockLiquidityPoolData.totalFeesGenerated0 + expectations.amount0In,
     );
     expect(updatedPool?.totalFeesGenerated1).toBe(
-      mockLiquidityPoolData.totalFeesGenerated1 + expectations.amount1In,
+      // token1 has 6 decimals; the raw fee is normalized to a 1e18 base (#812)
+      mockLiquidityPoolData.totalFeesGenerated1 +
+        expectations.amount1In * 10n ** 12n,
     );
   });
 
@@ -124,7 +126,8 @@ describe("Pool Fees Event", () => {
       expectations.amount0In,
     );
     expect(createdUserStats?.totalFeesContributed1).toBe(
-      expectations.amount1In,
+      // token1 (6 decimals) raw fee normalized to a 1e18 base (#812)
+      expectations.amount1In * 10n ** 12n,
     );
 
     // Per issue #797: Fees no longer writes USD — user fee USD stays at the
@@ -217,7 +220,8 @@ describe("Pool Fees Event", () => {
       existingUserStats.totalFeesContributed0 + 500n,
     );
     expect(updatedUserStats?.totalFeesContributed1).toBe(
-      existingUserStats.totalFeesContributed1 + 300n,
+      // token1 (6 decimals): 300 raw → 300 * 1e12 on a 1e18 base (#812)
+      existingUserStats.totalFeesContributed1 + 300n * 10n ** 12n,
     );
     expect(updatedUserStats?.numberOfSwaps).toBe(
       existingUserStats.numberOfSwaps,

--- a/test/EventHandlers/Pool/PoolFeesLogic.test.ts
+++ b/test/EventHandlers/Pool/PoolFeesLogic.test.ts
@@ -1,9 +1,14 @@
-import type { EvmEvent } from "envio";
+import type { EvmEvent, Token } from "envio";
 import { toChecksumAddress } from "../../../src/Constants";
 import type { handlerContext } from "../../../src/EntityTypes";
 import { processPoolFees } from "../../../src/EventHandlers/Pool/PoolFeesLogic";
+import { setupCommon } from "./common";
 
 describe("PoolFeesLogic", () => {
+  const { mockToken0Data, mockToken1Data } = setupCommon();
+  const token0 = mockToken0Data as Token; // 18 decimals
+  const token1 = mockToken1Data as Token; // 6 decimals
+
   const mockEvent = {
     chainId: 10,
     block: {
@@ -36,27 +41,28 @@ describe("PoolFeesLogic", () => {
   });
 
   describe("processPoolFees", () => {
-    it("returns pool and user diffs with raw token-amount fees only", () => {
-      const result = processPoolFees(mockEvent);
+    it("returns pool and user diffs with 1e18-normalized token-amount fees only", () => {
+      const result = processPoolFees(mockEvent, token0, token1);
+
+      // token0 has 18 decimals (normalization is identity); token1 has 6, so
+      // 2000 raw units → 2000 × 1e12 on a 1e18 base (issue #812).
+      const expected0 = mockEvent.params.amount0; // 1000n (18 decimals → identity)
+      const expected1 = mockEvent.params.amount1 * 10n ** 12n; // 2000 → 2e15
 
       expect(result.liquidityPoolDiff).toBeDefined();
       expect(result.liquidityPoolDiff?.incrementalTotalFeesGenerated0).toBe(
-        mockEvent.params.amount0,
+        expected0,
       );
       expect(result.liquidityPoolDiff?.incrementalTotalFeesGenerated1).toBe(
-        mockEvent.params.amount1,
+        expected1,
       );
       expect(result.liquidityPoolDiff?.lastUpdatedTimestamp).toEqual(
         new Date(mockEvent.block.timestamp * 1000),
       );
 
       expect(result.userDiff).toBeDefined();
-      expect(result.userDiff?.incrementalTotalFeesContributed0).toBe(
-        mockEvent.params.amount0,
-      );
-      expect(result.userDiff?.incrementalTotalFeesContributed1).toBe(
-        mockEvent.params.amount1,
-      );
+      expect(result.userDiff?.incrementalTotalFeesContributed0).toBe(expected0);
+      expect(result.userDiff?.incrementalTotalFeesContributed1).toBe(expected1);
       expect(result.userDiff?.lastActivityTimestamp).toEqual(
         new Date(mockEvent.block.timestamp * 1000),
       );
@@ -68,7 +74,7 @@ describe("PoolFeesLogic", () => {
     // single-leg-valued here is what produced 1000/1000 V2 pools warning
     // [FEE_VOLUME_DIVERGENCE] on c9b8978.
     it("does not write any USD fee field (issue #797)", () => {
-      const result = processPoolFees(mockEvent);
+      const result = processPoolFees(mockEvent, token0, token1);
 
       expect(
         result.liquidityPoolDiff?.incrementalTotalFeesGeneratedUSD,
@@ -84,8 +90,9 @@ describe("PoolFeesLogic", () => {
         params: { ...mockEvent.params, amount0: 1000n, amount1: 0n },
       } as unknown as EvmEvent<"Pool", "Fees">;
 
-      const result = processPoolFees(event);
+      const result = processPoolFees(event, token0, token1);
 
+      // token0 has 18 decimals, so the 1e18 normalization is the identity here.
       expect(result.liquidityPoolDiff?.incrementalTotalFeesGenerated0).toBe(
         1000n,
       );

--- a/test/EventHandlers/Pool/PoolSwapLogic.test.ts
+++ b/test/EventHandlers/Pool/PoolSwapLogic.test.ts
@@ -1,5 +1,9 @@
 import type { EvmEvent, Token } from "envio";
-import { toChecksumAddress } from "../../../src/Constants";
+import {
+  FEE_SCALE,
+  toCanonicalFeeScale,
+  toChecksumAddress,
+} from "../../../src/Constants";
 import { processPoolSwap } from "../../../src/EventHandlers/Pool/PoolSwapLogic";
 import * as Helpers from "../../../src/Helpers";
 import { setupCommon } from "./common";
@@ -11,8 +15,11 @@ describe("PoolSwapLogic", () => {
     mockToken1Data,
     createMockPool,
   } = setupCommon();
-  // Pool with a typical V2 vAMM fee rate (30 = 0.30% on the 1e4 basis).
-  const mockPool = createMockPool({ currentFee: 30n });
+  // Pool with a typical V2 vAMM fee rate (0.30%), stored in the canonical
+  // FEE_SCALE (1e6) like production after issue #812.
+  const mockPool = createMockPool({
+    currentFee: toCanonicalFeeScale(30n, false),
+  });
   // Shared mock event for all tests
   const mockEvent = {
     params: {
@@ -376,19 +383,22 @@ describe("PoolSwapLogic", () => {
   });
 
   // Issue #797: V2 fee USD must be derived from trusted volume × currentFee /
-  // V2_FEE_SCALE at Swap time, mirroring the CL fee path (CLPoolSwapLogic).
+  // FEE_SCALE at Swap time, mirroring the CL fee path (CLPoolSwapLogic).
   // The V2 Fees event has only one non-zero leg (input side), so the old
   // single-leg valuation flowed any poisoned/inconsistent input-leg price
   // straight into totalFeesGeneratedUSD with no second leg to min against.
   describe("V2 fee USD derived from trusted volume × rate (issue #797)", () => {
-    it("derives incrementalTotalFeesGeneratedUSD as volumeInUSD × currentFee / V2_FEE_SCALE", () => {
-      const pool = createMockPool({ currentFee: 30n }); // 0.30%
+    it("derives incrementalTotalFeesGeneratedUSD as volumeInUSD × currentFee / FEE_SCALE", () => {
+      const pool = createMockPool({
+        currentFee: toCanonicalFeeScale(30n, false),
+      }); // 0.30%
       const result = processPoolSwap(mockEvent, pool, mockToken0, mockToken1);
 
       // volumeInUSD = min(token0=1000n, token1=5e14) = 1000n (see existing tests)
-      // feeUSD = 1000 * 30 / 10000 = 3n
+      // feeUSD = 1000 * 3000 / 1e6 = 3n (0.30% on the canonical FEE_SCALE)
       const expectedVolumeUSD = 1000n;
-      const expectedFeeUSD = (expectedVolumeUSD * 30n) / 10000n;
+      const expectedFeeUSD =
+        (expectedVolumeUSD * toCanonicalFeeScale(30n, false)) / FEE_SCALE;
       expect(result.liquidityPoolDiff?.incrementalTotalVolumeUSD).toBe(
         expectedVolumeUSD,
       );
@@ -428,7 +438,9 @@ describe("PoolSwapLogic", () => {
           amount1Out: 1000000n, // 1 USDC (6 decimals) → $1
         },
       };
-      const pool = createMockPool({ currentFee: 30n });
+      const pool = createMockPool({
+        currentFee: toCanonicalFeeScale(30n, false),
+      });
 
       const result = processPoolSwap(
         swapEvent,
@@ -437,9 +449,10 @@ describe("PoolSwapLogic", () => {
         honestToken1,
       );
 
-      // Trusted volume picks the honest $1 leg, so fee USD = $1 × 30 / 10000.
+      // Trusted volume picks the honest $1 leg: fee USD = $1 × 3000 / 1e6.
       const expectedVolumeUSD = 1000000000000000000n; // 1e18 = $1
-      const expectedFeeUSD = (expectedVolumeUSD * 30n) / 10000n;
+      const expectedFeeUSD =
+        (expectedVolumeUSD * toCanonicalFeeScale(30n, false)) / FEE_SCALE;
       expect(result.liquidityPoolDiff?.incrementalTotalVolumeUSD).toBe(
         expectedVolumeUSD,
       );
@@ -456,7 +469,9 @@ describe("PoolSwapLogic", () => {
     // truncation. (This is the same shape as the existing PoolFeesLogic
     // "fee ≤ 1% of volume invariant (#670)" test, ported to the Swap-time path.)
     it("matches volume × rate exactly for a clean pool at 0.05% fee", () => {
-      const pool = createMockPool({ currentFee: 5n }); // 0.05% stable
+      const pool = createMockPool({
+        currentFee: toCanonicalFeeScale(5n, false),
+      }); // 0.05% stable
       const usdt: Token = {
         ...mockToken0,
         decimals: 6n,
@@ -485,7 +500,9 @@ describe("PoolSwapLogic", () => {
         result.liquidityPoolDiff?.incrementalTotalVolumeUSD ?? 0n;
       const feeUSD =
         result.liquidityPoolDiff?.incrementalTotalFeesGeneratedUSD ?? 0n;
-      expect(feeUSD).toBe((volumeUSD * 5n) / 10000n);
+      expect(feeUSD).toBe(
+        (volumeUSD * toCanonicalFeeScale(5n, false)) / FEE_SCALE,
+      );
       // Hard invariant: fee ≤ 1% of volume at any V2 rate up to 1%.
       expect(feeUSD * 100n).toBeLessThanOrEqual(volumeUSD);
     });

--- a/test/EventHandlers/PoolFactory.test.ts
+++ b/test/EventHandlers/PoolFactory.test.ts
@@ -7,6 +7,7 @@ import {
   PoolId,
   RootPoolLeafPoolId,
   TokenId,
+  toCanonicalFeeScale,
   toChecksumAddress,
 } from "../../src/Constants";
 import { rehydrateTimestamps } from "../../src/EntityTimestamps";
@@ -133,9 +134,13 @@ describe("PoolFactory Events", () => {
     });
 
     it("should set baseFee and currentFee for non-CL pools (vAMM)", () => {
-      // Non-CL pools should always have baseFee and currentFee set
-      expect(createdPool?.baseFee).toBe(DEFAULT_VAMM_FEE_BPS);
-      expect(createdPool?.currentFee).toBe(DEFAULT_VAMM_FEE_BPS);
+      // V2 bps defaults are lifted to canonical FEE_SCALE (1e6) at write (#812).
+      expect(createdPool?.baseFee).toBe(
+        toCanonicalFeeScale(DEFAULT_VAMM_FEE_BPS, false),
+      );
+      expect(createdPool?.currentFee).toBe(
+        toCanonicalFeeScale(DEFAULT_VAMM_FEE_BPS, false),
+      );
     });
 
     it("should set factoryAddress to event.srcAddress for non-CL pools", async () => {
@@ -206,9 +211,13 @@ describe("PoolFactory Events", () => {
       });
       const stablePool = await indexer.Pool.get(PoolId(chainId, poolAddress));
 
-      // Stable pools should use DEFAULT_SAMM_FEE_BPS
-      expect(stablePool?.baseFee).toBe(DEFAULT_SAMM_FEE_BPS);
-      expect(stablePool?.currentFee).toBe(DEFAULT_SAMM_FEE_BPS);
+      // Stable pools use DEFAULT_SAMM_FEE_BPS, lifted to FEE_SCALE (#812)
+      expect(stablePool?.baseFee).toBe(
+        toCanonicalFeeScale(DEFAULT_SAMM_FEE_BPS, false),
+      );
+      expect(stablePool?.currentFee).toBe(
+        toCanonicalFeeScale(DEFAULT_SAMM_FEE_BPS, false),
+      );
     });
 
     it("should NOT create RootPool_LeafPool for Optimism (chainId 10)", async () => {
@@ -328,8 +337,11 @@ describe("PoolFactory Events", () => {
         ? rehydrateTimestamps("Pool", rawPool)
         : undefined;
       expect(updatedPool).toBeDefined();
-      expect(updatedPool?.baseFee).toBe(customFee);
-      expect(updatedPool?.currentFee).toBe(customFee);
+      // V2 SetCustomFee bps lifted to canonical FEE_SCALE (1e6) at write (#812)
+      expect(updatedPool?.baseFee).toBe(toCanonicalFeeScale(customFee, false));
+      expect(updatedPool?.currentFee).toBe(
+        toCanonicalFeeScale(customFee, false),
+      );
       expect(updatedPool?.lastUpdatedTimestamp).toEqual(
         new Date(blockTimestamp * 1000),
       );
@@ -385,8 +397,8 @@ describe("PoolFactory Events", () => {
         ? rehydrateTimestamps("Pool", rawPool)
         : undefined;
       expect(updatedPool).toBeDefined();
-      expect(updatedPool?.baseFee).toBe(newFee);
-      expect(updatedPool?.currentFee).toBe(newFee);
+      expect(updatedPool?.baseFee).toBe(toCanonicalFeeScale(newFee, false));
+      expect(updatedPool?.currentFee).toBe(toCanonicalFeeScale(newFee, false));
       expect(updatedPool?.baseFee).not.toBe(existingFee);
       expect(updatedPool?.lastUpdatedTimestamp).toEqual(
         new Date(blockTimestamp * 1000),

--- a/test/EventHandlers/SwapFeeModule/CustomSwapFeeModule.test.ts
+++ b/test/EventHandlers/SwapFeeModule/CustomSwapFeeModule.test.ts
@@ -1,5 +1,5 @@
 import { createTestIndexer } from "envio";
-import { toChecksumAddress } from "../../../src/Constants";
+import { toCanonicalFeeScale, toChecksumAddress } from "../../../src/Constants";
 import { setupCommon } from "../Pool/common";
 
 describe("CustomSwapFeeModule Events", () => {
@@ -88,11 +88,18 @@ describe("CustomSwapFeeModule Events", () => {
         },
       });
 
-      // Assert: Check that pool's baseFee was updated
+      // Assert: Check that pool's baseFee was updated. mockPool is a V2 pool
+      // (isCL=false), so the basis-point fee is lifted to canonical FEE_SCALE
+      // (1e6) at write — issue #812. (A CL pool's fee, already in FEE_SCALE,
+      // would be stored unchanged.)
       const updatedPool = await indexer.Pool.get(mockPool.id);
       expect(updatedPool).toBeDefined();
-      expect(updatedPool?.baseFee).toBe(fee);
-      expect(updatedPool?.currentFee).toBe(fee);
+      expect(updatedPool?.baseFee).toBe(
+        toCanonicalFeeScale(fee, mockPool.isCL),
+      );
+      expect(updatedPool?.currentFee).toBe(
+        toCanonicalFeeScale(fee, mockPool.isCL),
+      );
     });
   });
 });


### PR DESCRIPTION
## What & why

The same schema fields carried different scales depending on pool type, so cross-pool-type aggregation/interpretation was wrong. Verified live on the deployed endpoint. Closes #812.

- **Token-amount fee fields** (`totalFeesGenerated0/1`, `totalFeesContributed0/1`): V2 stored **raw** token units, CL stored **1e18-normalized** (a USDC leg read `~1.2e13` on V2 vs `~3.6e25` on CL).
- **`baseFee` / `currentFee`**: V2 in basis points (÷1e4), CL in hundredths-of-a-bp (÷1e6); since #797 each path also had its own divisor. A stored `100` meant **1%** on V2 but **0.01%** on CL.

## Change — adopt CL's scales as canonical

- **Token amounts → 1e18-normalized on both paths.** `processPoolFees` normalizes V2's raw `Pool.Fees` amounts via `normalizeTokenAmountTo1e18` (CL already did this).
- **`baseFee`/`currentFee` → a single `FEE_SCALE = 1e6`.** `V2_FEE_SCALE` + `CL_FEE_SCALE` are merged; V2 on-chain bps are lifted at write via `toCanonicalFeeScale(raw, isCL)` at the `PoolFactory` and `CustomSwapFeeModule` sites. `DynamicSwapFeeModule` is CL-only (all `feeCap`/`scalingFactor` pools are `isCL`, 70/70) and already 1e6 — left untouched.

`FEE_SCALE = 1e6` (rather than unifying down to bps) because CL uses sub-basis-point dynamic fees (e.g. `9`, `313`, `2090` seen live) that ÷100 would truncate; 1e6 is lossless and matches the CL on-chain value + what `getSwapFee` returns.

## ⚠️ Breaking (served-data semantics)

The served V2 `baseFee`/`currentFee` changes (e.g. `30` → `3000`). Any consumer reading V2 `baseFee` as basis points must switch to ÷`FEE_SCALE` (1e6). **No USD values change** — the `*USD` fields are derived separately, and for fees the V2 rate ×100 is cancelled by the ×100 divisor.

## Docs

- `schema.graphql` field comments + regenerated `docs/schema.md`.
- New ADR: `docs/adr/0001-canonical-fee-field-scaling.md`.

## Test plan

- [x] `test/EventHandlers/FeeFieldScaling.test.ts` (new) — asserts equal scaling for an equivalent V2 vs CL fee (1e18 token amounts + shared `FEE_SCALE` for `baseFee`).
- [x] Updated V2 expectations in `PoolFactory` / `Fees` / `PoolFeesLogic` / `PoolSwapLogic` / `CustomSwapFeeModule` tests.
- [x] Full suite: **1495 tests pass**; `tsc --noEmit` clean; `biome` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented unified canonical fee-field scaling across V2 and CL pools for consistent fee representation.
  * Token-amount fee fields now standardized to 1e18 normalization across all pool types.
  * Fee rates now use a single `FEE_SCALE` (1e6) divisor across V2 and CL pools.

* **Documentation**
  * Updated fee-field specifications in schema documentation and ADR records.

* **Tests**
  * Added comprehensive fee-field scaling parity tests.
  * Updated existing tests to validate new fee normalization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->