### PR TITLE
Recompute V2 staked liquidity USD at snapshot boundaries

### DIFF
--- a/src/Aggregators/Pool.ts
+++ b/src/Aggregators/Pool.ts
@@ -791,6 +791,50 @@ export async function updatePool(
           ),
         };
       }
+    } else if (
+      updated.currentLiquidityStaked > 0n &&
+      updated.totalLPTokenSupply > 0n
+    ) {
+      // Issue #899: V2 (non-CL) pools must refresh currentLiquidityStakedUSD at
+      // the snapshot boundary too. CL pools recompute from the running
+      // stakedReserve0/1 accumulators above; V2 has no such running staked
+      // reserves, so derive the staked USD as the staked-LP fraction of the
+      // pool's already-valued totalLiquidityUSD:
+      //
+      //     stakedUSD = totalLiquidityUSD × min(staked, supply) / supply
+      //
+      // Sharing totalLiquidityUSD's valuation basis is what makes the invariant
+      // currentLiquidityStakedUSD ≤ totalLiquidityUSD hold by construction for
+      // the snapshot row written here (the live entity between snapshots is still
+      // written by the gauge path's uncapped computeNonCLStakedUSD — a pre-
+      // existing condition this branch re-caps at each hourly boundary):
+      //  - totalLiquidityUSD is already trust-gated AND #892-directional-capped
+      //    at Sync (PoolSyncLogic). Re-valuing reserves here through the UNCAPPED
+      //    calculateTotalUSD path instead would re-inject the inflated dollar
+      //    figure #892 suppresses on whitelisted-but-poisoned-oracle pools
+      //    (DEUS-class), pushing staked above the capped total every snapshot.
+      //  - clamping the numerator to `supply` bounds the fraction at 1, guarding
+      //    the accumulator-drift case (staked units transiently exceeding supply
+      //    from a missed LP Transfer) the CL #890/#891 guards cover.
+      //
+      // Floor division only ever rounds staked DOWN, never above total. The
+      // phantom case (un-whitelisted V2 pool whose totalLiquidityUSD already
+      // re-gated to 0) self-heals: 0 × fraction = 0. The currentLiquidityStaked
+      // === 0n ⇒ USD = 0n lockstep clamp above covers the zero-stake case, and
+      // the supply > 0n gate preserves the prior value (matching the gauge
+      // path's computeNonCLStakedUSDIfAvailable) rather than overwriting to 0
+      // when supply is transiently 0. Pure O(1) arithmetic — no token reads,
+      // only at hourly snapshot boundaries, never per swap.
+      const supply = updated.totalLPTokenSupply;
+      const stakedShare =
+        updated.currentLiquidityStaked < supply
+          ? updated.currentLiquidityStaked
+          : supply;
+      updated = {
+        ...updated,
+        currentLiquidityStakedUSD:
+          (updated.totalLiquidityUSD * stakedShare) / supply,
+      };
     }
 
     setPoolSnapshot(updated, timestamp, context);

--- a/test/Aggregators/Pool.test.ts
+++ b/test/Aggregators/Pool.test.ts
@@ -10,6 +10,7 @@ import {
   PoolId,
   PoolSnapshotId,
   RootPoolLeafPoolId,
+  TEN_TO_THE_18_BI,
   toChecksumAddress,
 } from "../../src/Constants";
 import { getSwapFee } from "../../src/Effects/SwapFee";
@@ -2041,16 +2042,21 @@ describe("Pool Functions", () => {
       expect(ctx.NonFungiblePosition.getWhere).not.toHaveBeenCalled();
     });
 
-    it("should NOT recompute staked USD for non-CL pools at snapshot time", async () => {
+    it("should recompute staked USD for non-CL pools at snapshot time (issue #899)", async () => {
       const oldTimestamp = new Date(Date.now() - 2 * 60 * 60 * 1000);
       const currentTimestamp = new Date();
 
+      // Default mock totalLiquidityUSD is $400; half the LP supply is staked, so
+      // the staked share is $200. The stale 100n baked at an old gauge event
+      // must be refreshed to that fraction of total — not preserved (the #899
+      // regression). Derived from totalLiquidityUSD, so no token reads.
       const v2Pool = createMockPool({
         chainId: 10,
         isCL: false,
         lastSnapshotTimestamp: oldTimestamp,
-        currentLiquidityStaked: 5000n,
-        currentLiquidityStakedUSD: 100n,
+        totalLPTokenSupply: 100n * TEN_TO_THE_18_BI,
+        currentLiquidityStaked: 50n * TEN_TO_THE_18_BI, // half of supply
+        currentLiquidityStakedUSD: 100n, // stale residue from an old gauge event
       });
 
       const setMock = vi.fn();
@@ -2067,12 +2073,19 @@ describe("Pool Functions", () => {
 
       await updatePool(diff, v2Pool, currentTimestamp, ctx, 10, blockNumber);
 
-      // getWhere should NOT have been called (non-CL pool)
+      // getWhere should NOT have been called (non-CL pools never query NFPM
+      // positions; the recompute derives from totalLiquidityUSD instead)
       expect(ctx.NonFungiblePosition.getWhere).not.toHaveBeenCalled();
 
-      // Staked USD should be preserved
+      // Stale staked USD refreshed to the staked fraction of total:
+      // 400e18 × 50e18 / 100e18 = 200e18, and stays ≤ totalLiquidityUSD.
       const updatedAggregator = setMock.mock.calls[0]?.[0] as Pool;
-      expect(updatedAggregator.currentLiquidityStakedUSD).toBe(100n);
+      expect(updatedAggregator.currentLiquidityStakedUSD).toBe(
+        200n * TEN_TO_THE_18_BI,
+      );
+      expect(updatedAggregator.currentLiquidityStakedUSD).toBeLessThanOrEqual(
+        updatedAggregator.totalLiquidityUSD,
+      );
     });
   });
 

--- a/test/Aggregators/PoolStakedUSDLockstep.test.ts
+++ b/test/Aggregators/PoolStakedUSDLockstep.test.ts
@@ -1,5 +1,5 @@
 import { updatePool } from "../../src/Aggregators/Pool";
-import { toChecksumAddress } from "../../src/Constants";
+import { TEN_TO_THE_18_BI, toChecksumAddress } from "../../src/Constants";
 import type { Pool, handlerContext } from "../../src/EntityTypes";
 import { setupCommon } from "../EventHandlers/Pool/common";
 
@@ -273,5 +273,209 @@ describe("Pool staked-USD lockstep on the CL snapshot recompute path (issue #890
     expect(updated.currentLiquidityStaked).toBe(600_000n);
     // 18-dec token @ $1 -> USD == reserve dust value.
     expect(updated.currentLiquidityStakedUSD).toBe(152_000_000_000_014n);
+  });
+});
+
+/**
+ * Issue #899: V2 (non-CL) pools never refresh `currentLiquidityStakedUSD` after
+ * the gauge deposit/withdraw that last wrote it, so it drifts relative to
+ * `totalLiquidityUSD` (which updates on every swap) and breaks the invariant
+ * `currentLiquidityStakedUSD ≤ totalLiquidityUSD`. CL pools recompute from the
+ * running `stakedReserve0/1` accumulators inside the `shouldSnapshot` block; V2
+ * pools had no `else` branch and fell through frozen.
+ *
+ * The fix adds the missing non-CL branch in the same snapshot block, deriving
+ * staked USD as the staked-LP fraction of the pool's already-valued
+ * `totalLiquidityUSD`: `totalLiquidityUSD × min(staked, supply) / supply`.
+ * Because `totalLiquidityUSD` is already trust-gated AND #892-directional-capped
+ * (PoolSyncLogic), the staked value shares that basis and the invariant holds
+ * by construction — re-valuing reserves through the uncapped `calculateTotalUSD`
+ * path instead would re-inject the inflated figure #892 suppresses (the dominant
+ * review finding). The `min(staked, supply)` clamp bounds the fraction at 1.
+ *
+ * These tests cross an epoch boundary so the snapshot recompute actually fires.
+ */
+describe("Pool staked-USD recompute on the non-CL snapshot path (issue #899)", () => {
+  let common: ReturnType<typeof setupCommon>;
+
+  const chainId = 10;
+  // Mirrors the live audit row 8453-0x1524a14C…; reused on chain 10 so the
+  // default mock tokens (chain-10 ids) line up with the pool's token ids.
+  const poolAddress = toChecksumAddress(
+    "0x1524a14C0C55c45229f7C8B5D0E1C2b9aBcDef12",
+  );
+
+  // lastSnapshotTimestamp sits in an earlier hour-epoch than the update, so
+  // shouldSnapshot() fires and the non-CL recompute runs.
+  const lastSnapshot = new Date(1_000_000 * 1000);
+  const newEpochTimestamp = new Date((1_000_000 + 7_200) * 1000); // +2h -> new epoch
+
+  beforeEach(() => {
+    common = setupCommon();
+  });
+
+  // The non-CL recompute derives staked USD from totalLiquidityUSD / stake /
+  // supply alone — no token reads — so the context only needs Pool + snapshot.
+  function buildMockContext(setMock: ReturnType<typeof vi.fn>) {
+    return common.createMockContext({
+      Pool: { set: setMock },
+      PoolSnapshot: { set: vi.fn() },
+      log: { error: () => {}, warn: () => {}, info: () => {} },
+    }) as unknown as handlerContext;
+  }
+
+  it("recomputes currentLiquidityStakedUSD as the staked fraction of total at the snapshot boundary, restoring staked ≤ total (V2 pool)", async () => {
+    // $400 of trust-gated TVL, half the LP supply staked -> staked share $200.
+    const pool = common.createMockPool({
+      poolAddress,
+      chainId,
+      isCL: false,
+      lastSnapshotTimestamp: lastSnapshot,
+      lastUpdatedTimestamp: lastSnapshot,
+      totalLPTokenSupply: 100n * TEN_TO_THE_18_BI,
+      currentLiquidityStaked: 50n * TEN_TO_THE_18_BI, // half of supply
+      totalLiquidityUSD: 400n * TEN_TO_THE_18_BI,
+      // Stale residue baked at an old gauge event — 1000 USD, far above current
+      // TVL, exactly the staked > total violation the audit surfaced.
+      currentLiquidityStakedUSD: 1_000n * TEN_TO_THE_18_BI,
+    });
+
+    const setMock = vi.fn();
+    const ctx = buildMockContext(setMock);
+
+    await updatePool(
+      {}, // no diff — a swap-triggered update that merely crosses the epoch
+      pool,
+      newEpochTimestamp,
+      ctx,
+      chainId,
+      131_536_921,
+    );
+
+    const updated = setMock.mock.calls[0]?.[0] as Pool;
+    // 400e18 × 50e18 / 100e18 = 200e18.
+    expect(updated.currentLiquidityStakedUSD).toBe(200n * TEN_TO_THE_18_BI);
+    expect(updated.currentLiquidityStakedUSD).toBeLessThanOrEqual(
+      updated.totalLiquidityUSD,
+    );
+  });
+
+  it("recomputes the phantom case to 0 — V2 pool whose totalLiquidityUSD already re-gated to 0 (AC #3)", async () => {
+    // Live row 1923-0xF1C0e9F8…: tokens were trusted when the staked-USD value
+    // was baked, later un-whitelisted. totalLiquidityUSD correctly re-gated to 0
+    // via the trust gate at the next Sync, but staked-USD was never refreshed
+    // and stayed at a phantom positive value. Deriving from totalLiquidityUSD
+    // (0) heals it: 0 × any fraction = 0.
+    const pool = common.createMockPool({
+      poolAddress,
+      chainId,
+      isCL: false,
+      lastSnapshotTimestamp: lastSnapshot,
+      lastUpdatedTimestamp: lastSnapshot,
+      totalLPTokenSupply: 100n * TEN_TO_THE_18_BI,
+      currentLiquidityStaked: 50n * TEN_TO_THE_18_BI,
+      totalLiquidityUSD: 0n, // already re-gated to 0 by the trust gate
+      currentLiquidityStakedUSD: 275_821n * TEN_TO_THE_18_BI, // phantom residue
+    });
+
+    const setMock = vi.fn();
+    const ctx = buildMockContext(setMock);
+
+    await updatePool({}, pool, newEpochTimestamp, ctx, chainId, 131_536_921);
+
+    const updated = setMock.mock.calls[0]?.[0] as Pool;
+    expect(updated.currentLiquidityStakedUSD).toBe(0n);
+    expect(updated.currentLiquidityStakedUSD).toBeLessThanOrEqual(
+      updated.totalLiquidityUSD,
+    );
+  });
+
+  it("preserves the prior staked USD when totalLPTokenSupply is transiently 0 (no overwrite to 0)", async () => {
+    // supply === 0n with a positive stake is an inconsistent transient (e.g. a
+    // full-burn Sync while the staked-units counter lags). Dividing by it is
+    // undefined, so the branch is gated `supply > 0n` and leaves the last-good
+    // value untouched — matching the gauge path's computeNonCLStakedUSDIfAvailable
+    // preserve-on-undefined behavior, not overwriting staked TVL to 0.
+    const pool = common.createMockPool({
+      poolAddress,
+      chainId,
+      isCL: false,
+      lastSnapshotTimestamp: lastSnapshot,
+      lastUpdatedTimestamp: lastSnapshot,
+      totalLPTokenSupply: 0n, // transiently unset
+      currentLiquidityStaked: 50n * TEN_TO_THE_18_BI,
+      totalLiquidityUSD: 400n * TEN_TO_THE_18_BI,
+      currentLiquidityStakedUSD: 500n, // last-good value, must be preserved
+    });
+
+    const setMock = vi.fn();
+    const ctx = buildMockContext(setMock);
+
+    await updatePool({}, pool, newEpochTimestamp, ctx, chainId, 131_536_921);
+
+    const updated = setMock.mock.calls[0]?.[0] as Pool;
+    expect(updated.currentLiquidityStakedUSD).toBe(500n);
+  });
+
+  it("keeps staked ≤ total on a #892-capped pool by deriving from the capped total, not the uncapped reserves (poisoned-oracle V2 pool)", async () => {
+    // A whitelisted-but-poisoned-oracle token (DEUS-class, residual #892/#897):
+    // the directional TVL cap deflates totalLiquidityUSD at Sync (here 100e18)
+    // well below what the uncapped reserve valuation would imply (~400e18). The
+    // recompute derives from the CAPPED total, so staked == 50e18; re-valuing
+    // reserves through the uncapped calculateTotalUSD path would instead give
+    // ~200e18, re-injecting the inflated figure #892 suppresses and breaking
+    // staked ≤ total at every snapshot (the dominant #899 review finding).
+    const pool = common.createMockPool({
+      poolAddress,
+      chainId,
+      isCL: false,
+      lastSnapshotTimestamp: lastSnapshot,
+      lastUpdatedTimestamp: lastSnapshot,
+      totalLPTokenSupply: 100n * TEN_TO_THE_18_BI,
+      currentLiquidityStaked: 50n * TEN_TO_THE_18_BI, // half of supply
+      totalLiquidityUSD: 100n * TEN_TO_THE_18_BI, // #892-capped
+      currentLiquidityStakedUSD: 0n,
+    });
+
+    const setMock = vi.fn();
+    const ctx = buildMockContext(setMock);
+
+    await updatePool({}, pool, newEpochTimestamp, ctx, chainId, 131_536_921);
+
+    const updated = setMock.mock.calls[0]?.[0] as Pool;
+    // 100e18 (capped) × 50e18 / 100e18 = 50e18.
+    expect(updated.currentLiquidityStakedUSD).toBe(50n * TEN_TO_THE_18_BI);
+    expect(updated.currentLiquidityStakedUSD).toBeLessThanOrEqual(
+      updated.totalLiquidityUSD,
+    );
+  });
+
+  it("clamps the staked fraction to ≤ 1 when staked units exceed totalLPTokenSupply (accumulator drift)", async () => {
+    // Same accumulator-drift class the CL #890/#891 guards cover: a missed LP
+    // Transfer can leave currentLiquidityStaked > totalLPTokenSupply. The
+    // staked fraction then exceeds 1, so the staked share must clamp to the
+    // whole pool — staked-USD == totalLiquidityUSD, never above it.
+    const pool = common.createMockPool({
+      poolAddress,
+      chainId,
+      isCL: false,
+      lastSnapshotTimestamp: lastSnapshot,
+      lastUpdatedTimestamp: lastSnapshot,
+      totalLPTokenSupply: 100n * TEN_TO_THE_18_BI,
+      currentLiquidityStaked: 150n * TEN_TO_THE_18_BI, // 1.5x supply (drift)
+      totalLiquidityUSD: 400n * TEN_TO_THE_18_BI,
+      currentLiquidityStakedUSD: 0n,
+    });
+
+    const setMock = vi.fn();
+    const ctx = buildMockContext(setMock);
+
+    await updatePool({}, pool, newEpochTimestamp, ctx, chainId, 131_536_921);
+
+    const updated = setMock.mock.calls[0]?.[0] as Pool;
+    expect(updated.currentLiquidityStakedUSD).toBe(400n * TEN_TO_THE_18_BI);
+    expect(updated.currentLiquidityStakedUSD).toBeLessThanOrEqual(
+      updated.totalLiquidityUSD,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- V2 (non-CL) pools never refreshed `currentLiquidityStakedUSD` after the gauge deposit/withdraw that last wrote it, so it drifted past `totalLiquidityUSD` (updated every swap) and broke the invariant `currentLiquidityStakedUSD ≤ totalLiquidityUSD`. Closes #899.
- Adds the missing non-CL branch in the `shouldSnapshot` block of `updatePool`, deriving staked-USD as the staked-LP fraction of the pool's already-valued `totalLiquidityUSD`:

  ```
  stakedUSD = totalLiquidityUSD × min(staked, supply) / supply
  ```

- **Why not `computeNonCLStakedUSD` (the issue's suggested helper)?** That helper re-values reserves through the *uncapped* `calculateTotalUSD` path, but V2 `totalLiquidityUSD` is written at Sync via the **#892 directional-capped** `calculateLiquidityUSD`. On a whitelisted-but-poisoned-oracle pool (DEUS-class) where the cap is active, the uncapped staked recompute exceeds the capped total — re-breaking the very invariant #899 restores and re-injecting the inflated figure #892 suppresses. Deriving from the (capped) total instead makes the invariant hold **by construction** for the snapshot row.
- The `min(staked, supply)` clamp bounds the fraction at 1, guarding the accumulator-drift case the CL #890/#891 guards cover. The `supply > 0n` gate preserves the prior value (matching the gauge path) rather than overwriting to 0 when supply is transiently 0. Phantom case (`totalLiquidityUSD` already re-gated to 0) self-heals: `0 × fraction = 0`.
- CL behavior unchanged; no per-swap cost (pure O(1) arithmetic, no token reads, hourly snapshot boundaries only).

**Note (pre-existing, out of scope):** the *live* `Pool.currentLiquidityStakedUSD` written between snapshots by the gauge path still uses the uncapped helper, so it can exceed total *between* hourly boundaries; this branch re-caps it each hour. Worth a follow-up to align the live/per-user paths.

## Test plan
- [x] `tsc --noEmit` clean
- [x] Regression test: #892-capped V2 pool keeps `staked ≤ total` (derives from capped total, not uncapped reserves) — fails on the original `computeNonCLStakedUSD` approach, passes here
- [x] Regression test: over-stake (`staked > supply`) clamps the fraction to ≤ 1
- [x] Phantom case (`totalLiquidityUSD = 0`) recomputes to `0`; preserve-on-zero-supply leaves the prior value
- [x] Full suite green (113 files / 1604 tests) pre-rebase; tsc + Pool/lockstep suites (84 tests) green post-rebase onto current main
- [x] CL behavior unchanged (existing #890 snapshot tests still pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)