### PR TITLE
Hold staked-USD lockstep across the CL snapshot recompute

### DIFF
--- a/src/Aggregators/Pool.ts
+++ b/src/Aggregators/Pool.ts
@@ -705,10 +705,19 @@ export async function updatePool(
         )),
       };
 
-      // Compute CL staked USD from running staked reserves — O(1) instead of O(N) position scan
+      // Compute CL staked USD from running staked reserves — O(1) instead of O(N) position scan.
+      // Issue #890 (residual of #857): currentLiquidityStaked and stakedReserve0/1
+      // are independent accumulators, so a full unstake drives units to 0n while the
+      // reserves can still hold wei-scale dust. Gate the recompute on staked units so
+      // that dust can't value to a non-zero USD and overwrite the lockstep clamp
+      // applied above — `currentLiquidityStaked === 0n ⇒ currentLiquidityStakedUSD === 0n`
+      // must hold after the snapshot recompute too, not only on the live write path.
       const stakedReserve0 = updated.stakedReserve0 ?? 0n;
       const stakedReserve1 = updated.stakedReserve1 ?? 0n;
-      if (stakedReserve0 <= 0n && stakedReserve1 <= 0n) {
+      if (
+        updated.currentLiquidityStaked === 0n ||
+        (stakedReserve0 <= 0n && stakedReserve1 <= 0n)
+      ) {
         updated = { ...updated, currentLiquidityStakedUSD: 0n };
       } else {
         const [token0Instance, token1Instance] = await Promise.all([

--- a/test/Aggregators/PoolStakedUSDLockstep.test.ts
+++ b/test/Aggregators/PoolStakedUSDLockstep.test.ts
@@ -147,3 +147,131 @@ describe("Pool staked-USD lockstep on live path (issue #857)", () => {
     expect(updated.currentLiquidityStakedUSD).toBe(5_000n);
   });
 });
+
+/**
+ * Issue #890 (residual of #857): the lockstep clamp at the tail of `updatePool`
+ * is re-broken at snapshot-epoch boundaries by the CL-only staked-USD recompute
+ * inside the `shouldSnapshot` block. That block values the running
+ * `stakedReserve0/1` accumulators via `calculateTotalUSD`; on a full unstake
+ * `currentLiquidityStaked` reaches `0n` while `stakedReserve0/1` can still hold
+ * wei-scale dust (they are independent accumulators). The recompute then
+ * overwrites the just-applied `0n`, producing `currentLiquidityStaked === 0n`
+ * alongside `currentLiquidityStakedUSD > 0n` — exactly the 2 rows (Base + Ink)
+ * surfaced by the 2026-06-19 integrity audit.
+ *
+ * These tests cross an epoch boundary (unlike the #857 tests above, which stay
+ * in-epoch and never enter the snapshot block) so the CL recompute actually
+ * fires.
+ */
+describe("Pool staked-USD lockstep on the CL snapshot recompute path (issue #890)", () => {
+  let common: ReturnType<typeof setupCommon>;
+
+  const chainId = 10;
+  // Address mirrors the Base audit row; reused on the test chain (10) so the
+  // default mock tokens (chain-10 ids) line up with the pool's token ids.
+  const poolAddress = toChecksumAddress(
+    "0xa4FDd479eda160671636e2eCF8f993Cbf86258a8",
+  );
+  const factoryAddress = toChecksumAddress(
+    "0x548118C7E0B865C2CfA94D15EC86B666468ac758",
+  );
+
+  // lastSnapshotTimestamp sits in an earlier hour-epoch than the update, so
+  // shouldSnapshot() fires and the CL stakedReserve-based USD recompute runs.
+  const lastSnapshot = new Date(1_000_000 * 1000);
+  const newEpochTimestamp = new Date((1_000_000 + 7_200) * 1000); // +2h -> new epoch
+
+  beforeEach(() => {
+    common = setupCommon();
+  });
+
+  function buildMockContext(setMock: ReturnType<typeof vi.fn>) {
+    const ctx = common.createMockContext({
+      Pool: { set: setMock },
+      PoolSnapshot: { set: vi.fn() },
+      Token: {
+        get: vi.fn(async (id: string) =>
+          id === common.mockToken1Data.id
+            ? common.mockToken1Data
+            : common.mockToken0Data,
+        ),
+      },
+      log: { error: () => {}, warn: () => {}, info: () => {} },
+    }) as unknown as handlerContext;
+    // `effect` is a top-level context fn, not an entity store, so it's attached
+    // after construction. getSwapFee (via updateDynamicFeePools) -> undefined
+    // skips the dynamic-fee update; the test only exercises the staked-USD recompute.
+    (ctx as unknown as { effect: unknown }).effect = vi.fn(
+      async () => undefined,
+    );
+    return ctx;
+  }
+
+  it("keeps currentLiquidityStakedUSD at 0n on a full unstake even when stakedReserve dust remains (snapshot boundary, CL pool)", async () => {
+    const pool = common.createMockPool({
+      poolAddress,
+      chainId,
+      isCL: true,
+      factoryAddress,
+      lastSnapshotTimestamp: lastSnapshot,
+      lastUpdatedTimestamp: lastSnapshot,
+      currentLiquidityStaked: 1_000_000n,
+      currentLiquidityStakedUSD: 4_126n, // stale residue mirroring the audit value
+      // Wei-scale dust left on the running staked-reserve accumulators after a
+      // full unstake. token0 is 18-dec @ $1, so the buggy recompute would value
+      // this at ~152000000000014n — the Base audit row's currentLiquidityStakedUSD.
+      stakedReserve0: 152_000_000_000_014n,
+      stakedReserve1: 0n,
+    });
+
+    const setMock = vi.fn();
+    const ctx = buildMockContext(setMock);
+
+    await updatePool(
+      { incrementalCurrentLiquidityStaked: -1_000_000n }, // full unstake -> units 0
+      pool,
+      newEpochTimestamp,
+      ctx,
+      chainId,
+      131_536_921,
+    );
+
+    const updated = setMock.mock.calls[0]?.[0] as Pool;
+    expect(updated.currentLiquidityStaked).toBe(0n);
+    expect(updated.currentLiquidityStakedUSD).toBe(0n);
+  });
+
+  it("still computes currentLiquidityStakedUSD from stakedReserves when units stay > 0 (snapshot boundary, CL pool)", async () => {
+    // Guard-rail for AC #2: the non-zero path must be unchanged — staked USD is
+    // still derived from the staked reserves at the snapshot boundary.
+    const pool = common.createMockPool({
+      poolAddress,
+      chainId,
+      isCL: true,
+      factoryAddress,
+      lastSnapshotTimestamp: lastSnapshot,
+      lastUpdatedTimestamp: lastSnapshot,
+      currentLiquidityStaked: 1_000_000n,
+      currentLiquidityStakedUSD: 0n,
+      stakedReserve0: 152_000_000_000_014n,
+      stakedReserve1: 0n,
+    });
+
+    const setMock = vi.fn();
+    const ctx = buildMockContext(setMock);
+
+    await updatePool(
+      { incrementalCurrentLiquidityStaked: -400_000n }, // partial -> units 600k
+      pool,
+      newEpochTimestamp,
+      ctx,
+      chainId,
+      131_536_921,
+    );
+
+    const updated = setMock.mock.calls[0]?.[0] as Pool;
+    expect(updated.currentLiquidityStaked).toBe(600_000n);
+    // 18-dec token @ $1 -> USD == reserve dust value.
+    expect(updated.currentLiquidityStakedUSD).toBe(152_000_000_000_014n);
+  });
+});


### PR DESCRIPTION
## Summary
- `updatePool`'s CL staked-USD recompute (inside the snapshot-epoch block) re-valued residual wei-scale `stakedReserve0/1` dust via `calculateTotalUSD` after a full unstake, overwriting the lockstep clamp and leaving `currentLiquidityStaked === 0n` alongside `currentLiquidityStakedUSD > 0n`. This is the residual of #857 that the 2026-06-19 integrity audit re-detected on 2 CL pools (Base `0xa4FD…`, Ink `0xF77c…`).
- Fix: gate the recompute on staked units — when `currentLiquidityStaked === 0n` the USD companion is forced to `0n`, so the `currentLiquidityStaked === 0n ⇒ currentLiquidityStakedUSD === 0n` invariant now holds on the snapshot path too, not only on the live write path. The non-zero path (units > 0) is unchanged.
- Adds two regression tests that cross an epoch boundary so the snapshot recompute actually fires (the existing #857 tests deliberately stay in-epoch and never reach this code path).

Closes #890

## Test plan
- [x] New regression tests pass — `test/Aggregators/PoolStakedUSDLockstep.test.ts` (5/5). The full-unstake-with-dust test reproduces the exact Base audit value `152000000000014n` before the fix and asserts `0n` after; the guard-rail test confirms units > 0 still derives USD from staked reserves.
- [x] Full test suite green — `vitest run`: 1565 tests across 112 files.
- [x] `tsc --noEmit` and `biome check` clean on the changed files.
- [ ] The 2 flagged pools (Base `0xa4FDd479…`, Ink `0xF77cc94…`) no longer report `currentLiquidityStaked = 0 ∧ currentLiquidityStakedUSD ≠ 0` *(needs human — requires a live re-index + integrity-audit re-run against the deployed indexer; the fix logically closes it)*.

## Note (no action implied)
- The gate uses `=== 0n`, matching the existing tail clamp at `Pool.ts:688` and the issue's literal AC. It would not catch a *negative* `currentLiquidityStaked` (the counter has no `>= 0n` accumulator clamp). This is a pre-existing, unobserved edge: the V2 gauge path already guards against underflow (`GaugeSharedLogic.ts:421`), and the CL/NFPM underflow root-causes were addressed structurally by #780 (counter mirroring) and #795 (missing NFPM in config). The audit found only `= 0` rows, not negative ones. Recorded here as a breadcrumb only — not a follow-up to action unless a log/audit scan shows the counter actually going negative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a snapshot edge case so staked USD now correctly drops to zero when a pool’s staked liquidity is fully removed, even if tiny reserve dust remains.
  * Preserved correct USD recalculation for partial unstake scenarios at epoch boundaries, keeping staked values in sync with remaining liquidity.
* **Tests**
  * Added coverage for full and partial unstake behavior in CL pools to verify the lockstep between staked liquidity and staked USD.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->