### PR TITLE
fix(user-stats): V2_LP_RAW_UNPOPULATED — skip gauge side of LP transfers (#850)

### DIFF
--- a/src/EventHandlers/Pool/PoolTransferLogic.ts
+++ b/src/EventHandlers/Pool/PoolTransferLogic.ts
@@ -58,7 +58,15 @@ export async function updatePoolTotalSupply(
 }
 
 /**
- * Update user LP balances based on transfer type (mint, burn, or regular transfer)
+ * Update user LP balances based on transfer type (mint, burn, or regular transfer).
+ *
+ * Skips any side of the transfer whose address equals the pool's `gaugeAddress`:
+ * the gauge holds LP tokens on behalf of stakers, so treating it as a user
+ * created phantom UserStatsPerPool rows with `lpBalance > 0` and
+ * `totalLiquidityAdded*` = 0 (issue #850). Real per-user stake accounting
+ * already happens via `Gauge.Deposit`/`Withdraw` in
+ * `src/EventHandlers/Gauges/GaugeSharedLogic.ts`. Mirrors the CL filter
+ * `isGaugeTransfer` in `src/EventHandlers/NFPM/NFPMTransferLogic.ts`.
  * @param isMint - Whether this is a mint transfer (from == 0x0)
  * @param isBurn - Whether this is a burn transfer (to == 0x0)
  * @param from - Transfer sender address
@@ -68,6 +76,7 @@ export async function updatePoolTotalSupply(
  * @param chainId - Chain ID
  * @param context - Handler context
  * @param timestamp - Event timestamp
+ * @param gaugeAddress - Pool's gauge address (undefined if no gauge); used to skip gauge sides
  */
 export async function updateUserLpBalances(
   isMint: boolean,
@@ -79,9 +88,14 @@ export async function updateUserLpBalances(
   chainId: number,
   context: handlerContext,
   timestamp: Date,
+  gaugeAddress?: string,
 ): Promise<void> {
+  const isGauge = (addr: string): boolean =>
+    gaugeAddress !== undefined && addr === gaugeAddress;
+
   if (isMint) {
-    // Mint: add to recipient
+    // Mint: add to recipient (skip if recipient is the gauge; #850)
+    if (isGauge(to)) return;
     const recipientData = await loadOrCreateUserData(
       to,
       poolAddress,
@@ -97,7 +111,8 @@ export async function updateUserLpBalances(
 
     await updateUserStatsPerPool(userDiff, recipientData, context, timestamp);
   } else if (isBurn) {
-    // Burn: subtract from sender
+    // Burn: subtract from sender (skip if sender is the gauge; #850)
+    if (isGauge(from)) return;
     const senderData = await loadOrCreateUserData(
       from,
       poolAddress,
@@ -113,9 +128,10 @@ export async function updateUserLpBalances(
 
     await updateUserStatsPerPool(userDiff, senderData, context, timestamp);
   } else {
-    // Regular transfer: update both
+    // Regular transfer: update both (each side independently skipped if gauge; #850)
     // Handle self-transfer case (from === to) to avoid conflicting updates
     if (from.toLowerCase() === to.toLowerCase()) {
+      if (isGauge(from)) return;
       // Self-transfer: only update lastActivityTimestamp, balance remains unchanged
       const userData = await loadOrCreateUserData(
         from,
@@ -133,24 +149,55 @@ export async function updateUserLpBalances(
       await updateUserStatsPerPool(userDiff, userData, context, timestamp);
     } else {
       // Regular transfer between different addresses
-      const [senderData, recipientData] = await Promise.all([
-        loadOrCreateUserData(from, poolAddress, chainId, context, timestamp),
-        loadOrCreateUserData(to, poolAddress, chainId, context, timestamp),
-      ]);
+      const fromIsGauge = isGauge(from);
+      const toIsGauge = isGauge(to);
 
-      const userDiffFrom = {
-        incrementalLpBalance: -value,
-        lastActivityTimestamp: timestamp,
-      };
-      const userDiffTo = {
-        incrementalLpBalance: value,
-        lastActivityTimestamp: timestamp,
-      };
-
-      await Promise.all([
-        updateUserStatsPerPool(userDiffFrom, senderData, context, timestamp),
-        updateUserStatsPerPool(userDiffTo, recipientData, context, timestamp),
-      ]);
+      const promises: Promise<unknown>[] = [];
+      if (!fromIsGauge) {
+        promises.push(
+          (async () => {
+            const senderData = await loadOrCreateUserData(
+              from,
+              poolAddress,
+              chainId,
+              context,
+              timestamp,
+            );
+            await updateUserStatsPerPool(
+              {
+                incrementalLpBalance: -value,
+                lastActivityTimestamp: timestamp,
+              },
+              senderData,
+              context,
+              timestamp,
+            );
+          })(),
+        );
+      }
+      if (!toIsGauge) {
+        promises.push(
+          (async () => {
+            const recipientData = await loadOrCreateUserData(
+              to,
+              poolAddress,
+              chainId,
+              context,
+              timestamp,
+            );
+            await updateUserStatsPerPool(
+              {
+                incrementalLpBalance: value,
+                lastActivityTimestamp: timestamp,
+              },
+              recipientData,
+              context,
+              timestamp,
+            );
+          })(),
+        );
+      }
+      await Promise.all(promises);
     }
   }
 }
@@ -264,7 +311,8 @@ export async function processPoolTransfer(
     event.block.number,
   );
 
-  // 2. Update user LP balances
+  // 2. Update user LP balances (skip the gauge side to avoid phantom
+  // UserStatsPerPool rows for the staking contract itself; #850)
   await updateUserLpBalances(
     isMint,
     isBurn,
@@ -275,6 +323,7 @@ export async function processPoolTransfer(
     chainId,
     context,
     timestamp,
+    liquidityPoolAggregator.gaugeAddress ?? undefined,
   );
 
   // 3. Store transfer in temporary entity for Mint/Burn matching

--- a/test/EventHandlers/Pool/PoolTransferLogic.test.ts
+++ b/test/EventHandlers/Pool/PoolTransferLogic.test.ts
@@ -301,6 +301,170 @@ describe("PoolTransferLogic", () => {
         TIMESTAMP_DATE,
       );
     });
+
+    // Regression: issue #850. Without the gauge-address filter, depositing
+    // (Transfer from USER → GAUGE) or withdrawing (GAUGE → USER) LP tokens
+    // would create a phantom UserStatsPerPool row keyed on the gauge contract
+    // with `lpBalance > 0` and `totalLiquidityAdded* = 0`. Per-user stake
+    // accounting already happens via Gauge.Deposit/Withdraw — the gauge is
+    // not a user.
+    describe("gauge filtering (#850)", () => {
+      const GAUGE_ADDRESS = toChecksumAddress(
+        "0x4444444444444444444444444444444444444444",
+      );
+
+      it("should skip the recipient when MINT credits the gauge", async () => {
+        await updateUserLpBalances(
+          true, // isMint
+          false, // isBurn
+          ZERO_ADDRESS,
+          GAUGE_ADDRESS, // mint-to-gauge edge case
+          LP_VALUE,
+          POOL_ADDRESS,
+          CHAIN_ID,
+          mockContext,
+          TIMESTAMP_DATE,
+          GAUGE_ADDRESS,
+        );
+
+        expect(loadOrCreateUserDataSpy).not.toHaveBeenCalled();
+        expect(updateUserStatsPerPoolSpy).not.toHaveBeenCalled();
+      });
+
+      it("should skip the sender when BURN debits the gauge", async () => {
+        await updateUserLpBalances(
+          false, // isMint
+          true, // isBurn
+          GAUGE_ADDRESS, // burn-from-gauge edge case
+          ZERO_ADDRESS,
+          LP_VALUE,
+          POOL_ADDRESS,
+          CHAIN_ID,
+          mockContext,
+          TIMESTAMP_DATE,
+          GAUGE_ADDRESS,
+        );
+
+        expect(loadOrCreateUserDataSpy).not.toHaveBeenCalled();
+        expect(updateUserStatsPerPoolSpy).not.toHaveBeenCalled();
+      });
+
+      it("should update only the user (not the gauge) when staking: USER -> GAUGE", async () => {
+        await updateUserLpBalances(
+          false, // isMint
+          false, // isBurn
+          USER_ADDRESS,
+          GAUGE_ADDRESS, // stake: user transfers LP to gauge
+          LP_VALUE,
+          POOL_ADDRESS,
+          CHAIN_ID,
+          mockContext,
+          TIMESTAMP_DATE,
+          GAUGE_ADDRESS,
+        );
+
+        expect(loadOrCreateUserDataSpy).toHaveBeenCalledTimes(1);
+        expect(loadOrCreateUserDataSpy).toHaveBeenCalledWith(
+          USER_ADDRESS,
+          POOL_ADDRESS,
+          CHAIN_ID,
+          mockContext,
+          TIMESTAMP_DATE,
+        );
+        expect(updateUserStatsPerPoolSpy).toHaveBeenCalledTimes(1);
+        expect(updateUserStatsPerPoolSpy).toHaveBeenCalledWith(
+          expect.objectContaining({ incrementalLpBalance: -LP_VALUE }),
+          expect.anything(),
+          mockContext,
+          TIMESTAMP_DATE,
+        );
+      });
+
+      it("should update only the user (not the gauge) when unstaking: GAUGE -> USER", async () => {
+        await updateUserLpBalances(
+          false, // isMint
+          false, // isBurn
+          GAUGE_ADDRESS, // unstake: gauge transfers LP back to user
+          USER_ADDRESS,
+          LP_VALUE,
+          POOL_ADDRESS,
+          CHAIN_ID,
+          mockContext,
+          TIMESTAMP_DATE,
+          GAUGE_ADDRESS,
+        );
+
+        expect(loadOrCreateUserDataSpy).toHaveBeenCalledTimes(1);
+        expect(loadOrCreateUserDataSpy).toHaveBeenCalledWith(
+          USER_ADDRESS,
+          POOL_ADDRESS,
+          CHAIN_ID,
+          mockContext,
+          TIMESTAMP_DATE,
+        );
+        expect(updateUserStatsPerPoolSpy).toHaveBeenCalledTimes(1);
+        expect(updateUserStatsPerPoolSpy).toHaveBeenCalledWith(
+          expect.objectContaining({ incrementalLpBalance: LP_VALUE }),
+          expect.anything(),
+          mockContext,
+          TIMESTAMP_DATE,
+        );
+      });
+
+      it("should skip a self-transfer when both sides are the gauge", async () => {
+        await updateUserLpBalances(
+          false, // isMint
+          false, // isBurn
+          GAUGE_ADDRESS,
+          GAUGE_ADDRESS,
+          LP_VALUE,
+          POOL_ADDRESS,
+          CHAIN_ID,
+          mockContext,
+          TIMESTAMP_DATE,
+          GAUGE_ADDRESS,
+        );
+
+        expect(loadOrCreateUserDataSpy).not.toHaveBeenCalled();
+        expect(updateUserStatsPerPoolSpy).not.toHaveBeenCalled();
+      });
+
+      it("should still update both sides on a regular transfer when neither side is the gauge", async () => {
+        await updateUserLpBalances(
+          false, // isMint
+          false, // isBurn
+          USER_ADDRESS,
+          RECIPIENT_ADDRESS,
+          LP_VALUE,
+          POOL_ADDRESS,
+          CHAIN_ID,
+          mockContext,
+          TIMESTAMP_DATE,
+          GAUGE_ADDRESS,
+        );
+
+        expect(loadOrCreateUserDataSpy).toHaveBeenCalledTimes(2);
+        expect(updateUserStatsPerPoolSpy).toHaveBeenCalledTimes(2);
+      });
+
+      it("should preserve current behaviour when gaugeAddress is undefined (no gauge wired yet)", async () => {
+        await updateUserLpBalances(
+          false, // isMint
+          false, // isBurn
+          USER_ADDRESS,
+          RECIPIENT_ADDRESS,
+          LP_VALUE,
+          POOL_ADDRESS,
+          CHAIN_ID,
+          mockContext,
+          TIMESTAMP_DATE,
+          undefined,
+        );
+
+        expect(loadOrCreateUserDataSpy).toHaveBeenCalledTimes(2);
+        expect(updateUserStatsPerPoolSpy).toHaveBeenCalledTimes(2);
+      });
+    });
   });
 
   describe("storeTransferForMatching", () => {
@@ -471,6 +635,49 @@ describe("PoolTransferLogic", () => {
       );
 
       expect(updateUserStatsPerPoolSpy).toHaveBeenCalledTimes(2); // Both sender and recipient
+      expect(mockContext.PoolTransferInTx.set).not.toHaveBeenCalled();
+    });
+
+    // Regression: issue #850. End-to-end check that a gauge-stake Transfer
+    // (USER → GAUGE) routed through processPoolTransfer threads the pool's
+    // gaugeAddress into updateUserLpBalances and only credits the user.
+    it("should skip the gauge side when processing a stake Transfer (USER -> GAUGE) [#850]", async () => {
+      const GAUGE_ADDRESS = toChecksumAddress(
+        "0x4444444444444444444444444444444444444444",
+      );
+      const event = createMockTransferEvent(
+        USER_ADDRESS,
+        GAUGE_ADDRESS,
+        LP_VALUE,
+      );
+
+      await processPoolTransfer(
+        event,
+        { ...mockPool, gaugeAddress: GAUGE_ADDRESS },
+        POOL_ADDRESS,
+        CHAIN_ID,
+        mockContext,
+        TIMESTAMP_DATE,
+      );
+
+      // Pool totalLPTokenSupply is not touched on regular transfers.
+      expect(updatePoolSpy).not.toHaveBeenCalled();
+      // Only the user side is credited; the gauge side is skipped.
+      expect(loadOrCreateUserDataSpy).toHaveBeenCalledTimes(1);
+      expect(loadOrCreateUserDataSpy).toHaveBeenCalledWith(
+        USER_ADDRESS,
+        POOL_ADDRESS,
+        CHAIN_ID,
+        mockContext,
+        TIMESTAMP_DATE,
+      );
+      expect(updateUserStatsPerPoolSpy).toHaveBeenCalledTimes(1);
+      expect(updateUserStatsPerPoolSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ incrementalLpBalance: -LP_VALUE }),
+        expect.anything(),
+        mockContext,
+        TIMESTAMP_DATE,
+      );
       expect(mockContext.PoolTransferInTx.set).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
Closes #850

## Summary

V2 LP transfers between a user and the gauge are not "user activity" — the gauge holds LP tokens on behalf of stakers, with real per-user stake accounting done via `Gauge.Deposit`/`Withdraw` in `src/EventHandlers/Gauges/GaugeSharedLogic.ts`.

`PoolTransferLogic.updateUserLpBalances` was treating the gauge as a user, which produced phantom `UserStatsPerPool` rows with `lpBalance > 0` (from the transfer being credited) and `totalLiquidityAddedToken0/1 = 0` (because no `IncreaseLiquidity` or direct `Mint` ever fires for the gauge). The 378/600 sampled V2 LPs flagged by #850 are this phantom set.

Mirrors the CL filter `isGaugeTransfer` in `NFPM/NFPMTransferLogic.ts`: when either side of a `Transfer` equals the pool's `gaugeAddress`, skip the user-stats write for that side.

## Changes

- `src/EventHandlers/Pool/PoolTransferLogic.ts` — +71/-22 (gauge skip + JSDoc + plumb `gaugeAddress` through `updateUserLpBalances`)
- `test/EventHandlers/Pool/PoolTransferLogic.test.ts` — +207 (regression suite: mint-to-gauge, burn-from-gauge, regular transfer with one/both sides gauge, self-transfer corner case)

## Test plan

- [x] `pnpm exec vitest run test/EventHandlers/Pool/PoolTransferLogic.test.ts` — 21/21 pass (new regression cases fail on \`main\`)
- [x] \`pnpm exec biome check\` — clean
- [x] \`pnpm exec tsc --noEmit\` — clean