### PR TITLE
chore(schema): make PoolLauncherConfig.pairableTokens non-null

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -605,7 +605,7 @@ type PoolLauncherPool {
 type PoolLauncherConfig {
   id: ID! # Format: {chainId}-{poolLauncherAddress} (PoolId with launcher contract as address)
   version: String! # "CL" for concentrated liquidity, "V2" for V2 pools
-  pairableTokens: [String!] # Whitelisted tokens an emerging-token pool may be paired against on this launcher
+  pairableTokens: [String!]! # Whitelisted tokens an emerging-token pool may be paired against on this launcher
 }
 
 # A superswap is characterized by 3 steps:


### PR DESCRIPTION
## Summary
- Change `PoolLauncherConfig.pairableTokens` from `[String!]` to `[String!]!` in `schema.graphql:608`.
- The field is always written (empty list when no tokens are whitelisted), so the list itself should be non-nullable. Items were already non-null.

## Test plan
- [ ] `pnpm envio codegen` regenerates `.envio/types.d.ts` cleanly
- [ ] `tsc --noEmit` passes (callers that read the field no longer need null-guards)
- [ ] `pnpm test` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Changes**
  * Updated the pool launcher configuration schema to guarantee the presence of pairable tokens in API responses. This change ensures callers can reliably expect token data without null checks, improving API reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->