### PR TITLE
fix(pool): directional TVL cap against hard-anchor counterparty (#892)

### DIFF
--- a/src/EventHandlers/CLPool/CLPoolBurnLogic.ts
+++ b/src/EventHandlers/CLPool/CLPoolBurnLogic.ts
@@ -3,7 +3,7 @@ import type { PoolDiff } from "../../Aggregators/Pool";
 import { CLPositionPendingPrincipalId } from "../../Constants";
 import type { handlerContext } from "../../EntityTypes";
 import type { Pool } from "../../EntityTypes";
-import { calculateTotalUSD } from "../../Helpers";
+import { calculateLiquidityUSD } from "../../Helpers";
 
 export interface CLPoolBurnResult {
   liquidityPoolDiff: Partial<PoolDiff>;
@@ -40,11 +40,16 @@ export async function processCLPoolBurn(
   // until collect(), but are no longer part of any LP position's liquidity).
   const newReserve0 = liquidityPoolAggregator.reserve0 - event.params.amount0;
   const newReserve1 = liquidityPoolAggregator.reserve1 - event.params.amount1;
-  const currentTotalLiquidityUSD = calculateTotalUSD(
+  // Issue #892: directional TVL cap against a hard-anchor counterparty. Burn
+  // does not move the price, so the stored pool ratio is the correct witness.
+  const currentTotalLiquidityUSD = calculateLiquidityUSD(
     newReserve0,
     newReserve1,
     token0Instance,
     token1Instance,
+    liquidityPoolAggregator.token0Price,
+    liquidityPoolAggregator.token1Price,
+    liquidityPoolAggregator.chainId,
   );
 
   // Track burned principal so Collect can isolate fees.

--- a/src/EventHandlers/CLPool/CLPoolMintLogic.ts
+++ b/src/EventHandlers/CLPool/CLPoolMintLogic.ts
@@ -2,7 +2,7 @@ import type { EvmEvent } from "envio";
 import type { Token } from "envio";
 import type { PoolDiff } from "../../Aggregators/Pool";
 import type { Pool } from "../../EntityTypes";
-import { calculateTotalUSD } from "../../Helpers";
+import { calculateLiquidityUSD } from "../../Helpers";
 
 export interface CLPoolMintResult {
   liquidityPoolDiff: Partial<PoolDiff>;
@@ -34,11 +34,16 @@ export function processCLPoolMint(
   // Mint deposits new capital into the pool — always increases reserves.
   const newReserve0 = liquidityPoolAggregator.reserve0 + event.params.amount0;
   const newReserve1 = liquidityPoolAggregator.reserve1 + event.params.amount1;
-  const currentTotalLiquidityUSD = calculateTotalUSD(
+  // Issue #892: directional TVL cap against a hard-anchor counterparty. Mint
+  // does not move the price, so the stored pool ratio is the correct witness.
+  const currentTotalLiquidityUSD = calculateLiquidityUSD(
     newReserve0,
     newReserve1,
     token0Instance,
     token1Instance,
+    liquidityPoolAggregator.token0Price,
+    liquidityPoolAggregator.token1Price,
+    liquidityPoolAggregator.chainId,
   );
 
   const currentTick = liquidityPoolAggregator.tick;

--- a/src/EventHandlers/CLPool/CLPoolSwapLogic.ts
+++ b/src/EventHandlers/CLPool/CLPoolSwapLogic.ts
@@ -5,7 +5,7 @@ import type { UserStatsPerPoolDiff } from "../../Aggregators/UserStatsPerPool";
 import { FEE_SCALE } from "../../Constants";
 import type { Pool, handlerContext } from "../../EntityTypes";
 import {
-  calculateTotalUSD,
+  calculateLiquidityUSD,
   normalizeTokenAmountTo1e18,
   pickTrustedSwapVolumeUSD,
 } from "../../Helpers";
@@ -279,12 +279,6 @@ export async function processCLPoolSwap(
   const reserveDelta1 = totalCrossings.delta1;
   const newReserve0 = liquidityPoolAggregator.reserve0 + reserveDelta0;
   const newReserve1 = liquidityPoolAggregator.reserve1 + reserveDelta1;
-  const currentTotalLiquidityUSD = calculateTotalUSD(
-    newReserve0,
-    newReserve1,
-    token0Instance,
-    token1Instance,
-  );
 
   // Staked-share tracking (#666) — unchanged. Same edge-walk math, but over the
   // staked-only edge map, producing the staked slice of the reserve deltas.
@@ -321,6 +315,19 @@ export async function processCLPoolSwap(
         )
       : { token0Price: 0n, token1Price: 0n },
     liquidityPoolAggregator,
+  );
+
+  // Issue #892: directional TVL cap against a hard-anchor counterparty. Computed
+  // after priceRatios so the cap uses the swap's post-trade pool ratio (the same
+  // ratio written to the diff) as the pool-implied witness.
+  const currentTotalLiquidityUSD = calculateLiquidityUSD(
+    newReserve0,
+    newReserve1,
+    token0Instance,
+    token1Instance,
+    priceRatios.token0Price,
+    priceRatios.token1Price,
+    event.chainId,
   );
 
   // Build complete liquidity pool aggregator diff

--- a/src/EventHandlers/Pool/PoolSyncLogic.ts
+++ b/src/EventHandlers/Pool/PoolSyncLogic.ts
@@ -1,7 +1,7 @@
 import type { EvmEvent, Token } from "envio";
 import type { PoolDiff } from "../../Aggregators/Pool";
 import type { Pool } from "../../EntityTypes";
-import { calculateTotalUSD } from "../../Helpers";
+import { calculateLiquidityUSD } from "../../Helpers";
 import { deriveV2PriceRatios, pickPriceRatios } from "../../PoolPriceRatio";
 
 export interface PoolSyncResult {
@@ -24,6 +24,24 @@ export function processPoolSync(
   token0Instance: Token | undefined,
   token1Instance: Token | undefined,
 ): PoolSyncResult {
+  // token0Price/token1Price are the pool-internal exchange rate, derived from
+  // the synced reserves — NOT from token oracle prices. This keeps the ratio
+  // oracle-independent so a mispriced token (e.g. a non-WL scam token) can no
+  // longer inflate it without bound (#783). pickPriceRatios falls back to the
+  // last-known ratio per leg when decimals are unavailable or reserves are zero.
+  // Computed before the reserve branches so the #892 TVL cap below can use it.
+  const priceRatios = pickPriceRatios(
+    token0Instance && token1Instance
+      ? deriveV2PriceRatios(
+          event.params.reserve0,
+          event.params.reserve1,
+          token0Instance.decimals,
+          token1Instance.decimals,
+        )
+      : { token0Price: 0n, token1Price: 0n },
+    liquidityPoolAggregator,
+  );
+
   // Handle different scenarios based on token availability and amounts
   let reserve0Change: bigint;
   let reserve1Change: bigint;
@@ -48,30 +66,18 @@ export function processPoolSync(
 
     // totalLiquidityUSD is non-cumulative: overwrite it using the absolute
     // post-sync reserves rather than applying a delta from the previous value.
-    currentTotalLiquidityUSD = calculateTotalUSD(
+    // Issue #892: directional TVL cap against a hard-anchor counterparty, using
+    // the freshly-derived pool ratio as the implied-price witness.
+    currentTotalLiquidityUSD = calculateLiquidityUSD(
       event.params.reserve0,
       event.params.reserve1,
       token0Instance,
       token1Instance,
+      priceRatios.token0Price,
+      priceRatios.token1Price,
+      liquidityPoolAggregator.chainId,
     );
   }
-
-  // token0Price/token1Price are the pool-internal exchange rate, derived from
-  // the synced reserves — NOT from token oracle prices. This keeps the ratio
-  // oracle-independent so a mispriced token (e.g. a non-WL scam token) can no
-  // longer inflate it without bound (#783). pickPriceRatios falls back to the
-  // last-known ratio per leg when decimals are unavailable or reserves are zero.
-  const priceRatios = pickPriceRatios(
-    token0Instance && token1Instance
-      ? deriveV2PriceRatios(
-          event.params.reserve0,
-          event.params.reserve1,
-          token0Instance.decimals,
-          token1Instance.decimals,
-        )
-      : { token0Price: 0n, token1Price: 0n },
-    liquidityPoolAggregator,
-  );
 
   const liquidityPoolDiff = {
     incrementalReserve0: reserve0Change,

--- a/src/Helpers.ts
+++ b/src/Helpers.ts
@@ -9,7 +9,20 @@ import { TEN_TO_THE_18_BI } from "./Constants";
 import type { handlerContext } from "./EntityTypes";
 import type { Pool } from "./EntityTypes";
 import { multiplyBase1e18 } from "./Maths";
-import { getTrustedUSD } from "./PriceTrust";
+import { getHardAnchorUnitUSD, getTrustedUSD } from "./PriceTrust";
+
+// Directional TVL cap (issue #892). A pool leg is re-valued at its pool-implied
+// price only when its oracle price exceeds that implied price by more than this
+// ratio. Reuses the 10× band of the #668 price-spike guard.
+const TVL_CAP_RATIO = 10n;
+
+// Minimum anchor-leg reserve USD (1e18-base) for the directional cap to engage.
+// Below this the pool is too thin for its spot ratio to be a trustworthy
+// witness — a drained / edge pool's implied price can blow up in either
+// direction (the #784/#785 failure mode). $1,000 isolated the live LFI/USDC
+// poison on Base while leaving every drained-stablecoin false positive (e.g.
+// Swell USDe/rUSDC) untouched.
+const TVL_CAP_ANCHOR_FLOOR_USD = 1_000n * TEN_TO_THE_18_BI;
 
 /**
  * Normalises an unknown value to an error message string.
@@ -181,6 +194,137 @@ export function calculateTotalUSD(
   token1: Token | undefined,
 ): bigint {
   return getTrustedUSD(amount0, token0) + getTrustedUSD(amount1, token1);
+}
+
+/**
+ * One leg of {@link calculateLiquidityUSD}: token T's trusted USD value, capped
+ * to its pool-implied value when its hard-anchor counterparty C shows that T's
+ * oracle price is more than {@link TVL_CAP_RATIO}× too high (issue #892).
+ *
+ * Returns the untouched {@link getTrustedUSD} value unless ALL of:
+ *  - T is trusted and contributes a positive USD leg (untrusted ⇒ already 0n),
+ *  - the pool ratio for T-in-C is positive,
+ *  - C is a hard anchor we can value (stablecoin = $1, WETH = oracle price),
+ *  - C's reserve is worth ≥ `$1,000` (thin-pool guard),
+ *  - and T's oracle price exceeds the pool-implied price by > 10×.
+ * When they hold, T is re-valued at the pool-implied price. The cap is
+ * downward-only by construction (it fires on oracle ≫ implied), so it can only
+ * deflate an inflated leg toward the liquid pool's truth, never inflate a
+ * correct one.
+ *
+ * @param amountT - Raw reserve of the priced leg T (token's decimal base)
+ * @param tokenT - The priced leg's token (undefined / untrusted ⇒ 0n)
+ * @param amountC - Raw reserve of the counterparty leg C (candidate anchor)
+ * @param tokenC - The counterparty token
+ * @param ratioTinC - Price of T in C units, 1e18-scaled (`Pool.token0Price` when
+ *   T = token0, `Pool.token1Price` when T = token1)
+ * @param chainId - Chain the pool lives on (for the hard-anchor lookup)
+ * @returns T's USD contribution (1e18-base): trusted, or pool-implied when capped
+ */
+function cappedLegUSD(
+  amountT: bigint,
+  tokenT: Token | undefined,
+  amountC: bigint,
+  tokenC: Token | undefined,
+  ratioTinC: bigint,
+  chainId: number,
+): bigint {
+  const trustedUSD = getTrustedUSD(amountT, tokenT);
+  // Nothing to cap: untrusted / zero leg, no priced T, or no usable pool ratio.
+  if (trustedUSD <= 0n || !tokenT || ratioTinC <= 0n) return trustedUSD;
+
+  // The counterparty must be a hard anchor we can value ($1 pin for stablecoins,
+  // oracle price for WETH; 0n ⇒ not an anchor or unpriced WETH).
+  const anchorUnitUSD = getHardAnchorUnitUSD(chainId, tokenC);
+  if (anchorUnitUSD <= 0n || !tokenC) return trustedUSD;
+
+  // Thin/drained-pool guard: the spot ratio is only a trustworthy witness when
+  // the anchor leg holds real liquidity.
+  const anchorReserveUSD = calculateTokenAmountUSD(
+    amountC,
+    Number(tokenC.decimals),
+    anchorUnitUSD,
+  );
+  if (anchorReserveUSD < TVL_CAP_ANCHOR_FLOOR_USD) return trustedUSD;
+
+  // Pool-implied USD price of T: ratio(T in C units) × USD(C).
+  const impliedPriceT = multiplyBase1e18(ratioTinC, anchorUnitUSD);
+  if (impliedPriceT <= 0n) return trustedUSD;
+
+  // Directional, downward-only: only cap when the oracle is > 10× the implied.
+  if (tokenT.pricePerUSDNew > impliedPriceT * TVL_CAP_RATIO) {
+    return calculateTokenAmountUSD(
+      amountT,
+      Number(tokenT.decimals),
+      impliedPriceT,
+    );
+  }
+  return trustedUSD;
+}
+
+/**
+ * Pool TVL valuation with a directional, downward-only sanity cap against a
+ * hard-anchor counterparty (issue #892).
+ *
+ * Identical to {@link calculateTotalUSD} (each leg routed through the
+ * {@link getTrustedUSD} trust gate) EXCEPT that a leg whose counterparty is a
+ * stablecoin / WETH hard anchor (see `isHardAnchor`) and whose oracle price
+ * exceeds the pool-implied price by more than 10× is re-valued at the implied
+ * price. This catches a persistently poisoned but whitelisted oracle — e.g.
+ * LFI/USDC on Base reading ~$23 against a pool implying ~$0.00006, inflating
+ * one pool's TVL to ~$26B — that the global spike / re-anchor guards
+ * (#668/#784/#785) cannot heal because the bad value is stable, not a spike.
+ *
+ * Safety properties:
+ *  - **Directional & downward-only** — the cap fires only on `oracle ≫ implied`,
+ *    so it can only LOWER a leg toward the liquid pool's truth, never raise it.
+ *    A drained-pool ratio that blows up HIGH (oracle ≪ implied — e.g. a $1
+ *    stablecoin whose edge pool implies $254K) does not trigger it, so it is
+ *    regression-safe.
+ *  - **Anchor-gated, liquidity-floored** — only against a stablecoin / WETH
+ *    anchor holding ≥ `$1,000`, never an arbitrary trusted counterparty. This
+ *    avoids the broad false-positive set a naive "re-anchor on any 10× gap"
+ *    produced (#784/#785).
+ *  - **TVL-only** — does NOT mutate the token's global `pricePerUSDNew`, so
+ *    price snapshots, volume, fees, and reward USD are untouched.
+ *
+ * @param amount0 - Token0 amount (raw, token0 decimal base) — pool reserve0
+ * @param amount1 - Token1 amount (raw, token1 decimal base) — pool reserve1
+ * @param token0 - Token0 entity; undefined / untrusted contributes 0n
+ * @param token1 - Token1 entity; undefined / untrusted contributes 0n
+ * @param token0Price - Pool ratio: price of token0 in token1 units, 1e18-scaled
+ *   (`Pool.token0Price`); implies token0's USD when token1 is the anchor
+ * @param token1Price - Pool ratio: price of token1 in token0 units, 1e18-scaled
+ *   (`Pool.token1Price`); implies token1's USD when token0 is the anchor
+ * @param chainId - Chain the pool lives on (for the hard-anchor lookup)
+ * @returns Total pool USD (1e18-base), summing each leg's trusted-or-capped value
+ */
+export function calculateLiquidityUSD(
+  amount0: bigint,
+  amount1: bigint,
+  token0: Token | undefined,
+  token1: Token | undefined,
+  token0Price: bigint,
+  token1Price: bigint,
+  chainId: number,
+): bigint {
+  const usd0 = cappedLegUSD(
+    amount0,
+    token0,
+    amount1,
+    token1,
+    token0Price,
+    chainId,
+  );
+  const usd1 = cappedLegUSD(
+    amount1,
+    token1,
+    amount0,
+    token0,
+    token1Price,
+    chainId,
+  );
+  return usd0 + usd1;
 }
 
 /**

--- a/src/PriceOverrides.ts
+++ b/src/PriceOverrides.ts
@@ -672,6 +672,27 @@ const REBINDS: ReadonlyArray<{
     ],
   },
   {
+    // Issue #892: WETH on Metal -> WETH on Optimism. Both are the canonical
+    // OP-stack WETH at `0x4200…0006`. Metal's local oracle prices everything
+    // against oUSDT, which reads structurally high (~+28%), inflating Metal WETH
+    // to ~$2,005 vs the ~$1,565 cross-chain consensus. Optimism prices WETH
+    // cleanly; copying it makes WETH a trustworthy hard anchor on Metal for the
+    // directional TVL cap (Piece 1). The broader Metal oUSDT unit inflation is a
+    // separate, sub-10× follow-up.
+    source: {
+      chainId: 10,
+      address: toChecksumAddress("0x4200000000000000000000000000000000000006"),
+    },
+    targets: [
+      {
+        chainId: 1750,
+        address: toChecksumAddress(
+          "0x4200000000000000000000000000000000000006",
+        ),
+      },
+    ],
+  },
+  {
     // XVELO on every superchain -> canonical VELO on Optimism
     source: {
       chainId: 10,

--- a/src/PriceTrust.ts
+++ b/src/PriceTrust.ts
@@ -1,4 +1,5 @@
 import type { Token } from "envio";
+import { CHAIN_CONSTANTS, TEN_TO_THE_18_BI } from "./Constants";
 import type { handlerContext } from "./EntityTypes";
 import { calculateTokenAmountUSD } from "./Helpers";
 import { multiplyBase1e18 } from "./Maths";
@@ -110,6 +111,74 @@ export function getPoolImpliedUSD(
     return 0n;
   }
   return multiplyBase1e18(priceRatio1e18, counterparty.pricePerUSDNew);
+}
+
+/**
+ * Whether `address` is a "hard anchor" on `chainId` — a token whose USD value
+ * is structurally reliable enough to use as ground truth for the directional
+ * TVL cap (#892): the chain's USDC `destinationToken`, any configured
+ * stablecoin, or the chain's canonical WETH connector.
+ *
+ * Stricter than {@link isTrusted}: being protocol-whitelisted is not enough; a
+ * hard anchor is one of the few tokens the indexer treats as a USD yardstick.
+ * Stablecoins are valued at a hard $1 pin and WETH at its own oracle price (see
+ * {@link getHardAnchorUnitUSD}).
+ *
+ * `destinationToken` is checked explicitly because `buildStablecoinSet`
+ * (src/Constants.ts) deliberately EXCLUDES it from `stablecoins` — it is the
+ * oracle's pricing target, not a connector — yet it is the primary stablecoin
+ * on every chain (USDC on Optimism/Base, oUSDT on Lisk/Metal, …).
+ *
+ * @param chainId - Chain the token lives on
+ * @param address - Token address (any case; compared lowercased)
+ * @returns true iff the address is a stablecoin / destination token or WETH on
+ *   the chain; false for unknown chains
+ */
+export function isHardAnchor(chainId: number, address: string): boolean {
+  const constants = CHAIN_CONSTANTS[chainId];
+  if (!constants) return false;
+  const lower = address.toLowerCase();
+  return (
+    lower === constants.destinationToken.toLowerCase() ||
+    constants.stablecoins.has(lower) ||
+    lower === constants.weth.toLowerCase()
+  );
+}
+
+/**
+ * USD value of one whole unit of a hard-anchor token (1e18-base), or `0n` when
+ * the token is not a hard anchor on the chain or cannot be valued.
+ *
+ * Stablecoins and the chain's `destinationToken` are pinned to exactly $1 —
+ * deliberately NOT their oracle `pricePerUSDNew`, so a drifting or poisoned
+ * stablecoin oracle can never move the anchor used to sanity-check other legs.
+ * WETH is valued at its oracle `pricePerUSDNew`; an unpriced WETH (`0n`) returns
+ * `0n`, which makes every downstream cap check inert (an unusable anchor).
+ *
+ * @param chainId - Chain the token lives on
+ * @param token - Candidate anchor token (carries address + pricePerUSDNew).
+ *   Undefined ⇒ `0n`.
+ * @returns `$1` (1e18-base) for a stablecoin / destination anchor, WETH's oracle
+ *   price for the WETH anchor, or `0n` when `token` is not a hard anchor
+ */
+export function getHardAnchorUnitUSD(
+  chainId: number,
+  token: Token | undefined,
+): bigint {
+  if (!token) return 0n;
+  const constants = CHAIN_CONSTANTS[chainId];
+  if (!constants) return 0n;
+  const lower = token.address.toLowerCase();
+  if (
+    lower === constants.destinationToken.toLowerCase() ||
+    constants.stablecoins.has(lower)
+  ) {
+    return TEN_TO_THE_18_BI; // hard $1 pin
+  }
+  if (lower === constants.weth.toLowerCase()) {
+    return token.pricePerUSDNew; // WETH oracle price (0n ⇒ anchor unusable)
+  }
+  return 0n;
 }
 
 /**

--- a/test/EventHandlers/CLPool/CLPoolMintLogic.test.ts
+++ b/test/EventHandlers/CLPool/CLPoolMintLogic.test.ts
@@ -1,5 +1,9 @@
 import type { EvmEvent, Token } from "envio";
-import { toChecksumAddress } from "../../../src/Constants";
+import {
+  TEN_TO_THE_18_BI,
+  TokenId,
+  toChecksumAddress,
+} from "../../../src/Constants";
 import type { Pool } from "../../../src/EntityTypes";
 import { processCLPoolMint } from "../../../src/EventHandlers/CLPool/CLPoolMintLogic";
 import { setupCommon } from "../Pool/common";
@@ -224,6 +228,84 @@ describe("CLPoolMintLogic", () => {
 
       expect(result.liquidityPoolDiff.incrementalLiquidityInRange).toBe(
         1000000000000000000n,
+      );
+    });
+
+    it("caps TVL against a stablecoin anchor on a Base LFI/USDC pool (issue #892)", () => {
+      const BASE = 8453;
+      const LFI = toChecksumAddress(
+        "0x3722264aB15a1dfCe5a5af89e6547F7949A8ABA3",
+      );
+      const USDC = toChecksumAddress(
+        "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      );
+
+      const lfiToken: Token = {
+        ...mockToken0Data,
+        id: TokenId(BASE, LFI),
+        address: LFI as `0x${string}`,
+        symbol: "LFI",
+        name: "LFI",
+        chainId: BASE,
+        decimals: 18n,
+        pricePerUSDNew: 24n * TEN_TO_THE_18_BI, // poisoned oracle ~$24
+        isWhitelisted: true,
+      };
+      const usdcToken: Token = {
+        ...mockToken1Data,
+        id: TokenId(BASE, USDC),
+        address: USDC as `0x${string}`,
+        symbol: "USDC",
+        name: "USD Coin",
+        chainId: BASE,
+        decimals: 6n,
+        pricePerUSDNew: 1n * TEN_TO_THE_18_BI,
+        isWhitelisted: true,
+      };
+
+      // CL pool carries the stored ratio (Mint does not move the price); the
+      // ratio implies LFI ≈ $0.00006 against the $1 USDC anchor.
+      const basePool = {
+        ...mockLiquidityPoolData,
+        chainId: BASE,
+        isCL: true,
+        token0_id: TokenId(BASE, LFI),
+        token1_id: TokenId(BASE, USDC),
+        reserve0: 1_000_000_000n * TEN_TO_THE_18_BI, // 1e9 LFI
+        reserve1: 4_000n * 1_000_000n, // $4,000 USDC (≥ floor)
+        token0Price: 60_000_000_000_000n, // 6e13 → implies LFI = $0.00006
+        token1Price: 16_000_000_000_000_000_000_000n,
+      } as Pool;
+
+      // Zero-amount mint: reserves stay put so the assertion targets the cap.
+      const zeroMint = {
+        params: {
+          sender: toChecksumAddress(
+            "0x1111111111111111111111111111111111111111",
+          ),
+          owner: toChecksumAddress(
+            "0x1111111111111111111111111111111111111111",
+          ),
+          tickLower: -100n,
+          tickUpper: 100n,
+          amount: 0n,
+          amount0: 0n,
+          amount1: 0n,
+        },
+        block: { timestamp: 1000000, number: 123456, hash: "0xfeed" },
+        chainId: BASE,
+        logIndex: 1,
+        srcAddress: toChecksumAddress(
+          "0x8343C68279587498526114e6385F0a87f248E0D9",
+        ),
+        transaction: { hash: "0xbeef" },
+      } as unknown as EvmEvent<"CLPool", "Mint">;
+
+      const result = processCLPoolMint(zeroMint, basePool, lfiToken, usdcToken);
+
+      // LFI leg capped to implied $60,000; USDC leg $4,000 → $64,000 total.
+      expect(result.liquidityPoolDiff.currentTotalLiquidityUSD).toBe(
+        64_000n * TEN_TO_THE_18_BI,
       );
     });
   });

--- a/test/EventHandlers/Pool/PoolSyncLogic.test.ts
+++ b/test/EventHandlers/Pool/PoolSyncLogic.test.ts
@@ -1,5 +1,9 @@
 import type { EvmEvent, Token } from "envio";
-import { toChecksumAddress } from "../../../src/Constants";
+import {
+  TEN_TO_THE_18_BI,
+  TokenId,
+  toChecksumAddress,
+} from "../../../src/Constants";
 import type { Pool, handlerContext } from "../../../src/EntityTypes";
 import { processPoolSync } from "../../../src/EventHandlers/Pool/PoolSyncLogic";
 import { deriveV2PriceRatios } from "../../../src/PoolPriceRatio";
@@ -235,6 +239,63 @@ describe("PoolSyncLogic", () => {
       );
       expect(mispricedResult.liquidityPoolDiff.token1Price).toBe(
         expected.token1Price,
+      );
+    });
+
+    it("caps TVL against a stablecoin anchor using the freshly-derived V2 ratio (issue #892)", () => {
+      const BASE = 8453;
+      const LFI = toChecksumAddress(
+        "0x3722264aB15a1dfCe5a5af89e6547F7949A8ABA3",
+      );
+      const USDC = toChecksumAddress(
+        "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      );
+
+      const lfiToken = {
+        ...mockToken0,
+        id: TokenId(BASE, LFI),
+        address: LFI,
+        symbol: "LFI",
+        name: "LFI",
+        chainId: BASE,
+        decimals: 18n,
+        pricePerUSDNew: 24n * TEN_TO_THE_18_BI, // poisoned oracle ~$24
+      } as Token;
+      const usdcToken = {
+        ...mockToken1,
+        id: TokenId(BASE, USDC),
+        address: USDC,
+        symbol: "USDC",
+        name: "USD Coin",
+        chainId: BASE,
+        decimals: 6n,
+        pricePerUSDNew: 1n * TEN_TO_THE_18_BI,
+      } as Token;
+
+      const basePool = {
+        ...mockPool,
+        chainId: BASE,
+        isCL: false,
+        token0_id: TokenId(BASE, LFI),
+        token1_id: TokenId(BASE, USDC),
+      } as Pool;
+
+      // Sync sets absolute reserves: 1e9 LFI vs $60,000 USDC. The derived V2
+      // ratio implies LFI ≈ $0.00006 against the $1 USDC anchor.
+      const syncEvent = {
+        ...mockEvent,
+        chainId: BASE,
+        params: {
+          reserve0: 1_000_000_000n * TEN_TO_THE_18_BI, // 1e9 LFI
+          reserve1: 60_000n * 1_000_000n, // $60,000 USDC (≥ floor)
+        },
+      } as unknown as EvmEvent<"Pool", "Sync">;
+
+      const result = processPoolSync(syncEvent, basePool, lfiToken, usdcToken);
+
+      // LFI leg capped to implied $60,000; USDC leg $60,000 → $120,000 total.
+      expect(result.liquidityPoolDiff.currentTotalLiquidityUSD).toBe(
+        120_000n * TEN_TO_THE_18_BI,
       );
     });
   });

--- a/test/Helpers.test.ts
+++ b/test/Helpers.test.ts
@@ -5,10 +5,11 @@ import {
 } from "@uniswap/v3-sdk";
 import type { Token } from "envio";
 import JSBI from "jsbi";
-import { TokenId, toChecksumAddress } from "../src/Constants";
+import { TEN_TO_THE_18_BI, TokenId, toChecksumAddress } from "../src/Constants";
 import type { handlerContext } from "../src/EntityTypes";
 import type { Pool } from "../src/EntityTypes";
 import {
+  calculateLiquidityUSD,
   calculatePositionAmountsFromLiquidity,
   calculateTotalUSD,
   computeLiquidityDeltaFromAmounts,
@@ -223,6 +224,174 @@ describe("Helpers", () => {
         undefined,
       );
       expect(total).toBe(0n);
+    });
+  });
+
+  describe("calculateLiquidityUSD (#892 directional TVL cap)", () => {
+    const { createMockToken } = setupCommon();
+    const BASE = 8453;
+    // USDC is Base's destinationToken (excluded from the stablecoins set), WETH
+    // the canonical connector, LFI the live poisoned whitelisted token, and
+    // NON_ANCHOR a trusted-but-not-anchor address.
+    const USDC = toChecksumAddress(
+      "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    );
+    const WETH = toChecksumAddress(
+      "0x4200000000000000000000000000000000000006",
+    );
+    const LFI = toChecksumAddress("0x3722264aB15a1dfCe5a5af89e6547F7949A8ABA3");
+    const NON_ANCHOR = toChecksumAddress(
+      "0x4444444444444444444444444444444444444444",
+    );
+
+    const mk = (
+      address: string,
+      decimals: bigint,
+      pricePerUSDNew: bigint,
+      isWhitelisted = true,
+    ): Token =>
+      createMockToken({
+        id: TokenId(BASE, address),
+        address: address as `0x${string}`,
+        chainId: BASE,
+        decimals,
+        pricePerUSDNew,
+        isWhitelisted,
+      });
+
+    it("caps a poisoned leg against a stablecoin anchor (the LFI/USDC defect)", () => {
+      const lfi = mk(LFI, 18n, 24n * TEN_TO_THE_18_BI); // oracle $24 (poisoned)
+      const usdc = mk(USDC, 6n, 1n * TEN_TO_THE_18_BI); // $1 (destination token)
+      const lfiReserve = 1_000_000_000n * TEN_TO_THE_18_BI; // 1e9 LFI
+      const usdcReserve = 4_000n * 1_000_000n; // $4,000 (≥ floor)
+      const token0Price = 60_000_000_000_000n; // 6e13 → pool implies LFI = $0.00006
+      const token1Price = 16_000_000_000_000_000_000_000n; // USDC-in-LFI (unused: LFI is not an anchor)
+
+      const capped = calculateLiquidityUSD(
+        lfiReserve,
+        usdcReserve,
+        lfi,
+        usdc,
+        token0Price,
+        token1Price,
+        BASE,
+      );
+      // LFI leg re-valued at implied $0.00006 → $60,000; USDC leg $4,000.
+      expect(capped).toBe(64_000n * TEN_TO_THE_18_BI);
+      // Sanity: the un-capped oracle path would have produced > $24B.
+      const uncapped = calculateTotalUSD(lfiReserve, usdcReserve, lfi, usdc);
+      expect(uncapped > 24_000_000_000n * TEN_TO_THE_18_BI).toBe(true);
+    });
+
+    it("does NOT cap a correct leg whose pool ratio implies a broken-HIGH price (USDe drained-pool regression)", () => {
+      // A $1 stablecoin in a drained pool against a real USDC anchor: the spot
+      // ratio blows up HIGH (implies $254K), but oracle ($1) ≪ implied, so the
+      // downward-only cap must NOT fire — it would corrupt $1 → $254K.
+      const usde = mk(NON_ANCHOR, 18n, 1n * TEN_TO_THE_18_BI); // $1, non-anchor token
+      const usdc = mk(USDC, 6n, 1n * TEN_TO_THE_18_BI);
+      const usdeReserve = 1n * TEN_TO_THE_18_BI; // 1 USDe
+      const usdcReserve = 300_000n * 1_000_000n; // $300,000 (floor passes)
+      const token0Price = 254_000n * TEN_TO_THE_18_BI; // pool implies USDe = $254,000
+
+      const capped = calculateLiquidityUSD(
+        usdeReserve,
+        usdcReserve,
+        usde,
+        usdc,
+        token0Price,
+        4_000_000_000_000n, // unused
+        BASE,
+      );
+      // USDe leg stays $1; total = $1 + $300,000 — identical to the un-capped sum.
+      expect(capped).toBe(300_001n * TEN_TO_THE_18_BI);
+      expect(capped).toBe(
+        calculateTotalUSD(usdeReserve, usdcReserve, usde, usdc),
+      );
+    });
+
+    it("caps a poisoned leg against a WETH anchor", () => {
+      const poison = mk(NON_ANCHOR, 18n, 10n * TEN_TO_THE_18_BI); // oracle $10 (poisoned)
+      const weth = mk(WETH, 18n, 1_600n * TEN_TO_THE_18_BI); // $1,600
+      const poisonReserve = 1_000_000n * TEN_TO_THE_18_BI; // 1e6 poison
+      const wethReserve = 1n * TEN_TO_THE_18_BI; // 1 WETH = $1,600 (≥ floor)
+      const token0Price = 625_000_000_000n; // 6.25e11 → implies poison = $0.001
+
+      const capped = calculateLiquidityUSD(
+        poisonReserve,
+        wethReserve,
+        poison,
+        weth,
+        token0Price,
+        1n, // unused (WETH is the anchor)
+        BASE,
+      );
+      // poison leg → 1e6 × $0.001 = $1,000; WETH leg $1,600.
+      expect(capped).toBe(2_600n * TEN_TO_THE_18_BI);
+    });
+
+    it("does NOT cap when the anchor leg holds < $1,000 of reserve (dead-pool guard)", () => {
+      const lfi = mk(LFI, 18n, 24n * TEN_TO_THE_18_BI);
+      const usdc = mk(USDC, 6n, 1n * TEN_TO_THE_18_BI);
+      const lfiReserve = 1_000_000_000n * TEN_TO_THE_18_BI;
+      const usdcReserve = 100n * 1_000_000n; // $100 < $1,000 floor
+
+      const result = calculateLiquidityUSD(
+        lfiReserve,
+        usdcReserve,
+        lfi,
+        usdc,
+        60_000_000_000_000n,
+        0n,
+        BASE,
+      );
+      // Floor blocks the cap; identical to the un-capped (poisoned) sum.
+      expect(result).toBe(
+        calculateTotalUSD(lfiReserve, usdcReserve, lfi, usdc),
+      );
+    });
+
+    it("does NOT cap when the oracle/implied gap is ≤ 10× (boundary; normal pools untouched)", () => {
+      const tok = mk(NON_ANCHOR, 18n, 10n * TEN_TO_THE_18_BI); // oracle $10
+      const usdc = mk(USDC, 6n, 1n * TEN_TO_THE_18_BI);
+      const tokReserve = 1_000n * TEN_TO_THE_18_BI;
+      const usdcReserve = 4_000n * 1_000_000n; // floor passes
+      const token0Price = 1n * TEN_TO_THE_18_BI; // implies $1 → oracle is exactly 10×
+
+      const result = calculateLiquidityUSD(
+        tokReserve,
+        usdcReserve,
+        tok,
+        usdc,
+        token0Price,
+        0n,
+        BASE,
+      );
+      // 10× is not > 10×, so no cap: token leg = 1,000 × $10 = $10,000; USDC $4,000.
+      expect(result).toBe(14_000n * TEN_TO_THE_18_BI);
+      expect(result).toBe(
+        calculateTotalUSD(tokReserve, usdcReserve, tok, usdc),
+      );
+    });
+
+    it("does NOT cap when the counterparty is not a hard anchor", () => {
+      const lfi = mk(LFI, 18n, 24n * TEN_TO_THE_18_BI);
+      const other = mk(NON_ANCHOR, 18n, 1n * TEN_TO_THE_18_BI); // trusted but not an anchor
+      const lfiReserve = 1_000_000_000n * TEN_TO_THE_18_BI;
+      const otherReserve = 1_000_000n * TEN_TO_THE_18_BI;
+
+      const result = calculateLiquidityUSD(
+        lfiReserve,
+        otherReserve,
+        lfi,
+        other,
+        60_000_000_000_000n,
+        1n * TEN_TO_THE_18_BI,
+        BASE,
+      );
+      // No hard anchor → no cap; identical to the un-capped sum.
+      expect(result).toBe(
+        calculateTotalUSD(lfiReserve, otherReserve, lfi, other),
+      );
     });
   });
 

--- a/test/PriceOverrides.test.ts
+++ b/test/PriceOverrides.test.ts
@@ -137,11 +137,28 @@ describe("PriceOverrides", () => {
     const WRSETH_BASE = toChecksumAddress(
       "0xEDfa23602D0EC14714057867A78d01e94176BEA0",
     );
+    const WETH_OP_STACK = toChecksumAddress(
+      "0x4200000000000000000000000000000000000006",
+    );
     it("rebinds rsETH/Swell to wrsETH/Base", () => {
       expect(getRebindTarget(1923, RSETH_SWELL)).toEqual({
         chainId: 8453,
         address: WRSETH_BASE,
       });
+    });
+
+    it("rebinds WETH/Metal to WETH/Optimism (issue #892)", () => {
+      expect(getRebindTarget(1750, WETH_OP_STACK)).toEqual({
+        chainId: 10,
+        address: WETH_OP_STACK,
+      });
+    });
+
+    it("does not rebind WETH on other OP-stack chains (Base, source Optimism)", () => {
+      // The #892 rebind targets Metal only; the same WETH address on Base must
+      // keep its local price, and Optimism is the source (not a target).
+      expect(getRebindTarget(8453, WETH_OP_STACK)).toBeUndefined();
+      expect(getRebindTarget(10, WETH_OP_STACK)).toBeUndefined();
     });
 
     it.each([

--- a/test/PriceTrust.test.ts
+++ b/test/PriceTrust.test.ts
@@ -6,10 +6,30 @@ import {
   PRICE_TRUST_REASON,
   getGateDecision,
   getGateDecisionFromSignals,
+  getHardAnchorUnitUSD,
   getPoolImpliedUSD,
   getTrustedUSD,
+  isHardAnchor,
   isTrusted,
 } from "../src/PriceTrust";
+
+// Real anchor + non-anchor addresses on Base (chainId 8453) used by the #892
+// hard-anchor helpers. USDC is the chain's `destinationToken` (excluded from the
+// stablecoins set by buildStablecoinSet), DAI is a member of that set, WETH is
+// the canonical OP-stack connector, and LFI is a non-anchor whitelisted token.
+const BASE = 8453;
+const BASE_USDC = toChecksumAddress(
+  "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+);
+const BASE_DAI = toChecksumAddress(
+  "0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb",
+);
+const BASE_WETH = toChecksumAddress(
+  "0x4200000000000000000000000000000000000006",
+);
+const LFI_BASE = toChecksumAddress(
+  "0x3722264aB15a1dfCe5a5af89e6547F7949A8ABA3",
+);
 
 /**
  * Minimal mock for the slice of {@link handlerContext} that
@@ -352,6 +372,81 @@ describe("PriceTrust", () => {
       });
       expect(getPoolImpliedUSD(0n, trusted)).toBe(0n);
       expect(getPoolImpliedUSD(50_000_000_000_000n, undefined)).toBe(0n);
+    });
+  });
+
+  describe("isHardAnchor (#892)", () => {
+    it("returns true for the chain's destination token (USDC/Base)", () => {
+      // USDC is the destinationToken — excluded from the stablecoins set, so
+      // this proves the explicit destinationToken check is load-bearing.
+      expect(isHardAnchor(BASE, BASE_USDC)).toBe(true);
+    });
+
+    it("returns true for a stablecoin-set member (DAI/Base)", () => {
+      expect(isHardAnchor(BASE, BASE_DAI)).toBe(true);
+    });
+
+    it("returns true for the chain's WETH connector", () => {
+      expect(isHardAnchor(BASE, BASE_WETH)).toBe(true);
+    });
+
+    it("is case-insensitive on the address", () => {
+      expect(isHardAnchor(BASE, BASE_USDC.toLowerCase())).toBe(true);
+    });
+
+    it("returns false for a non-anchor whitelisted token (LFI/Base)", () => {
+      expect(isHardAnchor(BASE, LFI_BASE)).toBe(false);
+    });
+
+    it("returns false for an unknown chain", () => {
+      expect(isHardAnchor(999999, BASE_USDC)).toBe(false);
+    });
+  });
+
+  describe("getHardAnchorUnitUSD (#892)", () => {
+    it("pins a destination-token stablecoin to $1, ignoring its oracle price", () => {
+      const usdc = makeToken({
+        chainId: BASE,
+        address: BASE_USDC,
+        decimals: 6n,
+        // Deliberately wrong oracle value — the $1 pin must override it.
+        pricePerUSDNew: 999n * TEN_TO_THE_18_BI,
+      });
+      expect(getHardAnchorUnitUSD(BASE, usdc)).toBe(TEN_TO_THE_18_BI);
+    });
+
+    it("pins a stablecoin-set member to $1", () => {
+      const dai = makeToken({
+        chainId: BASE,
+        address: BASE_DAI,
+        decimals: 18n,
+      });
+      expect(getHardAnchorUnitUSD(BASE, dai)).toBe(TEN_TO_THE_18_BI);
+    });
+
+    it("values WETH at its oracle pricePerUSDNew", () => {
+      const weth = makeToken({
+        chainId: BASE,
+        address: BASE_WETH,
+        decimals: 18n,
+        pricePerUSDNew: 1600n * TEN_TO_THE_18_BI,
+      });
+      expect(getHardAnchorUnitUSD(BASE, weth)).toBe(1600n * TEN_TO_THE_18_BI);
+    });
+
+    it("returns 0n for a non-anchor token", () => {
+      const lfi = makeToken({
+        chainId: BASE,
+        address: LFI_BASE,
+        pricePerUSDNew: 24n * TEN_TO_THE_18_BI,
+      });
+      expect(getHardAnchorUnitUSD(BASE, lfi)).toBe(0n);
+    });
+
+    it("returns 0n for an undefined token and for an unknown chain", () => {
+      expect(getHardAnchorUnitUSD(BASE, undefined)).toBe(0n);
+      const usdc = makeToken({ chainId: BASE, address: BASE_USDC });
+      expect(getHardAnchorUnitUSD(999999, usdc)).toBe(0n);
     });
   });
 });


### PR DESCRIPTION
## Summary

Closes the live **$25B fake-TVL defect** surfaced while investigating #892: a
persistently poisoned but **whitelisted** oracle inflates `totalLiquidityUSD`
without bound because `getTrustedUSD` multiplies the price straight into TVL with
no upper check. The global spike / re-anchor guards (#668 / #784 / #785) can't
heal it — the bad value is *stable*, not a spike, so every read agrees with the
poisoned anchor.

> **Note on #892's three tokens (AITECH, KLIMA, PHI):** re-checked against live
> GeckoTerminal/snapshot data — their series track the real market; the audit's
> "≥10× jump" was a cross-deployment artifact, **not** anchor poisoning. The
> stale-anchor spike-guard gap #892 describes is real in code but latent. The
> investigation instead found the live LFI defect below, in the same family.

### The defect (verified against the deployed indexer)
`LFI` (`8453-0x3722264a…ABA3`, whitelisted) oracle ≈ **$23.5**, but its CL-200
USDC pool (≈1.1B LFI vs ≈$4.4K USDC) implies **≈$0.00006** → one pool reads
**≈$25B** TVL.

## Piece 1 — directional TVL cap (`calculateLiquidityUSD`)

For a pool leg `T` whose counterparty `C` is a **hard anchor** (stablecoin /
`destinationToken` valued at a hard **$1 pin**, or **WETH** valued at its oracle
price) holding **≥ $1,000** of reserve, if `oracle(T) > 10 × implied(T)` (where
`implied(T) = ratio × anchorUSD`), `T` is re-valued at the implied price.

- **Directional & downward-only** → can only deflate an inflated leg toward the
  liquid pool's truth, never inflate a correct one. A drained pool implying
  broken-HIGH (`oracle ≪ implied`, e.g. Swell USDe/rUSDC) does **not** fire.
- **Anchor-gated + $1,000 liquidity floor** → never against an arbitrary trusted
  counterparty, avoiding the broad false positives a naive "re-anchor on any 10×
  gap" produced (#784/#785).
- **TVL-only** → does **not** mutate `pricePerUSDNew`; snapshots / volume / fees
  / reward USD are untouched.

Threaded through the four `totalLiquidityUSD` producers: CL Swap & V2 Sync use
the freshly-derived post-event ratio; CL Mint & Burn use the stored pool ratio.
New `isHardAnchor` / `getHardAnchorUnitUSD` in `PriceTrust` (`destinationToken`
is treated as an anchor explicitly because `buildStablecoinSet` excludes it).

## Piece 2 — Metal WETH rebind

Metal prices everything against oUSDT (≈+28% high), inflating Metal WETH to
**≈$2,005** vs the **≈$1,553** cross-chain consensus (both verified live).
Rebinding Metal WETH (`0x4200…0006`) → Optimism WETH makes WETH a trustworthy
hard anchor on Metal. The broader Metal oUSDT unit inflation is a separate
sub-10× follow-up.

## Live validation (deployed indexer, top 1000 pools / chain)

| chain | pools capped | notes |
|---|---|---|
| Base | 3 | LFI/USDC (**≈$25B → ≈$67K**) + 2× USDC/DEUS (`0x940A319B`) |
| Swell | 0 | USDe drained-pool regression case **does not fire** ✓ |
| Metal | 0 | no false positives ✓ |

No blue-chip pool (WETH/USDC, AERO/USDC, cbBTC/USDC) is touched.

**DEUS note:** two whitelisted "DEUS" exist on Base — real DEUS Finance
(`0xDE5ed76E…`) and `0x940A319B…`. The cap deflates only `0x940A319B…`
(oracle $0.527 → ~$0.023), and **two independent USDC pools both imply ~$0.023**,
so the deflation is corroborated. Safe either way.

## Tests
`calculateLiquidityUSD` matrix (LFI cap, USDe broken-HIGH regression, WETH
anchor, sub-$1k floor, ≤10× boundary, non-anchor counterparty); `isHardAnchor` /
`getHardAnchorUnitUSD` units; producer integration tests (CL Mint stored-ratio,
V2 Sync fresh-ratio); Metal WETH rebind. Full suite green (1593).

## Out of scope (follow-ups)
ezETH/Ink rebind-staleness; XOP missing rebind; broader Metal oUSDT ~28% unit
inflation; latent code gaps (freshness re-arm, low-side first-fetch cap, BTC
substring exemption, decimals-heal, re-anchor `fresh` mis-tag); the USDe/rUSDC
drained-pool broken-ratio itself.

## Issue tracking
LFI is an *observed live* symptom distinct from #892's stale-anchor-spike
framing. **Open question for a maintainer:** file a dedicated issue (referencing
#892 as origin) vs. repurpose #892. Not resolved in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smarter pool USD valuation that better handles stablecoin and WETH “anchor” prices.
  * Introduced updated price rebinding for Metal WETH to follow the Optimism WETH reference.

* **Bug Fixes**
  * Improved TVL calculations for mint, burn, swap, and sync events to reduce inflated or distorted pool value estimates.
  * Added safeguards that cap extreme pricing when pool and oracle prices diverge too much, while avoiding caps in low-liquidity or non-anchor cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->