### PR TITLE
fix(pool): NEG_TLU — clamp totalLiquidityUSD >= 0 (closes #856)

### DIFF
--- a/src/Aggregators/Pool.ts
+++ b/src/Aggregators/Pool.ts
@@ -419,6 +419,22 @@ export async function updatePool(
     );
   }
 
+  // Clamp totalLiquidityUSD to >= 0n at the accumulator path (issue #856).
+  // CL Swap/Burn producers compute currentTotalLiquidityUSD from a synthetic
+  // running newReserve0/1 (current ± delta) BEFORE the reserve clamp above,
+  // so wei-scale tick-crossing drift can briefly drive that sum negative even
+  // though reserves themselves end up clamped to 0n. The negative residue
+  // then propagates into totalLiquidityUSD on write. Mirrors the reserve
+  // clamp shape — clamp-and-log, never persist a negative.
+  const tluReplacement =
+    diff.currentTotalLiquidityUSD ?? current.totalLiquidityUSD;
+  const clampedTotalLiquidityUSD = tluReplacement < 0n ? 0n : tluReplacement;
+  if (tluReplacement < 0n) {
+    context.log.warn(
+      `[NEG_TLU_GUARD][updatePool] field=totalLiquidityUSD poolAddress=${current.poolAddress} chainId=${current.chainId} priorTLU=${current.totalLiquidityUSD} replacement=${tluReplacement} clampedTo=${clampedTotalLiquidityUSD}`,
+    );
+  }
+
   // Clamp stakedLiquidityInRange to >= 0n at the accumulator path (issue #719).
   // The structural fix at the three writer sites derives this field from edge
   // state on every update; this tactical clamp is the belt-and-suspenders that
@@ -481,8 +497,7 @@ export async function updatePool(
     reserve1: clampedReserve1,
     totalLPTokenSupply:
       (diff.incrementalTotalLPSupply ?? 0n) + current.totalLPTokenSupply,
-    totalLiquidityUSD:
-      diff.currentTotalLiquidityUSD ?? current.totalLiquidityUSD,
+    totalLiquidityUSD: clampedTotalLiquidityUSD,
     totalVolume0: (diff.incrementalTotalVolume0 ?? 0n) + current.totalVolume0,
     totalVolume1: (diff.incrementalTotalVolume1 ?? 0n) + current.totalVolume1,
     totalVolumeUSD:

--- a/test/Aggregators/Pool.test.ts
+++ b/test/Aggregators/Pool.test.ts
@@ -1224,6 +1224,78 @@ describe("Pool Functions", () => {
       });
     });
 
+    // Regression test for issue #856: totalLiquidityUSD must never persist
+    // negative. CL Swap/Burn handlers compute currentTotalLiquidityUSD from a
+    // synthetic newReserve0/1 = current ± delta BEFORE the reserve clamp at
+    // the accumulator path, so wei-scale tick-crossing drift (or a Burn that
+    // exceeds the cumulative Mint) can produce a sub-cent negative USD even
+    // though the reserves themselves end up at 0n. The aggregator clamps
+    // totalLiquidityUSD to >= 0n and emits [NEG_TLU_GUARD] with
+    // {poolAddress, chainId, priorTLU, replacement, clampedTo}.
+    describe("negative totalLiquidityUSD clamp guard (issue #856)", () => {
+      const sameEpochAsTimestamp = () => timestamp;
+
+      const negTluGuardLogs = () => {
+        const warnMock = vi.mocked(mockContext.log?.warn);
+        const calls = warnMock?.mock.calls ?? [];
+        return calls.filter((args) =>
+          String(args[0] ?? "").includes("[NEG_TLU_GUARD]"),
+        );
+      };
+
+      const lastSet = (): Pool => {
+        const setMock = vi.mocked(mockContext.Pool?.set);
+        return setMock?.mock.lastCall?.[0] as Pool;
+      };
+
+      it("clamps totalLiquidityUSD to 0n and logs guard when diff supplies a sub-cent negative", async () => {
+        // Mirrors the 2 Fraxtal CL pools reported in #856: the producer
+        // computed currentTotalLiquidityUSD from a pre-clamp newReserve that
+        // briefly went negative, leaking a tiny negative residue here.
+        await updatePool(
+          { currentTotalLiquidityUSD: -20970n },
+          {
+            ...(liquidityPoolAggregator as Pool),
+            isCL: true,
+            totalLiquidityUSD: 0n,
+            lastSnapshotTimestamp: sameEpochAsTimestamp(),
+            lastUpdatedTimestamp: sameEpochAsTimestamp(),
+          },
+          timestamp,
+          mockContext as handlerContext,
+          252,
+          blockNumber,
+        );
+
+        expect(lastSet().totalLiquidityUSD).toBe(0n);
+        const logs = negTluGuardLogs();
+        expect(logs.length).toBe(1);
+        const msg = String(logs[0]?.[0] ?? "");
+        expect(msg).toContain("totalLiquidityUSD");
+        expect(msg).toContain("replacement=-20970");
+        expect(msg).toContain("clampedTo=0");
+      });
+
+      it("does not clamp or log when currentTotalLiquidityUSD is zero or positive", async () => {
+        await updatePool(
+          { currentTotalLiquidityUSD: 5000n },
+          {
+            ...(liquidityPoolAggregator as Pool),
+            totalLiquidityUSD: 0n,
+            lastSnapshotTimestamp: sameEpochAsTimestamp(),
+            lastUpdatedTimestamp: sameEpochAsTimestamp(),
+          },
+          timestamp,
+          mockContext as handlerContext,
+          8453,
+          blockNumber,
+        );
+
+        expect(lastSet().totalLiquidityUSD).toBe(5000n);
+        expect(negTluGuardLogs().length).toBe(0);
+      });
+    });
+
     // Regression test for issue #719: stakedLiquidityInRange must never
     // persist negative. Mirrors the #702 reserve-clamp shape but for the
     // staked-in-range field. The aggregator emits [NEG_STAKED_LIQ_GUARD]


### PR DESCRIPTION
## Summary

- CL Swap/Burn handlers compute `currentTotalLiquidityUSD` from a synthetic `newReserve0/1 = current ± delta` BEFORE the existing reserve clamp in `updatePool`, so wei-scale tick-crossing drift (or a Burn larger than the cumulative Mint) can briefly drive that sum negative even though the reserves themselves end up clamped to `0n`. The negative residue then propagated into `totalLiquidityUSD` on write.
- Adds a `[NEG_TLU_GUARD]` clamp at the aggregator that mirrors the existing `[NEG_RESERVE_GUARD]` / `[NEG_STAKED_RESERVE_GUARD]` shape — clamp-and-log, never persist a negative.

## Audit context (closes #856)

The 2026-06-10 integrity audit flagged 2 Fraxtal pools as `[NEG_TLU]` blockers. A direct query against the production indexer (`indexer.us.hyperindex.xyz/8179a7a`) shows the pattern is wider than sampled:

| chain | pool | totalLiquidityUSD (raw 1e18) | USD |
| --- | --- | --- | --- |
| 252 (Fraxtal) | `0xdBb5d821…ef64fFf` (CL-10 WFRAX/sfrxUSD) | -2 | -2e-18 |
| 252 (Fraxtal) | `0x16B6d4e2…7D082C` (CL-200 DKDEFI/frxETH) | -20970 | -2e-14 |
| 8453 (Base) | `0x67300582…9B6290` (CL-100 AUDD/cbBTC) | -8056822920812079 | -0.0081 |

70 pools in total carry a negative `totalLiquidityUSD`; the largest magnitude is ≈ -$0.008. The issue body's "≈\$21K" reading mistook the raw BigInt `-20970` for dollars — these are all sub-cent rounding residues, not material drift. Reserves on all 70 pools are non-negative, confirming the root cause is the pre-clamp `newReserve` computation in CL Swap/Burn, not negative reserves persisted on the entity.

## Test plan

- [x] `pnpm test` — 1548 passed (111 files)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec biome check` — 281 files, no fixes
- [x] New regression test in `test/Aggregators/Pool.test.ts`:
  - `clamps totalLiquidityUSD to 0n and logs guard when diff supplies a sub-cent negative` (reproduces the Fraxtal `-20970` residue and asserts both clamp and `[NEG_TLU_GUARD]` log)
  - `does not clamp or log when currentTotalLiquidityUSD is zero or positive`

🤖 Generated with [Claude Code](https://claude.com/claude-code)