### PR TITLE
Migrate envio to v3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@uniswap/sdk-core": "^7.9.0",
     "@uniswap/v3-sdk": "3.29.1",
     "dotenv": "^16.4.5",
-    "envio": "3.0.2",
+    "envio": "3.1.0",
     "jsbi": "^4.3.2",
     "viem": "2.24.3",
     "web3": "^4.16.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^16.4.5
         version: 16.6.1
       envio:
-        specifier: 3.0.2
-        version: 3.0.2(react-dom@19.2.4(react@19.2.5))(typescript@5.9.3)(zod@3.25.76)
+        specifier: 3.1.0
+        version: 3.1.0(react-dom@19.2.4(react@19.2.5))(typescript@5.9.3)(zod@3.25.76)
       jsbi:
         specifier: ^4.3.2
         version: 4.3.2
@@ -150,28 +150,24 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-arm64@1.9.4':
     resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@1.9.4':
     resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-x64@1.9.4':
     resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@1.9.4':
     resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
@@ -221,21 +217,18 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@envio-dev/hyperfuel-client-linux-x64-gnu@1.2.2':
     resolution: {integrity: sha512-XDkvkBG/frS+xiZkJdY4KqOaoAwyxPdi2MysDQgF8NmZdssi32SWch0r4LTqKWLLlCBg9/R55POeXL5UAjg2wQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@envio-dev/hyperfuel-client-linux-x64-musl@1.2.2':
     resolution: {integrity: sha512-DKnKJJSwsYtA7YT0EFGhFB5Eqoo42X0l0vZBv4lDuxngEXiiNjeLemXoKQVDzhcbILD7eyXNa5jWUc+2hpmkEg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@envio-dev/hyperfuel-client-win32-x64-msvc@1.2.2':
     resolution: {integrity: sha512-SwIgTAVM9QhCFPyHwL+e1yQ6o3paV6q25klESkXw+r/KW9QPhOOyA6Yr8nfnur3uqMTLJHAKHTLUnkyi/Nh7Aw==}
@@ -245,43 +238,6 @@ packages:
 
   '@envio-dev/hyperfuel-client@1.2.2':
     resolution: {integrity: sha512-raKA6DshYSle0sAOHBV1OkSRFMN+Mkz8sFiMmS3k+m5nP6pP56E17CRRePBL5qmR6ZgSEvGOz/44QUiKNkK9Pg==}
-    engines: {node: '>= 10'}
-
-  '@envio-dev/hypersync-client-darwin-arm64@1.3.0':
-    resolution: {integrity: sha512-JZwiVRbMSuJnKsVUpfjTHc3YgAMvGlyuqWQxVc7Eok4Xp/sZLUCXRQUykbCh6fOUWRmoa2JG/ykP/NotoTRCBg==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@envio-dev/hypersync-client-darwin-x64@1.3.0':
-    resolution: {integrity: sha512-2eSzQqqqFBMK2enVucYGcny5Ep4DEKYxf3Xme7z9qp2d3c6fMcbVvM4Gt8KOzb7ySjwJ2gU+qY2h545T2NiJXQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@envio-dev/hypersync-client-linux-arm64-gnu@1.3.0':
-    resolution: {integrity: sha512-gsjMp3WKekwnA89HvJXvcTM3BE5wVFG/qTF4rmk3rGiXhZ+MGaZQKrYRAhnzQZblueFtF/xnnBYpO35Z3ZFThg==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@envio-dev/hypersync-client-linux-x64-gnu@1.3.0':
-    resolution: {integrity: sha512-Lkvi4lRVwCyFOXf9LYH2X91zmW2l1vbfojKhTwKgqFWv6PMN5atlYjt+/NcUCAAhk5EUavWGjoikwnvLp870cg==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@envio-dev/hypersync-client-linux-x64-musl@1.3.0':
-    resolution: {integrity: sha512-UIjB/gUX2sl23EMXLBxqtkgMnOjNSiaHK+CSU5vXMXkzL3fOGbz24bvyaPsSv82cxCFEE0yTwlSKkCX6/L8o6Q==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@envio-dev/hypersync-client@1.3.0':
-    resolution: {integrity: sha512-wUdfZzbsFPbGq6n/1mmUMsWuiAil+m+fL/GBX5LGUyMJV86TXy2SBtAqYYNyDxWLO6gvGr6PYKrP8pLVAUZDZg==}
     engines: {node: '>= 10'}
 
   '@esbuild/aix-ppc64@0.27.4':
@@ -738,79 +694,66 @@ packages:
     resolution: {integrity: sha512-DxH0P3wxm+Yzs/p3zrk9dw1rURu8p0Nv5+MRK/L7OtnLNg5rLZraSBFZ8iUXOd9f2BlhJyEpIZUH/emjq4UJ4g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.61.0':
     resolution: {integrity: sha512-T6ZvMNe84kAz6TBWHC7hGAoEtzP1LWYw/AqayGWEF6uISt3Abk/st06LqRD9THd7Xz3NxzurUpzAuEAUbZf+nw==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.61.0':
     resolution: {integrity: sha512-q/4hzvQkDs8b4jIBab1pnLiiM0ayTZsN2amBFPDzuyZxjEd4wDwx0UJFYM3cOZzSf5Kw8fnWSprJzIBMkcR44Q==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.61.0':
     resolution: {integrity: sha512-vvYWX3akdEAY6km+9wAqFDnk6pQsbJKVnj7xawcvs/+fdlYBGp+U+Qq/lLfpIxYIZvZLHMAKD9HLdacSx/r3dw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.61.0':
     resolution: {integrity: sha512-DePa5cqOxDP/Zp0VOXpeWaGew5iIv5DXp9NYbzkX5PFQyWVX9184WCTh3hvr/7lhXo8ZVlbFLkz8+o/q1dU6gA==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.61.0':
     resolution: {integrity: sha512-LV8aWMB8UChglMCEzs7RkN0GsH29RJaLLqwm9fCIjlqwxQTiWAqNcc7wjBkH31hV0PU/yVxGYvrYsgfea2qw6g==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.61.0':
     resolution: {integrity: sha512-QoNSnwQtaeNu5grdBbsL0tt1uyl5EnS8DA8Mr3nluMXbhdQNyhN+G4tBax7VCdxLKj8YJ0/4OO9Ho84jMnJtKA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.61.0':
     resolution: {integrity: sha512-/zZp5MKapIIApE8trN8qLGNSiRN9TUoaUZ1cmVu4XnVdd5LQLOXTtyi+vtfUbNnT3iyjzpPqYeKXmvJ+gJGYWw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.61.0':
     resolution: {integrity: sha512-RbrzcD3aJ1k3UbtMRRBNwojdVVyXjuVAFTfn/xPa6EEl6GE9Sm/akPgFTb9aAC9pMKGJ6CtWxaGrqWcabH+ySg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.61.0':
     resolution: {integrity: sha512-ZF+onDsBso8PJf1XaG9lB+O9RnBpKGnY6OrzC4CSHrtC1jb6jWLTKK4bRqdoCXHd22gyr2hiYmEAm8Wns/BOCw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.61.0':
     resolution: {integrity: sha512-Atk0aSIk5Zx2Wuh9dgRQgLP0Koc8hOeYpbWryMXyk8G8/HmPkwPPkMqIIDhrXHHYqfUzSJA/I7IWSBv8xSmRBA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.61.0':
     resolution: {integrity: sha512-0uMOcf3eZ5K+K4cYHkdxShFMPlPXCOdfDFEFn9dNYAEEd2cVvmOfH7zFgRVoDgmtQ1m9k5q7qfrHzyMAubKYUA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.61.0':
     resolution: {integrity: sha512-mvFtE4A/t/7hRJ7X8Ozmu8FsIkAUat2nzl12pgU337BRmq87AQUJztwHz2Zv5/tjo9/C95E66CK03SI/ToEDJw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.61.0':
     resolution: {integrity: sha512-z9b9+aTxvt8n2rNltMPvyaUfB8NJ+CVyOrGK/MdIKHx7B+lXmZpm/XbRsU7Rpf3fRqJ2uS6mBJiJveCtq8LHDg==}
@@ -1435,36 +1378,33 @@ packages:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
 
-  envio-darwin-arm64@3.0.2:
-    resolution: {integrity: sha512-h5mbaTWqDTaTeC2TMOzdD7cd1RKhSjCf003Bw0IKfx+799+J+N3MbNylRIwJGxpUhs5mTeeVefe7S42bLmH4dw==}
+  envio-darwin-arm64@3.1.0:
+    resolution: {integrity: sha512-6oY9/J7HrG/d6hGKfjgM8WqttkT5ECYtHRtxzOxzQBm+NqGAuJX+8ev/xSP5juKAayYu2z6K1XYGg0wSGNT6dw==}
     cpu: [arm64]
     os: [darwin]
 
-  envio-darwin-x64@3.0.2:
-    resolution: {integrity: sha512-OWHh3kgz+aMnjD5yIDb2CbFGNz3o+Hhkj1GMijNAyqtwAmKNhFEIDPb7RPu5VnHpq0ydLwhSHJI1gER27vZBrw==}
+  envio-darwin-x64@3.1.0:
+    resolution: {integrity: sha512-I03Fcww7zUNoX+RsPnh6MsoOw/Mramt6NDhA1k/6kcp0ttjAEAFbptw50yiQ2D1RFllj0j6J7GiiEBCu1Qc77w==}
     cpu: [x64]
     os: [darwin]
 
-  envio-linux-arm64@3.0.2:
-    resolution: {integrity: sha512-Y16qjfTR36qb/+52eomBYO8Zbr1GZRalIF/bl33TwDiQ9mdqExgf2qAEr0q5JLoRansEudO5H1yzTXDo7YuU1w==}
+  envio-linux-arm64@3.1.0:
+    resolution: {integrity: sha512-DAAHrNref4vR3+JC+/2rkvjG34bpOdRqbEMH9NBvyMF0Fwjh1Y5S1tWhoUTlYC20vdq4pRasKt2oFeCGxmWziQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
-  envio-linux-x64-musl@3.0.2:
-    resolution: {integrity: sha512-JA+GkfQHg8j4GuiU3s0QrmnHX27Gd2fasIxetJQruzrxMgmRxuqJZbAqARyG5iWbRNnIC7Ml4gu2jLjtepC6Hg==}
+  envio-linux-x64-musl@3.1.0:
+    resolution: {integrity: sha512-TmhEWtzMYrlypaozzaVGJLPedlOseQ4q7WWqfmFzlJXbMdAxAT0len3SDQJZCZfb8ooLN/ck6kUUE0C2HTJo1w==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
-  envio-linux-x64@3.0.2:
-    resolution: {integrity: sha512-Z9MFRNNBPZ0jvBBuT53thBTXrBZw9Jg4fd9ldldcEG84Xa1JQKqyEDte/zrSg09nFh0LtvjeyaxZLLfJRY/Ncg==}
+  envio-linux-x64@3.1.0:
+    resolution: {integrity: sha512-Oe7SzfQJXC/jqJHbEsjqUiluCSdVol/EYda2wmrqxwQKNifYWdodcPCG+T8jNHMSkXLDVXO6990pLNmmMy4HpQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
-  envio@3.0.2:
-    resolution: {integrity: sha512-Xl4DgVSqxKEaRn12Jxt7s6gDi3Y2x1CwTh9f28m4c9Rwd4STG4ZcmqHVQJp0u2jAz6eITHS5VRnsjXlyRhbRzQ==}
+  envio@3.1.0:
+    resolution: {integrity: sha512-58b5f/mXYQjHTd4STNYpjRlLqTA32mRrAWaHYsX4yEFZq4QlHO05CRnaA7H4xCRP42XQviI6lzspAH6g5nSViA==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
@@ -3119,29 +3059,6 @@ snapshots:
       '@envio-dev/hyperfuel-client-linux-x64-musl': 1.2.2
       '@envio-dev/hyperfuel-client-win32-x64-msvc': 1.2.2
 
-  '@envio-dev/hypersync-client-darwin-arm64@1.3.0':
-    optional: true
-
-  '@envio-dev/hypersync-client-darwin-x64@1.3.0':
-    optional: true
-
-  '@envio-dev/hypersync-client-linux-arm64-gnu@1.3.0':
-    optional: true
-
-  '@envio-dev/hypersync-client-linux-x64-gnu@1.3.0':
-    optional: true
-
-  '@envio-dev/hypersync-client-linux-x64-musl@1.3.0':
-    optional: true
-
-  '@envio-dev/hypersync-client@1.3.0':
-    optionalDependencies:
-      '@envio-dev/hypersync-client-darwin-arm64': 1.3.0
-      '@envio-dev/hypersync-client-darwin-x64': 1.3.0
-      '@envio-dev/hypersync-client-linux-arm64-gnu': 1.3.0
-      '@envio-dev/hypersync-client-linux-x64-gnu': 1.3.0
-      '@envio-dev/hypersync-client-linux-x64-musl': 1.3.0
-
   '@esbuild/aix-ppc64@0.27.4':
     optional: true
 
@@ -4238,27 +4155,26 @@ snapshots:
 
   env-paths@2.2.1: {}
 
-  envio-darwin-arm64@3.0.2:
+  envio-darwin-arm64@3.1.0:
     optional: true
 
-  envio-darwin-x64@3.0.2:
+  envio-darwin-x64@3.1.0:
     optional: true
 
-  envio-linux-arm64@3.0.2:
+  envio-linux-arm64@3.1.0:
     optional: true
 
-  envio-linux-x64-musl@3.0.2:
+  envio-linux-x64-musl@3.1.0:
     optional: true
 
-  envio-linux-x64@3.0.2:
+  envio-linux-x64@3.1.0:
     optional: true
 
-  envio@3.0.2(react-dom@19.2.4(react@19.2.5))(typescript@5.9.3)(zod@3.25.76):
+  envio@3.1.0(react-dom@19.2.4(react@19.2.5))(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       '@clickhouse/client': 1.17.0
       '@elastic/ecs-pino-format': 1.4.0
       '@envio-dev/hyperfuel-client': 1.2.2
-      '@envio-dev/hypersync-client': 1.3.0
       '@fuel-ts/crypto': 0.96.1
       '@fuel-ts/errors': 0.96.1
       '@fuel-ts/hasher': 0.96.1
@@ -4285,11 +4201,11 @@ snapshots:
       viem: 2.46.2(typescript@5.9.3)(zod@3.25.76)
       yargs: 17.7.2
     optionalDependencies:
-      envio-darwin-arm64: 3.0.2
-      envio-darwin-x64: 3.0.2
-      envio-linux-arm64: 3.0.2
-      envio-linux-x64: 3.0.2
-      envio-linux-x64-musl: 3.0.2
+      envio-darwin-arm64: 3.1.0
+      envio-darwin-x64: 3.1.0
+      envio-linux-arm64: 3.1.0
+      envio-linux-x64: 3.1.0
+      envio-linux-x64-musl: 3.1.0
     transitivePeerDependencies:
       - '@types/react'
       - bufferutil

--- a/src/Aggregators/Pool.ts
+++ b/src/Aggregators/Pool.ts
@@ -9,7 +9,11 @@ import { getSwapFee, roundBlockToInterval } from "../Effects/Index";
 import { getRehydrated, getWhereRehydrated } from "../EntityTimestamps";
 import type { handlerContext } from "../EntityTypes";
 import type { Pool } from "../EntityTypes";
-import { calculateTotalUSD, generatePoolName } from "../Helpers";
+import {
+  calculateTotalUSD,
+  generatePoolName,
+  optionalBigintEffect,
+} from "../Helpers";
 import { refreshTokenPrice } from "../PriceOracle";
 import { getPoolImpliedUSD, getTrustedUSD } from "../PriceTrust";
 import {
@@ -282,12 +286,14 @@ export async function updateDynamicFeePools(
   const minBlock = Number(
     liquidityPoolAggregator.createdBlockNumber ?? BigInt(blockNumber),
   );
-  const currentFee = await context.effect(getSwapFee, {
-    poolAddress,
-    factoryAddress,
-    chainId,
-    blockNumber: roundBlockToInterval(blockNumber, chainId, minBlock),
-  });
+  const currentFee = optionalBigintEffect(
+    await context.effect(getSwapFee, {
+      poolAddress,
+      factoryAddress,
+      chainId,
+      blockNumber: roundBlockToInterval(blockNumber, chainId, minBlock),
+    }),
+  );
 
   if (currentFee === undefined) {
     context.log.warn(

--- a/src/EventHandlers/Voter/VoterCommonLogic.ts
+++ b/src/EventHandlers/Voter/VoterCommonLogic.ts
@@ -14,7 +14,10 @@ import {
 import { getTokensDeposited } from "../../Effects/Index";
 import type { handlerContext } from "../../EntityTypes";
 import type { Pool } from "../../EntityTypes";
-import { normalizeTokenAmountTo1e18 } from "../../Helpers";
+import {
+  normalizeTokenAmountTo1e18,
+  optionalBigintEffect,
+} from "../../Helpers";
 import { getTrustedUSD } from "../../PriceTrust";
 
 export interface VoterCommonResult {
@@ -39,12 +42,14 @@ export async function computeVoterDistributeValues(
   context: handlerContext,
   gaugeIsAlive: boolean,
 ): Promise<VoterCommonResult> {
-  const tokensDepositedResult = await context.effect(getTokensDeposited, {
-    rewardTokenAddress: rewardToken.address,
-    gaugeAddress,
-    blockNumber,
-    eventChainId: chainId,
-  });
+  const tokensDepositedResult = optionalBigintEffect(
+    await context.effect(getTokensDeposited, {
+      rewardTokenAddress: rewardToken.address,
+      gaugeAddress,
+      blockNumber,
+      eventChainId: chainId,
+    }),
+  );
 
   const tokensDeposited = tokensDepositedResult ?? 0n;
 

--- a/src/Helpers.ts
+++ b/src/Helpers.ts
@@ -21,6 +21,31 @@ export function getErrorMessage(err: unknown): string {
 }
 
 /**
+ * Coerces the result of an effect declared with `output: S.optional(S.bigint)`
+ * to `bigint | undefined`.
+ *
+ * Works around an envio v3.1.0-rc.x regression in the effect cache: a cached
+ * effect with an *optional* output returns the ReScript nested-option sentinel
+ * `{ BS_PRIVATE_NESTED_SOME_NONE: 0 }` instead of JS `undefined` on a cache hit
+ * of a "no value" (None) result. The in-memory effect cache stores
+ * `option<output>` — here `option<option<bigint>>` — and `LoadManager.call`
+ * returns it on a hit without unwrapping the outer option, so `Some(None)`
+ * leaks through (envio 3.0.2 returned `undefined` directly). Consumers that
+ * branch on `=== undefined` / `?? fallback` would otherwise treat the sentinel
+ * as a real value and crash — persisting a non-bigint into an entity field
+ * (write-batch schema error) or calling `.toString()` on the object.
+ *
+ * A genuine bigint passes through untouched (only `Some(None)` is boxed; real
+ * values stay unboxed), so this is a no-op once the leak is fixed upstream.
+ *
+ * @param result - Raw value from `context.effect(<optional-bigint effect>)`
+ * @returns The bigint when present, otherwise `undefined`
+ */
+export function optionalBigintEffect(result: unknown): bigint | undefined {
+  return typeof result === "bigint" ? result : undefined;
+}
+
+/**
  * Logs an error via context. If err is provided, appends ": " + getErrorMessage(err) to the message.
  * @param context - The handler context
  * @param message - The message to log

--- a/test/Helpers.test.ts
+++ b/test/Helpers.test.ts
@@ -14,6 +14,7 @@ import {
   computeLiquidityDeltaFromAmounts,
   computeNonCLStakedUSD,
   concentratedLiquidityToUSD,
+  optionalBigintEffect,
   pickTrustedSwapVolumeUSD,
   runAsyncWithErrorLog,
   sortByBlockThenLogIndex,
@@ -22,6 +23,24 @@ import { setupCommon } from "./EventHandlers/Pool/common";
 
 describe("Helpers", () => {
   const Q96 = 2n ** 96n;
+
+  describe("optionalBigintEffect", () => {
+    it("passes a genuine bigint through unchanged", () => {
+      expect(optionalBigintEffect(500n)).toBe(500n);
+      expect(optionalBigintEffect(0n)).toBe(0n);
+    });
+
+    it("maps undefined to undefined", () => {
+      expect(optionalBigintEffect(undefined)).toBeUndefined();
+    });
+
+    it("maps the envio v3.1.0-rc.x nested-option sentinel (Some(None)) to undefined", () => {
+      // ReScript's runtime encoding of Some(None) for an option<option<bigint>>
+      // — what a cached S.optional(S.bigint) effect leaks on a None cache hit.
+      const sentinel = { BS_PRIVATE_NESTED_SOME_NONE: 0 };
+      expect(optionalBigintEffect(sentinel)).toBeUndefined();
+    });
+  });
 
   describe("sortByBlockThenLogIndex", () => {
     it("should sort by block number ascending when blocks differ", () => {


### PR DESCRIPTION
## Summary
- Bump `envio` 3.0.2 → **3.1.0** (stable) and regenerate the lockfile. Reviewed every release in range — **rc.0** (HyperSync client embedded in the NAPI addon, native Rust event decoder, `InMemoryStore` per-indexer singleton, ordered-multichain mode removed), **rc.1** (HyperSync rate-limit / memory-limit / stale-SSE fixes), **rc.2** (concurrent batch writes), and **3.1.0 final** (GraphQL entity/field descriptions, `envio tools` CLI, rate-limit TUI visibility, `skip` config field, 4.5M-contract startup fix, SSE-DDOS fix). All additive / opt-in; `pnpm envio codegen` accepts `config.yaml` + `schema.graphql` unchanged; no production handler logic changed.
- Work around a **v3.1.0 effect-cache regression** (introduced in the rc.x line and **still present in 3.1.0 final** — the cache-return path is byte-identical to rc.2): a *cached* effect with an *optional* output (`S.optional(S.bigint)`) returns the ReScript nested-option sentinel `{ BS_PRIVATE_NESTED_SOME_NONE: 0 }` (`Some(None)`) instead of JS `undefined` on a cache hit of a "no value" result. The in-memory effect cache stores `option<output>` (here `option<option<bigint>>`) and `LoadManager.call` returns it on a hit without unwrapping the outer option (3.0.2 returned `undefined` directly). Left unguarded, the sentinel slips past `=== undefined` / `?? 0n` checks and either lands a non-bigint in `Pool.currentFee` (strict write-batch schema crash) or reaches `BigInt("[object Object]")`.
- Add `optionalBigintEffect()` in `src/Helpers.ts` to coerce such results to `bigint | undefined`, wired into the **only two** affected consumers: `getSwapFee` (`updateDynamicFeePools`) and `getTokensDeposited` (`VoterCommonLogic`). Every other effect has a non-optional / object output or `cache: false` and is unaffected. The helper is a verified no-op on 3.0.2 and once the leak is fixed upstream.
- Add 3 unit tests for the helper (genuine bigint passthrough incl. `0n`, `undefined`, and the sentinel object).
- Rebased onto current `main` (which includes #842), so the branch builds clean and the full suite is green.

## Caching is preserved (verified)
The coercion is **purely consumer-side** and runs *downstream* of `LoadManager.call`'s hit/miss decision, so it cannot affect caching; the output schema is unchanged, so the persisted `envio_effect_*` cache stays fully reachable (each row is re-parsed through the same output schema on load). Verified empirically on the **real** `getSwapFee` under 3.1.0: across the CLFactory suite, **68 same-key `getSwapFee` calls → 17 handler executions (cache misses) → 51 served from cache**, with every cache hit returning the sentinel and `optionalBigintEffect` coercing it to the correct `undefined`. `getTokensDeposited` uses the identical machinery and output shape, so it behaves the same.

## Test plan
- [x] `pnpm envio codegen` succeeds on 3.1.0 (config + schema accepted, types regenerated)
- [x] `tsc --noEmit` — **0 errors** (the earlier lone error was the pre-existing #815, now fixed on `main` by #842 and inherited via rebase)
- [x] Full `vitest` suite green (1540 passed); the CLFactory `currentFee` crash is fixed by this PR, and the formerly-pre-existing #814/#815 failures are fixed on `main` by #842
- [x] `biome check` clean on changed files

## Note
The effect-cache regression is an upstream envio bug (`enviodev/hyperindex`) worth reporting; this PR works around it without changing the effect contracts, and the workaround becomes a harmless no-op once upstream fixes the leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated envio dependency to version 3.1.0

* **Bug Fixes**
  * Improved robustness of optional bigint value handling to address an envio regression affecting fee and token deposit data retrieval

<!-- end of auto-generated comment: release notes by coderabbit.ai -->