### PR TITLE
fix(price-trust): WHITELIST_TRUST_DRIFT — audit invariant missed WL+BLACKLISTED tier

### DIFF
--- a/scripts/integrity-audit.ts
+++ b/scripts/integrity-audit.ts
@@ -36,13 +36,11 @@ const ABIS = join(__dirname, "..", "abis");
 const OLD_URL =
   process.env.OLD_GRAPHQL_URL ??
   "https://indexer.us.hyperindex.xyz/e38a72a/v1/graphql";
-const NEW_URL = process.env.NEW_GRAPHQL_URL;
-if (!NEW_URL) {
-  console.error(
-    "NEW_GRAPHQL_URL is required (set OLD_GRAPHQL_URL to override the c9b8978 default).",
-  );
-  process.exit(1);
-}
+// `?? ""` keeps the binding `string`-typed for the rest of the module so the
+// script body type-checks. The empty string is only ever reached when the
+// module is imported (e.g. by tests), and the script-mode entry point below
+// runs an explicit non-empty check before invoking main().
+const NEW_URL: string = process.env.NEW_GRAPHQL_URL ?? "";
 
 const CHAIN_IDS = [
   10, 8453, 34443, 1135, 252, 1750, 1868, 57073, 130, 42220, 1923, 5330,
@@ -282,7 +280,7 @@ const POOL_FIELDS_NEW_ONLY = `
   tickEdges tickEdgeNets stakedTickEdges stakedTickEdgeNets
 `;
 
-type TokenRow = {
+export type TokenRow = {
   id: string;
   chainId: number;
   address: string;
@@ -835,6 +833,34 @@ function absBI(x: bigint): bigint {
 const PRICE_CEILING_1M = 10n ** 24n; // $1M scaled by 1e18
 const PRICE_INFLATED = 10n ** 28n;
 
+/**
+ * Returns true when a whitelisted token's persisted price-trust fields
+ * disagree with the two-tier gate's correct outcome (#761/#855).
+ *
+ * Per the gate (#755, src/PriceTrust.ts): WL && !BLACKLISTED ⇒ TRUSTED;
+ * WL && BLACKLISTED ⇒ UNTRUSTED/BLACKLISTED is the correct intentional
+ * outcome (operator override for WL'd tokens with broken oracles). Drift
+ * is only present when a WL token is UNTRUSTED for a non-BLACKLISTED
+ * reason. Non-whitelisted tokens, and rows with no persisted outcome yet,
+ * never count as drift.
+ *
+ * @param tok - Token row from the audit's GraphQL query
+ * @returns true when the row violates the lockstep invariant
+ */
+export function hasWhitelistTrustDrift(
+  tok: Pick<
+    TokenRow,
+    "isWhitelisted" | "priceTrustOutcome" | "priceTrustReason"
+  >,
+): boolean {
+  if (!tok.isWhitelisted) return false;
+  if (tok.priceTrustOutcome == null) return false;
+  const isTrusted =
+    tok.priceTrustOutcome === "trusted" || tok.priceTrustOutcome === "TRUSTED";
+  if (isTrusted) return false;
+  return tok.priceTrustReason !== "BLACKLISTED";
+}
+
 function checkTokenInvariants(
   tok: TokenRow,
   oldTok: TokenRow | undefined,
@@ -866,22 +892,16 @@ function checkTokenInvariants(
   }
 
   // priceTrustOutcome lockstep with isWhitelisted (#761).
-  // Whitelisted tokens must be trusted; non-whitelisted may be trusted or not.
-  if (tok.isWhitelisted && tok.priceTrustOutcome != null) {
-    if (
-      tok.priceTrustOutcome !== "trusted" &&
-      tok.priceTrustOutcome !== "TRUSTED"
-    ) {
-      record({
-        flag: "[WHITELIST_TRUST_DRIFT]",
-        classification: "NEW_REGRESSION",
-        entity: ent,
-        chainId: tok.chainId,
-        entityId: tok.id,
-        newValue: tok.priceTrustOutcome,
-        note: "Whitelisted but priceTrustOutcome != trusted (#761)",
-      });
-    }
+  if (hasWhitelistTrustDrift(tok)) {
+    record({
+      flag: "[WHITELIST_TRUST_DRIFT]",
+      classification: "NEW_REGRESSION",
+      entity: ent,
+      chainId: tok.chainId,
+      entityId: tok.id,
+      newValue: `${tok.priceTrustOutcome}/${tok.priceTrustReason ?? "null"}`,
+      note: "Whitelisted but priceTrustOutcome != trusted and reason != BLACKLISTED (#761)",
+    });
   }
 
   // priceTrustOutcome should be non-null. We can't reliably detect "pre-field"
@@ -1423,9 +1443,22 @@ async function main(): Promise<void> {
   process.stdout.write("\n");
 }
 
-main().catch((err) => {
-  process.stderr.write(
-    `\nFATAL: ${err instanceof Error ? err.stack : String(err)}\n`,
-  );
-  process.exit(1);
-});
+// Run main() only when invoked as a script, not when imported by tests.
+// Importing the module merely exposes the pure helpers (hasWhitelistTrustDrift,
+// TokenRow, etc.) without firing the audit pipeline.
+const isInvokedAsScript =
+  process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (isInvokedAsScript) {
+  if (NEW_URL === "") {
+    console.error(
+      "NEW_GRAPHQL_URL is required (set OLD_GRAPHQL_URL to override the c9b8978 default).",
+    );
+    process.exit(1);
+  }
+  main().catch((err) => {
+    process.stderr.write(
+      `\nFATAL: ${err instanceof Error ? err.stack : String(err)}\n`,
+    );
+    process.exit(1);
+  });
+}

--- a/test/IntegrityAuditWhitelistTrust.test.ts
+++ b/test/IntegrityAuditWhitelistTrust.test.ts
@@ -1,0 +1,73 @@
+import { hasWhitelistTrustDrift } from "../scripts/integrity-audit";
+
+// Audit-script regression test: the two-tier price-trust gate (#755) defines
+// WL && BLACKLISTED ⇒ UNTRUSTED/BLACKLISTED as the correct, intentional
+// outcome — an operator override for WL'd tokens with broken oracles. The
+// pre-fix audit asserted the looser invariant `isWhitelisted ⇒ TRUSTED` and
+// flagged the four legitimate WL-and-BLACKLISTED tokens (wOptiDoge/OP,
+// ION/Lisk, XAUt0/Ink, KING/Swell) as NEW_REGRESSION (#855). These cases
+// must now classify as non-drift.
+describe("hasWhitelistTrustDrift", () => {
+  it("flags a WL token persisted as UNTRUSTED/NON_WL (the #761 stuck state)", () => {
+    expect(
+      hasWhitelistTrustDrift({
+        isWhitelisted: true,
+        priceTrustOutcome: "UNTRUSTED",
+        priceTrustReason: "NON_WL",
+      }),
+    ).toBe(true);
+  });
+
+  it("does NOT flag a WL token correctly overridden as UNTRUSTED/BLACKLISTED (#855)", () => {
+    // Mirrors all four flagged rows from the 2026-06-10 audit: wOptiDoge/OP,
+    // ION/Lisk, XAUt0/Ink, KING/Swell — all WL on-chain, all in PriceOverrides
+    // BLACKLIST, correctly resolved by the two-tier gate.
+    expect(
+      hasWhitelistTrustDrift({
+        isWhitelisted: true,
+        priceTrustOutcome: "UNTRUSTED",
+        priceTrustReason: "BLACKLISTED",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not flag a WL token correctly persisted as TRUSTED/WL", () => {
+    expect(
+      hasWhitelistTrustDrift({
+        isWhitelisted: true,
+        priceTrustOutcome: "TRUSTED",
+        priceTrustReason: "WL",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not flag a non-WL token regardless of outcome", () => {
+    expect(
+      hasWhitelistTrustDrift({
+        isWhitelisted: false,
+        priceTrustOutcome: "UNTRUSTED",
+        priceTrustReason: "NON_WL",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not flag a row with priceTrustOutcome=null (pre-field)", () => {
+    expect(
+      hasWhitelistTrustDrift({
+        isWhitelisted: true,
+        priceTrustOutcome: null,
+        priceTrustReason: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("accepts the lowercase legacy spelling of TRUSTED", () => {
+    expect(
+      hasWhitelistTrustDrift({
+        isWhitelisted: true,
+        priceTrustOutcome: "trusted",
+        priceTrustReason: "WL",
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

The 2026-06-10 integrity audit reported 7 (4 unique) WL tokens as `NEW_REGRESSION` with `priceTrustOutcome=UNTRUSTED`. Live-indexer probes show all four (wOptiDoge/OP, ION/Lisk, XAUt0/Ink, KING/Swell) are persisted as `isWhitelisted=true ∧ priceTrustReason=BLACKLISTED` — the correct, intentional outcome of the two-tier price-trust gate (#755), not a regression. The persisted indexer state is fine in every case; the audit's WL drift check encoded the looser invariant `isWhitelisted ⇒ TRUSTED` and missed that the operator BLACKLIST tier overrides the protocol whitelist for tokens with structurally broken oracles.

This PR fixes the false positive in `scripts/integrity-audit.ts` and adds a regression test. The indexer code is untouched.

- `hasWhitelistTrustDrift(tok)` exported pure helper encodes the real invariant: `WL && outcome != TRUSTED && reason != BLACKLISTED ⇒ drift`. Inlined at the existing call site.
- WL drift `newValue` now includes `priceTrustReason` so future findings are self-describing.
- `scripts/integrity-audit.ts` made test-importable: `NEW_URL` typed `string` via `?? ""`, `main()` invocation gated behind a script-mode check (no behaviour change when invoked via `pnpm dlx tsx`).
- `test/IntegrityAuditWhitelistTrust.test.ts` covers the six classification cells (WL+BLACKLISTED non-drift, WL+NON_WL drift, WL+TRUSTED, non-WL, null outcome, legacy lowercase `trusted`).

Closes #855.

## Test plan

- [x] `pnpm vitest run test/IntegrityAuditWhitelistTrust.test.ts` — 6 cases pass; the `WL+BLACKLISTED ⇒ non-drift` case fails against pre-fix logic
- [x] `pnpm test` — 1543 tests across 111 files green
- [x] `pnpm tsc --noEmit` — clean after `pnpm envio codegen`
- [x] `pnpm exec biome check` — clean across the 281 tracked files
- [x] Live-probe verification: all 4 flagged tokens return `priceTrustReason=BLACKLISTED` from the NEW deployment — matches the corrected invariant

## Base branch

Stacked on `chore/integrity-audit-vs-c9b8978` (PR #859) because `scripts/integrity-audit.ts` is introduced there. Merge order: #859 first, then this PR rebases onto `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)