### PR TITLE
Fix superchain ClaimRewards param-name collision (envio 3.1.0)

### DIFF
--- a/abis/SuperchainIncentiveVotingReward.json
+++ b/abis/SuperchainIncentiveVotingReward.json
@@ -109,19 +109,19 @@
       {
         "indexed": true,
         "internalType": "address",
-        "name": "_sender",
+        "name": "from",
         "type": "address"
       },
       {
         "indexed": true,
         "internalType": "address",
-        "name": "_reward",
+        "name": "reward",
         "type": "address"
       },
       {
         "indexed": false,
         "internalType": "uint256",
-        "name": "_amount",
+        "name": "amount",
         "type": "uint256"
       }
     ],

--- a/src/EventHandlers/VotingReward/SuperchainIncentiveVotingReward.ts
+++ b/src/EventHandlers/VotingReward/SuperchainIncentiveVotingReward.ts
@@ -11,12 +11,12 @@ indexer.onEvent(
   async ({ event, context }) => {
     const data = {
       votingRewardAddress: event.srcAddress,
-      userAddress: event.params._sender,
+      userAddress: event.params.from,
       chainId: event.chainId,
       blockNumber: event.block.number,
       timestamp: event.block.timestamp,
-      reward: event.params._reward,
-      amount: event.params._amount,
+      reward: event.params.reward,
+      amount: event.params.amount,
     };
 
     const loadedData = await loadVotingRewardData(

--- a/test/EventHandlers/VotingReward/SuperchainIncentiveVotingReward.test.ts
+++ b/test/EventHandlers/VotingReward/SuperchainIncentiveVotingReward.test.ts
@@ -128,9 +128,9 @@ describe("SuperchainIncentiveVotingReward Events", () => {
                   hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
                 },
                 params: {
-                  _sender: userAddress,
-                  _reward: rewardTokenAddress,
-                  _amount: 1000000n, // 1 token with 18 decimals
+                  from: userAddress,
+                  reward: rewardTokenAddress,
+                  amount: 1000000n, // 1 token with 18 decimals
                 },
               },
             ],
@@ -180,9 +180,9 @@ describe("SuperchainIncentiveVotingReward Events", () => {
                     hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
                   },
                   params: {
-                    _sender: userAddress,
-                    _reward: rewardTokenAddress,
-                    _amount: 1000000n,
+                    from: userAddress,
+                    reward: rewardTokenAddress,
+                    amount: 1000000n,
                   },
                 },
               ],
@@ -202,6 +202,74 @@ describe("SuperchainIncentiveVotingReward Events", () => {
           userStats.totalBribeClaimedUSD,
         );
       });
+    });
+  });
+
+  // Issue #844: envio 3.1.0's native decoder dedupes shared-signature param
+  // names first-contract-wins, so `ClaimRewards(address,address,uint256)` logs
+  // emitted by SuperchainIncentiveVotingReward arrive named after
+  // FeesVotingReward (`from/reward/amount`). The handler must read those
+  // canonical names — reading `_reward` yielded `undefined` →
+  // `{chainId}-undefined` → a null-address Token write that crashed the deploy.
+  // This block runs the real shared logic (only the pool/user lookup is mocked;
+  // the reward token is pre-seeded so no RPC / createTokenEntity fires).
+  describe("ClaimRewards Event — issue #844 param-name regression", () => {
+    beforeEach(() => {
+      vi.spyOn(
+        VotingRewardSharedLogic,
+        "loadVotingRewardData",
+      ).mockResolvedValue({
+        pool: liquidityPool,
+        poolData: {
+          liquidityPoolAggregator: liquidityPool,
+        },
+        userData: userStats,
+      });
+    });
+
+    it("attributes USD against token id {chainId}-{rewardAddress}, never {chainId}-undefined", async () => {
+      await indexer.process({
+        chains: {
+          [chainId]: {
+            simulate: [
+              {
+                contract: "SuperchainIncentiveVotingReward",
+                event: "ClaimRewards",
+                srcAddress: votingRewardAddress,
+                logIndex: 1,
+                block: {
+                  number: 1000000,
+                  timestamp: 1000000,
+                  hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
+                },
+                params: {
+                  from: userAddress,
+                  reward: rewardTokenAddress,
+                  amount: 1000000n, // 1 token with 18 decimals
+                },
+              },
+            ],
+          },
+        },
+      });
+
+      // USD is attributed to the pool and the user (1e18 price × 1 token = 1e6
+      // in 1e18-base, matching getTrustedUSD on the pre-seeded reward token).
+      const updatedPool = await indexer.Pool.get(liquidityPool.id);
+      expect(updatedPool?.totalBribeClaimedUSD).toBe(1000000n);
+
+      const updatedUser = await indexer.UserStatsPerPool.get(userStats.id);
+      expect(updatedUser?.totalBribeClaimedUSD).toBe(1000000n);
+
+      // The reward token is resolved by its real id; the null-address row the
+      // pre-fix handler produced (reading the now-absent `_reward`) is absent.
+      const rewardTokenEntity = await indexer.Token.get(
+        TokenId(chainId, rewardTokenAddress),
+      );
+      expect(rewardTokenEntity).toBeDefined();
+
+      const undefinedToken = await indexer.Token.get(`${chainId}-undefined`);
+      expect(undefinedToken).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## Summary
- envio 3.1.0's native HyperSync decoder builds its param-name table per event *signature* (`sighash + topicCount`) and dedupes **first-contract-wins**. `ClaimRewards(address,address,uint256)` is registered by `Fees`/`BribesVotingReward` (`from/reward/amount`) **and** `SuperchainIncentiveVotingReward` (`_sender/_reward/_amount`). Fees registers first, so **every** `ClaimRewards` log — including ones emitted by `SuperchainIncentiveVotingReward` — decoded under `from/reward/amount`. The handler read `event.params._reward`, which was `undefined` → `TokenId(chainId, undefined)` = `{chainId}-undefined` → a null-address `Token` write that halted the deploy on every superchain-leaf chain.
- **Fix:** rename the `ClaimRewards` inputs in `abis/SuperchainIncentiveVotingReward.json` to `from/reward/amount` so the names agree and the dedup order is irrelevant. Types and `indexed` flags are unchanged, so on-chain decoding is byte-identical — the renamed `reward` field resolves to the exact address `_reward` did.
- Update `SuperchainIncentiveVotingReward.ts` to read `event.params.from/.reward/.amount`.
- Add a real-shared-logic regression test asserting a `ClaimRewards` event attributes USD to the pool/user against token id `{chainId}-{rewardAddress}`, never `{chainId}-undefined`.

Param names are not part of the EVM wire format (the keccak signature hash uses types only), so this is a label-only change to the ABI; the decoded values are unchanged. Blast radius is one event — `ClaimRewards` is the only divergent collision among the 19 shared-signature groups, and it is the only registered handler for this contract.

Closes #844

## Test plan
- [x] `pnpm envio codegen` succeeds and `tsc --noEmit` is clean
- [x] Full `pnpm test` suite green (110 test files passed)
- [x] `biome check` clean (279 files, no fixes)
- [x] Regression test produces reward Token id `{chainId}-{rewardAddress}` (RED `0n` before fix → GREEN `1000000n` after) and never `{chainId}-undefined`
- [ ] Deploy against superchain-leaf chains (Celo, Metal, …) no longer crashes processing `ClaimRewards` *(needs human — requires live deploy; the test harness bypasses the native decoder, so this class is only verifiable on-chain)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Issue `#844`: Improved accuracy of voting reward claim tracking and token entity resolution.

* **Tests**
  * Added regression test for voting reward claim event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->