### PR TITLE
Skip persisting tokens with undefined or invalid addresses

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -1,5 +1,5 @@
 import dotenv from "dotenv";
-import { http, createPublicClient } from "viem";
+import { http, createPublicClient, isAddress } from "viem";
 import type { Chain, PublicClient } from "viem";
 import {
   base,
@@ -70,6 +70,24 @@ export const SNAPSHOT_INTERVAL_IN_MS = 60 * 60 * 1000;
 
 export const toChecksumAddress = (address: string): `0x${string}` =>
   Web3.utils.toChecksumAddress(address) as `0x${string}`;
+
+/**
+ * Defense-in-depth address validator (issue #845): true only when `address`
+ * is a well-formed EVM address (`0x` + 40 hex chars). Returns `false` — never
+ * throws — for `undefined`, `null`, empty string, or any non-hex/wrong-length
+ * input, so token-creation choke points can skip persisting a `Token` with a
+ * garbage id instead of crashing the write batch on a NOT-NULL violation.
+ *
+ * Uses viem's `isAddress` in non-strict mode: format-only, no checksum
+ * requirement, so a legitimately-lowercase address still validates.
+ *
+ * @param address - Candidate address, possibly missing/garbage from a decoder mismatch.
+ * @returns `true` iff `address` is a syntactically valid EVM address.
+ */
+export const isValidEvmAddress = (
+  address: string | undefined | null,
+): boolean =>
+  typeof address === "string" && isAddress(address, { strict: false });
 
 // Note:
 // These pools factories addresses are hardcoded since we can't check the pool type from the Voter contract.

--- a/src/EventHandlers/Voter/SuperchainLeafVoter.ts
+++ b/src/EventHandlers/Voter/SuperchainLeafVoter.ts
@@ -6,6 +6,7 @@ import {
   SUPERCHAIN_LEAF_VOTER_CLPOOLS_FACTORY_LIST,
   SUPERCHAIN_LEAF_VOTER_NONCL_POOLS_FACTORY_LIST,
   TokenId,
+  isValidEvmAddress,
 } from "../../Constants";
 import { getTokenDetails, hasContractBytecode } from "../../Effects/Index";
 import { getRehydrated } from "../../EntityTimestamps";
@@ -171,6 +172,18 @@ indexer.onEvent(
       };
 
       context.Token.set(updatedToken as Token);
+      return;
+    }
+
+    // Issue #845: defense-in-depth. A decoder mismatch (e.g. #844) can deliver
+    // an `undefined`/garbage token here; persisting it would write a Token with
+    // a malformed `${chainId}-` id (hasContractBytecode fail-opens to `true`
+    // once RPCs are exhausted, so the bytecode gate below would not catch it).
+    // Skip + warn before any effect runs, mirroring createTokenEntity's guard.
+    if (!isValidEvmAddress(event.params.token)) {
+      context.log.warn(
+        `[SuperchainLeafVoter.WhitelistToken] Skipping Token row for invalid address ${event.params.token} on chain ${event.chainId}`,
+      );
       return;
     }
 

--- a/src/EventHandlers/Voter/Voter.ts
+++ b/src/EventHandlers/Voter/Voter.ts
@@ -25,6 +25,7 @@ import {
   VOTER_CLPOOLS_FACTORY_LIST,
   VOTER_NONCL_POOLS_FACTORY_LIST,
   isKnownSinkRootPool,
+  isValidEvmAddress,
 } from "../../Constants";
 import { getTokenDetails, hasContractBytecode } from "../../Effects/Index";
 import { getRehydrated } from "../../EntityTimestamps";
@@ -465,6 +466,18 @@ indexer.onEvent(
       };
 
       context.Token.set(updatedToken as Token);
+      return;
+    }
+
+    // Issue #845: defense-in-depth. A decoder mismatch (e.g. #844) can deliver
+    // an `undefined`/garbage token here; persisting it would write a Token with
+    // a malformed `${chainId}-` id (hasContractBytecode fail-opens to `true`
+    // once RPCs are exhausted, so the bytecode gate below would not catch it).
+    // Skip + warn before any effect runs, mirroring createTokenEntity's guard.
+    if (!isValidEvmAddress(event.params.token)) {
+      context.log.warn(
+        `[Voter.WhitelistToken] Skipping Token row for invalid address ${event.params.token} on chain ${event.chainId}`,
+      );
       return;
     }
 

--- a/src/PriceOracle.ts
+++ b/src/PriceOracle.ts
@@ -1,6 +1,11 @@
 import type { Token } from "envio";
 import { estimateBlockAtTimestamp } from "./ChainBlockTime";
-import { MS_IN_AN_HOUR, TEN_TO_THE_18_BI, TokenId } from "./Constants";
+import {
+  MS_IN_AN_HOUR,
+  TEN_TO_THE_18_BI,
+  TokenId,
+  isValidEvmAddress,
+} from "./Constants";
 import {
   getTokenDetails,
   getTokenPrice,
@@ -88,7 +93,8 @@ const withinRatioBand = (a: bigint, b: bigint): boolean =>
  * @param blockNumber - Block at which the entity is being created.
  * @param context - Envio handler context for effects + Token.set.
  * @param blockTimestamp - Block timestamp in seconds; stored as `lastUpdatedTimestamp`.
- * @returns The created Token entity, or `null` when the address has no deployed bytecode.
+ * @returns The created Token entity, or `null` when the address is invalid (issue
+ *   #845) or has no deployed bytecode.
  */
 export async function createTokenEntity(
   tokenAddress: string,
@@ -97,6 +103,18 @@ export async function createTokenEntity(
   context: handlerContext,
   blockTimestamp: number,
 ): Promise<Token | null> {
+  // Issue #845: defense-in-depth. Refuse to build a Token from a missing or
+  // malformed address before any effect runs — a decoder mismatch (e.g. #844)
+  // that yields `undefined`/garbage here would otherwise persist a `{chainId}-
+  // undefined` row and crash the whole write batch on the NOT-NULL id. Skip +
+  // warn instead, mirroring the #677 bytecode-gate skip; callers handle `null`.
+  if (!isValidEvmAddress(tokenAddress)) {
+    context.log.warn(
+      `[createTokenEntity] Skipping Token row for invalid address ${tokenAddress} on chain ${chainId}`,
+    );
+    return null;
+  }
+
   const blockDatetime = new Date(blockTimestamp * 1000);
 
   const { hasCode } = await context.effect(hasContractBytecode, {

--- a/test/Constants.test.ts
+++ b/test/Constants.test.ts
@@ -8,6 +8,7 @@ import {
   SUPERCHAIN_LEAF_VOTER_NONCL_POOLS_FACTORY_LIST,
   VOTER_CLPOOLS_FACTORY_LIST,
   VOTER_NONCL_POOLS_FACTORY_LIST,
+  isValidEvmAddress,
   nfpmForCLPool,
   toChecksumAddress,
 } from "../src/Constants";
@@ -415,5 +416,57 @@ describe("config.yaml ↔ Constants.ts factory parity (#770, subsumes #769)", ()
         }
       },
     );
+  });
+});
+
+// Issue #845: defense-in-depth address validator used by the token-creation
+// choke points to refuse persisting a Token with a missing/garbage address.
+describe("isValidEvmAddress", () => {
+  it("returns false for undefined", () => {
+    expect(isValidEvmAddress(undefined)).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isValidEvmAddress(null)).toBe(false);
+  });
+
+  it("returns false for an empty string", () => {
+    expect(isValidEvmAddress("")).toBe(false);
+  });
+
+  it("returns false for a non-hex string", () => {
+    expect(
+      isValidEvmAddress("0xZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"),
+    ).toBe(false);
+    expect(isValidEvmAddress("not-an-address")).toBe(false);
+  });
+
+  it("returns false for a wrong-length hex string (missing 0x / too short / too long)", () => {
+    // 40 hex chars but no 0x prefix
+    expect(isValidEvmAddress("1111111111111111111111111111111111111111")).toBe(
+      false,
+    );
+    // 39 hex chars after 0x
+    expect(isValidEvmAddress("0x111111111111111111111111111111111111111")).toBe(
+      false,
+    );
+    // 41 hex chars after 0x
+    expect(
+      isValidEvmAddress("0x11111111111111111111111111111111111111111"),
+    ).toBe(false);
+  });
+
+  it("returns true for a correctly checksummed address", () => {
+    expect(
+      isValidEvmAddress(
+        toChecksumAddress("0x4200000000000000000000000000000000000006"),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true for a valid lowercase address (no checksum requirement)", () => {
+    expect(
+      isValidEvmAddress("0x4200000000000000000000000000000000000006"),
+    ).toBe(true);
   });
 });

--- a/test/EventHandlers/Voter/SuperchainLeafVoter.test.ts
+++ b/test/EventHandlers/Voter/SuperchainLeafVoter.test.ts
@@ -438,6 +438,79 @@ describe("SuperchainLeafVoter Events", () => {
       });
     });
 
+    describe("when token address is invalid (issue #845)", () => {
+      // A decoder mismatch (#844) can feed an empty/garbage address into the
+      // new-token branch. Without the guard, hasContractBytecode fail-opens to
+      // `true` once RPCs are exhausted, so the handler would persist a Token
+      // with the malformed id `${chainId}-`. The guard must skip instead.
+      it("does not persist a Token for an empty-string token", async () => {
+        const indexer = createTestIndexer();
+
+        await indexer.process({
+          chains: {
+            [chainId]: {
+              simulate: [
+                {
+                  contract: "SuperchainLeafVoter",
+                  event: "WhitelistToken",
+                  srcAddress: toChecksumAddress(
+                    "0x1111111111111111111111111111111111111111",
+                  ),
+                  logIndex: 1,
+                  block: {
+                    number: blockNumber,
+                    timestamp: blockTimestamp,
+                    hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
+                  },
+                  params: {
+                    token: "" as `0x${string}`,
+                    _bool: true,
+                  },
+                },
+              ],
+            },
+          },
+        });
+
+        const tokens = await indexer.Token.getAll();
+        expect(tokens).toHaveLength(0);
+      });
+
+      it("does not persist a Token for a non-hex token", async () => {
+        const indexer = createTestIndexer();
+
+        await indexer.process({
+          chains: {
+            [chainId]: {
+              simulate: [
+                {
+                  contract: "SuperchainLeafVoter",
+                  event: "WhitelistToken",
+                  srcAddress: toChecksumAddress(
+                    "0x1111111111111111111111111111111111111111",
+                  ),
+                  logIndex: 1,
+                  block: {
+                    number: blockNumber,
+                    timestamp: blockTimestamp,
+                    hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
+                  },
+                  params: {
+                    token:
+                      "0xZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ" as `0x${string}`,
+                    _bool: true,
+                  },
+                },
+              ],
+            },
+          },
+        });
+
+        const tokens = await indexer.Token.getAll();
+        expect(tokens).toHaveLength(0);
+      });
+    });
+
     describe("priceTrust recomputation on existing tokens (issue #761)", () => {
       it("flips UNTRUSTED/NON_WL to TRUSTED/WL when WhitelistToken(true) lands", async () => {
         const existing = {

--- a/test/EventHandlers/Voter/Voter.test.ts
+++ b/test/EventHandlers/Voter/Voter.test.ts
@@ -2306,6 +2306,42 @@ describe("Voter Events", () => {
         );
       });
     });
+    describe("when token address is invalid (issue #845)", () => {
+      // Mirror of the SuperchainLeafVoter guard: a decoder mismatch (#844) can
+      // feed an empty/garbage address into the new-token branch. Without the
+      // guard, hasContractBytecode fail-opens to `true` once RPCs are
+      // exhausted, so the handler would persist a Token with the malformed id
+      // `${chainId}-`. The guard must skip instead.
+      it("does not persist a Token for an empty-string token", async () => {
+        const idx = createTestIndexer();
+
+        await idx.process({
+          chains: {
+            [wlChainId]: {
+              simulate: [
+                {
+                  contract: "Voter",
+                  event: "WhitelistToken",
+                  logIndex: 1,
+                  block: wlBlock,
+                  params: {
+                    whitelister: toChecksumAddress(
+                      "0x1111111111111111111111111111111111111111",
+                    ),
+                    token: "" as `0x${string}`,
+                    _bool: true,
+                  },
+                },
+              ],
+            },
+          },
+        });
+
+        const tokens = await idx.Token.getAll();
+        expect(tokens).toHaveLength(0);
+      });
+    });
+
     describe("priceTrust recomputation on existing tokens (issue #761)", () => {
       it("flips UNTRUSTED/NON_WL to TRUSTED/WL when WhitelistToken(true) lands", async () => {
         const existing = {

--- a/test/PriceOracle.test.ts
+++ b/test/PriceOracle.test.ts
@@ -2441,6 +2441,51 @@ describe("PriceOracle", () => {
       });
     });
 
+    describe("when address is invalid (issue #845)", () => {
+      // `undefined` is the real #844 decoder-mismatch case. The full
+      // invalid-input truth table (empty string, non-hex, wrong length) is
+      // covered against the validator itself in test/Constants.test.ts; here we
+      // only need to prove the handler's reaction to an invalid address.
+      const badAddress = undefined as unknown as string;
+
+      it("returns null and does not call Token.set", async () => {
+        const token = await PriceOracle.createTokenEntity(
+          badAddress,
+          chainId,
+          blockNumber,
+          mockContext as handlerContext,
+          blockTimestamp,
+        );
+
+        expect(token).toBeNull();
+        expect(vi.mocked(mockContext.Token?.set)).not.toHaveBeenCalled();
+      });
+
+      it("does not call any effect (guard runs before effects)", async () => {
+        await PriceOracle.createTokenEntity(
+          badAddress,
+          chainId,
+          blockNumber,
+          mockContext as handlerContext,
+          blockTimestamp,
+        );
+
+        expect(vi.mocked(mockContext.effect)).not.toHaveBeenCalled();
+      });
+
+      it("logs a warning", async () => {
+        await PriceOracle.createTokenEntity(
+          badAddress,
+          chainId,
+          blockNumber,
+          mockContext as handlerContext,
+          blockTimestamp,
+        );
+
+        expect(vi.mocked(mockContext.log?.warn)).toHaveBeenCalled();
+      });
+    });
+
     describe("pool-implied ground-truth re-anchor (#784/#785)", () => {
       // USD price scaled by 1e18, matching `pricePerUSDNew`.
       const usd = (n: number) => BigInt(Math.round(n * 1e6)) * 10n ** 12n;


### PR DESCRIPTION
## Summary
- Add `isValidEvmAddress` to `src/Constants.ts` (viem `isAddress` in non-strict / format-only mode): `true` only for a well-formed `0x`+40-hex address; `false` (never throws) for `undefined`/`null`/empty/non-hex/wrong-length.
- Gate the three token-creation choke points that build a `Token` from an event/param address to **warn + skip before any effect runs** (return `null`/`void`), mirroring the #677 bytecode-gate skip:
  - `createTokenEntity` (`src/PriceOracle.ts`)
  - `SuperchainLeafVoter.WhitelistToken` new-token branch
  - `Voter.WhitelistToken` new-token branch
- Defense-in-depth follow-up to #844: a decoder/param mismatch can feed `undefined`/garbage into these sites, persisting a `Token` with a malformed `${chainId}-` id and crashing the **entire write batch** on the NOT-NULL id. The bytecode gate alone can't catch this — `hasContractBytecode` fail-opens to `true` once RPCs are exhausted, so the garbage address sails past it.

## Scope note for reviewers
The issue named **two** sites (`createTokenEntity` + `SuperchainLeafVoter.WhitelistToken`). I extended the same guard to a **third identical site**, `Voter.WhitelistToken` — the canonical-chain sibling of the leaf-chain handler, with the same hand-rolled `Token` builder and the same fail-open exposure. Happy to drop the `Voter.ts` change if you'd prefer the PR scoped strictly to the two named sites.

This is **not** a substitute for #844 (the actual `ClaimRewards` decode fix, shipped separately as PR #847). It's the recoverable-skip safety net so the *next* param/decoder mismatch degrades to a logged skip instead of a deploy-halting crash.

## Test plan
- [x] Full `vitest` suite green — 1553 passed (110 files)
- [x] `biome check` clean — 279 files, no fixes
- [x] `tsc --noEmit` clean
- [x] Validator truth-table covered in `test/Constants.test.ts` (undefined / null / empty / non-hex / wrong-length / lowercase / checksummed)
- [x] Handler-skip tests in `test/PriceOracle.test.ts`, `test/EventHandlers/Voter/SuperchainLeafVoter.test.ts`, `test/EventHandlers/Voter/Voter.test.ts` (each RED before the guard: a garbage `Token` row was persisted)

Closes #845

🤖 Generated with [Claude Code](https://claude.com/claude-code)