### PR TITLE
chore(storage): use envio v3.2.0 `default: true` for dual-write routing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ The indexer tracks these protocol domains, each with its own event handlers:
 
 ## Storage
 
-Dual-write Postgres + ClickHouse is enabled. The `storage:` block in `config.yaml` declares both backends and every entity in `schema.graphql` carries `@storage(postgres: true, clickhouse: true)` (envio requires explicit per-entity routing whenever two backends are enabled).
+Dual-write Postgres + ClickHouse is enabled. The `storage:` block in `config.yaml` marks both backends with `default: true`, so every entity in `schema.graphql` is auto-routed to both — no `@storage` annotation is needed unless you want to override the default routing for a specific entity. (Requires envio ≥ 3.2.0.)
 
 ClickHouse env vars (Envio Hosted ClickHouse in production, placeholders in `.env.example`):
 

--- a/config.yaml
+++ b/config.yaml
@@ -5,8 +5,10 @@ rollback_on_reorg: true
 raw_events: false
 # Docs: https://docs.envio.dev/docs/HyperIndex/configuration-file#storage
 storage:
-  postgres: true
-  clickhouse: true
+  postgres:
+    default: true
+  clickhouse:
+    default: true
 field_selection:
   transaction_fields:
     - "hash"

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,4 +1,4 @@
-type Pool @storage(postgres: true, clickhouse: true) {
+type Pool {
   id: ID! # Format: {chainId}-{poolAddress} (PoolId)
   chainId: Int! # chain id
   poolAddress: String! # address of the pool
@@ -148,7 +148,7 @@ type Pool @storage(postgres: true, clickhouse: true) {
 }
 
 # Snapshot of the LiquidityPool entity
-type PoolSnapshot @storage(postgres: true, clickhouse: true) {
+type PoolSnapshot {
   id: ID! # Format: {chainId}-{poolAddress}-{epochMs} (PoolId-epochMs, epochMs from getSnapshotEpoch)
   chainId: Int! # chain id
   name: String! # name of the pool
@@ -239,7 +239,7 @@ type PoolSnapshot @storage(postgres: true, clickhouse: true) {
 }
 
 # Entity for tracking user activity and positions in specific pools
-type UserStatsPerPool @storage(postgres: true, clickhouse: true) {
+type UserStatsPerPool {
   id: ID! # Format: {chainId}-{userAddress}-{poolAddress} (UserStatsPerPoolId)
   userAddress: String! @index # user wallet address
   poolAddress: String! @index # address of the pool these stats are scoped to
@@ -300,7 +300,7 @@ type UserStatsPerPool @storage(postgres: true, clickhouse: true) {
 }
 
 # Snapshot of UserStatsPerPool at an epoch (invariant fields + position params for recomputation)
-type UserStatsPerPoolSnapshot @storage(postgres: true, clickhouse: true) {
+type UserStatsPerPoolSnapshot {
   id: ID! # Format: {chainId}-{userAddress}-{poolAddress}-{epochMs} (UserStatsPerPoolSnapshotId)
   userAddress: String! @index # user wallet address
   poolAddress: String! @index # address of the pool these stats are scoped to
@@ -359,7 +359,7 @@ type UserStatsPerPoolSnapshot @storage(postgres: true, clickhouse: true) {
 
 # Entity that tracks the latest state of the token entity
 # By nature this entity saves the latest state of the token, and its state at different times should be attained from the snapshot entities
-type Token @storage(postgres: true, clickhouse: true) {
+type Token {
   id: ID! # Format: {chainId}-{address} (TokenId)
   address: String! @index # token address
   symbol: String! # token symbol
@@ -393,7 +393,7 @@ type Token @storage(postgres: true, clickhouse: true) {
 }
 
 # Snapshot of the Token entity
-type TokenPriceSnapshot @storage(postgres: true, clickhouse: true) {
+type TokenPriceSnapshot {
   id: ID! # Format: {chainId}-{address}-{blockNumber} (TokenIdByBlock)
   address: String! @index # Address of the token
   pricePerUSDNew: BigInt! @config(precision: 76) # price of token per USD
@@ -418,7 +418,7 @@ type TokenPriceSnapshot @storage(postgres: true, clickhouse: true) {
 
 # Tracks relevant data for each NFT minted: each NFT represents a concentrated position in a pool
 # Note: amount0, amount1, amountUSD are derived fields computed on-demand from liquidity + sqrtPriceX96 + ticks
-type NonFungiblePosition @storage(postgres: true, clickhouse: true) {
+type NonFungiblePosition {
   id: ID! # Format: {chainId}-{nfpmAddress}-{tokenId} (NonFungiblePositionId). Natural key is (NFPM, tokenId); pool is metadata and preserved as a field. nfpmAddress disambiguates intra-chain tokenId collisions across multiple NFPMs (e.g. Optimism has two).
   chainId: Int! # Chain ID where the NFT exists
   tokenId: BigInt! @index # Token ID of the NFT (from Transfer event)
@@ -438,7 +438,7 @@ type NonFungiblePosition @storage(postgres: true, clickhouse: true) {
 }
 
 # Snapshot of NonFungiblePosition at an epoch (full state for historical queries / recomputation)
-type NonFungiblePositionSnapshot @storage(postgres: true, clickhouse: true) {
+type NonFungiblePositionSnapshot {
   id: ID! # Format: {chainId}-{nfpmAddress}-{tokenId}-{epochMs} (NonFungiblePositionSnapshotId). nfpmAddress disambiguates intra-chain tokenId collisions across multiple NFPMs (e.g. Optimism has two).
   chainId: Int! # chain id where the NFT exists
   tokenId: BigInt! @index # token ID of the NFT
@@ -457,7 +457,7 @@ type NonFungiblePositionSnapshot @storage(postgres: true, clickhouse: true) {
   timestamp: Timestamp! @index # snapshot epoch timestamp
 }
 
-type VeNFTState @storage(postgres: true, clickhouse: true) {
+type VeNFTState {
   id: ID! # Format: {chainId}-{tokenId} (VeNFTId)
   chainId: Int! # chain id
   tokenId: BigInt! @config(precision: 76) # veNFT token ID
@@ -472,7 +472,7 @@ type VeNFTState @storage(postgres: true, clickhouse: true) {
 }
 
 # Snapshot of VeNFTState at an epoch (full state for historical queries)
-type VeNFTStateSnapshot @storage(postgres: true, clickhouse: true) {
+type VeNFTStateSnapshot {
   id: ID! # Format: {chainId}-{tokenId}-{epochMs} (VeNFTStateSnapshotId)
   chainId: Int! # chain id
   tokenId: BigInt! @index # veNFT token ID
@@ -488,7 +488,7 @@ type VeNFTStateSnapshot @storage(postgres: true, clickhouse: true) {
     @derivedFrom(field: "veNFTStateSnapshot")
 }
 
-type VeNFTPoolVote @storage(postgres: true, clickhouse: true) {
+type VeNFTPoolVote {
   id: ID! # Format: {chainId}-{tokenId}-{poolAddress} (VeNFTPoolVoteId)
   poolAddress: String! @index # pool this veNFT allocated votes to
   veNFTamountStaked: BigInt! @config(precision: 76) # vote weight this veNFT allocated to the pool, in veToken units
@@ -496,7 +496,7 @@ type VeNFTPoolVote @storage(postgres: true, clickhouse: true) {
   lastUpdatedTimestamp: Timestamp! # timestamp of last update
 }
 
-type VeNFTPoolVoteSnapshot @storage(postgres: true, clickhouse: true) {
+type VeNFTPoolVoteSnapshot {
   id: ID! # Format: {chainId}-{tokenId}-{poolAddress}-{epochMs}
   chainId: Int! # chain id
   tokenId: BigInt! @config(precision: 76) # veNFT token ID
@@ -511,7 +511,7 @@ type VeNFTPoolVoteSnapshot @storage(postgres: true, clickhouse: true) {
 # Tracks both the LP wrapper state (aggregated deposits/withdrawals) and the strategy position state
 # Relationship: 1 LP wrapper per pool, 1 strategy per LP wrapper, 1 tokenId per strategy, 1 AMM position per tokenId (1:1:1:1 relationship)
 # Therefore this single entity tracks everything for the wrapper and its strategy
-type ALM_LP_Wrapper @storage(postgres: true, clickhouse: true) {
+type ALM_LP_Wrapper {
   id: ID! # Format: {chainId}-{wrapperAddress} (ALMLPWrapperId)
   chainId: Int! # The blockchain network ID where this wrapper exists
   pool: String! @index # Address of the pool this ALM wrapper is associated with
@@ -541,7 +541,7 @@ type ALM_LP_Wrapper @storage(postgres: true, clickhouse: true) {
 }
 
 # Snapshot of ALM_LP_Wrapper at an epoch (full state for historical queries / recomputation)
-type ALM_LP_WrapperSnapshot @storage(postgres: true, clickhouse: true) {
+type ALM_LP_WrapperSnapshot {
   id: ID! # Format: {chainId}-{wrapperAddress}-{epochMs} (ALMLPWrapperSnapshotId)
   wrapper: String! @index # address of the ALM LP wrapper
   pool: String! @index # address of the pool this wrapper is associated with
@@ -565,7 +565,7 @@ type ALM_LP_WrapperSnapshot @storage(postgres: true, clickhouse: true) {
   timestamp: Timestamp! @index # snapshot epoch timestamp
 }
 
-type FactoryRegistryConfig @storage(postgres: true, clickhouse: true) {
+type FactoryRegistryConfig {
   id: ID! # Format: {srcAddress}_{chainId} (factory registry contract address)
   currentActivePoolFactory: String! # Address of the currently active pool factory (creates vAMM/sAMM or CL pools)
   currentActiveVotingRewardsFactory: String! # Address of the currently active voting rewards factory (creates fee and bribe voting reward contracts)
@@ -573,14 +573,14 @@ type FactoryRegistryConfig @storage(postgres: true, clickhouse: true) {
   lastUpdatedTimestamp: Timestamp! # Timestamp when the factory registry configuration was last updated
 }
 
-type DynamicFeeGlobalConfig @storage(postgres: true, clickhouse: true) {
+type DynamicFeeGlobalConfig {
   id: ID! # Format: contract address (DynamicSwapFeeModule)
   chainId: Int! @index # chain id
   secondsAgo: BigInt @config(precision: 32) # The amount of time used to calculate price change
 }
 
 # One per underlying pool (per chain) launched or migrated via Pool Launcher
-type PoolLauncherPool @storage(postgres: true, clickhouse: true) {
+type PoolLauncherPool {
   id: ID! # Format: {chainId}-{underlyingPool}
   chainId: Int! # chain id
   underlyingPool: Bytes! # pool address
@@ -602,7 +602,7 @@ type PoolLauncherPool @storage(postgres: true, clickhouse: true) {
   poolStats: [Pool!]! @derivedFrom(field: "poolLauncherPoolId") # reverse relation: Pool aggregates launched under this PoolLauncherPool
 }
 
-type PoolLauncherConfig @storage(postgres: true, clickhouse: true) {
+type PoolLauncherConfig {
   id: ID! # Format: {chainId}-{poolLauncherAddress} (PoolId with launcher contract as address)
   version: String! # "CL" for concentrated liquidity, "V2" for V2 pools
   pairableTokens: [String!] # Whitelisted tokens an emerging-token pool may be paired against on this launcher
@@ -612,7 +612,7 @@ type PoolLauncherConfig @storage(postgres: true, clickhouse: true) {
 # 1. Original asset is swapped for oUSDT on the source chain.
 # 2. The oUSDT is then bridged through Hyperlane to the destination chain.
 # 3. Bridged oUSDT is then swapped into the preferred asset on the destination chain.
-type SuperSwap @storage(postgres: true, clickhouse: true) {
+type SuperSwap {
   id: ID! # Format: {messageId} — globally unique Hyperlane message identifier
   originChainId: BigInt! @config(precision: 24) # Chain ID where the swap originated
   destinationChainId: BigInt! @config(precision: 24) # Resolved EVM chain ID of the swap target/recipient (mapped from the Hyperlane domain via domainToChainId)
@@ -626,7 +626,7 @@ type SuperSwap @storage(postgres: true, clickhouse: true) {
   timestamp: Timestamp! # Block timestamp of the swap event
 }
 
-type OUSDTBridgedTransaction @storage(postgres: true, clickhouse: true) {
+type OUSDTBridgedTransaction {
   id: ID! # Format: transaction hash (unique per bridge tx)
   transactionHash: String! @index # Transaction hash
   originChainId: BigInt! @config(precision: 24) # Chain ID where the bridge transaction originated
@@ -638,7 +638,7 @@ type OUSDTBridgedTransaction @storage(postgres: true, clickhouse: true) {
 
 # Registering each event related from/to oUSDT. Needed for filtering and eventual registration of source/destination token
 # and corresponding amounts during superswaps execution
-type OUSDTSwaps @storage(postgres: true, clickhouse: true) {
+type OUSDTSwaps {
   id: ID! # Format: {transactionHash}_{chainId}_{tokenInPool}_{amountIn}_{tokenOutPool}_{amountOut}
   transactionHash: String! @index # Transaction hash of the swap transaction
   tokenInPool: String! # Token that goes into the pool after swap
@@ -652,7 +652,7 @@ type OUSDTSwaps @storage(postgres: true, clickhouse: true) {
 # handler can resolve it with a direct get() without a per-chain lookup constant.
 # Last-writer-wins across gauge factory generations (V2, V3, ...) — the row
 # reflects the most recent chain-wide defaults.
-type CLGaugeConfig @storage(postgres: true, clickhouse: true) {
+type CLGaugeConfig {
   id: ID! # Format: stringified chainId (e.g. "8453" for Base)
   defaultEmissionsCap: BigInt! @config(precision: 24) # Chain-wide default gauge emissions cap; applied when a pool's gauge has no SetEmissionsCap override.
   defaultMinStakeTime: BigInt! @config(precision: 24) # Chain-wide default LP stake lockup (seconds), set via CLGaugeFactoryV3.SetDefaultMinStakeTime. 0 before V3.
@@ -660,30 +660,28 @@ type CLGaugeConfig @storage(postgres: true, clickhouse: true) {
   lastUpdatedTimestamp: Timestamp! # Timestamp of the last CLGaugeConfig update
 }
 
-type DispatchId_event @storage(postgres: true, clickhouse: true) {
+type DispatchId_event {
   id: ID! # Format: {transactionHash}_{chainId}_{messageId}
   chainId: Int! # Chain ID where the message was dispatched (origin chain)
   transactionHash: String! @index # Transaction hash of the dispatch transaction
   messageId: String! @index # Unique message ID identifying the cross-chain message in Hyperlane
 }
 
-type ProcessId_event @storage(postgres: true, clickhouse: true) {
+type ProcessId_event {
   id: ID! # Format: {transactionHash}_{chainId}_{messageId}
   chainId: Int! # Chain ID where the message was processed (destination chain)
   transactionHash: String! @index # Transaction hash of the process transaction
   messageId: String! @index # Unique message ID identifying the cross-chain message in Hyperlane (matches DispatchId messageId)
 }
 
-type ALM_TotalSupplyLimitUpdated_event
-  @storage(postgres: true, clickhouse: true)
-{
+type ALM_TotalSupplyLimitUpdated_event {
   id: ID! # Format: {chainId}-{lpWrapperAddress} (ALMLPWrapperId)
   lpWrapperAddress: String! # LP Wrapper associated to the event
   currentTotalSupplyLPTokens: BigInt! @config(precision: 76) # Current supply of LP tokens for the pool, emitted by the event
   transactionHash: String! # Transaction hash of the event
 }
 
-type RootPool_LeafPool @storage(postgres: true, clickhouse: true) {
+type RootPool_LeafPool {
   id: ID! # Format: {rootChainId}-{leafChainId}-{rootPoolAddress}-{leafPoolAddress} (RootPoolLeafPoolId)
   rootChainId: Int! # Optimism chain ID
   rootPoolAddress: String! @index # Placeholder contract that isn't a real pool (i.e., doesn't allow for LP, swap, etc). Mainly just for registring purposes
@@ -692,7 +690,7 @@ type RootPool_LeafPool @storage(postgres: true, clickhouse: true) {
 }
 
 # Maps root gauge (RootGauge/RootCLGauge on OP) to root pool for DistributeReward cross-chain resolution
-type RootGauge_RootPool @storage(postgres: true, clickhouse: true) {
+type RootGauge_RootPool {
   id: ID! # Unique identifier, formatted as {rootChainId}-{rootGaugeAddress}
   rootChainId: Int! # Chain ID of the root chain (typically Optimism)
   rootGaugeAddress: String! @index # Address of the root gauge contract on the root chain
@@ -700,7 +698,7 @@ type RootGauge_RootPool @storage(postgres: true, clickhouse: true) {
 }
 
 # Deferred vote: stored when Voted/Abstained fires but RootPool_LeafPool mapping does not exist yet
-type PendingVote @storage(postgres: true, clickhouse: true) {
+type PendingVote {
   id: ID! # Format: {chainId}-{rootPoolAddress}-{tokenId}-{txHash}-{logIndex}
   chainId: Int! # Chain ID for which the vote was intended
   rootPoolAddress: String! @index # Address of the root pool being voted on
@@ -718,7 +716,7 @@ type PendingVote @storage(postgres: true, clickhouse: true) {
 # (and at a LOWER log index than) PoolCreated from the factory, so Envio
 # delivers Initialize first. PoolCreated reads this buffer when constructing
 # the new aggregator and deletes the entry afterwards.
-type CLPoolPendingInitialize @storage(postgres: true, clickhouse: true) {
+type CLPoolPendingInitialize {
   id: ID! # Format: {chainId}-{poolAddress} (PoolId)
   chainId: Int! # chain id
   poolAddress: String! # address of the CL pool awaiting PoolCreated
@@ -727,7 +725,7 @@ type CLPoolPendingInitialize @storage(postgres: true, clickhouse: true) {
 }
 
 # Deferred RootPool->LeafPool mapping: stored when RootPoolCreated fires but no Pool exists yet
-type PendingRootPoolMapping @storage(postgres: true, clickhouse: true) {
+type PendingRootPoolMapping {
   id: ID! # Format: {rootChainId}-{rootPoolAddress}
   rootChainId: Int! # Chain ID where the root pool exists (typically Optimism)
   rootPoolAddress: String! # Address of the root pool (matches RootPool_LeafPool)
@@ -739,7 +737,7 @@ type PendingRootPoolMapping @storage(postgres: true, clickhouse: true) {
 }
 
 # Deferred distribution: stored when DistributeReward fires for a root gauge but RootPool_LeafPool mapping does not exist yet
-type PendingDistribution @storage(postgres: true, clickhouse: true) {
+type PendingDistribution {
   id: ID! # Format: {rootChainId}-{rootPoolAddress}-{blockNumber}-{logIndex}
   rootChainId: Int! # Chain ID where the root gauge and pool exist
   rootPoolAddress: String! @index # Address of the root pool (matches RootPool_LeafPool)
@@ -754,7 +752,7 @@ type PendingDistribution @storage(postgres: true, clickhouse: true) {
 # It allows to initialise currentFee field for all CLPools
 # CLPool fees can then be modified by either CustomSwapFeeModule or DynamicSwapFeeModule
 # The same tick spacing can be enabled multiple times (to update the fee), so this entity is updated, not created new
-type FeeToTickSpacingMapping @storage(postgres: true, clickhouse: true) {
+type FeeToTickSpacingMapping {
   id: ID! # Format: {chainId}-{tickSpacing} (FeeToTickSpacingMappingId)
   chainId: Int! @index # chain id
   tickSpacing: BigInt! @config(precision: 24) @index # Tick spacing value
@@ -767,7 +765,7 @@ type FeeToTickSpacingMapping @storage(postgres: true, clickhouse: true) {
 # However, the transfer event doesn't have all the necessary data (e.g. tickLower, tickUpper, etc).
 # This is where CLpoolMintEvent comes in
 # Deleted immediately after consumption
-type CLPoolMintEvent @storage(postgres: true, clickhouse: true) {
+type CLPoolMintEvent {
   id: ID! # Format: {chainId}_{poolAddress}_{txHash}_{logIndex}
   chainId: Int! @index # chain id
   pool: String! @index # address of the CL pool the Mint fired on
@@ -791,7 +789,7 @@ type CLPoolMintEvent @storage(postgres: true, clickhouse: true) {
 #
 # Flow: Burn adds principal here → Collect subtracts it → remainder = fees.
 # Keyed by contract-level position identity (pool + owner + tick range).
-type CLPositionPendingPrincipal @storage(postgres: true, clickhouse: true) {
+type CLPositionPendingPrincipal {
   id: ID! # {chainId}-{poolAddress}-{owner}-{tickLower}-{tickUpper}
   # Principal from Burn events not yet drained by Collect.
   # Accumulates across multiple Burns; reduced when Collect fires.
@@ -804,7 +802,7 @@ type CLPositionPendingPrincipal @storage(postgres: true, clickhouse: true) {
 # The consumer knows chainId + txHash; it reads this row and then PK-gets each event by id.
 # Cleaned up as events are consumed: ids are removed on consumption and the row is deleted
 # when the last id is removed.
-type TxCLPoolMintRegistry @storage(postgres: true, clickhouse: true) {
+type TxCLPoolMintRegistry {
   id: ID! # Format: {chainId}-{txHash}
   mintEventIds: [String!]! # CLPoolMintEvent ids produced in this tx, in insertion order
 }
@@ -813,14 +811,14 @@ type TxCLPoolMintRegistry @storage(postgres: true, clickhouse: true) {
 # on PoolTransferInTx.getWhere({ txHash }) in the Pool.Mint / Pool.Burn consumer.
 # The consumer knows chainId + txHash + pool; it reads this row and then PK-gets
 # each transfer by id. Rows are pruned on consumption and deleted when empty.
-type TxPoolTransferRegistry @storage(postgres: true, clickhouse: true) {
+type TxPoolTransferRegistry {
   id: ID! # Format: {chainId}-{txHash}-{poolAddress}
   transferIds: [String!]! # PoolTransferInTx ids produced in this (tx, pool), in insertion order
 }
 
 # Temporary entity for matching Mint/Burn with Transfer events
 # Only stores mint/burn transfers (isMint || isBurn) to reduce storage
-type PoolTransferInTx @storage(postgres: true, clickhouse: true) {
+type PoolTransferInTx {
   id: ID! # Format: {chainId}-{txHash}-{poolAddress}-{logIndex}
   chainId: Int! @index # chain id
   txHash: String! @index # transaction hash containing the transfer
@@ -839,7 +837,7 @@ type PoolTransferInTx @storage(postgres: true, clickhouse: true) {
 # Similar to PoolTransferInTx but for ALM LP Wrapper
 # Only needed for burns (to = 0x0) since Deposit events emit the correct minted amount
 # Needed for LPWrapper V1 Withdraw event handler fix
-type ALMLPWrapperTransferInTx @storage(postgres: true, clickhouse: true) {
+type ALMLPWrapperTransferInTx {
   id: ID! # Format: {chainId}-{txHash}-{wrapperAddress}-{logIndex}
   chainId: Int! @index # chain id
   txHash: String! @index # transaction hash containing the transfer
@@ -860,7 +858,7 @@ type ALMLPWrapperTransferInTx @storage(postgres: true, clickhouse: true) {
 # Redistributed and Deposited events are folded into Pool
 # counters (totalEmissionsRedistributed / totalEmissionsForfeited) via a
 # gauge→pool lookup; they have no dedicated entity.
-type RedistributorConfig @storage(postgres: true, clickhouse: true) {
+type RedistributorConfig {
   id: ID! # Format: {chainId}-{redistributorAddress}
   chainId: Int! @index # chain id
   redistributorAddress: String! # Redistributor contract address


### PR DESCRIPTION
## Summary

- Switch `config.yaml` storage block to the v3.2.0 form where both backends are marked `default: true` (per [v3.2.0 release notes](https://github.com/enviodev/hyperindex/releases/tag/v3.2.0)).
- Drop the now-redundant `@storage(postgres: true, clickhouse: true)` annotation from all 39 entities in `schema.graphql` — entities auto-route to every default backend unless overridden.
- Update `CLAUDE.md` storage section to reflect the new rule (per-entity annotation is now optional, not required).

```diff
 storage:
-  postgres: true
-  clickhouse: true
+  postgres:
+    default: true
+  clickhouse:
+    default: true
```

Behavior is unchanged: every entity continues to dual-write to Postgres + ClickHouse.

Requires `envio` ≥ 3.2.0 (already pinned in `package.json` / `pnpm-lock.yaml`).

## Test plan

- [x] `pnpm envio codegen` succeeds against the new config + schema
- [x] `tsc --noEmit` clean
- [x] `biome check` clean
- [ ] CI build + indexer dev run on a reviewer's box to confirm dual-write still works end-to-end
- [ ] Spot-check ClickHouse + Postgres receive writes for a sample entity after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)