### PR TITLE
fix(test): restore green CI by dropping two stale assertions

### DIFF
--- a/test/EventHandlers/Pool/Fees.test.ts
+++ b/test/EventHandlers/Pool/Fees.test.ts
@@ -295,7 +295,10 @@ describe("Pool Fees Event", () => {
     it("attributes fee contributions to tx.from (the user)", () => {
       expect(attributed).toBeDefined();
       expect(attributed?.totalFeesContributed0).toBe(expectations.amount0In);
-      expect(attributed?.totalFeesContributed1).toBe(expectations.amount1In);
+      expect(attributed?.totalFeesContributed1).toBe(
+        // token1 (6 decimals) raw fee normalized to a 1e18 base (#812)
+        expectations.amount1In * 10n ** 12n,
+      );
     });
 
     it("does not attribute fee contributions to params.sender (the router)", () => {

--- a/test/EventHandlers/VotingReward/VotingRewardSharedLogic.test.ts
+++ b/test/EventHandlers/VotingReward/VotingRewardSharedLogic.test.ts
@@ -331,8 +331,7 @@ describe("VotingRewardSharedLogic", () => {
         PoolAddressField.BRIBE_VOTING_REWARD_ADDRESS,
       );
 
-      // Raw amount passes through; the untrusted price contributes 0n USD.
-      expect(result.poolDiff?.incrementalTotalBribeClaimed).toBe(1000000n);
+      // The untrusted price contributes 0n USD.
       expect(result.poolDiff?.incrementalTotalBribeClaimedUSD).toBe(0n);
       expect(result.userDiff?.incrementalTotalBribeClaimedUSD).toBe(0n);
 


### PR DESCRIPTION
## Why

`main` CI has been **red since #835** (2026-06-02). The pipeline is Install → Generate types → **Build (`tsc --build`)** → QA → Test. The Build step dies on a stale test reference, so **QA and the test run never execute**. A second stale assertion — a *runtime* failure — sits behind that gate, invisible to CI until Build is fixed.

Both fixes are **test-only**; the production paths are correct (they match the intent of #812 and #813). PR #841 (the envio 3.1.0-rc.2 migration) is branched off this broken `main` and inherits the same red Build, so this also unblocks #841.

## What

**#815 — the tsc error that kills Build.**
#813 dropped the raw `incrementalTotalBribeClaimed` field from `PoolDiff`, keeping only the `*USD` companion. #835 (merged after) carried a stale test still asserting the dropped raw field → `TS2551`. Drop that one assertion; the two surviving `*USD` assertions (`0n` on `poolDiff` + `userDiff`) are the correct ones.

**#814 — the masked runtime failure (×1e12 mismatch).**
#812 normalized `totalFeesContributed1` to a 1e18 base. The #814 attribution test (from `edebde0`) still expected the un-normalized 1e6 amount (`expected 2000000000000000000n to be 2000000n`). Mirror the sibling assertions already in the same file (lines ~94, ~130, ~224): `expectations.amount1In * 10n ** 12n`.

## Verification (full CI order — `vitest` alone hides the Build gate)

- `tsc --build --force` → **0 errors** (baseline was 1: `TS2551` @ `VotingRewardSharedLogic.test.ts:335`)
- `biome check` → **clean**
- `vitest run --coverage` → **1537 passed, 0 failures** (110 files)

No production code changed (`+5 / −3` across two test files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
