### PR TITLE
fix(pool): clamp stakedLiquidityInRange <= liquidityInRange (#891)

### DIFF
--- a/src/Aggregators/Pool.ts
+++ b/src/Aggregators/Pool.ts
@@ -454,6 +454,64 @@ export async function updatePool(
     );
   }
 
+  // Resolve the FINAL liquidityInRange persisted this update up-front so the
+  // upper-bound clamp below — and the object literal further down — compare
+  // against the exact value being written, not a stale prior. #703 semantics:
+  // an absolute diff.liquidityInRange (Swap-authoritative) wins; otherwise the
+  // incremental Mint/Burn delta lands on top of the carried value. (current
+  // and the increment are nullable, hence the `?? 0n` coalesces.)
+  const liquidityInRangeReplacement =
+    diff.liquidityInRange ??
+    (diff.incrementalLiquidityInRange ?? 0n) + (current.liquidityInRange ?? 0n);
+  // Clamp liquidityInRange to >= 0n (issue #891 follow-up). In-range liquidity
+  // is physically non-negative, but a Burn underflow (or accumulated
+  // tick-crossing drift) can drive the running value below zero. This was the
+  // only in-range/reserve field in updatePool lacking a floor — its siblings
+  // reserve0/1 (#702), stakedReserve0/1 (#771/#854), totalLiquidityUSD (#856)
+  // and stakedLiquidityInRange (#719) all clamp here. A negative total would
+  // also corrupt snapshots / gauge-share AND become a negative CEILING for the
+  // #891 staked clamp below (re-introducing a negative staked counter), so we
+  // floor it first — which keeps that clamp a faithful mirror of the reserve
+  // clamp, whose ceiling clampedReserve0 is already >= 0n. Clamp-and-log,
+  // mirroring [NEG_TLU_GUARD].
+  const finalLiquidityInRange =
+    liquidityInRangeReplacement < 0n ? 0n : liquidityInRangeReplacement;
+  if (liquidityInRangeReplacement < 0n) {
+    context.log.warn(
+      `[NEG_LIQ_IN_RANGE_GUARD][updatePool] field=liquidityInRange poolAddress=${current.poolAddress} chainId=${current.chainId} priorLiquidityInRange=${current.liquidityInRange} replacement=${liquidityInRangeReplacement} clampedTo=${finalLiquidityInRange}`,
+    );
+  }
+
+  // Upper-bound clamp: staked in-range liquidity is a SUBSET of the pool's
+  // total in-range liquidity and must never exceed it (issue #891). The staked
+  // value is derived from the staked-only tick-edge map (#719) while
+  // liquidityInRange is the Swap-authoritative total (#703); the two maps drift
+  // independently, so on tick-crossings the staked value can be left above the
+  // total (3 Superseed CL pools were observed in this state). Mirrors the
+  // [OVER_STAKED_RESERVE_GUARD] reserve clamp (#854): clamp
+  // stakedLiquidityInRange = min(stakedLiquidityInRange, liquidityInRange) and
+  // log the overshoot. `finalLiquidityInRange` is already floored >= 0n above
+  // (like the reserve clamp's clampedReserve0 ceiling), so the min() can never
+  // persist a negative staked value; the >= 0n lower clamp (#719) still applies.
+  const finalStakedLiquidityInRange =
+    clampedStakedLiquidityInRange > finalLiquidityInRange
+      ? finalLiquidityInRange
+      : clampedStakedLiquidityInRange;
+  if (clampedStakedLiquidityInRange > finalLiquidityInRange) {
+    // Log LEVEL split (mirrors #802's reserve-guard split): a zero total (pool
+    // pre-Swap/pre-init, or a Burn underflow floored to 0n above) is the benign
+    // #719 self-healing transient where a freshly-derived staked counter is
+    // briefly capped to 0n; log it at `info` so it doesn't flood the warn
+    // channel. A genuine overshoot against a POPULATED (> 0n) total — the #891
+    // Superseed case — stays at `warn` as a real-divergence tripwire.
+    const guardMsg = `[OVER_STAKED_LIQ_GUARD][updatePool] field=stakedLiquidityInRange poolAddress=${current.poolAddress} chainId=${current.chainId} priorStakedLiqInRange=${current.stakedLiquidityInRange} replacement=${clampedStakedLiquidityInRange} liquidityInRange=${finalLiquidityInRange} clampedTo=${finalStakedLiquidityInRange}`;
+    if (finalLiquidityInRange > 0n) {
+      context.log.warn(guardMsg);
+    } else {
+      context.log.info(guardMsg);
+    }
+  }
+
   // Clamp stakedReserve0 / stakedReserve1 to >= 0n at the accumulator path
   // (issue #771). Per-segment deltas computed in `segmentReserveDelta`
   // are exact-when-rounded (round-half-to-nearest); the residual wei-scale
@@ -635,12 +693,11 @@ export async function updatePool(
     // are reflected without waiting for the next swap. Absolute wins if both
     // are set in the same diff. `current.liquidityInRange` is nullable on the
     // entity (see schema.graphql:50); coalesce to 0n so a pre-first-swap pool
-    // can still accept Mint/Burn increments.
-    liquidityInRange:
-      diff.liquidityInRange ??
-      (diff.incrementalLiquidityInRange ?? 0n) +
-        (current.liquidityInRange ?? 0n),
-    stakedLiquidityInRange: clampedStakedLiquidityInRange,
+    // can still accept Mint/Burn increments. Resolved above as
+    // `finalLiquidityInRange` so the #891 over-clamp bounds against the same
+    // value that is persisted here.
+    liquidityInRange: finalLiquidityInRange,
+    stakedLiquidityInRange: finalStakedLiquidityInRange,
     stakedReserve0: finalStakedReserve0,
     stakedReserve1: finalStakedReserve1,
     // Monotonic latch: once a pool has ever been staked, hasStakes stays true

--- a/test/Aggregators/CLStakedLiquidityEdgeSanity.test.ts
+++ b/test/Aggregators/CLStakedLiquidityEdgeSanity.test.ts
@@ -358,6 +358,11 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
         sqrtPriceX96: 0n,
         tick: 0n,
         hasStakes: false,
+        // The staked position is part of the pool's total in-range liquidity,
+        // so seed liquidityInRange to cover it. Without this the #891 upper
+        // clamp (staked ≤ total) would cap the derived counter to 0n and mask
+        // the #719 derivation this test exercises.
+        liquidityInRange: 500n,
       });
       indexer.Pool.set(liquidityPool);
       indexer.Token.set(mockToken0Data as Token);
@@ -636,6 +641,11 @@ describe("CLStakedLiquidity edge-list sanity (#649)", () => {
         sqrtPriceX96: sqrtAt(0n),
         tick: 0n,
         hasStakes: false,
+        // The staked position is part of the pool's total in-range liquidity,
+        // so seed liquidityInRange to cover it. Without this the #891 upper
+        // clamp (staked ≤ total) would cap the derived counter to 0n and mask
+        // the #719 round-trip this test exercises.
+        liquidityInRange: 500n,
       });
       indexer.Pool.set(liquidityPool);
       indexer.Token.set(mockToken0Data as Token);

--- a/test/Aggregators/Pool.test.ts
+++ b/test/Aggregators/Pool.test.ts
@@ -1486,6 +1486,10 @@ describe("Pool Functions", () => {
           {
             ...(liquidityPoolAggregator as Pool),
             stakedLiquidityInRange: 100n,
+            // Keep total in-range liquidity above the staked replacement so the
+            // #891 upper clamp doesn't fire — this test isolates the lower-bound
+            // (>= 0n) clamp's no-op behaviour on a non-negative value.
+            liquidityInRange: 1000n,
             lastSnapshotTimestamp: sameEpochAsTimestamp(),
             lastUpdatedTimestamp: sameEpochAsTimestamp(),
           },
@@ -1497,6 +1501,273 @@ describe("Pool Functions", () => {
 
         expect(lastSet().stakedLiquidityInRange).toBe(50n);
         expect(negStakedLiqGuardLogs().length).toBe(0);
+      });
+    });
+
+    // Regression test for issue #891: stakedLiquidityInRange must never exceed
+    // liquidityInRange — staked in-range liquidity is a SUBSET of the pool's
+    // total in-range liquidity. The staked-only tick-edge map (#719) and the
+    // Swap-authoritative total (#703) drift independently, so on tick-crossings
+    // the staked value can be left above the total (3 Superseed CL pools were
+    // observed in this state, the worst a 2.7× overshoot). The upper-bound
+    // clamp pulls it back to liquidityInRange and emits [OVER_STAKED_LIQ_GUARD]
+    // with {poolAddress, chainId, priorStakedLiqInRange, replacement,
+    // liquidityInRange, clampedTo}. Mirrors the [OVER_STAKED_RESERVE_GUARD]
+    // reserve clamp (#854); the lower-bound >= 0n clamp (#719) still applies.
+    describe("over-staked stakedLiquidityInRange clamp guard (issue #891)", () => {
+      const sameEpochAsTimestamp = () => timestamp;
+
+      const overStakedLiqGuardLogs = (level: "warn" | "info") => {
+        const mock = vi.mocked(mockContext.log?.[level]);
+        const calls = mock?.mock.calls ?? [];
+        return calls.filter((args) =>
+          String(args[0] ?? "").includes("[OVER_STAKED_LIQ_GUARD]"),
+        );
+      };
+
+      const lastSet = (): Pool => {
+        const setMock = vi.mocked(mockContext.Pool?.set);
+        return setMock?.mock.lastCall?.[0] as Pool;
+      };
+
+      it("clamps stakedLiquidityInRange down to liquidityInRange when the replacement exceeds it (reproduces Superseed 0xDaC2 2.7× overshoot)", async () => {
+        // Field values lifted from the #891 audit (5330-0xDaC26c3f…): the
+        // staked-in-range replacement is ~2.7× the pool's total in-range
+        // liquidity. The upper-bound clamp must pull staked back down to the
+        // liquidityInRange written in this same update.
+        const liquidityInRange = 728_496_859_484_955n;
+        const stakedReplacement = 1_959_834_779_580_129n;
+        await updatePool(
+          {
+            stakedLiquidityInRange: stakedReplacement,
+            liquidityInRange,
+          },
+          {
+            ...(liquidityPoolAggregator as Pool),
+            isCL: true,
+            stakedLiquidityInRange: 0n,
+            liquidityInRange: 0n,
+            lastSnapshotTimestamp: sameEpochAsTimestamp(),
+            lastUpdatedTimestamp: sameEpochAsTimestamp(),
+          },
+          timestamp,
+          mockContext as handlerContext,
+          5330,
+          blockNumber,
+        );
+
+        // Invariant restored: staked in-range ≤ total in-range.
+        expect(lastSet().stakedLiquidityInRange).toBe(liquidityInRange);
+        expect(lastSet().liquidityInRange).toBe(liquidityInRange);
+
+        // Genuine overshoot against a POPULATED total → warn channel.
+        const logs = overStakedLiqGuardLogs("warn");
+        expect(logs.length).toBe(1);
+        expect(overStakedLiqGuardLogs("info").length).toBe(0);
+        const msg = String(logs[0]?.[0] ?? "");
+        expect(msg).toContain("stakedLiquidityInRange");
+        expect(msg).toContain(`replacement=${stakedReplacement}`);
+        expect(msg).toContain(`liquidityInRange=${liquidityInRange}`);
+        expect(msg).toContain(`clampedTo=${liquidityInRange}`);
+        expect(msg).toContain(
+          `poolAddress=${(liquidityPoolAggregator as Pool).poolAddress}`,
+        );
+        expect(msg).toContain(
+          `chainId=${(liquidityPoolAggregator as Pool).chainId}`,
+        );
+      });
+
+      it("clamps against the CARRIED liquidityInRange when the diff omits it (not a stale prior)", async () => {
+        // The diff bumps stakedLiquidityInRange but does not supply a fresh
+        // liquidityInRange, so the persisted total is the carried current
+        // (700n). The clamp must bound staked against THAT value — the one
+        // actually being written — pulling 1000n down to 700n.
+        await updatePool(
+          { stakedLiquidityInRange: 1000n },
+          {
+            ...(liquidityPoolAggregator as Pool),
+            isCL: true,
+            stakedLiquidityInRange: 0n,
+            liquidityInRange: 700n,
+            lastSnapshotTimestamp: sameEpochAsTimestamp(),
+            lastUpdatedTimestamp: sameEpochAsTimestamp(),
+          },
+          timestamp,
+          mockContext as handlerContext,
+          5330,
+          blockNumber,
+        );
+
+        expect(lastSet().stakedLiquidityInRange).toBe(700n);
+        expect(lastSet().liquidityInRange).toBe(700n);
+        // Carried total is positive → warn channel.
+        expect(overStakedLiqGuardLogs("warn").length).toBe(1);
+        expect(overStakedLiqGuardLogs("info").length).toBe(0);
+      });
+
+      it("does not clamp or log when stakedLiquidityInRange stays <= liquidityInRange", async () => {
+        await updatePool(
+          {
+            stakedLiquidityInRange: 500n,
+            liquidityInRange: 1000n,
+          },
+          {
+            ...(liquidityPoolAggregator as Pool),
+            isCL: true,
+            stakedLiquidityInRange: 0n,
+            liquidityInRange: 0n,
+            lastSnapshotTimestamp: sameEpochAsTimestamp(),
+            lastUpdatedTimestamp: sameEpochAsTimestamp(),
+          },
+          timestamp,
+          mockContext as handlerContext,
+          5330,
+          blockNumber,
+        );
+
+        expect(lastSet().stakedLiquidityInRange).toBe(500n);
+        expect(lastSet().liquidityInRange).toBe(1000n);
+        expect(overStakedLiqGuardLogs("warn").length).toBe(0);
+        expect(overStakedLiqGuardLogs("info").length).toBe(0);
+      });
+
+      it("cannot drive stakedLiquidityInRange negative: the floored total is the ceiling", async () => {
+        // An in-range Burn whose magnitude exceeds the carried total would drive
+        // the total negative; liquidityInRange is now floored to 0n (see the
+        // [NEG_LIQ_IN_RANGE_GUARD] block), so the staked clamp's ceiling is
+        // always >= 0n and min(staked, total) can never persist a NEGATIVE
+        // staked value (which would otherwise defeat the #719 lower clamp).
+        await updatePool(
+          {
+            stakedLiquidityInRange: 500n,
+            incrementalLiquidityInRange: -100n,
+          },
+          {
+            ...(liquidityPoolAggregator as Pool),
+            isCL: true,
+            stakedLiquidityInRange: 0n,
+            liquidityInRange: 0n,
+            lastSnapshotTimestamp: sameEpochAsTimestamp(),
+            lastUpdatedTimestamp: sameEpochAsTimestamp(),
+          },
+          timestamp,
+          mockContext as handlerContext,
+          5330,
+          blockNumber,
+        );
+
+        // Total floored to 0n; staked floored to 0n (never negative).
+        expect(lastSet().liquidityInRange).toBe(0n);
+        expect(lastSet().stakedLiquidityInRange).toBe(0n);
+        // staked capped against a (floored) zero total → benign info, not warn.
+        expect(overStakedLiqGuardLogs("warn").length).toBe(0);
+        expect(overStakedLiqGuardLogs("info").length).toBe(1);
+      });
+
+      it("logs the benign zero-total transient (#719 gauge Deposit before first Swap) on info, not warn", async () => {
+        // A gauge Deposit derives a positive staked counter before the pool's
+        // total liquidityInRange has been established (still 0n). Capping staked
+        // to 0n here is the expected self-healing transient — it must not spam
+        // the warn channel (mirrors #802's reserve-guard level split).
+        await updatePool(
+          { stakedLiquidityInRange: 500n },
+          {
+            ...(liquidityPoolAggregator as Pool),
+            isCL: true,
+            stakedLiquidityInRange: 0n,
+            liquidityInRange: 0n,
+            lastSnapshotTimestamp: sameEpochAsTimestamp(),
+            lastUpdatedTimestamp: sameEpochAsTimestamp(),
+          },
+          timestamp,
+          mockContext as handlerContext,
+          5330,
+          blockNumber,
+        );
+
+        expect(lastSet().stakedLiquidityInRange).toBe(0n);
+        expect(lastSet().liquidityInRange).toBe(0n);
+        expect(overStakedLiqGuardLogs("info").length).toBe(1);
+        expect(overStakedLiqGuardLogs("warn").length).toBe(0);
+      });
+    });
+
+    // Regression test for the #891 follow-up: liquidityInRange must never
+    // persist negative. It was the only in-range/reserve field in updatePool
+    // without a >= 0n floor (reserves #702, stakedReserves #771/#854, TLU #856,
+    // stakedLiquidityInRange #719 all clamp). A Burn underflow / tick-crossing
+    // drift can drive it below zero, corrupting snapshots and gauge-share, and —
+    // as the #891 staked clamp's ceiling — re-introducing a negative staked
+    // counter. Clamp-and-log under [NEG_LIQ_IN_RANGE_GUARD], mirroring
+    // [NEG_TLU_GUARD] (#856).
+    describe("negative liquidityInRange clamp guard (issue #891 / #856-analog)", () => {
+      const sameEpochAsTimestamp = () => timestamp;
+
+      const negLiqInRangeGuardLogs = () => {
+        const warnMock = vi.mocked(mockContext.log?.warn);
+        const calls = warnMock?.mock.calls ?? [];
+        return calls.filter((args) =>
+          String(args[0] ?? "").includes("[NEG_LIQ_IN_RANGE_GUARD]"),
+        );
+      };
+
+      const lastSet = (): Pool => {
+        const setMock = vi.mocked(mockContext.Pool?.set);
+        return setMock?.mock.lastCall?.[0] as Pool;
+      };
+
+      it("clamps liquidityInRange to 0n and logs guard when an in-range Burn underflows it", async () => {
+        await updatePool(
+          { incrementalLiquidityInRange: -100n },
+          {
+            ...(liquidityPoolAggregator as Pool),
+            isCL: true,
+            liquidityInRange: 50n,
+            stakedLiquidityInRange: 0n,
+            lastSnapshotTimestamp: sameEpochAsTimestamp(),
+            lastUpdatedTimestamp: sameEpochAsTimestamp(),
+          },
+          timestamp,
+          mockContext as handlerContext,
+          5330,
+          blockNumber,
+        );
+
+        expect(lastSet().liquidityInRange).toBe(0n);
+
+        const logs = negLiqInRangeGuardLogs();
+        expect(logs.length).toBe(1);
+        const msg = String(logs[0]?.[0] ?? "");
+        expect(msg).toContain("field=liquidityInRange");
+        expect(msg).toContain("priorLiquidityInRange=50");
+        expect(msg).toContain("replacement=-50");
+        expect(msg).toContain("clampedTo=0");
+        expect(msg).toContain(
+          `poolAddress=${(liquidityPoolAggregator as Pool).poolAddress}`,
+        );
+        expect(msg).toContain(
+          `chainId=${(liquidityPoolAggregator as Pool).chainId}`,
+        );
+      });
+
+      it("does not clamp or log when liquidityInRange stays non-negative", async () => {
+        await updatePool(
+          { incrementalLiquidityInRange: 100n },
+          {
+            ...(liquidityPoolAggregator as Pool),
+            isCL: true,
+            liquidityInRange: 50n,
+            lastSnapshotTimestamp: sameEpochAsTimestamp(),
+            lastUpdatedTimestamp: sameEpochAsTimestamp(),
+          },
+          timestamp,
+          mockContext as handlerContext,
+          5330,
+          blockNumber,
+        );
+
+        expect(lastSet().liquidityInRange).toBe(150n);
+        expect(negLiqInRangeGuardLogs().length).toBe(0);
       });
     });
   });


### PR DESCRIPTION
## Summary

`Pool.stakedLiquidityInRange` (staked in-range liquidity) is a **subset** of `Pool.liquidityInRange` (total in-range liquidity), but the aggregator only **lower-clamped** it (`>= 0n` via `[NEG_STAKED_LIQ_GUARD]`, #719). It was never bounded above by the total. The staked-only tick-edge map (#719) and the Swap-authoritative total (#703) drift independently, so on tick-crossings `stakedLiquidityInRange` could persist **above** `liquidityInRange` — physically impossible. The 2026-06-19 integrity audit found 3 Superseed (chain 5330) CL pools in this state, the worst (`0xDaC2…`) at a 2.7× overshoot.

This is the in-range-liquidity analog of the reserve-side invariant #854 already fixed via `[OVER_STAKED_RESERVE_GUARD]`.

## Fix

In `updatePool` (`src/Aggregators/Pool.ts`):

- **Upper-bound clamp** `stakedLiquidityInRange = min(stakedLiquidityInRange, liquidityInRange)`, emitting `[OVER_STAKED_LIQ_GUARD]`, mirroring `[OVER_STAKED_RESERVE_GUARD]` (#854). The comparison is against the **final** `liquidityInRange` persisted in the *same* update (resolved up-front), not a stale prior — honoring #703 replace-vs-increment semantics.
- **Floor `liquidityInRange` itself at `0n`** with a new `[NEG_LIQ_IN_RANGE_GUARD]` (mirrors `[NEG_TLU_GUARD]` #856). This was the only in-range/reserve field in `updatePool` lacking a negative floor — reserves (#702), staked reserves (#771/#854), `totalLiquidityUSD` (#856) and `stakedLiquidityInRange` (#719) all clamp here. A Burn underflow (or tick-crossing drift) could otherwise drive it negative, corrupting snapshots / gauge-share **and** — as the staked clamp's ceiling — re-introducing a negative staked counter. Flooring the total first makes the staked clamp a faithful mirror of the reserve clamp (whose ceiling `clampedReserve0` is already `>= 0n`), so `min()` can never persist a negative staked value.
- **Log-level split** on the staked guard (mirrors #802): a zero total (pool pre-Swap/pre-init, or a Burn underflow floored to `0n`) is the benign #719 self-healing transient and logs at `info`; a genuine overshoot against a **populated** (`> 0n`) total — the #891 Superseed case — logs at `warn`.

The lower-bound `>= 0n` clamp (#719) is unchanged and still feeds the upper clamp.

## Test plan

Maps to the issue's acceptance criteria (`test/Aggregators/Pool.test.ts`):

- [x] After any update, `stakedLiquidityInRange <= liquidityInRange` holds — tracer test reproduces the Superseed `0xDaC2…` 2.7× overshoot (`1.96e15 → 7.28e14`); carry-forward + no-clamp cases covered.
- [x] Lower-bound `>= 0n` clamp (`[NEG_STAKED_LIQ_GUARD]`) still applies — three #719 tests stay green.
- [x] Upper-clamp guard log records pool, chain, pre-clamp value, `liquidityInRange`, clamped result — asserted field-by-field; `warn`/`info` level split asserted.
- [x] A test sets a staked replacement above `liquidityInRange` and asserts it clamps down — tracer test.
- [x] `liquidityInRange` floored to `0n` on Burn underflow + `[NEG_LIQ_IN_RANGE_GUARD]` logged — dedicated describe block; staked stays `>= 0n` as a consequence.
- [x] Full suite green (`vitest run`: 112 files, **1570 tests**), `tsc --noEmit` clean, `biome check` clean. CI `build-and-test` (install→codegen→build→qa→test) green.
- [ ] Flagged Superseed (5330) pools satisfy the invariant after a live reindex *(needs human — runtime reindex against chain 5330; guaranteed by construction + unit-reproduced here)*

## Code review notes

A multi-agent code review (43 agents, xhigh) surfaced three findings; all addressed:

- **Finding A (most severe) — negative staked.** The clamp's ceiling was un-floored, so a negative total persisted a negative `stakedLiquidityInRange`, defeating #719. **Fixed** by flooring `liquidityInRange` at the source (`[NEG_LIQ_IN_RANGE_GUARD]`); the staked ceiling is now always `>= 0n`, so `min()` of two non-negatives can't go negative. Re-verified SOUND by an independent adversarial pass. *(The floor on `liquidityInRange` was added in review follow-up — it also closes the latent negative-total data-quality gap, so AC #1 now holds unconditionally rather than only when the total is sane.)*
- **Finding C — log noise.** The guard logged unconditionally at `warn`. **Fixed** via the `warn`/`info` split above (mirrors #802).
- **Finding B — transient under-count (accepted tradeoff).** On gauge/NFPM/burn-only diffs that supply `stakedLiquidityInRange` but never refresh `liquidityInRange`, the clamp caps a correctly edge-derived staked value against the carried (possibly stale/zero) total, briefly understating staked liquidity. This is inherent to the AC-mandated approach: AC #1 requires `staked <= total` after **every** update, and the issue marks root-causing the staked-vs-total divergence as out of scope. It **self-heals on the next Swap** (when `liquidityInRange` is re-anchored absolutely from `slot0` and staked is re-derived) — the same property as the sibling #854/#702/#856 clamps. Caveat: an immutable `PoolSnapshot` taken inside the transient window records the understated value. A precise fix (re-deriving the total on non-Swap paths) is a possible follow-up beyond this issue's scope.

The two `liquidityInRange: 500n` seeds added to `CLStakedLiquidityEdgeSanity.test.ts` keep the #891 clamp from masking the orthogonal #719 derivation those tests verify — a staked position *is* part of the pool's total in-range liquidity, so seeding the total to cover it represents a physically valid state.

Closes #891

🤖 Generated with [Claude Code](https://claude.com/claude-code)