### PR TITLE
fix(cl-staked): NEG_STAKED_RESERVE_GUARD — clamp stakedReserve_i to reserve_i

### DIFF
--- a/src/Aggregators/Pool.ts
+++ b/src/Aggregators/Pool.ts
@@ -62,8 +62,10 @@ const NEG_STAKED_RESERVE_WARN_FLOOR_USD = 1_000n * TEN_TO_THE_18_BI;
  * @param msg - Pre-formatted clamp message. Content is unchanged across both
  *   log channels per #802 AC (poolAddress, chainId, priorStakedReserve,
  *   delta, clampedTo).
- * @param overshoot - Positive raw-unit magnitude of the discarded overshoot
- *   (= `-stakedReserveSum` since `stakedReserveSum < 0n`).
+ * @param overshoot - Positive raw-unit magnitude of the discarded overshoot.
+ *   For the lower-bound clamp (#771), this is `-stakedReserveSum` since
+ *   `stakedReserveSum < 0n`. For the upper-bound clamp (#854,
+ *   `stakedReserve_i > reserve_i`), this is `stakedReserve_i - reserve_i`.
  * @param tokenId - Pool's token entity ID for the field that overflowed
  *   (`token0_id` for stakedReserve0, `token1_id` for stakedReserve1).
  * @param context - Handler context for Token entity load and log emission.
@@ -474,6 +476,40 @@ export async function updatePool(
     );
   }
 
+  // Upper-bound clamp: staked reserves are a SUBSET of total reserves and
+  // must not exceed them (issue #854). `reserve0/1` and `stakedReserve0/1`
+  // accumulate via independent calls to `divRoundNearest` per-segment math —
+  // one over the pool's total tick-edge map (#803), one over the staked-only
+  // map (#666) — so their wei-scale rounding residues drift in different
+  // directions and can leave `stakedReserve_i > reserve_i` on full-drain
+  // swaps. Mirrors the lower-bound clamp above (#771); same accumulator-noise
+  // assumption (per-segment exact-when-rounded), same clamp-and-log shape,
+  // same USD-magnitude split for the log channel via `logNegStakedReserveGuard`.
+  const finalStakedReserve0 =
+    clampedStakedReserve0 > clampedReserve0
+      ? clampedReserve0
+      : clampedStakedReserve0;
+  if (clampedStakedReserve0 > clampedReserve0) {
+    await logNegStakedReserveGuard(
+      `[OVER_STAKED_RESERVE_GUARD][updatePool] field=stakedReserve0 poolAddress=${current.poolAddress} chainId=${current.chainId} priorStakedReserve=${current.stakedReserve0 ?? 0n} delta=${stakedReserve0Delta} reserve=${clampedReserve0} clampedTo=${finalStakedReserve0}`,
+      clampedStakedReserve0 - clampedReserve0,
+      current.token0_id,
+      context,
+    );
+  }
+  const finalStakedReserve1 =
+    clampedStakedReserve1 > clampedReserve1
+      ? clampedReserve1
+      : clampedStakedReserve1;
+  if (clampedStakedReserve1 > clampedReserve1) {
+    await logNegStakedReserveGuard(
+      `[OVER_STAKED_RESERVE_GUARD][updatePool] field=stakedReserve1 poolAddress=${current.poolAddress} chainId=${current.chainId} priorStakedReserve=${current.stakedReserve1 ?? 0n} delta=${stakedReserve1Delta} reserve=${clampedReserve1} clampedTo=${finalStakedReserve1}`,
+      clampedStakedReserve1 - clampedReserve1,
+      current.token1_id,
+      context,
+    );
+  }
+
   let updated: Pool = {
     ...current,
     // Handle cumulative fields by adding diff values to current values
@@ -590,8 +626,8 @@ export async function updatePool(
       (diff.incrementalLiquidityInRange ?? 0n) +
         (current.liquidityInRange ?? 0n),
     stakedLiquidityInRange: clampedStakedLiquidityInRange,
-    stakedReserve0: clampedStakedReserve0,
-    stakedReserve1: clampedStakedReserve1,
+    stakedReserve0: finalStakedReserve0,
+    stakedReserve1: finalStakedReserve1,
     // Monotonic latch: once a pool has ever been staked, hasStakes stays true
     // even if the diff doesn't explicitly re-assert it.
     hasStakes: current.hasStakes || (diff.hasStakes ?? false),

--- a/test/Aggregators/Pool.test.ts
+++ b/test/Aggregators/Pool.test.ts
@@ -748,6 +748,13 @@ describe("Pool Functions", () => {
           {
             ...(liquidityPoolAggregator as Pool),
             isCL: true,
+            // reserve0/1 set above stakedReserve0/1 to satisfy the #854
+            // upper-bound invariant (staked is a subset of total); without
+            // this the new OVER_STAKED_RESERVE_GUARD would clamp the
+            // unrelated stakedReserve1 down to 0 and mask the lower-bound
+            // assertion under test.
+            reserve0: 10_000n,
+            reserve1: 10_000n,
             stakedReserve0: 50n,
             stakedReserve1: 1000n,
             lastSnapshotTimestamp: sameEpochAsTimestamp(),
@@ -784,6 +791,10 @@ describe("Pool Functions", () => {
           {
             ...(liquidityPoolAggregator as Pool),
             isCL: true,
+            // reserve0/1 set above stakedReserve0/1 to satisfy the #854
+            // upper-bound invariant; see sibling test for rationale.
+            reserve0: 10_000n,
+            reserve1: 10_000n,
             stakedReserve0: 1000n,
             stakedReserve1: 50n,
             lastSnapshotTimestamp: sameEpochAsTimestamp(),
@@ -813,6 +824,10 @@ describe("Pool Functions", () => {
           {
             ...(liquidityPoolAggregator as Pool),
             isCL: true,
+            // reserve0/1 set above stakedReserve0/1 to satisfy the #854
+            // upper-bound invariant; see sibling tests for rationale.
+            reserve0: 10_000n,
+            reserve1: 10_000n,
             stakedReserve0: 100n,
             stakedReserve1: 100n,
             lastSnapshotTimestamp: sameEpochAsTimestamp(),
@@ -1041,6 +1056,99 @@ describe("Pool Functions", () => {
         expect(lastSet().stakedReserve0).toBe(0n);
         expect(negStakedReserveGuardLogs("info").length).toBe(1);
         expect(negStakedReserveGuardLogs("warn").length).toBe(0);
+      });
+    });
+
+    // Regression test for issue #854: stakedReserve0/1 must never exceed
+    // reserve0/1 (staked is a subset of total). The total-reserve and
+    // staked-reserve accumulators run independent `divRoundNearest`
+    // per-segment passes — over the pool's full tick map (#803) and the
+    // staked-only map (#666) respectively — so their wei-scale rounding
+    // residues can leave `stakedReserve_i > reserve_i` on full-drain swaps.
+    // The upper-bound clamp at the accumulator path clamps
+    // `stakedReserve_i = min(stakedReserve_i, reserve_i)` and emits
+    // [OVER_STAKED_RESERVE_GUARD] with the same USD-magnitude log-level
+    // split as the lower-bound clamp (#771 / #802).
+    describe("over-staked reserve clamp guard (issue #854)", () => {
+      const sameEpochAsTimestamp = () => timestamp;
+
+      const overStakedReserveGuardLogs = (level: "warn" | "info") => {
+        const mock = vi.mocked(mockContext.log?.[level]);
+        const calls = mock?.mock.calls ?? [];
+        return calls.filter((args) =>
+          String(args[0] ?? "").includes("[OVER_STAKED_RESERVE_GUARD]"),
+        );
+      };
+
+      const lastSet = (): Pool => {
+        const setMock = vi.mocked(mockContext.Pool?.set);
+        return setMock?.mock.lastCall?.[0] as Pool;
+      };
+
+      it("clamps stakedReserve1 to reserve1 when wei-scale rounding leaves staked > total (reproduces 10-0x844B drift)", async () => {
+        // Field values lifted from the deployed-indexer snapshot reported in
+        // #854 (10-0x844BdA8C…): reserve1=1.8e22, stakedReserve1 drifts ~3.9e15
+        // above it. With a 0-delta update the upper-bound clamp must pull
+        // stakedReserve1 back down to reserve1, matching the on-chain invariant.
+        const reserve1 = 18425260124867999206688n;
+        const priorStakedReserve1 = 18425264052148983809444n;
+        await updatePool(
+          {},
+          {
+            ...(liquidityPoolAggregator as Pool),
+            isCL: true,
+            reserve0: 24670167986310698043n,
+            reserve1,
+            stakedReserve0: 24492612720183636798n,
+            stakedReserve1: priorStakedReserve1,
+            lastSnapshotTimestamp: sameEpochAsTimestamp(),
+            lastUpdatedTimestamp: sameEpochAsTimestamp(),
+          },
+          timestamp,
+          mockContext as handlerContext,
+          8453,
+          blockNumber,
+        );
+
+        // Invariant restored: staked ≤ total on both legs.
+        expect(lastSet().stakedReserve1).toBe(reserve1);
+        expect(lastSet().stakedReserve0).toBeLessThanOrEqual(
+          lastSet().reserve0,
+        );
+        // Single guard fires (token unpriced → safe-degrade to info per #802).
+        const infoLogs = overStakedReserveGuardLogs("info");
+        expect(infoLogs.length).toBe(1);
+        expect(overStakedReserveGuardLogs("warn").length).toBe(0);
+        const msg = String(infoLogs[0]?.[0] ?? "");
+        expect(msg).toContain("stakedReserve1");
+        expect(msg).toContain(`priorStakedReserve=${priorStakedReserve1}`);
+        expect(msg).toContain(`reserve=${reserve1}`);
+        expect(msg).toContain(`clampedTo=${reserve1}`);
+      });
+
+      it("does not clamp or log when stakedReserves stay <= reserves", async () => {
+        await updatePool(
+          {},
+          {
+            ...(liquidityPoolAggregator as Pool),
+            isCL: true,
+            reserve0: 1000n,
+            reserve1: 1000n,
+            stakedReserve0: 500n,
+            stakedReserve1: 800n,
+            lastSnapshotTimestamp: sameEpochAsTimestamp(),
+            lastUpdatedTimestamp: sameEpochAsTimestamp(),
+          },
+          timestamp,
+          mockContext as handlerContext,
+          8453,
+          blockNumber,
+        );
+
+        expect(lastSet().stakedReserve0).toBe(500n);
+        expect(lastSet().stakedReserve1).toBe(800n);
+        expect(overStakedReserveGuardLogs("warn").length).toBe(0);
+        expect(overStakedReserveGuardLogs("info").length).toBe(0);
       });
     });
 


### PR DESCRIPTION
Closes #854

## Root cause

`reserve0/1` and `stakedReserve0/1` accumulate via two independent passes of `divRoundNearest` per-segment math — one over the pool's full tick-edge map (#803), one over the staked-only map (#666). Their wei-scale rounding residues drift in different directions, so on full-drain swaps the staked side can end up slightly above the total. The 2026-06-10 audit found this on 10 residual CL pools after #732 / #771 / #666 / #780 / #802 had each closed adjacent failure modes.

Confirmed live on the deployed indexer (`indexer.us.hyperindex.xyz/e38a72a`):

| pool | reserve1 | stakedReserve1 | drift |
| --- | --- | --- | --- |
| `10-0x844BdA8C…` | 1.8425e22 | 1.8425e22 | +3.93e15 wei |
| `8453-0x2ae9DF02…` | 3.3964e20 | 3.3964e20 | +1.90e14 wei |

Magnitudes are wei-scale against ~1e20–1e22 reserves — consistent with accumulator-divergence, not real liquidity imbalance (same population shape as #771's lower-bound clamp).

## Fix

Mirror the existing #771 / #802 lower-bound clamp shape at the upper bound: clamp `stakedReserve_i = min(stakedReserve_i, reserve_i)` at the accumulator path in `updatePool` (`src/Aggregators/Pool.ts`), and log under `[OVER_STAKED_RESERVE_GUARD]` reusing `logNegStakedReserveGuard` so the same USD-magnitude split (`info` ≤ \$1k, `warn` > \$1k) keeps benign rounding residue off the warn channel.

## Test plan

- [x] `pnpm exec vitest run test/Aggregators/Pool.test.ts` — 65 pass (62 prior + 2 new for #854 + 1 incidental). New regression test reproduces the deployed `10-0x844BdA8C…` drift with `reserve1=1.8425e22` and `stakedReserve1` already drifted ~3.93e15 above; without the production fix the assertion `stakedReserve1 === reserve1` fails (the prior code would persist the unclamped value).
- [x] `pnpm exec tsc --noEmit` clean.
- [x] `pnpm exec biome check` clean across all 281 files.
- [ ] Full `pnpm test` (running in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)