### PR TITLE
fix(pool-factory): persist Pool when bytecode gate skips token (closes #864)

### DIFF
--- a/src/EventHandlers/PoolFactory.ts
+++ b/src/EventHandlers/PoolFactory.ts
@@ -78,22 +78,24 @@ indexer.onEvent(
       for (let i = 0; i < missingTokenMappings.length; i++) {
         const created = createdTokens[i];
         if (created === null) {
+          // Bytecode gate (#677) rejected the token side: skip the Token row but
+          // STILL create the Pool — the factory has authoritatively registered
+          // it (closes #864). Dropping the pool here orphans every downstream
+          // entity (snapshots, user-stats) for an on-chain reality.
           context.log.warn(
-            `[PoolFactory.PoolCreated] Skipping Pool for pool ${event.params.pool} on chain ${event.chainId} — non-contract token side`,
+            `[PoolFactory.PoolCreated] Pool ${event.params.pool} on chain ${event.chainId} has non-contract token side ${missingTokenMappings[i].address}; persisting Pool with empty symbol on that side`,
           );
-          return;
-        }
-        if (created !== undefined) {
+        } else if (created !== undefined) {
           missingTokenMappings[i].tokenInstance = created;
         }
       }
     }
 
-    // Build symbol array
-    for (const poolTokenAddressMapping of poolTokenAddressMappings) {
-      if (poolTokenAddressMapping.tokenInstance) {
-        poolTokenSymbols.push(poolTokenAddressMapping.tokenInstance.symbol);
-      }
+    // Build symbol array — index-based so a missing token instance does not
+    // shift the other token's symbol into the wrong slot (#864).
+    for (let i = 0; i < poolTokenAddressMappings.length; i++) {
+      poolTokenSymbols[i] =
+        poolTokenAddressMappings[i].tokenInstance?.symbol ?? "";
     }
 
     // V2 PoolFactory reports fees in basis points; lift to canonical FEE_SCALE

--- a/test/EventHandlers/PoolFactory.test.ts
+++ b/test/EventHandlers/PoolFactory.test.ts
@@ -288,6 +288,65 @@ describe("PoolFactory Events", () => {
       const rootPoolLeafPools = await indexer.RootPool_LeafPool.getAll();
       expect(rootPoolLeafPools).toHaveLength(0);
     });
+
+    // Regression for #864 (FACTORY_POOL_COUNT_GAP). Before the fix, when the
+    // #677 bytecode gate confirmed one token side was a non-contract,
+    // createTokenEntity returned `null` and the V2 handler early-returned —
+    // dropping the Pool entity even though the factory had authoritatively
+    // registered it on-chain. The Base V2 audit found 3 pools missing this way.
+    // Now: the gate still skips the Token row, but the Pool is persisted with
+    // an empty symbol on the offending side.
+    it("creates the Pool even when one token side is a non-contract (#864)", async () => {
+      // 0x...dEaD is an EOA on Optimism; eth_getCode returns 0x so the bytecode
+      // gate in createTokenEntity returns null for that side.
+      const eoaTokenAddress = toChecksumAddress(
+        "0x000000000000000000000000000000000000dEaD",
+      );
+      const indexer = createTestIndexer();
+      // Only pre-seed token0 — token1 must traverse createTokenEntity/the gate.
+      indexer.Token.set({
+        ...mockToken0Data,
+        id: TokenId(chainId, token0Address),
+        address: token0Address,
+        chainId,
+      } as Token);
+
+      await indexer.process({
+        chains: {
+          [chainId]: {
+            simulate: [
+              {
+                contract: "PoolFactory",
+                event: "PoolCreated",
+                srcAddress: poolAddress,
+                logIndex: 1,
+                block: {
+                  timestamp: 1000000,
+                  number: 123456,
+                  hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
+                },
+                params: {
+                  token0: token0Address as `0x${string}`,
+                  token1: eoaTokenAddress as `0x${string}`,
+                  pool: poolAddress as `0x${string}`,
+                  stable: false,
+                },
+              },
+            ],
+          },
+        },
+      });
+
+      const pool = await indexer.Pool.get(PoolId(chainId, poolAddress));
+      expect(pool).toBeDefined();
+      // Pool keeps the on-chain token1 address; only the Token row is skipped.
+      expect(pool?.token1_address).toBe(eoaTokenAddress);
+      // No Token row created for the EOA side (the gate still wins there).
+      const eoaToken = await indexer.Token.get(
+        TokenId(chainId, eoaTokenAddress),
+      );
+      expect(eoaToken).toBeUndefined();
+    });
   });
 
   describe("SetCustomFee event", () => {


### PR DESCRIPTION
## Summary

Fixes the V2 `[FACTORY_POOL_COUNT_GAP]` audit finding (#864) where Base `PoolFactory.allPoolsLength()` reported **27,916** pools on-chain but the indexer had **27,913** — a gap of **3** missing V2 pools.

**Root cause** (verified end-to-end with on-chain enumeration + per-token RPC):

The 3 missing addresses are:

| Index | Address | Block | Token1 |
|------:|---------|------:|--------|
| 1331  | `0x8b1da19416e22b722e382338444563c8abaafd60` | 15708145 | TBT — `decimals()` reverts at HEAD |
| 12323 | `0x6e77208ad71f3107fa5182a08c8384fc23786f8d` | 37074307 | BIB — works at HEAD |
| 12324 | `0xf408d16d9aaaf92cb2de806093d5af2cb4bf71c9` | 37074316 | GMAC — works at HEAD |

All three have `token0 = WETH` and `token1` with deployed bytecode at the event block; **none are legitimate #677 EOA skips**. They were dropped by the V2 handler at `src/EventHandlers/PoolFactory.ts:80-85`:

```ts
if (created === null) {
  context.log.warn(`Skipping Pool ... non-contract token side`);
  return;   // <-- drops the Pool entirely
}
```

`createTokenEntity` returned `null` because the `#677` bytecode gate (`fetchHasContractBytecode`) queries `eth_getCode` + `decimals()` **at HEAD**, not at `event.block.number`. For TBT (#1331), `decimals()` reverts at HEAD today, so the gate is deterministic-false on every replay — and the result is cached (`CONTRACT_REVERT` is intentionally cached). For BIB/GMAC, the likely cause is the same cache-poison pattern at the time the indexer first observed them (newly-deployed launchpad tokens whose state was non-ERC20-shaped briefly).

Regardless of why the gate said `null`, **the factory authoritatively created the pool**; dropping it orphans every downstream entity (snapshots, user-stats, volume, fees) for an on-chain reality.

**Fix** (`src/EventHandlers/PoolFactory.ts`, **net +2 lines**):

1. When the gate returns `null`, log a warn and continue — persist the Pool entity, just skip the Token row (which the gate's #677 purpose already accomplishes inside `createTokenEntity`).
2. Switch the symbol loop to index-based assignment so a missing instance on one side cannot shift the other side's symbol into the wrong slot (matches the CL handler convention at `CLFactoryPoolCreatedLogic.ts:68-70`).

**Supersedes #867** — the diagnostic script can be closed too; the script identifies missing addresses for a one-shot ops re-index, but with this fix the indexer self-heals on future replays.

**Scope**: V2 only. The sibling CL audit (#865, 22 missing CL pools on Base) has the same root cause in `CLFactoryPoolCreatedLogic.ts:84-89` and will need its own PR with this same fix pattern.

## Test plan

- [x] `pnpm vitest run test/EventHandlers/PoolFactory.test.ts` — 12 passed (1 new regression test, 11 existing)
- [x] Verified regression test **fails** on `main` with `expected undefined to be defined` on the Pool fetch
- [x] `pnpm test` (full suite) — 1547 passed across 111 files
- [x] `pnpm exec biome check` — 281 files clean
- [x] `pnpm exec tsc --noEmit` — clean
- [x] Manual: ran end-to-end on-chain enumeration of all 27,916 pools in `0x420DD381b31aEf6683db6B902084cB0FFECe40Da` against the live GraphQL — identified exact 3 missing addresses, verified token bytecode at event block

Closes #864
Supersedes #867
Related #865