### PR TITLE
fix(price-oracle): TOKEN_PRICE_STUCK — heal-on-read for whitelisted null-timestamp tokens

### DIFF
--- a/src/PriceOracle.ts
+++ b/src/PriceOracle.ts
@@ -152,6 +152,14 @@ export async function createTokenEntity(
  *   with hourly retries. The fallback covers every oracle generation
  *   (#775 extended it from V3-only to V1/V2 too).
  *
+ * Issue #862: the throttle is bypassed for whitelisted tokens that have never
+ * recorded a successful price write (`isWhitelisted && !lastSuccessfulPriceTimestamp`).
+ * Without the bypass the first $0 read of a freshly-whitelisted token bumps
+ * `lastUpdatedTimestamp` and re-throttles every subsequent event in the same
+ * hour, leaving the token stuck at $0 for as long as the transient condition
+ * persists. The Envio effect cache amortises the extra attempts into one RPC
+ * per hourly block bucket per (chain, token).
+ *
  * When a caller supplies `impliedPriceHint` — a pool-implied USD price derived
  * from the counterparty leg's trusted price (see {@link getPoolImpliedUSD}) —
  * it acts as an independent ground-truth witness against a poisoned anchor:
@@ -193,11 +201,31 @@ export async function refreshTokenPrice(
   // `symbol && name` guard inside {@link healTokenMetadata}.
   const healed = await healTokenMetadata(token, chainId, context);
 
+  // Issue #862: heal-on-read for whitelisted tokens that have never recorded a
+  // successful price write. `isWhitelisted = true` is the protocol's promise of
+  // a reliable on-chain pricing route, so the invariant
+  // `isWhitelisted && lastSuccessfulPriceTimestamp == null` should never hold
+  // once the token has been observed. The throttle below bumps
+  // `lastUpdatedTimestamp` on every attempt (including $0 / fallback / reject
+  // ticks), so a whitelisted token whose very first refresh produced a $0 read
+  // (transient RPC, oracle not deployed, etc.) is otherwise re-throttled on
+  // every subsequent event in the same hour — and once the next hour lands the
+  // pattern can recur if the same transient condition still holds, leaving the
+  // token stuck. Bypassing the throttle on this exact shape (whitelisted AND
+  // never-successful) forces one extra refresh attempt per qualifying event
+  // until the gate finally clears; the Envio effect cache (hourly-rounded
+  // block bucket on `getTokenPrice`) absorbs the redundant work into one RPC
+  // per hour. Bounded by the count of stuck whitelisted tokens (~hundreds at
+  // worst — see audit), not the event firehose.
+  const forceRefreshForStuckWhitelisted =
+    healed.isWhitelisted && !healed.lastSuccessfulPriceTimestamp;
+
   // Issue #676: uniform 1-hour throttle for all tokens (regardless of current
   // price). RPC cost is bounded by the throttle plus Envio's hourly-rounded
   // effect cache key on `getTokenPrice`. Safe because we always bump
   // `lastUpdatedTimestamp` below, so the throttle advances even on $0 results.
   const shouldRefresh =
+    forceRefreshForStuckWhitelisted ||
     !healed.lastUpdatedTimestamp ||
     blockTimestampMs - healed.lastUpdatedTimestamp.getTime() >= MS_IN_AN_HOUR;
 

--- a/test/EventHandlers/Voter/DistributeRewardEmissionsUSD.test.ts
+++ b/test/EventHandlers/Voter/DistributeRewardEmissionsUSD.test.ts
@@ -66,6 +66,11 @@ describe("Voter.DistributeReward → totalEmissionsUSD regression (#673)", () =>
       isWhitelisted: true,
       // Match block timestamp so refreshTokenPrice is a no-op (avoids real RPC).
       lastUpdatedTimestamp: new Date(blockTimestamp * 1000),
+      // Issue #862: required in lockstep with `lastUpdatedTimestamp` for a
+      // whitelisted token carrying a real price — the heal-on-read path
+      // bypasses the throttle when `lastSuccessfulPriceTimestamp` is null,
+      // which would zero out the seeded price.
+      lastSuccessfulPriceTimestamp: new Date(blockTimestamp * 1000),
       ...overrides,
     } as Token;
   }

--- a/test/EventHandlers/VotingReward/BribesVotingReward.test.ts
+++ b/test/EventHandlers/VotingReward/BribesVotingReward.test.ts
@@ -60,6 +60,11 @@ describe("BribesVotingReward Events", () => {
       pricePerUSDNew: 1n * 10n ** 18n, // 1 USD
       isWhitelisted: true,
       lastUpdatedTimestamp: new Date(1000000 * 1000),
+      // Issue #862: a whitelisted token with a real price has, by construction,
+      // had at least one successful oracle write — `lastSuccessfulPriceTimestamp`
+      // must be set in lockstep with `lastUpdatedTimestamp` for the throttle to
+      // preserve `pricePerUSDNew` (the heal-on-read otherwise bypasses it).
+      lastSuccessfulPriceTimestamp: new Date(1000000 * 1000),
     } as Token;
 
     // Set up entities in test indexer

--- a/test/EventHandlers/VotingReward/FeesVotingReward.test.ts
+++ b/test/EventHandlers/VotingReward/FeesVotingReward.test.ts
@@ -58,6 +58,11 @@ describe("FeesVotingReward Events", () => {
       pricePerUSDNew: 1n * 10n ** 18n, // 1 USD
       isWhitelisted: true,
       lastUpdatedTimestamp: new Date(1000000 * 1000),
+      // Issue #862: a whitelisted token with a real price has, by construction,
+      // had at least one successful oracle write — `lastSuccessfulPriceTimestamp`
+      // must be set in lockstep with `lastUpdatedTimestamp` for the throttle to
+      // preserve `pricePerUSDNew` (the heal-on-read otherwise bypasses it).
+      lastSuccessfulPriceTimestamp: new Date(1000000 * 1000),
     } as Token;
 
     // Set up entities in test indexer

--- a/test/EventHandlers/VotingReward/SuperchainIncentiveVotingReward.test.ts
+++ b/test/EventHandlers/VotingReward/SuperchainIncentiveVotingReward.test.ts
@@ -71,6 +71,11 @@ describe("SuperchainIncentiveVotingReward Events", () => {
       pricePerUSDNew: 1n * 10n ** 18n, // 1 USD
       isWhitelisted: true,
       lastUpdatedTimestamp: new Date(1000000 * 1000),
+      // Issue #862: a whitelisted token with a real price has, by construction,
+      // had at least one successful oracle write — `lastSuccessfulPriceTimestamp`
+      // must be set in lockstep with `lastUpdatedTimestamp` for the throttle to
+      // preserve `pricePerUSDNew` (the heal-on-read otherwise bypasses it).
+      lastSuccessfulPriceTimestamp: new Date(1000000 * 1000),
     } as Token;
 
     // Set up entities in test indexer

--- a/test/PriceOracle.test.ts
+++ b/test/PriceOracle.test.ts
@@ -386,6 +386,122 @@ describe("PriceOracle", () => {
       });
     });
 
+    describe("Issue #862: heal-on-read for whitelisted tokens with null lastSuccessfulPriceTimestamp", () => {
+      // The 2026-06-11 integrity audit found 436 whitelisted tokens stuck with
+      // `lastSuccessfulPriceTimestamp = null` despite their `lastUpdatedTimestamp`
+      // having advanced (the 1-hour throttle was bumping the latter on every $0
+      // / fallback / reject tick, leaving the former indefinitely null). The
+      // heal-on-read path bypasses the throttle on this exact shape so the
+      // token can recover the next time any event touches it, instead of
+      // waiting for the next hourly window AND a transient-condition clear.
+      it("bypasses the 1-hour throttle when isWhitelisted and lastSuccessfulPriceTimestamp is null", async () => {
+        vi.mocked(mockContext.Token?.set)?.mockClear();
+        vi.mocked(mockContext.TokenPriceSnapshot?.set)?.mockClear();
+
+        // Throttle would normally apply: lastUpdatedTimestamp 30 minutes ago.
+        const thirtyMinutesAgo = new Date(
+          blockDatetime.getTime() - 30 * 60 * 1000,
+        );
+        const fetchedToken = {
+          ...mockToken0Data,
+          isWhitelisted: true,
+          pricePerUSDNew: 0n,
+          lastUpdatedTimestamp: thirtyMinutesAgo,
+          lastSuccessfulPriceTimestamp: undefined,
+        };
+        const blockTimestamp = blockDatetime.getTime() / 1000;
+
+        await PriceOracle.refreshTokenPrice(
+          fetchedToken,
+          blockNumber,
+          blockTimestamp,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        // Throttle bypassed → oracle was hit and a fresh price persisted.
+        const updatedToken = vi.mocked(mockContext.Token?.set)?.mock
+          .lastCall?.[0] as Token;
+        expect(updatedToken).toBeDefined();
+        expect(updatedToken.pricePerUSDNew).toBe(
+          mockTokenPriceData.pricePerUSDNew,
+        );
+        expect(updatedToken.lastSuccessfulPriceTimestamp).toBeInstanceOf(Date);
+        // Snapshot is written on the non-throttle exit (the fresh oracle path).
+        const snapshot = vi.mocked(mockContext.TokenPriceSnapshot?.set)?.mock
+          .lastCall?.[0];
+        expect(snapshot?.priceSource).toBe("fresh");
+      });
+
+      it("keeps the throttle for whitelisted tokens that have already had a successful price write", async () => {
+        // Negative control: once the heal succeeds, the throttle should re-engage
+        // on subsequent intra-hour events so the indexer doesn't re-hit RPC on
+        // every event for the rest of the hour.
+        vi.mocked(mockContext.Token?.set)?.mockClear();
+        vi.mocked(mockContext.TokenPriceSnapshot?.set)?.mockClear();
+
+        const thirtyMinutesAgo = new Date(
+          blockDatetime.getTime() - 30 * 60 * 1000,
+        );
+        const fetchedToken = {
+          ...mockToken0Data,
+          isWhitelisted: true,
+          pricePerUSDNew: 1n * 10n ** 18n,
+          lastUpdatedTimestamp: thirtyMinutesAgo,
+          // A successful write has already landed → no heal needed.
+          lastSuccessfulPriceTimestamp: thirtyMinutesAgo,
+        };
+        const blockTimestamp = blockDatetime.getTime() / 1000;
+
+        await PriceOracle.refreshTokenPrice(
+          fetchedToken,
+          blockNumber,
+          blockTimestamp,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        expect(vi.mocked(mockContext.Token?.set)).not.toHaveBeenCalled();
+        expect(
+          vi.mocked(mockContext.TokenPriceSnapshot?.set),
+        ).not.toHaveBeenCalled();
+      });
+
+      it("keeps the throttle for non-whitelisted tokens with null lastSuccessfulPriceTimestamp", async () => {
+        // Negative control: the heal is scoped to the WHITELIST × null shape.
+        // Non-whitelisted tokens with null `lastSuccessfulPriceTimestamp` are
+        // common (every fresh token starts there) and the indexer must not
+        // start hitting the oracle on every event for them.
+        vi.mocked(mockContext.Token?.set)?.mockClear();
+        vi.mocked(mockContext.TokenPriceSnapshot?.set)?.mockClear();
+
+        const thirtyMinutesAgo = new Date(
+          blockDatetime.getTime() - 30 * 60 * 1000,
+        );
+        const fetchedToken = {
+          ...mockToken0Data,
+          isWhitelisted: false,
+          pricePerUSDNew: 0n,
+          lastUpdatedTimestamp: thirtyMinutesAgo,
+          lastSuccessfulPriceTimestamp: undefined,
+        };
+        const blockTimestamp = blockDatetime.getTime() / 1000;
+
+        await PriceOracle.refreshTokenPrice(
+          fetchedToken,
+          blockNumber,
+          blockTimestamp,
+          chainId,
+          mockContext as handlerContext,
+        );
+
+        expect(vi.mocked(mockContext.Token?.set)).not.toHaveBeenCalled();
+        expect(
+          vi.mocked(mockContext.TokenPriceSnapshot?.set),
+        ).not.toHaveBeenCalled();
+      });
+    });
+
     describe("Override path: blacklist + rebind (issue #669)", () => {
       // Issue #669: tokens whose on-chain oracle is structurally unusable get
       // either forced to 0 (blacklist) or copied from another chain's already-


### PR DESCRIPTION
Closes #862

## Summary

The 1-hour throttle in `refreshTokenPrice` is gated on `lastUpdatedTimestamp`, which advances on every refresh attempt (including $0, fallback, and reject ticks). A whitelisted token whose very first oracle read returns 0 — transient RPC failure, oracle not yet deployed, broken pricing connector — lands with `lastSuccessfulPriceTimestamp` still null but `lastUpdatedTimestamp` bumped. Every subsequent event in the same hour is then re-throttled, and if the transient condition persists past the hour, the pattern recurs. The 2026-06-11 external integrity audit (`G-3 STALE` check) found **436 whitelisted tokens** (71 Optimism + 365 Base) frozen in this shape, biasing every downstream USD aggregate they appear in.

The fix is a single boolean OR'd into `shouldRefresh`: when `isWhitelisted && !lastSuccessfulPriceTimestamp`, bypass the throttle so the next event forces a fresh refresh attempt. The invariant `isWhitelisted == true && lastSuccessfulPriceTimestamp == null` is a contradiction in the protocol's promise (whitelisting attests to a reliable on-chain pricing route), so the bypass condition is exact — it fires only on the broken-shape tokens, not on the steady-state hot path. The Envio effect cache (hourly-rounded block bucket on `getTokenPrice`) amortises any redundant attempts into one RPC per (chain, token) per hour, so RPC cost stays bounded by the count of stuck whitelisted tokens (~hundreds at worst per the audit), not the event firehose.

## Changes

- **`src/PriceOracle.ts`** (+28 lines, ~3 lines of actual logic): heal-on-read bypass for the throttle when the invariant violation is detected.
- **`test/PriceOracle.test.ts`** (+116 lines): new `describe` block covering the positive case (whitelisted + null-timestamp + intra-hour event → forced refresh) and two negative controls (whitelisted + non-null timestamp stays throttled; non-whitelisted + null timestamp stays throttled).
- **4 fixture files** (5 lines each): `BribesVotingReward`, `FeesVotingReward`, `SuperchainIncentiveVotingReward`, and `DistributeRewardEmissionsUSD` constructed mock reward tokens with `isWhitelisted: true`, a real `pricePerUSDNew`, but no `lastSuccessfulPriceTimestamp` — the exact production invariant violation this fix targets, so the fixtures had to be aligned (set `lastSuccessfulPriceTimestamp` in lockstep with `lastUpdatedTimestamp`) for the throttle to preserve their seeded prices.

## Relationship to #863 (`TOKEN_PRICE_SNAPSHOT_GAPS`)

The companion issue #863 found **433 whitelisted tokens** with `TokenPriceSnapshot` rows more than 2 h stale. The post-#822 contract is that every non-throttle tick writes a snapshot row — so a snapshot gap means either `refreshTokenPrice` never ran or it was throttled.

For tokens that were **stuck in the throttle window because of the null-timestamp shape**, this fix also resolves the snapshot gap: bypassing the throttle re-engages the snapshot write that #822 added. The top-of-the-list cases in #863 (the four tokens frozen at 2026-01-20 20:50 UTC for 142 days, several others at 100+ days) overlap with #862's null-timestamp list, so once #862 unblocks those tokens, #863 will heal in lockstep.

For tokens whose snapshot gap stems from a different cause (e.g. the four-at-once 2026-01-20 cluster suggesting an indexer-side processing failure in that window), #863 will need separate investigation. So this PR partially resolves #863 — the overlap subset — but is not a full close. The remaining #863 work is a deployment-incident-log cross-reference, which is operational rather than a code change.

## Test plan

- [x] `pnpm test` — all 1540 tests pass on this branch (4 fixture files were updated; see Changes above).
- [x] `pnpm exec biome check` — clean.
- [x] `pnpm exec tsc --noEmit` — clean.
- [x] Verified the new test fails without the source fix (positive test → `expected undefined to be defined`).
- [x] Verified the two negative controls (whitelisted with real `lastSuccessfulPriceTimestamp`; non-whitelisted with null) still pass without the fix — proving the bypass is scoped correctly to the broken shape, not a wholesale throttle disablement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)