### PR TITLE
fix(cl-factory): persist Pool when bytecode gate skips a token side (#865)

### DIFF
--- a/src/EventHandlers/CLFactory.ts
+++ b/src/EventHandlers/CLFactory.ts
@@ -78,21 +78,15 @@ indexer.onEvent(
         : undefined,
     );
 
-    // Drop the buffer once consumed so it cannot leak into future blocks
-    // (also when we skip pool creation below, so a stale Initialize doesn't
-    // bleed into a future PoolCreated at the same address).
+    // Drop the buffer once consumed so it cannot leak into future blocks.
     if (pendingInitialize) {
       context.CLPoolPendingInitialize.deleteUnsafe(pendingInitializeId);
     }
 
-    // Bytecode-gate (#677): processCLFactoryPoolCreated returns null when
-    // either token side is a non-contract, so we skip aggregator creation and
-    // any root-pool flush to avoid persisting dangling token references.
-    if (!result) {
-      return;
-    }
-
-    // For new pool creation, set the entity directly (updatePool is for updates, not creation)
+    // For new pool creation, set the entity directly (updatePool is for updates,
+    // not creation). The pool is persisted even when a token side failed the
+    // #677 bytecode gate (#865): processCLFactoryPoolCreated now carries the
+    // aggregator with an empty symbol on that side instead of dropping the pool.
     context.Pool.set(result.liquidityPoolAggregator);
 
     await flushPendingRootPoolMappingAndVotes(

--- a/src/EventHandlers/CLFactory/CLFactoryPoolCreatedLogic.ts
+++ b/src/EventHandlers/CLFactory/CLFactoryPoolCreatedLogic.ts
@@ -100,6 +100,10 @@ export async function processCLFactoryPoolCreated(
           context.log.error(
             `Error in cl factory fetching token details for ${poolTokenAddressMapping.address} on chain ${event.chainId}: ${error}`,
           );
+          // A thrown fetch (transient RPC failure, distinct from the gate's
+          // null) must still leave a defined symbol so the Pool name doesn't
+          // become "…/undefined"; fall back to "" like the null branch (#865).
+          poolTokenSymbols[index] = "";
         }
       } else {
         poolTokenSymbols[index] = poolTokenAddressMapping.tokenInstance.symbol;

--- a/src/EventHandlers/CLFactory/CLFactoryPoolCreatedLogic.ts
+++ b/src/EventHandlers/CLFactory/CLFactoryPoolCreatedLogic.ts
@@ -43,10 +43,11 @@ export interface CLPoolPendingInitializeInput {
  * @param feeToTickSpacingMapping - FeeToTickSpacingMapping for this pool's tick spacing
  * @param context - The handler context
  * @param pendingInitialize - Optional opening price buffered by CLPool.Initialize
- * @returns The constructed aggregator, or `null` when the bytecode gate (#677)
- *   confirmed either token side is a non-contract — caller should skip
- *   `context.Pool.set` and any root-pool flush so no
- *   dangling token references are persisted.
+ * @returns The constructed aggregator. The pool is persisted even when a token
+ *   side fails the #677 bytecode gate (#865, mirroring the V2 PoolFactory fix
+ *   #864/#880): that side is left with an empty symbol and no Token row rather
+ *   than dropping the whole pool, which would orphan every downstream entity
+ *   (snapshots, user-stats, gauge/vote state).
  */
 export async function processCLFactoryPoolCreated(
   event: EvmEvent<"CLFactory", "PoolCreated">,
@@ -57,7 +58,7 @@ export async function processCLFactoryPoolCreated(
   feeToTickSpacingMapping: FeeToTickSpacingMapping,
   context: handlerContext,
   pendingInitialize?: CLPoolPendingInitializeInput,
-): Promise<CLFactoryPoolCreatedResult | null> {
+): Promise<CLFactoryPoolCreatedResult> {
   try {
     const poolTokenSymbols: string[] = [];
     const poolTokenAddressMappings: TokenEntityMapping[] = [
@@ -82,13 +83,19 @@ export async function processCLFactoryPoolCreated(
             event.block.timestamp,
           );
           if (created === null) {
+            // Bytecode gate (#677) rejected this token side: skip the Token row
+            // but STILL persist the Pool (#865, mirroring the V2 PoolFactory fix
+            // #864/#880). CLFactory has authoritatively registered the pool
+            // on-chain; dropping it orphans every downstream entity (snapshots,
+            // user-stats, gauge/vote state). Leave an empty symbol on this side.
             context.log.warn(
-              `[CLFactory.PoolCreated] Skipping Pool for pool ${event.params.pool} on chain ${event.chainId} — non-contract token side`,
+              `[CLFactory.PoolCreated] Pool ${event.params.pool} on chain ${event.chainId} has non-contract token side ${poolTokenAddressMapping.address}; persisting Pool with empty symbol on that side`,
             );
-            return null;
+            poolTokenSymbols[index] = "";
+          } else {
+            poolTokenAddressMapping.tokenInstance = created;
+            poolTokenSymbols[index] = created.symbol;
           }
-          poolTokenAddressMapping.tokenInstance = created;
-          poolTokenSymbols[index] = created.symbol;
         } catch (error) {
           context.log.error(
             `Error in cl factory fetching token details for ${poolTokenAddressMapping.address} on chain ${event.chainId}: ${error}`,

--- a/test/EventHandlers/CLFactory.test.ts
+++ b/test/EventHandlers/CLFactory.test.ts
@@ -204,6 +204,73 @@ describe("CLFactory Events", () => {
       expect(pool).toBeUndefined();
     });
 
+    // Regression for #865 (CL_FACTORY_POOL_COUNT_GAP). Before the fix, when the
+    // #677 bytecode gate confirmed one token side was a non-contract,
+    // createTokenEntity returned null and the CL handler dropped the Pool even
+    // though CLFactory had authoritatively registered it on-chain (Base audit:
+    // 22 CL pools missing). Now the gate skips only the Token row; the Pool is
+    // persisted with an empty symbol on the offending side. Mirrors #864 (V2).
+    it("creates the Pool even when one token side is a non-contract (#865)", async () => {
+      // 0x...dEaD is an EOA on Base; eth_getCode returns 0x so the bytecode gate
+      // in createTokenEntity returns null for that side.
+      const eoaTokenAddress = toChecksumAddress(
+        "0x000000000000000000000000000000000000dEaD",
+      );
+      const idx = createTestIndexer();
+      // Seed token0 + config/mapping, but NOT token1 — token1 must traverse
+      // createTokenEntity and hit the gate.
+      idx.Token.set({
+        ...mockToken0Data,
+        id: TokenId(chainId, mockToken0Data.address),
+        chainId,
+      } as Token);
+      idx.CLGaugeConfig.set({
+        id: String(chainId),
+        defaultEmissionsCap: 0n,
+        defaultMinStakeTime: 0n,
+        penaltyRate: 0n,
+        lastUpdatedTimestamp: new Date(1000000 * 1000),
+      } satisfies CLGaugeConfig);
+      idx.FeeToTickSpacingMapping.set(createFeeToTickSpacingMapping());
+
+      await idx.process({
+        chains: {
+          [chainId]: {
+            simulate: [
+              {
+                contract: "CLFactory",
+                event: "PoolCreated",
+                srcAddress: poolAddress as `0x${string}`,
+                logIndex: 1,
+                block: {
+                  number: 1000000,
+                  timestamp: 1000000,
+                  hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
+                },
+                params: {
+                  token0: token0Address as `0x${string}`,
+                  token1: eoaTokenAddress as `0x${string}`,
+                  pool: poolAddress,
+                  tickSpacing: TICK_SPACING,
+                },
+              },
+            ],
+          },
+        },
+      });
+
+      const pool = await idx.Pool.get(PoolId(chainId, poolAddress));
+      expect(pool).toBeDefined();
+      expect(pool?.isCL).toBe(true);
+      // Empty symbol on the gated (EOA) side; token0's symbol stays in its slot.
+      expect(pool?.name).toBe("CL-60 AMM - USDT/");
+      // Pool keeps the on-chain token1 address; only the Token row is skipped.
+      expect(pool?.token1_address).toBe(eoaTokenAddress);
+      // No Token row created for the EOA side (the gate still wins there).
+      const eoaToken = await idx.Token.get(TokenId(chainId, eoaTokenAddress));
+      expect(eoaToken).toBeUndefined();
+    });
+
     describe("when PendingRootPoolMapping exists for the same rootPoolMatchingHash", () => {
       const rootChainId = 10;
       const rootPoolAddress = toChecksumAddress(

--- a/test/EventHandlers/CLFactory/CLFactoryPoolCreatedLogic.test.ts
+++ b/test/EventHandlers/CLFactory/CLFactoryPoolCreatedLogic.test.ts
@@ -452,11 +452,10 @@ describe("CLFactoryPoolCreatedLogic", () => {
       );
 
       // The function should complete successfully (errors are logged but don't stop processing)
-      // When token creation fails, symbols will be undefined
+      // When token creation throws on both sides, each falls back to an empty
+      // symbol so the name never contains "undefined" (#865).
       expect(result?.liquidityPoolAggregator).toBeDefined();
-      expect(result?.liquidityPoolAggregator.name).toBe(
-        "CL-60 AMM - undefined/undefined",
-      );
+      expect(result?.liquidityPoolAggregator.name).toBe("CL-60 AMM - /");
     });
 
     it("should set all initial values correctly for new pool", async () => {
@@ -750,6 +749,42 @@ describe("CLFactoryPoolCreatedLogic", () => {
         });
       },
     );
+
+    // Issue #865 follow-up (PR #894 review): the bytecode-gate `null` path
+    // writes an empty symbol, but a *thrown* createTokenEntity error (e.g. a
+    // transient RPC failure, which is distinct from a confirmed non-contract)
+    // must not leave the slot `undefined` — that would persist a pool name like
+    // "CL-60 AMM - USDT/undefined". The catch must fall back to "" as well,
+    // matching the V2 PoolFactory symbol assembly (`?? ""`).
+    it("persists the Pool with an empty symbol when token fetch throws (#865)", async () => {
+      vi.restoreAllMocks();
+      vi.spyOn(PriceOracle, "createTokenEntity").mockImplementation(
+        async (address: string) => {
+          if (address === mockEvent.params.token0)
+            return mockToken0Data as Token;
+          // token1 fetch throws instead of returning a gate null.
+          throw new Error("transient RPC failure");
+        },
+      );
+
+      const result = await processCLFactoryPoolCreated(
+        mockEvent,
+        mockEvent.srcAddress,
+        undefined,
+        undefined,
+        undefined,
+        mockFeeToTickSpacingMapping,
+        mockContext,
+      );
+
+      // Empty (not "undefined") symbol on the throwing side.
+      expect(result.liquidityPoolAggregator).toMatchObject({
+        id: LEAF_POOL_ID,
+        name: "CL-60 AMM - USDT/",
+        ...expectedTokenFields,
+        isCL: true,
+      });
+    });
   });
 
   describe("flushPendingRootPoolMappingAndVotes", () => {

--- a/test/EventHandlers/CLFactory/CLFactoryPoolCreatedLogic.test.ts
+++ b/test/EventHandlers/CLFactory/CLFactoryPoolCreatedLogic.test.ts
@@ -687,22 +687,46 @@ describe("CLFactoryPoolCreatedLogic", () => {
       },
     );
 
-    // Issue #677 follow-up: when createTokenEntity returns null (bytecode gate
-    // confirmed the address is a non-contract), the function must return null
-    // so the caller skips persisting an aggregator with a dangling token_id.
+    // Issue #865 (CL_FACTORY_POOL_COUNT_GAP): when createTokenEntity returns
+    // null (the #677 bytecode gate confirmed the address is a non-contract), the
+    // CL factory must STILL persist the Pool — CLFactory has authoritatively
+    // registered it on-chain. The gated side just gets an empty symbol and no
+    // Token row, mirroring the V2 PoolFactory fix (#864/#880). Before the fix
+    // this returned null and the handler dropped the pool (Base: 22 CL pools
+    // missing). The non-gated side's symbol must stay in its own slot.
     it.each([
-      { side: "token0", failsToken0: true, failsToken1: false },
-      { side: "token1", failsToken0: false, failsToken1: true },
-      { side: "both", failsToken0: true, failsToken1: true },
+      {
+        side: "token0",
+        failsToken0: true,
+        failsToken1: false,
+        name: "CL-60 AMM - /USDC",
+      },
+      {
+        side: "token1",
+        failsToken0: false,
+        failsToken1: true,
+        name: "CL-60 AMM - USDT/",
+      },
+      {
+        side: "both",
+        failsToken0: true,
+        failsToken1: true,
+        name: "CL-60 AMM - /",
+      },
     ])(
-      "returns null when bytecode gate skips $side",
-      async ({ failsToken0, failsToken1 }) => {
+      "persists the Pool with an empty symbol when the bytecode gate skips $side (#865)",
+      async ({ failsToken0, failsToken1, name }) => {
         vi.restoreAllMocks();
+        // token0 -> USDT, token1 -> USDC on the non-gated side; null on the
+        // gated side. Returning the matching mock per address keeps each side's
+        // symbol in its own slot (index-based assembly, the #864 concern).
         vi.spyOn(PriceOracle, "createTokenEntity").mockImplementation(
           async (address: string) => {
-            if (address === mockEvent.params.token0 && failsToken0) return null;
-            if (address === mockEvent.params.token1 && failsToken1) return null;
-            return mockToken0Data as Token;
+            if (address === mockEvent.params.token0)
+              return failsToken0 ? null : (mockToken0Data as Token);
+            if (address === mockEvent.params.token1)
+              return failsToken1 ? null : (mockToken1Data as Token);
+            return null;
           },
         );
 
@@ -716,7 +740,14 @@ describe("CLFactoryPoolCreatedLogic", () => {
           mockContext,
         );
 
-        expect(result).toBeNull();
+        // Pool is persisted (not dropped); on-chain token addresses preserved;
+        // empty symbol only on the gated side(s).
+        expect(result.liquidityPoolAggregator).toMatchObject({
+          id: LEAF_POOL_ID,
+          name,
+          ...expectedTokenFields,
+          isCL: true,
+        });
       },
     );
   });


### PR DESCRIPTION
## Summary

Closes #865 — `[CL_FACTORY_POOL_COUNT_GAP]`: Base's four CL factories report 5,914 pools on-chain but the indexer had 5,892 (a 22-pool gap).

When a CL pool is created, `processCLFactoryPoolCreated` calls `createTokenEntity` for each token side. The #677 bytecode gate returns `null` for a non-contract address. The handler treated that `null` as a hard failure: it returned `null` for the whole pool, and the `PoolCreated` registration early-returned (`if (!result) return;`) **without ever calling `context.Pool.set`** — silently dropping the Pool and every downstream entity (snapshots, user-stats, gauge/vote state). Because the gate is an `eth_getCode` probe at HEAD, even a *transient* RPC miss on a legitimate token permanently dropped the pool.

This is the **same mechanism** the V2 `PoolFactory` had, fixed in #864/#880 (commit `9544fd3`) — but that fix only touched the V2 path. This PR mirrors it for CL.

## Change

- When a token side fails the bytecode gate, **log** it (naming the pool, chain, and non-contract address — parity with the V2 log) and leave an **empty symbol on that side only** via the existing index-based symbol assembly, then **persist the Pool**.
- The function now always returns a result on non-throwing paths (the outer `catch` rethrows), so its return type is narrowed `Promise<…| null>` → `Promise<…>` and the now-dead `if (!result) return;` guard in `CLFactory.ts` is removed (single caller; no other consumer of the null signal).
- Both-have-bytecode pools are byte-for-byte unaffected (success branch unchanged).

## Tests

- **Rewrote** the bug-encoding `it.each` in `CLFactoryPoolCreatedLogic.test.ts` — it previously asserted `result === null` (encoding the drop). It now asserts the Pool is built with an empty symbol on the gated side(s) and the non-gated symbol kept in its own slot (`CL-60 AMM - /USDC` vs `USDT/` vs `/`).
- **Added** an indexer-level regression in `CLFactory.test.ts` simulating a `CLFactory.PoolCreated` with an EOA `token1` (`0x…dEaD`), asserting the Pool exists, the on-chain `token1_address` is preserved, the name carries the empty gated symbol (`CL-60 AMM - USDT/`), and **no** Token row is created for the EOA. Mirrors the V2 #864 test (live `eth_getCode` on Base; `vi.spyOn` mocks are inert inside the `createTestIndexer` worker, so the EOA-via-live-RPC pattern is the established approach).

## Verification

- `tsc --noEmit` clean
- `biome check` clean
- Full suite green: **112 files, 1564 tests passed**

## Out of scope

- The #677 bytecode gate and `createTokenEntity`'s `null` contract — unchanged.
- The V2 `PoolFactory` path — already fixed (#880); untouched.
- **Back-filling the 22 already-missing Base pools** requires a reprocess/replay and is a deploy concern, separate from this handler fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pool creation now succeeds even when one side of a pair cannot be fully identified, preventing valid pools from being skipped.
  * The affected pool name now uses an empty symbol for the unavailable side while still preserving the original token address.
  * Improved handling ensures pending pool data is cleaned up and pool-related updates continue as expected.

* **Tests**
  * Added and updated regression coverage for pool creation when one token is a non-contract address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->