### PR TITLE
Blacklist a frozen-anchor DEUS token inflating Base pool TVL (#901)

### DIFF
--- a/src/PriceOverrides.ts
+++ b/src/PriceOverrides.ts
@@ -571,6 +571,27 @@ const BLACKLIST: ReadonlySet<string> = new Set([
     toChecksumAddress("0x52b492a33E447Cdb854c7FC19F1e57E8BfA1777D"),
   ), // PEPE / Base (whitelisted; frozen route)
   TokenId(10, toChecksumAddress("0xC26921B5b9ee80773774d36C84328ccb22c3a819")), // wOptiDoge / Optimism (whitelisted; frozen route)
+  // Issue #901: the Base token at 0x940A319B… (symbol DEUS, 874M supply) is a
+  // SEPARATE, REAL token from canonical DEUS Finance — it merely shares the DEUS
+  // symbol. Canonical DEUS lives at 0xDE5ed76E7c05eC5e4572CfC88d1ACEA165109E44 on
+  // Base, is priced correctly (~$2.31), and is left untouched. The 0x940A319B
+  // token is whitelisted with a price anchor FROZEN at ~$0.528 while its own
+  // VIRTUAL/USDC pools imply ~$0.0229 (a 23× overprice) — the same frozen-anchor
+  // failure mode as the #786 PEPE/wOptiDoge entries above, not a worthless spoof.
+  // The frozen anchor inflates the VIRTUAL/DEUS V2 pool TVL to ~$8.2M (true
+  // ~$683k); #892/#897's directional cap misses it because VIRTUAL isn't a
+  // hard-anchor (stablecoin/WETH) counterparty. With no price-pin mechanism and
+  // nothing priced at ~$0.0229 to rebind to, blacklisting (price → 0) is the only
+  // available lever. It is lossy: it also zeroes the token's real ~$0.0229 leg, so
+  // the pool then UNDERCOUNTS (~$341k) instead of reporting the true ~$683k — a
+  // ~2× undercount accepted in place of a ~12× overcount, pending a proper
+  // re-anchor mechanism (tracked with the #786 frozen-route root cause). Volume
+  // and fees are unaffected: the min-of-legs picker and 10× out-of-band fee guard
+  // already discard the bad price; only TVL (sum-of-legs, ungated) was wrong.
+  TokenId(
+    8453,
+    toChecksumAddress("0x940A319B75861014A220D9c6c144d108552B089B"),
+  ), // DEUS (real token, frozen anchor 23× high; distinct from canonical DEUS Finance)
 ]);
 
 /**

--- a/test/PriceOverrides.test.ts
+++ b/test/PriceOverrides.test.ts
@@ -114,11 +114,34 @@ describe("PriceOverrides", () => {
       ).toBe(false);
     });
 
+    // Issue #901: 0x940A319B… (symbol DEUS, 874M supply) is a SEPARATE real token
+    // from canonical DEUS Finance — same symbol, anchor frozen at ~$0.528 vs
+    // ~$0.0229 pool-implied (#786 frozen-anchor class, not a worthless spoof).
+    // Blacklist forces its price to 0 so the inflated VIRTUAL/DEUS TVL routes
+    // through the counterparty leg.
+    it("returns true for the frozen-anchor DEUS token on Base (issue #901)", () => {
+      expect(
+        isBlacklistedToken(
+          8453,
+          toChecksumAddress("0x940A319B75861014A220D9c6c144d108552B089B"),
+        ),
+      ).toBe(true);
+    });
+
     it("does not blacklist the canonical AERO on Base", () => {
       expect(
         isBlacklistedToken(
           8453,
           toChecksumAddress("0x940181a94A35A4569E4529A3CDfB74e38FD98631"),
+        ),
+      ).toBe(false);
+    });
+
+    it("does not blacklist the canonical DEUS Finance token on Base (issue #901)", () => {
+      expect(
+        isBlacklistedToken(
+          8453,
+          toChecksumAddress("0xDE5ed76E7c05eC5e4572CfC88d1ACEA165109E44"),
         ),
       ).toBe(false);
     });


### PR DESCRIPTION
## Summary

- The Base token at `0x940A319B…` (symbol `DEUS`, 874M supply) is **not** canonical DEUS Finance (`0xDE5ed76E…`, correctly priced ~$2.31). It's a separate, **real** token that happens to share the `DEUS` symbol — verified on-chain and against the live deploy.
- It's whitelisted with a **frozen price anchor of $0.528**, while its own VIRTUAL and USDC pools imply **~$0.0229** — a **23× overprice**. This is the same frozen-anchor failure mode as #786 (PEPE / wOptiDoge), not a worthless symbol-spoof.
- The frozen anchor inflates the **VIRTUAL/DEUS V2 pool TVL to $8.20M** (true value ~$683k). #897's directional TVL cap doesn't fire here because VIRTUAL isn't a hard-anchor counterparty (only stablecoins / WETH are).
- **Fix:** add `0x940A319B…` to the `BLACKLIST` in `src/PriceOverrides.ts`, forcing its price to `0` so its leg drops out of USD aggregation. This is the **only available lever** — there is no price-pin mechanism, and nothing priced at ~$0.023 to rebind to.

## What this fixes — and what it doesn't (honest accounting)

Verified against the live deploy (`21b81aa`):

| Metric | Now (anchor $0.528) | After blacklist | True value |
| --- | --- | --- | --- |
| **TVL** | $8.20M ❌ | **~$341k** | ~$683k |
| **Volume** | $15.37M ✅ | $15.37M (unchanged) | already correct |
| **Fees** | $158.7k ✅ | $158.7k (unchanged) | already correct |
| **Token price** | $0.528 ❌ | $0 | $0.0229 |

- **TVL is the only broken metric.** Blacklisting removes the overcount but replaces it with a **~50% undercount** (it zeroes the token's real $0.023 leg). Net: a ~12× overcount becomes a ~2× undercount — a large improvement, not perfection.
- **Volume and fees were never corrupted** — the min-of-legs volume picker (`pickTrustedSwapVolumeUSD`) and the 10× out-of-band fee guard already discard the bad price leg. They don't change.
- **Raw token-unit fields** (`reserve0/1`, `totalVolume0/1`, fees0/1) are price-independent and unaffected.
- The only path to *correct* TVL is pricing the token at ~$0.023, which needs a re-anchor mechanism that doesn't exist today (tracked alongside the #786 frozen-route root cause).
- **Canonical DEUS (`0xDE5ed76E…`) is correctly priced and untouched** — a guard test asserts it is never blacklisted.

## Scope (AC#4)

- **DEUS-only.** The Base `RAY` / `MET` / `pippin` / `AVICI` frozen-anchor tokens are the same class but their pools have drained to ~$0, so there's no live TVL to fix today — they're a separate, low-urgency follow-up (each needs its own per-token implied-price check, like the one done here, before deciding). The live 18-decimal `MET` (`0x93dc5Cb3…`) is actively priced and explicitly excluded.
- `ezETH`/Ink is already handled by the #721 rebind — out of scope.

## Test plan

- [x] `isBlacklistedToken(8453, 0x940A319B…)` returns `true`; canonical `0xDE5ed76E…` returns `false`
- [x] 219 price-consuming runtime tests green (PriceOverrides / PriceTrust / PriceOracle / Helpers)
- [x] `biome check` clean on changed files
- [ ] Post-redeploy: VIRTUAL/DEUS `totalLiquidityUSD` drops from $8.2M to ~$341k *(needs human — go-forward only; requires reindex, won't retroactively correct history)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for treating a specific DEUS token on Base as blacklisted, so its price is now forced to zero.
  * Kept the canonical DEUS Finance token on Base unaffected.
  * Expanded coverage to verify both the blacklisted token and the non-blacklisted canonical token behave as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->