### PR TITLE
fix(audit): BASE_NFPM_GAP_795 — use real Base NFPM address

### DIFF
--- a/scripts/integrity-audit.ts
+++ b/scripts/integrity-audit.ts
@@ -60,9 +60,14 @@ const NEG_TLU_EXEMPT: ReadonlySet<string> = new Set([
   `8453-${toChecksumAddress("0x8Eea4BC2c84167ECF54Bef4d0bbd7eD0CE558686")}`,
 ]);
 
-// Base NFPM at the centre of the #795 indexing-gap fix.
+// Base NFPM at the centre of the #795 indexing-gap fix. This is the real
+// on-chain NFPM paired with CLFactory 0x9592CD9B…d51B ("Another CL") — same
+// address registered in config.yaml's Base NFPM block and CL_FACTORY_TO_NFPM
+// (src/Constants.ts). Previously this constant held an unrelated dead address
+// (no bytecode on Base), which caused the probe to always report 0 rows and
+// fire a false-positive [BASE_NFPM_GAP_795] regression (#858).
 const BASE_NFPM_795 = toChecksumAddress(
-  "0xc741beb2Bd293f8acfA8d4D02B58FB22a6d8aF54",
+  "0xc741beb2156827704A1466575ccA1cBf726a1178",
 );
 
 // Metal Hyperlane domain that should map to chainId 1750 (#811).


### PR DESCRIPTION
## Summary

The `BASE_NFPM_795` constant in `scripts/integrity-audit.ts` pointed at `0xc741beb2Bd293f8acfA8d4D02B58FB22a6d8aF54` — an address with **no bytecode on Base** (verified via `eth_getCode` on `mainnet.base.org` and `base-rpc.publicnode.com`, both return `0x`). The real Base NFPM paired with CLFactory `0x9592CD9B…d51B` ("Another CL") is `0xc741beb2156827704A1466575ccA1cBf726a1178` — already registered in:

- `config.yaml:355` (Base NFPM address list, added by #795)
- `src/Constants.ts:147` (`CL_FACTORY_TO_NFPM`)
- `test/Constants.test.ts:54` (`BASE_NFPM_V3`)

A live GraphQL query against the NEW deployment confirms 1000+ `NonFungiblePosition` rows already exist for the real address. The probe's typo just happened to share the first 8 hex chars (`c741beb2`), so the audit kept reporting a permanent false-positive `[BASE_NFPM_GAP_795]` NEW_REGRESSION even though #795's fix is working as intended.

Closes #858.

## Test plan

- [x] `eth_getCode` for the typo address returns `0x` on Base (two RPC endpoints)
- [x] `eth_getCode` for the real address returns ~49 KB of bytecode
- [x] GraphQL query for `NonFungiblePosition(chainId:8453, nfpmAddress:0xc741beb2156827704A1466575ccA1cBf726a1178)` on NEW returns 1000+ rows
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec biome check scripts/integrity-audit.ts` clean
- [x] `pnpm exec vitest run test/Constants.test.ts` — 70/70 green (`BASE_NFPM_V3` parity continues to hold)

Stacked on #859 (this branch only exists there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)