### PR TITLE
fix(snapshots): TOKEN_PRICE_SNAPSHOT_GAPS — write on every refresh tick (residual of #822)

### DIFF
--- a/src/PriceOracle.ts
+++ b/src/PriceOracle.ts
@@ -197,6 +197,17 @@ export async function refreshTokenPrice(
   // price). RPC cost is bounded by the throttle plus Envio's hourly-rounded
   // effect cache key on `getTokenPrice`. Safe because we always bump
   // `lastUpdatedTimestamp` below, so the throttle advances even on $0 results.
+  //
+  // Issue #863 (audit cross-reference): `refreshTokenPrice` is invoked only
+  // from event handlers — `Aggregators/Pool.ts` (every Swap/Mint/Burn/Sync),
+  // `Voter.ts` / `VotingRewardSharedLogic.ts` (every reward event), and
+  // `CrossChainPendingResolution.ts`. There is no background ticker. A
+  // whitelisted token whose pools see no events for >1 h legitimately produces
+  // no new snapshot in that window — gaps measured against wall-clock time
+  // (the E-2 audit check) are NOT a contract violation unless the token
+  // *also* shows recent event activity (see also #862, where the upstream
+  // cause is the absence of a `refreshTokenPrice` call at all for some
+  // whitelisted-but-inactive tokens).
   const shouldRefresh =
     !healed.lastUpdatedTimestamp ||
     blockTimestampMs - healed.lastUpdatedTimestamp.getTime() >= MS_IN_AN_HOUR;

--- a/test/PriceOracle.test.ts
+++ b/test/PriceOracle.test.ts
@@ -2843,5 +2843,89 @@ describe("PriceOracle", () => {
         },
       );
     });
+
+    // Issue #863 (audit follow-up to #822): the wall-clock E-2 check flags
+    // any whitelisted token whose latest TokenPriceSnapshot is > 2 h old.
+    // That shape is too loose: snapshots fire only on event-driven refresh
+    // ticks, so an inactive token legitimately has no fresh snapshot. The
+    // pair of tests below pins the two halves of the actual #822 contract
+    // — throttle skips snapshot, every event-driven tick on an active token
+    // writes one — so a future refactor that breaks either half is caught.
+    describe("Issue #863: snapshot cadence is per-tick, not wall-clock", () => {
+      const oneHourOneMinuteAgo = () =>
+        new Date(blockDatetime.getTime() - 61 * 60 * 1000);
+
+      beforeEach(() => {
+        vi.mocked(mockContext.Token?.set)?.mockClear();
+        vi.mocked(mockContext.TokenPriceSnapshot?.set)?.mockClear();
+      });
+
+      it("a throttled refresh writes no snapshot — wall-clock gaps on idle tokens are not bugs", async () => {
+        // The throttle return is the spec's sole snapshot-free exit
+        // ("no tick occurred"). E-2's wall-clock probe will flag idle
+        // whitelisted tokens because of this, but that is by design — not
+        // an indexer bug to chase.
+        const thirtyMinutesAgo = new Date(
+          blockDatetime.getTime() - 30 * 60 * 1000,
+        );
+        await PriceOracle.refreshTokenPrice(
+          {
+            ...mockToken0Data,
+            pricePerUSDNew: 2n * 10n ** 18n,
+            lastUpdatedTimestamp: thirtyMinutesAgo,
+          },
+          blockNumber,
+          blockDatetime.getTime() / 1000,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        expect(
+          vi.mocked(mockContext.TokenPriceSnapshot?.set),
+        ).not.toHaveBeenCalled();
+      });
+
+      it("three event-driven refreshes spaced > 1 h apart produce three snapshots", async () => {
+        // Per-event positive case: an *active* token sees one snapshot per
+        // non-throttle tick. The TokenIdByBlock id uses the block number, so
+        // three distinct refreshes at three distinct blocks yield three
+        // distinct snapshot rows.
+        vi.mocked(mockContext.effect)?.mockImplementation(async (effect) => {
+          if ((effect as { name?: string }).name === "getTokenPrice") {
+            return { pricePerUSDNew: 2n * 10n ** 18n };
+          }
+          return {};
+        });
+        const baseTs = blockDatetime.getTime() / 1000;
+
+        let carry: Token = {
+          ...mockToken0Data,
+          pricePerUSDNew: 2n * 10n ** 18n,
+          lastUpdatedTimestamp: oneHourOneMinuteAgo(),
+          lastSuccessfulPriceTimestamp: oneHourOneMinuteAgo(),
+        };
+        // Three ticks, each > 1 h after the previous lastUpdatedTimestamp,
+        // each at a distinct block to exercise per-block snapshot IDs.
+        for (const offsetHours of [0, 2, 4]) {
+          carry = await PriceOracle.refreshTokenPrice(
+            carry,
+            blockNumber + offsetHours,
+            baseTs + offsetHours * 60 * 60,
+            chainId,
+            mockContext as handlerContext,
+          );
+        }
+
+        expect(
+          vi.mocked(mockContext.TokenPriceSnapshot?.set),
+        ).toHaveBeenCalledTimes(3);
+        // Each snapshot uses TokenIdByBlock — three distinct block numbers,
+        // three distinct ids, no per-block collision.
+        const ids = vi
+          .mocked(mockContext.TokenPriceSnapshot?.set)
+          ?.mock.calls.map(([snap]) => snap?.id);
+        expect(new Set(ids).size).toBe(3);
+      });
+    });
   });
 });


### PR DESCRIPTION
Closes #863
References #862

## Summary

The 2026-06-11 external integrity audit's `[TOKEN_PRICE_SNAPSHOT_GAPS]` check (E-2) found 433 whitelisted tokens whose most-recent `TokenPriceSnapshot` is > 2 h old, framed as a residual of #822. I investigated each branch of `refreshTokenPrice` against the #822 contract and found the code already correct — every non-throttle return calls `snapshotTokenPrice` with the right tag, and the parametrized `Issue #822: every non-throttle return emits exactly one tagged snapshot` test (`test/PriceOracle.test.ts:2613`) already machine-enforces the invariant for all nine exit branches (`override`, `rebind`, `pool-implied`, `carried` × 5, `fresh`).

The audit findings are explained by:

1. **Legacy stuck data.** The 4 tokens at exactly `2026-01-20T20:5x` predate the #822 fix entirely — PR #834 (commit `738a110`) landed `2026-06-02`, while the audit baseline was `c9b8978` (`2026-05-22`). Once any new event on those tokens lands post-fix, a snapshot will be written. Data backfill is out of scope.
2. **Inherent design.** `refreshTokenPrice` is invoked only from event handlers (`Aggregators/Pool.ts`, `Voter.ts`, `VotingRewardSharedLogic.ts`, `CrossChainPendingResolution.ts`) — there is no background ticker. A whitelisted token whose pools see no events for > 1 h legitimately has no fresh snapshot. The E-2 audit check encodes a stricter wall-clock SLA than the spec promises; E-1 (Pool) already gates correctly on `activeRecently AND snapshotStale`.
3. **Companion #862 (`TOKEN_PRICE_STUCK`).** For some whitelisted tokens `refreshTokenPrice` is never called at all (no pool activity). That is the upstream defect this issue inherits from — fixing it requires a heal-on-read path for whitelisted-but-never-refreshed tokens, which is #862's scope.

Per the task's stop condition ("if the gaps are caused by indexer downtime / inherent design, open a draft PR"), this PR opens as draft and adds the minimum value-adding documentation + regression guards rather than a non-existent code fix.

## Changes (95 lines: 11 source comment, 84 test)

- **`src/PriceOracle.ts`** — 11-line comment near the throttle short-circuit cross-referencing #863 + #862, so the next reader of an E-2 audit finding doesn't re-investigate. Zero logic change.
- **`test/PriceOracle.test.ts`** — two new regression tests under `Issue #863: snapshot cadence is per-tick, not wall-clock`:
  - throttled refresh writes no snapshot (guards against a well-intentioned wall-clock-heal refactor that would violate the spec)
  - three event-driven refreshes > 1 h apart produce three distinct snapshots (guards the per-block id contract from per-token id collapse)

## Test plan

- [x] `pnpm test` — 1538 / 1539 pass (one unrelated flaky timing test in `Helpers.test.ts` — verified to pass on main HEAD, fails only under parallel load).
- [x] `pnpm exec biome check` — clean across all 278 files.
- [x] `pnpm exec tsc --noEmit` — clean.
- [x] `pnpm exec vitest run test/PriceOracle.test.ts` — 86 / 86 pass (84 existing + 2 new).

## Why draft

The action requested in the issue (a code-side snapshot write fix) is unnecessary — the fix already shipped in #834. This PR captures the investigation + tightens the test guard, but the real follow-ups belong elsewhere:

- The audit script's E-2 check should adopt E-1's `activeRecently AND snapshotStale` gate (separate audit-tooling PR).
- Companion issue #862 needs a heal-on-read path for whitelisted-but-inactive tokens; once that lands, the long-tail of E-2 findings will close.
- Backfill of pre-#834 snapshot history (the Jan-20 cluster) is a data-ops task, not a code change.

Convert to ready-for-review or close as `wontfix` once those decisions are made.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation describing the price refresh function's invocation patterns from event sources, behavior during extended operation gaps, and snapshot recording requirements for whitelisted tokens.

* **Tests**
  * Added comprehensive test coverage for price snapshot behavior, including scenarios with throttled refresh operations and multiple event-driven refresh calls spaced across extended time intervals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->