### PR TITLE
Fix PoolLauncherPool pairToken to read tokenToPair, not pool address

### DIFF
--- a/src/EventHandlers/PoolLauncher/CLPoolLauncher.ts
+++ b/src/EventHandlers/PoolLauncher/CLPoolLauncher.ts
@@ -15,7 +15,7 @@ indexer.onEvent(
     const creator = event.params.sender;
     const poolLauncherToken = event.params.poolLauncherToken;
     // poolLauncherPool struct fields: { createdAt, pool, poolLauncherToken, tokenToPair }
-    const pairToken = event.params.poolLauncherPool.pool;
+    const pairToken = event.params.poolLauncherPool.tokenToPair;
     const createdAt = new Date(event.block.timestamp * 1000);
 
     // Create or update PoolLauncherPool entity
@@ -48,10 +48,10 @@ indexer.onEvent(
     const oldLocker = event.params.locker;
     const newLocker = event.params.newLocker;
     // newPoolLauncherPool struct fields: { createdAt, pool, poolLauncherToken, tokenToPair }
-    const newPoolAddress = event.params.newPoolLauncherPool.tokenToPair;
+    const newPoolAddress = event.params.newPoolLauncherPool.pool;
     const poolLauncherToken =
       event.params.newPoolLauncherPool.poolLauncherToken;
-    const pairToken = event.params.newPoolLauncherPool.pool;
+    const pairToken = event.params.newPoolLauncherPool.tokenToPair;
     const timestamp = new Date(event.block.timestamp * 1000);
 
     const poolId = PoolId(event.chainId, underlyingPool);

--- a/src/EventHandlers/PoolLauncher/V2PoolLauncher.ts
+++ b/src/EventHandlers/PoolLauncher/V2PoolLauncher.ts
@@ -15,7 +15,7 @@ indexer.onEvent(
     const creator = event.params.sender;
     const poolLauncherToken = event.params.poolLauncherToken;
     // poolLauncherPool struct fields: { createdAt, pool, poolLauncherToken, tokenToPair }
-    const pairToken = event.params.poolLauncherPool.pool;
+    const pairToken = event.params.poolLauncherPool.tokenToPair;
     const createdAt = new Date(event.block.timestamp * 1000);
 
     // Create or update PoolLauncherPool entity
@@ -48,10 +48,10 @@ indexer.onEvent(
     const oldLocker = event.params.locker;
     const newLocker = event.params.newLocker;
     // newPoolLauncherPool struct fields: { createdAt, pool, poolLauncherToken, tokenToPair }
-    const newPoolAddress = event.params.newPoolLauncherPool.tokenToPair;
+    const newPoolAddress = event.params.newPoolLauncherPool.pool;
     const poolLauncherToken =
       event.params.newPoolLauncherPool.poolLauncherToken;
-    const pairToken = event.params.newPoolLauncherPool.pool;
+    const pairToken = event.params.newPoolLauncherPool.tokenToPair;
     const timestamp = new Date(event.block.timestamp * 1000);
 
     const poolId = PoolId(event.chainId, underlyingPool);

--- a/test/EventHandlers/PoolLauncher/CLPoolLauncher.test.ts
+++ b/test/EventHandlers/PoolLauncher/CLPoolLauncher.test.ts
@@ -94,9 +94,9 @@ describe("CLPoolLauncher Events", () => {
                   poolLauncherToken: mockPoolLauncherToken,
                   poolLauncherPool: {
                     createdAt: 1000000n,
-                    pool: mockPairToken,
+                    pool: mockPoolAddress,
                     poolLauncherToken: mockPoolLauncherToken,
-                    tokenToPair: mockPoolAddress,
+                    tokenToPair: mockPairToken,
                   },
                 },
               },
@@ -117,7 +117,14 @@ describe("CLPoolLauncher Events", () => {
       expect(poolLauncherPool?.launcher).toBe(mockLauncherAddress);
       expect(poolLauncherPool?.creator).toBe(mockCreator);
       expect(poolLauncherPool?.poolLauncherToken).toBe(mockPoolLauncherToken);
+      // #900: pairToken is the struct's tokenToPair leg, never the pool's own
+      // address. The bug read `.pool`, so pairToken equalled underlyingPool and
+      // joined to Token as null. tokenToPair (mockPairToken) differs from the pool
+      // address, so these assertions fail against the pre-fix handler.
       expect(poolLauncherPool?.pairToken).toBe(mockPairToken);
+      expect(poolLauncherPool?.pairToken).not.toBe(
+        poolLauncherPool?.underlyingPool,
+      );
       expect(poolLauncherPool?.isEmerging).toBe(false);
       // #818: Launch-created pools are not migration targets — migratedFrom stays empty.
       expect(poolLauncherPool?.migratedFrom).toBe("");
@@ -189,9 +196,9 @@ describe("CLPoolLauncher Events", () => {
                   newLocker,
                   newPoolLauncherPool: {
                     createdAt: 1000000n,
-                    pool: mockPairToken,
+                    pool: newPoolAddress,
                     poolLauncherToken: mockPoolLauncherToken,
-                    tokenToPair: newPoolAddress,
+                    tokenToPair: mockPairToken,
                   },
                 },
               },
@@ -268,9 +275,9 @@ describe("CLPoolLauncher Events", () => {
                   newLocker,
                   newPoolLauncherPool: {
                     createdAt: 1000000n,
-                    pool: mockPairToken,
+                    pool: newPoolAddress,
                     poolLauncherToken: mockPoolLauncherToken,
-                    tokenToPair: newPoolAddress,
+                    tokenToPair: mockPairToken,
                   },
                 },
               },

--- a/test/EventHandlers/PoolLauncher/V2PoolLauncher.test.ts
+++ b/test/EventHandlers/PoolLauncher/V2PoolLauncher.test.ts
@@ -93,9 +93,9 @@ describe("V2PoolLauncher Events", () => {
                   poolLauncherToken: mockPoolLauncherToken,
                   poolLauncherPool: {
                     createdAt: 1000000n,
-                    pool: mockPairToken,
+                    pool: mockPoolAddress,
                     poolLauncherToken: mockPoolLauncherToken,
-                    tokenToPair: mockPoolAddress,
+                    tokenToPair: mockPairToken,
                   },
                 },
               },
@@ -116,7 +116,14 @@ describe("V2PoolLauncher Events", () => {
       expect(poolLauncherPool?.launcher).toBe(mockLauncherAddress);
       expect(poolLauncherPool?.creator).toBe(mockCreator);
       expect(poolLauncherPool?.poolLauncherToken).toBe(mockPoolLauncherToken);
+      // #900: pairToken is the struct's tokenToPair leg, never the pool's own
+      // address. The bug read `.pool`, so pairToken equalled underlyingPool and
+      // joined to Token as null. tokenToPair (mockPairToken) differs from the pool
+      // address, so these assertions fail against the pre-fix handler.
       expect(poolLauncherPool?.pairToken).toBe(mockPairToken);
+      expect(poolLauncherPool?.pairToken).not.toBe(
+        poolLauncherPool?.underlyingPool,
+      );
       expect(poolLauncherPool?.isEmerging).toBe(false);
       // #818: Launch-created pools are not migration targets — migratedFrom stays empty.
       expect(poolLauncherPool?.migratedFrom).toBe("");
@@ -188,9 +195,9 @@ describe("V2PoolLauncher Events", () => {
                   newLocker,
                   newPoolLauncherPool: {
                     createdAt: 1000000n,
-                    pool: mockPairToken,
+                    pool: newPoolAddress,
                     poolLauncherToken: mockPoolLauncherToken,
-                    tokenToPair: newPoolAddress,
+                    tokenToPair: mockPairToken,
                   },
                 },
               },
@@ -267,9 +274,9 @@ describe("V2PoolLauncher Events", () => {
                   newLocker,
                   newPoolLauncherPool: {
                     createdAt: 1000000n,
-                    pool: mockPairToken,
+                    pool: newPoolAddress,
                     poolLauncherToken: mockPoolLauncherToken,
-                    tokenToPair: newPoolAddress,
+                    tokenToPair: mockPairToken,
                   },
                 },
               },


### PR DESCRIPTION
## Summary
- `PoolLauncherPool.pairToken` read `event.params.poolLauncherPool.pool` — the launched pool's own address — instead of `.tokenToPair`, so 100% of rows stored the pool address as the pair token and joined to `Token` as null.
- The `Migrate` handlers compounded it by swapping `.pool`/`.tokenToPair` when deriving `newPoolAddress` and `pairToken`.
- Fixed in both `CLPoolLauncher` and `V2PoolLauncher`: `Launch` now reads `.tokenToPair`; `Migrate` assigns `pool`/`tokenToPair` to the correct fields (un-swapped).

## Acceptance criteria
- [x] `pairToken` set from `.tokenToPair` in both Launch handlers
- [x] Migrate handlers assign `pool`/`tokenToPair` to the correct fields (un-swapped)
- [x] Regression test: new `PoolLauncherPool` rows have `pairToken != underlyingPool`. The corrected Launch/Migrate tests now fail against the pre-fix handler (their mock event data previously encoded the bug). The literal `pairToken ∈ {token0, token1}` sub-clause is **not** separately asserted: the handler copies `tokenToPair` verbatim and never reads the pool's legs, so a unit-test membership check would be tautological — the invariant holds in production because `tokenToPair` *is* a pool leg.
- [x] Backfill plan documented (below)

## Backfill plan
Existing rows have `pairToken` set to the pool's own address.
- **Preferred — reindex:** a fresh deploy reprocesses all historical `Launch`/`Migrate` events through the corrected handler, rewriting every `PoolLauncherPool.pairToken`. No separate script is needed if a reindex is part of the rollout.
- **In-place alternative (no reindex):** for each `PoolLauncherPool` row, set `pairToken` to the underlying `Pool` leg that is not `poolLauncherToken` — `pairToken = (pool.token0_address == poolLauncherToken) ? pool.token1_address : pool.token0_address` (both legs live on the `Pool` entity).

## Follow-up (out of scope)
Code review surfaced a related, pre-existing latent gap: `processPoolLauncherPool`'s update-existing branch (`PoolLauncherLogic.ts`) writes only `launcher` + `lastMigratedAt`, so a `Migrate` whose **target** pool already has a `PoolLauncherPool` row keeps a stale `pairToken`. Narrow, trigger unconfirmed, and the minimal-spread update branch is intentional (#818 preserves `migratedFrom` the same way). Worth a separate issue if confirmed.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `biome check` clean on changed files
- [x] Full suite green (113 files, 1599 tests)
- [x] PoolLauncher regression verified RED→GREEN (tests fail on the pre-fix handler, pass after)

Closes #900

🤖 Generated with [Claude Code](https://claude.com/claude-code)