### PR TITLE
chore(deps): upgrade envio to 3.1.1 and drop its 3.1.0 workarounds (#847 + optionalBigintEffect)

### DIFF
--- a/abis/SuperchainIncentiveVotingReward.json
+++ b/abis/SuperchainIncentiveVotingReward.json
@@ -109,19 +109,19 @@
       {
         "indexed": true,
         "internalType": "address",
-        "name": "from",
+        "name": "_sender",
         "type": "address"
       },
       {
         "indexed": true,
         "internalType": "address",
-        "name": "reward",
+        "name": "_reward",
         "type": "address"
       },
       {
         "indexed": false,
         "internalType": "uint256",
-        "name": "amount",
+        "name": "_amount",
         "type": "uint256"
       }
     ],

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@uniswap/sdk-core": "^7.9.0",
     "@uniswap/v3-sdk": "3.29.1",
     "dotenv": "^16.4.5",
-    "envio": "3.1.0",
+    "envio": "3.1.1",
     "jsbi": "^4.3.2",
     "viem": "2.24.3",
     "web3": "^4.16.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^16.4.5
         version: 16.6.1
       envio:
-        specifier: 3.1.0
-        version: 3.1.0(react-dom@19.2.4(react@19.2.5))(typescript@5.9.3)(zod@3.25.76)
+        specifier: 3.1.1
+        version: 3.1.1(react-dom@19.2.4(react@19.2.5))(typescript@5.9.3)(zod@3.25.76)
       jsbi:
         specifier: ^4.3.2
         version: 4.3.2
@@ -1378,33 +1378,33 @@ packages:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
 
-  envio-darwin-arm64@3.1.0:
-    resolution: {integrity: sha512-6oY9/J7HrG/d6hGKfjgM8WqttkT5ECYtHRtxzOxzQBm+NqGAuJX+8ev/xSP5juKAayYu2z6K1XYGg0wSGNT6dw==}
+  envio-darwin-arm64@3.1.1:
+    resolution: {integrity: sha512-TlnIjVPA46BVGXN8hQgbD68LjsTaDWPzrIOeQss1okjEcTT3nnK9ZqBT7yF4nhdaBOb4bnXSL44DQZcypmoEsQ==}
     cpu: [arm64]
     os: [darwin]
 
-  envio-darwin-x64@3.1.0:
-    resolution: {integrity: sha512-I03Fcww7zUNoX+RsPnh6MsoOw/Mramt6NDhA1k/6kcp0ttjAEAFbptw50yiQ2D1RFllj0j6J7GiiEBCu1Qc77w==}
+  envio-darwin-x64@3.1.1:
+    resolution: {integrity: sha512-wbwBksgBM9qNRRRJ7eoEIZc4fm1Va6NdGqpwCQSExgrkQ242m3uNXAh85CIUXxsi0x3k2dpBNjZ/W16SCHpRWQ==}
     cpu: [x64]
     os: [darwin]
 
-  envio-linux-arm64@3.1.0:
-    resolution: {integrity: sha512-DAAHrNref4vR3+JC+/2rkvjG34bpOdRqbEMH9NBvyMF0Fwjh1Y5S1tWhoUTlYC20vdq4pRasKt2oFeCGxmWziQ==}
+  envio-linux-arm64@3.1.1:
+    resolution: {integrity: sha512-sj6YdOQ8QgXnts+YnU55RSVZfBsLdE7Dw+elRCySHjiwbhWFPaaMLLYbjuwQ3y1B6F/3y1ersLD59Lmg3TuOcw==}
     cpu: [arm64]
     os: [linux]
 
-  envio-linux-x64-musl@3.1.0:
-    resolution: {integrity: sha512-TmhEWtzMYrlypaozzaVGJLPedlOseQ4q7WWqfmFzlJXbMdAxAT0len3SDQJZCZfb8ooLN/ck6kUUE0C2HTJo1w==}
+  envio-linux-x64-musl@3.1.1:
+    resolution: {integrity: sha512-RO1DOZ8W7QAm1aoT//9eqSvDFc1OjoR96eRW2a4tob/b9tysNVkLA3JYEVnwTTI3VINsLXvKhBG/ujza3SFnAQ==}
     cpu: [x64]
     os: [linux]
 
-  envio-linux-x64@3.1.0:
-    resolution: {integrity: sha512-Oe7SzfQJXC/jqJHbEsjqUiluCSdVol/EYda2wmrqxwQKNifYWdodcPCG+T8jNHMSkXLDVXO6990pLNmmMy4HpQ==}
+  envio-linux-x64@3.1.1:
+    resolution: {integrity: sha512-f1hpi+tIHNSv8FefuhVxhpJf+jRudpamaY5W0YL30UEFX6P4sfp8ZZyrdz8HBS+s4hjWXnPJmGRyb5Eij0YqCA==}
     cpu: [x64]
     os: [linux]
 
-  envio@3.1.0:
-    resolution: {integrity: sha512-58b5f/mXYQjHTd4STNYpjRlLqTA32mRrAWaHYsX4yEFZq4QlHO05CRnaA7H4xCRP42XQviI6lzspAH6g5nSViA==}
+  envio@3.1.1:
+    resolution: {integrity: sha512-jZcc83a05dS6aHWnV/gmhsfb4h/xAtVRRryr3nu3CllmzezM0M2yn3ailB5tszZ2GX4hGXP+8Dziru8GEsmxdw==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
@@ -4155,22 +4155,22 @@ snapshots:
 
   env-paths@2.2.1: {}
 
-  envio-darwin-arm64@3.1.0:
+  envio-darwin-arm64@3.1.1:
     optional: true
 
-  envio-darwin-x64@3.1.0:
+  envio-darwin-x64@3.1.1:
     optional: true
 
-  envio-linux-arm64@3.1.0:
+  envio-linux-arm64@3.1.1:
     optional: true
 
-  envio-linux-x64-musl@3.1.0:
+  envio-linux-x64-musl@3.1.1:
     optional: true
 
-  envio-linux-x64@3.1.0:
+  envio-linux-x64@3.1.1:
     optional: true
 
-  envio@3.1.0(react-dom@19.2.4(react@19.2.5))(typescript@5.9.3)(zod@3.25.76):
+  envio@3.1.1(react-dom@19.2.4(react@19.2.5))(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       '@clickhouse/client': 1.17.0
       '@elastic/ecs-pino-format': 1.4.0
@@ -4201,11 +4201,11 @@ snapshots:
       viem: 2.46.2(typescript@5.9.3)(zod@3.25.76)
       yargs: 17.7.2
     optionalDependencies:
-      envio-darwin-arm64: 3.1.0
-      envio-darwin-x64: 3.1.0
-      envio-linux-arm64: 3.1.0
-      envio-linux-x64: 3.1.0
-      envio-linux-x64-musl: 3.1.0
+      envio-darwin-arm64: 3.1.1
+      envio-darwin-x64: 3.1.1
+      envio-linux-arm64: 3.1.1
+      envio-linux-x64: 3.1.1
+      envio-linux-x64-musl: 3.1.1
     transitivePeerDependencies:
       - '@types/react'
       - bufferutil

--- a/src/Aggregators/Pool.ts
+++ b/src/Aggregators/Pool.ts
@@ -9,11 +9,7 @@ import { getSwapFee, roundBlockToInterval } from "../Effects/Index";
 import { getRehydrated, getWhereRehydrated } from "../EntityTimestamps";
 import type { handlerContext } from "../EntityTypes";
 import type { Pool } from "../EntityTypes";
-import {
-  calculateTotalUSD,
-  generatePoolName,
-  optionalBigintEffect,
-} from "../Helpers";
+import { calculateTotalUSD, generatePoolName } from "../Helpers";
 import { refreshTokenPrice } from "../PriceOracle";
 import { getPoolImpliedUSD, getTrustedUSD } from "../PriceTrust";
 import {
@@ -286,14 +282,12 @@ export async function updateDynamicFeePools(
   const minBlock = Number(
     liquidityPoolAggregator.createdBlockNumber ?? BigInt(blockNumber),
   );
-  const currentFee = optionalBigintEffect(
-    await context.effect(getSwapFee, {
-      poolAddress,
-      factoryAddress,
-      chainId,
-      blockNumber: roundBlockToInterval(blockNumber, chainId, minBlock),
-    }),
-  );
+  const currentFee = await context.effect(getSwapFee, {
+    poolAddress,
+    factoryAddress,
+    chainId,
+    blockNumber: roundBlockToInterval(blockNumber, chainId, minBlock),
+  });
 
   if (currentFee === undefined) {
     context.log.warn(

--- a/src/EventHandlers/Voter/VoterCommonLogic.ts
+++ b/src/EventHandlers/Voter/VoterCommonLogic.ts
@@ -14,10 +14,7 @@ import {
 import { getTokensDeposited } from "../../Effects/Index";
 import type { handlerContext } from "../../EntityTypes";
 import type { Pool } from "../../EntityTypes";
-import {
-  normalizeTokenAmountTo1e18,
-  optionalBigintEffect,
-} from "../../Helpers";
+import { normalizeTokenAmountTo1e18 } from "../../Helpers";
 import { getTrustedUSD } from "../../PriceTrust";
 
 export interface VoterCommonResult {
@@ -42,14 +39,12 @@ export async function computeVoterDistributeValues(
   context: handlerContext,
   gaugeIsAlive: boolean,
 ): Promise<VoterCommonResult> {
-  const tokensDepositedResult = optionalBigintEffect(
-    await context.effect(getTokensDeposited, {
-      rewardTokenAddress: rewardToken.address,
-      gaugeAddress,
-      blockNumber,
-      eventChainId: chainId,
-    }),
-  );
+  const tokensDepositedResult = await context.effect(getTokensDeposited, {
+    rewardTokenAddress: rewardToken.address,
+    gaugeAddress,
+    blockNumber,
+    eventChainId: chainId,
+  });
 
   const tokensDeposited = tokensDepositedResult ?? 0n;
 

--- a/src/EventHandlers/VotingReward/SuperchainIncentiveVotingReward.ts
+++ b/src/EventHandlers/VotingReward/SuperchainIncentiveVotingReward.ts
@@ -11,12 +11,12 @@ indexer.onEvent(
   async ({ event, context }) => {
     const data = {
       votingRewardAddress: event.srcAddress,
-      userAddress: event.params.from,
+      userAddress: event.params._sender,
       chainId: event.chainId,
       blockNumber: event.block.number,
       timestamp: event.block.timestamp,
-      reward: event.params.reward,
-      amount: event.params.amount,
+      reward: event.params._reward,
+      amount: event.params._amount,
     };
 
     const loadedData = await loadVotingRewardData(

--- a/src/Helpers.ts
+++ b/src/Helpers.ts
@@ -21,31 +21,6 @@ export function getErrorMessage(err: unknown): string {
 }
 
 /**
- * Coerces the result of an effect declared with `output: S.optional(S.bigint)`
- * to `bigint | undefined`.
- *
- * Works around an envio v3.1.0-rc.x regression in the effect cache: a cached
- * effect with an *optional* output returns the ReScript nested-option sentinel
- * `{ BS_PRIVATE_NESTED_SOME_NONE: 0 }` instead of JS `undefined` on a cache hit
- * of a "no value" (None) result. The in-memory effect cache stores
- * `option<output>` — here `option<option<bigint>>` — and `LoadManager.call`
- * returns it on a hit without unwrapping the outer option, so `Some(None)`
- * leaks through (envio 3.0.2 returned `undefined` directly). Consumers that
- * branch on `=== undefined` / `?? fallback` would otherwise treat the sentinel
- * as a real value and crash — persisting a non-bigint into an entity field
- * (write-batch schema error) or calling `.toString()` on the object.
- *
- * A genuine bigint passes through untouched (only `Some(None)` is boxed; real
- * values stay unboxed), so this is a no-op once the leak is fixed upstream.
- *
- * @param result - Raw value from `context.effect(<optional-bigint effect>)`
- * @returns The bigint when present, otherwise `undefined`
- */
-export function optionalBigintEffect(result: unknown): bigint | undefined {
-  return typeof result === "bigint" ? result : undefined;
-}
-
-/**
  * Logs an error via context. If err is provided, appends ": " + getErrorMessage(err) to the message.
  * @param context - The handler context
  * @param message - The message to log

--- a/test/EventHandlers/VotingReward/SuperchainIncentiveVotingReward.test.ts
+++ b/test/EventHandlers/VotingReward/SuperchainIncentiveVotingReward.test.ts
@@ -128,9 +128,9 @@ describe("SuperchainIncentiveVotingReward Events", () => {
                   hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
                 },
                 params: {
-                  from: userAddress,
-                  reward: rewardTokenAddress,
-                  amount: 1000000n, // 1 token with 18 decimals
+                  _sender: userAddress,
+                  _reward: rewardTokenAddress,
+                  _amount: 1000000n, // 1 token with 18 decimals
                 },
               },
             ],
@@ -180,9 +180,9 @@ describe("SuperchainIncentiveVotingReward Events", () => {
                     hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
                   },
                   params: {
-                    from: userAddress,
-                    reward: rewardTokenAddress,
-                    amount: 1000000n,
+                    _sender: userAddress,
+                    _reward: rewardTokenAddress,
+                    _amount: 1000000n,
                   },
                 },
               ],
@@ -202,74 +202,6 @@ describe("SuperchainIncentiveVotingReward Events", () => {
           userStats.totalBribeClaimedUSD,
         );
       });
-    });
-  });
-
-  // Issue #844: envio 3.1.0's native decoder dedupes shared-signature param
-  // names first-contract-wins, so `ClaimRewards(address,address,uint256)` logs
-  // emitted by SuperchainIncentiveVotingReward arrive named after
-  // FeesVotingReward (`from/reward/amount`). The handler must read those
-  // canonical names — reading `_reward` yielded `undefined` →
-  // `{chainId}-undefined` → a null-address Token write that crashed the deploy.
-  // This block runs the real shared logic (only the pool/user lookup is mocked;
-  // the reward token is pre-seeded so no RPC / createTokenEntity fires).
-  describe("ClaimRewards Event — issue #844 param-name regression", () => {
-    beforeEach(() => {
-      vi.spyOn(
-        VotingRewardSharedLogic,
-        "loadVotingRewardData",
-      ).mockResolvedValue({
-        pool: liquidityPool,
-        poolData: {
-          liquidityPoolAggregator: liquidityPool,
-        },
-        userData: userStats,
-      });
-    });
-
-    it("attributes USD against token id {chainId}-{rewardAddress}, never {chainId}-undefined", async () => {
-      await indexer.process({
-        chains: {
-          [chainId]: {
-            simulate: [
-              {
-                contract: "SuperchainIncentiveVotingReward",
-                event: "ClaimRewards",
-                srcAddress: votingRewardAddress,
-                logIndex: 1,
-                block: {
-                  number: 1000000,
-                  timestamp: 1000000,
-                  hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
-                },
-                params: {
-                  from: userAddress,
-                  reward: rewardTokenAddress,
-                  amount: 1000000n, // 1 token with 18 decimals
-                },
-              },
-            ],
-          },
-        },
-      });
-
-      // USD is attributed to the pool and the user (1e18 price × 1 token = 1e6
-      // in 1e18-base, matching getTrustedUSD on the pre-seeded reward token).
-      const updatedPool = await indexer.Pool.get(liquidityPool.id);
-      expect(updatedPool?.totalBribeClaimedUSD).toBe(1000000n);
-
-      const updatedUser = await indexer.UserStatsPerPool.get(userStats.id);
-      expect(updatedUser?.totalBribeClaimedUSD).toBe(1000000n);
-
-      // The reward token is resolved by its real id; the null-address row the
-      // pre-fix handler produced (reading the now-absent `_reward`) is absent.
-      const rewardTokenEntity = await indexer.Token.get(
-        TokenId(chainId, rewardTokenAddress),
-      );
-      expect(rewardTokenEntity).toBeDefined();
-
-      const undefinedToken = await indexer.Token.get(`${chainId}-undefined`);
-      expect(undefinedToken).toBeUndefined();
     });
   });
 });

--- a/test/Helpers.test.ts
+++ b/test/Helpers.test.ts
@@ -14,7 +14,6 @@ import {
   computeLiquidityDeltaFromAmounts,
   computeNonCLStakedUSD,
   concentratedLiquidityToUSD,
-  optionalBigintEffect,
   pickTrustedSwapVolumeUSD,
   runAsyncWithErrorLog,
   sortByBlockThenLogIndex,
@@ -23,24 +22,6 @@ import { setupCommon } from "./EventHandlers/Pool/common";
 
 describe("Helpers", () => {
   const Q96 = 2n ** 96n;
-
-  describe("optionalBigintEffect", () => {
-    it("passes a genuine bigint through unchanged", () => {
-      expect(optionalBigintEffect(500n)).toBe(500n);
-      expect(optionalBigintEffect(0n)).toBe(0n);
-    });
-
-    it("maps undefined to undefined", () => {
-      expect(optionalBigintEffect(undefined)).toBeUndefined();
-    });
-
-    it("maps the envio v3.1.0-rc.x nested-option sentinel (Some(None)) to undefined", () => {
-      // ReScript's runtime encoding of Some(None) for an option<option<bigint>>
-      // — what a cached S.optional(S.bigint) effect leaks on a None cache hit.
-      const sentinel = { BS_PRIVATE_NESTED_SOME_NONE: 0 };
-      expect(optionalBigintEffect(sentinel)).toBeUndefined();
-    });
-  });
 
   describe("sortByBlockThenLogIndex", () => {
     it("should sort by block number ascending when blocks differ", () => {


### PR DESCRIPTION
## Summary

envio **3.1.1** fixes the two 3.1.0-era bugs this repo worked around, so this PR bumps `envio` 3.1.0 → 3.1.1 and removes both workarounds:

1. **Native-decoder param-name collision** → revert #847.
2. **Effect-cache nested-option sentinel leak** → remove the `optionalBigintEffect` helper (the workaround portion of #841).

## 1. Decoder fix → revert #847

In 3.1.0 the native decoder built one param-name table per event *signature* (`sighash + topicCount`) and deduped first-contract-wins, so same-signature events emitted by different contracts decoded under the first contract's param names. 3.1.1 decodes **per-contract**:

- `HyperSyncClient.res` — `Decoder.eventParamsInput` carries `eventName` + `contractName`; `decodeLogs` returns params keyed by contract name.
- `HyperSyncSource.res` — the source picks the resolved contract's entry: `item.params -> Dict.get(_, eventConfig.contractName)`.
- `EvmChain.res` — `collectEventParams` no longer dedupes.

That was the cause of #844: `ClaimRewards(address,address,uint256)` is registered by Fees/BribesVotingReward (`from/reward/amount`) and by SuperchainIncentiveVotingReward (`_sender/_reward/_amount`); under 3.1.0 Fees won, so the superchain contract's `event.params._reward` read `undefined` → `{chainId}-undefined` → a null-address Token write that halted the deploy. #847 worked around it by renaming the ABI inputs to match Fees. With per-contract decoding that's unnecessary and the renamed ABI no longer reflected the real contract, so this restores the real names (`_sender/_reward/_amount`) and reads them directly.

## 2. Effect-cache fix → remove `optionalBigintEffect`

3.1.1's `InMemoryStore.getEffectOutputUnsafe` returns the raw optional output without re-wrapping it in another option, so a cached `None` result for an `S.optional(S.bigint)` effect comes back as plain `undefined` again (as in 3.0.2) instead of the `{ BS_PRIVATE_NESTED_SOME_NONE: 0 }` sentinel; both `LoadManager.call` hit paths resolve with that unwrapped value. That makes the `optionalBigintEffect` coercion a guaranteed no-op, so it's removed and its two consumers — `getSwapFee` (`updateDynamicFeePools`, Pool.ts) and `getTokensDeposited` (VoterCommonLogic.ts) — read the raw effect result directly.

## Verification

- `envio codegen` (3.1.1) regenerates `SuperchainIncentiveVotingReward.ClaimRewards` params as `{ _sender, _reward, _amount }`.
- `tsc --noEmit` clean; `biome check` clean.
- Full suite green at a clean checkout path.

> Heads-up for local runs: `src/Effects/Helpers.ts`'s `getErrorType` matches against `error.stack` as well as the message, so running this from a worktree whose **path contains the substring "revert"** makes constructed-Error stack traces match the `CONTRACT_REVERT` keyword and produces ~14 spurious `test/Effects/*` failures. CI and normal checkouts (no "revert" in the path) are unaffected.

## Related

- Reverts #847. #844 now resolved upstream.
- #846 (parity-CI for divergent param names) closed — made unnecessary (and would misfire) by per-contract decoding.
- #845 / #848 (invalid-address Token guard) closed — the root cause is fixed upstream; the defense-in-depth layer is dropped in favor of the upstream fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)