### PR TITLE
Trust price-connector tokens so leaf-chain USD isn't zeroed

### DIFF
--- a/docs/adr/0002-trust-price-connector-tokens.md
+++ b/docs/adr/0002-trust-price-connector-tokens.md
@@ -1,0 +1,83 @@
+# ADR 0002: Trust price-connector tokens for USD valuation
+
+- **Status:** Accepted (2026-06-26)
+- **Issue:** [#898](https://github.com/velodrome-finance/indexer/issues/898)
+
+## Context
+
+USD aggregates are gated by a price-trust system (#755): `getTrustedUSD` counts a
+pool leg only when its token passes `isTrusted`, which keyed trust **solely** on
+`isWhitelisted` — sourced from on-chain `WhitelistToken` events (`Voter` /
+`SuperchainLeafVoter`) — minus an operator `BLACKLIST` override.
+
+Verified live on the deployed endpoint (`21b81aa`):
+
+- **Mode (34443)** and **Swell (1923)** captured **zero** `WhitelistToken`
+  events (Mode is indexed from block 0, full history) → **every** USD field
+  reads `$0` across the whole chain (`Pool.totalLiquidityUSD / totalVolumeUSD /
+  totalFeesGeneratedUSD / …` and all `UserStatsPerPool` USD fields).
+- **Soneium (1868)** and **Metal (1750)**: WETH (`0x4200…0006`) was never
+  whitelisted, so every WETH-paired pool counted only its non-WETH leg
+  (~half TVL/volume/fees), because
+  `calculateTotalUSD = getTrustedUSD(leg0) + getTrustedUSD(leg1)` and an
+  untrusted leg contributes `$0`.
+
+The indexer was faithful to on-chain governance (those chains genuinely
+whitelisted nothing / not WETH), but the consumer outcome was unusable.
+
+The incoherence to resolve: each chain's `src/constants/price_connectors.json`
+**already** defines the canonical base assets (WETH, USDC/USDT, the chain's gov
+token, …) that the oracle uses to **derive** every other token's price — yet
+those same anchors were `UNTRUSTED` and contributed `$0`. A token the indexer
+trusts enough to *price the rest of the chain from* is, by the same token,
+trustworthy enough to *value*.
+
+## Decision (Option A)
+
+Treat a chain's configured price connectors as a positive trust signal,
+**alongside** the protocol whitelist. Implemented in `src/PriceTrust.ts`:
+
+- New `isConnectorToken(chainId, address)` — O(1) membership against
+  `CHAIN_CONSTANTS[chainId].oracle.priceConnectors`, via an eagerly-built
+  per-chain `Set` (mirrors the `PRICE_REBIND` eager-Map idiom).
+- The gate (`getGateDecisionFromSignals`, and `isTrusted`, which now delegates
+  to it so the live gate and the persisted fields cannot diverge) trusts a token
+  with **any** positive signal — whitelist **or** connector — unless the
+  operator `BLACKLIST` overrides it.
+- Reason precedence: no positive signal ⇒ `NON_WL` (blacklist membership is
+  irrelevant — nothing to override); positive signal but blacklisted ⇒
+  `BLACKLISTED`; otherwise `TRUSTED`, tagged `WL` (whitelisted, the stronger
+  provenance) or `CONNECTOR` (trusted solely by connector membership).
+
+This is symmetric with the existing `BLACKLIST` override, which already
+overrides the protocol signal **downward**; connector membership overrides it
+**upward**. It reuses an operator-curated surface (the connector config) rather
+than introducing a new one.
+
+### Alternatives rejected
+
+- **Option B — a separate operator whitelist-override list** for base assets:
+  redundant with the connector config and adds a second list to keep in sync.
+- **Option C — accept `$0`, document the chains as USD-unavailable:** faithful
+  to on-chain reality but ships unusable data on whole chains.
+
+## Consequences
+
+- **Mode (34443) and Swell (1923)** USD fields populate from their
+  connector-anchored pools (WETH/USDC, …).
+- **WETH on Soneium (1868) and Metal (1750)** is trusted; WETH-paired pools
+  count both legs.
+- **Optimism is a no-op** — all 16 connectors were already whitelisted. **Base**
+  gains its one not-yet-whitelisted connector, USDe (`0x5d3a…`): a ~`$400` total
+  correction across 5 small pools (a legitimate `$1` stable previously zeroed),
+  **not** a regression. All other leaf chains were already fully whitelisted on
+  their connectors (no change).
+- **Blacklist still wins.** No configured connector is currently blacklisted
+  (asserted by a test in `test/PriceTrust.test.ts`); if one is ever added it
+  resolves `UNTRUSTED`/`BLACKLISTED`. Metal WETH's thin local price (~30% high)
+  is handled by the #892/#897 directional cap + rebind, independent of this
+  trust decision.
+- **New `priceTrustReason` value `CONNECTOR`.** The field is a free-form
+  `String` in `schema.graphql`, so no schema/codegen change is required.
+- Pinned by `test/PriceTrust.test.ts`, data-driven over `price_connectors.json`
+  so config and trust policy cannot silently drift apart.

--- a/docs/querying.md
+++ b/docs/querying.md
@@ -309,9 +309,17 @@ The following are non-obvious properties of the data rather than defects.
   a price-trust system. A token whose price cannot be trusted contributes `$0` to
   USD aggregates rather than an unreliable figure. Check
   `Token.priceTrustOutcome`, `priceTrustReason`, and `isWhitelisted` when a USD
-  value is unexpectedly low or zero. On `TokenPriceSnapshot`, filter
-  `priceSource` to `fresh`, `pool-implied`, or `rebind` (or `pricePerUSDNew > 0`)
-  to exclude carried and zeroed ticks.
+  value is unexpectedly low or zero. A token is trusted when it is either
+  protocol-whitelisted **or** a configured price connector for its chain — and
+  not operator-blacklisted. `priceTrustReason` records which: `WL`
+  (protocol-whitelisted), `CONNECTOR` (a canonical base asset — WETH, USDC, the
+  chain's gov token — trusted without a `WhitelistToken` event, issue #898),
+  `BLACKLISTED`, or `NON_WL` (no trust signal). This is why USD is populated on
+  leaf chains that never whitelisted tokens on-chain (e.g. **Mode**, **Swell**)
+  and on WETH-paired pools on **Soneium**/**Metal** — connector legs count even
+  when `isWhitelisted` is `false`. On `TokenPriceSnapshot`, filter `priceSource`
+  to `fresh`, `pool-implied`, or `rebind` (or `pricePerUSDNew > 0`) to exclude
+  carried and zeroed ticks.
 - **Some legacy pools report `totalEmissionsUSD = 0` despite real emissions.**
   Gauges that stopped emitting before the chain's price oracle could value the
   reward token (AERO on Base before 2024-06-14, VELO on Optimism before

--- a/src/PriceTrust.ts
+++ b/src/PriceTrust.ts
@@ -21,11 +21,16 @@ export type PriceTrustOutcome =
  * Centralised values for the per-token `priceTrustReason` schema field.
  *
  * - `WL` — protocol-whitelisted and not in the operator BLACKLIST (trusted)
- * - `BLACKLISTED` — protocol-whitelisted but operator BLACKLIST overrides
- * - `NON_WL` — not protocol-whitelisted (regardless of BLACKLIST membership)
+ * - `CONNECTOR` — not protocol-whitelisted, but a configured price connector on
+ *   its chain and not in the operator BLACKLIST (trusted, #898)
+ * - `BLACKLISTED` — has a positive trust signal (whitelist and/or connector) but
+ *   the operator BLACKLIST overrides it
+ * - `NON_WL` — no positive trust signal: neither whitelisted nor a connector
+ *   (regardless of BLACKLIST membership)
  */
 export const PRICE_TRUST_REASON = {
   WL: "WL",
+  CONNECTOR: "CONNECTOR",
   NON_WL: "NON_WL",
   BLACKLISTED: "BLACKLISTED",
 } as const;
@@ -39,14 +44,53 @@ export interface PriceTrustDecision {
 }
 
 /**
- * Two-tier price-trust gate. Returns true iff the token is on-chain
- * whitelisted by the protocol's Voter contract AND is not present in the
+ * Per-chain set of lowercased price-connector addresses, built once at module
+ * load from {@link CHAIN_CONSTANTS}. Mirrors the eager-Map idiom used for
+ * `PRICE_REBIND` in PriceOverrides — so the hot trust gate ({@link isTrusted},
+ * consulted on every swap leg) does an O(1) membership test instead of
+ * re-scanning and re-lowercasing each chain's connector array per call.
+ */
+const CONNECTOR_SETS: ReadonlyMap<number, ReadonlySet<string>> = new Map(
+  Object.entries(CHAIN_CONSTANTS).map(([chainId, constants]) => [
+    Number(chainId),
+    new Set(
+      constants.oracle.priceConnectors.map((c) => c.address.toLowerCase()),
+    ),
+  ]),
+);
+
+/**
+ * Whether `address` is one of `chainId`'s configured price connectors — the
+ * canonical base assets (WETH, USDC, the chain's gov token, …) the oracle
+ * already uses to derive every other token's price (src/constants/
+ * price_connectors.json, surfaced as `CHAIN_CONSTANTS[chainId].oracle
+ * .priceConnectors`).
+ *
+ * A token the indexer trusts enough to *derive* prices from is, by the same
+ * token, trustworthy enough to *value* — so connector membership is a positive
+ * trust signal alongside the protocol whitelist (#898). This recovers
+ * whole-chain USD on leaf deployments (Mode/Swell) that never captured a
+ * `WhitelistToken` event, and WETH-paired TVL on Soneium/Metal.
+ *
+ * @param chainId - Chain the token lives on
+ * @param address - Token address (any case; compared lowercased)
+ * @returns true iff the address is a configured connector on the chain; false
+ *   for unknown chains
+ */
+export function isConnectorToken(chainId: number, address: string): boolean {
+  return CONNECTOR_SETS.get(chainId)?.has(address.toLowerCase()) ?? false;
+}
+
+/**
+ * Price-trust gate. Returns true iff the token has a positive trust signal —
+ * protocol whitelist (`WhitelistToken` events) OR membership in its chain's
+ * configured price connectors (#898) — AND is not present in the
  * operator-maintained BLACKLIST override.
  *
- * The gate consults only signals the indexer already has: the Token entity's
- * `isWhitelisted` (sourced from `WhitelistToken` events) and the static
- * BLACKLIST set in `PriceOverrides`. No RPC, no entity reads, no heuristics
- * — pure function, O(1).
+ * Delegates to {@link getGateDecisionFromSignals} so this live gate and the
+ * persisted `priceTrustOutcome` / `priceTrustReason` fields can never diverge.
+ * The gate consults only signals the indexer already has (no RPC, no entity
+ * reads): O(1) given the eagerly-built {@link isConnectorToken} lookup.
  *
  * @param token - Token entity from the indexer. Undefined inputs are
  *   treated as untrusted (the indexer cannot trust what it does not have).
@@ -55,8 +99,11 @@ export interface PriceTrustDecision {
  */
 export function isTrusted(token: Token | undefined): boolean {
   if (!token) return false;
-  if (!token.isWhitelisted) return false;
-  return !isBlacklistedToken(token.chainId, token.address);
+  return getGateDecisionFromSignals(
+    token.chainId,
+    token.address,
+    token.isWhitelisted,
+  ).trusted;
 }
 
 /**
@@ -187,21 +234,31 @@ export function getHardAnchorUnitUSD(
  * `priceTrustOutcome` / `priceTrustReason` fields are populated in lockstep
  * with `isWhitelisted` rather than left null until the first aggregator consult.
  *
- * Reason precedence: `NON_WL` dominates `BLACKLISTED` when both apply, since
- * the protocol-whitelist signal is the load-bearing one — a token's path to
- * trust runs through whitelisting, not through removing a blacklist entry.
+ * Trust requires a positive signal: protocol whitelist OR a configured price
+ * connector (#898). The operator BLACKLIST overrides either signal downward.
  *
- * @param chainId - Chain ID for BLACKLIST lookup
- * @param address - Token address (EIP-55 checksum) for BLACKLIST lookup
+ * Reason precedence:
+ *  - No positive signal at all ⇒ `NON_WL` — and BLACKLIST membership is
+ *    irrelevant here (there is nothing to override), preserving the pre-#898
+ *    semantic that a non-whitelisted, non-connector token reports `NON_WL` even
+ *    when blacklisted.
+ *  - A positive signal exists but the address is blacklisted ⇒ `BLACKLISTED`
+ *    (operator override beats both whitelist and connector).
+ *  - Otherwise trusted, tagged `WL` when whitelisted (the stronger provenance)
+ *    or `CONNECTOR` when trusted solely by connector membership.
+ *
+ * @param chainId - Chain ID for BLACKLIST + connector lookup
+ * @param address - Token address (EIP-55 checksum) for BLACKLIST + connector lookup
  * @param isWhitelisted - Protocol-whitelist signal from the Voter contract
- * @returns `{ trusted, reason }` decision
+ * @returns `{ trusted, outcome, reason }` decision
  */
 export function getGateDecisionFromSignals(
   chainId: number,
   address: string,
   isWhitelisted: boolean,
 ): PriceTrustDecision {
-  if (!isWhitelisted) {
+  const isConnector = isConnectorToken(chainId, address);
+  if (!isWhitelisted && !isConnector) {
     return {
       trusted: false,
       outcome: PRICE_TRUST_OUTCOME.UNTRUSTED,
@@ -218,7 +275,9 @@ export function getGateDecisionFromSignals(
   return {
     trusted: true,
     outcome: PRICE_TRUST_OUTCOME.TRUSTED,
-    reason: PRICE_TRUST_REASON.WL,
+    reason: isWhitelisted
+      ? PRICE_TRUST_REASON.WL
+      : PRICE_TRUST_REASON.CONNECTOR,
   };
 }
 

--- a/test/EventHandlers/Voter/SuperchainLeafVoter.test.ts
+++ b/test/EventHandlers/Voter/SuperchainLeafVoter.test.ts
@@ -490,6 +490,68 @@ describe("SuperchainLeafVoter Events", () => {
       });
 
       it("flips TRUSTED/WL to UNTRUSTED/NON_WL when WhitelistToken(false) lands", async () => {
+        // SNX on Optimism: real on-chain bytecode but NOT a price connector, so
+        // de-whitelisting fully untrusts it. (WETH — the block's shared
+        // tokenAddress — would stay TRUSTED/CONNECTOR under #898; that case is
+        // covered by the next test.)
+        const nonConnectorToken = toChecksumAddress(
+          "0x8700dAec35aF8Ff88c16BdF0418774CB3D7599B4",
+        );
+        const existing = {
+          id: TokenId(chainId, nonConnectorToken),
+          address: nonConnectorToken,
+          symbol: "TEST",
+          name: "TEST",
+          chainId,
+          decimals: BigInt(18),
+          pricePerUSDNew: BigInt(10000000),
+          isWhitelisted: true,
+          priceTrustOutcome: PRICE_TRUST_OUTCOME.TRUSTED,
+          priceTrustReason: PRICE_TRUST_REASON.WL,
+          lastUpdatedTimestamp: new Date(0),
+        } as Token;
+
+        const indexer = createTestIndexer();
+        indexer.Token.set(existing);
+
+        await indexer.process({
+          chains: {
+            [chainId]: {
+              simulate: [
+                {
+                  contract: "SuperchainLeafVoter",
+                  event: "WhitelistToken",
+                  srcAddress: toChecksumAddress(
+                    "0x1111111111111111111111111111111111111111",
+                  ),
+                  logIndex: 1,
+                  block: {
+                    number: blockNumber,
+                    timestamp: blockTimestamp,
+                    hash: "0x1234567890123456789012345678901234567890123456789012345678901234",
+                  },
+                  params: {
+                    token: nonConnectorToken,
+                    _bool: false,
+                  },
+                },
+              ],
+            },
+          },
+        });
+
+        const token = await indexer.Token.get(
+          TokenId(chainId, nonConnectorToken),
+        );
+        expect(token?.isWhitelisted).toBe(false);
+        expect(token?.priceTrustOutcome).toBe(PRICE_TRUST_OUTCOME.UNTRUSTED);
+        expect(token?.priceTrustReason).toBe(PRICE_TRUST_REASON.NON_WL);
+      });
+
+      it("keeps a connector TRUSTED/CONNECTOR when WhitelistToken(false) lands (#898)", async () => {
+        // WETH is a configured price connector on Optimism, so de-whitelisting
+        // it does NOT untrust it — connector membership is an independent trust
+        // signal. isWhitelisted still flips to false.
         const existing = {
           id: TokenId(chainId, tokenAddress),
           address: tokenAddress,
@@ -535,8 +597,8 @@ describe("SuperchainLeafVoter Events", () => {
 
         const token = await indexer.Token.get(TokenId(chainId, tokenAddress));
         expect(token?.isWhitelisted).toBe(false);
-        expect(token?.priceTrustOutcome).toBe(PRICE_TRUST_OUTCOME.UNTRUSTED);
-        expect(token?.priceTrustReason).toBe(PRICE_TRUST_REASON.NON_WL);
+        expect(token?.priceTrustOutcome).toBe(PRICE_TRUST_OUTCOME.TRUSTED);
+        expect(token?.priceTrustReason).toBe(PRICE_TRUST_REASON.CONNECTOR);
       });
 
       it("flags an existing blacklisted token UNTRUSTED/BLACKLISTED on WhitelistToken(true)", async () => {

--- a/test/EventHandlers/Voter/Voter.test.ts
+++ b/test/EventHandlers/Voter/Voter.test.ts
@@ -2347,6 +2347,60 @@ describe("Voter Events", () => {
       });
 
       it("flips TRUSTED/WL to UNTRUSTED/NON_WL when WhitelistToken(false) lands", async () => {
+        // SNX on Optimism: real on-chain bytecode but NOT a price connector, so
+        // de-whitelisting fully untrusts it. (WETH — the block's shared
+        // tokenAddress — would stay TRUSTED/CONNECTOR under #898; covered next.)
+        const nonConnectorToken = toChecksumAddress(
+          "0x8700dAec35aF8Ff88c16BdF0418774CB3D7599B4",
+        );
+        const existing = {
+          id: TokenId(10, nonConnectorToken),
+          address: nonConnectorToken,
+          symbol: "TEST",
+          name: "TEST",
+          chainId: 10,
+          decimals: BigInt(18),
+          pricePerUSDNew: BigInt(10000000),
+          isWhitelisted: true,
+          lastUpdatedTimestamp: new Date(0),
+          priceTrustOutcome: PRICE_TRUST_OUTCOME.TRUSTED,
+          priceTrustReason: PRICE_TRUST_REASON.WL,
+        } as Token;
+        const db = createTestIndexer();
+        db.Token.set(existing);
+
+        await db.process({
+          chains: {
+            [wlChainId]: {
+              simulate: [
+                {
+                  contract: "Voter",
+                  event: "WhitelistToken",
+                  logIndex: 1,
+                  block: wlBlock,
+                  params: {
+                    whitelister: toChecksumAddress(
+                      "0x1111111111111111111111111111111111111111",
+                    ),
+                    token: nonConnectorToken,
+                    _bool: false,
+                  },
+                },
+              ],
+            },
+          },
+        });
+        const token = await db.Token.get(TokenId(10, nonConnectorToken));
+
+        expect(token?.isWhitelisted).toBe(false);
+        expect(token?.priceTrustOutcome).toBe(PRICE_TRUST_OUTCOME.UNTRUSTED);
+        expect(token?.priceTrustReason).toBe(PRICE_TRUST_REASON.NON_WL);
+      });
+
+      it("keeps a connector TRUSTED/CONNECTOR when WhitelistToken(false) lands (#898)", async () => {
+        // WETH is a configured price connector on Optimism, so de-whitelisting
+        // it does NOT untrust it — connector membership is an independent trust
+        // signal. isWhitelisted still flips to false.
         const existing = {
           id: TokenId(10, tokenAddress),
           address: tokenAddress,
@@ -2387,8 +2441,8 @@ describe("Voter Events", () => {
         const token = await db.Token.get(TokenId(10, tokenAddress));
 
         expect(token?.isWhitelisted).toBe(false);
-        expect(token?.priceTrustOutcome).toBe(PRICE_TRUST_OUTCOME.UNTRUSTED);
-        expect(token?.priceTrustReason).toBe(PRICE_TRUST_REASON.NON_WL);
+        expect(token?.priceTrustOutcome).toBe(PRICE_TRUST_OUTCOME.TRUSTED);
+        expect(token?.priceTrustReason).toBe(PRICE_TRUST_REASON.CONNECTOR);
       });
 
       it("flags an existing blacklisted token UNTRUSTED/BLACKLISTED on WhitelistToken(true)", async () => {

--- a/test/PriceTrust.test.ts
+++ b/test/PriceTrust.test.ts
@@ -1,6 +1,7 @@
 import type { Token } from "envio";
 import { TEN_TO_THE_18_BI, TokenId, toChecksumAddress } from "../src/Constants";
 import type { handlerContext } from "../src/EntityTypes";
+import { isBlacklistedToken } from "../src/PriceOverrides";
 import {
   PRICE_TRUST_OUTCOME,
   PRICE_TRUST_REASON,
@@ -9,9 +10,11 @@ import {
   getHardAnchorUnitUSD,
   getPoolImpliedUSD,
   getTrustedUSD,
+  isConnectorToken,
   isHardAnchor,
   isTrusted,
 } from "../src/PriceTrust";
+import PriceConnectors from "../src/constants/price_connectors.json";
 
 // Real anchor + non-anchor addresses on Base (chainId 8453) used by the #892
 // hard-anchor helpers. USDC is the chain's `destinationToken` (excluded from the
@@ -64,6 +67,40 @@ const ION_LISK = toChecksumAddress(
 // A canonical, never-blacklisted token (WETH on Optimism).
 const WETH_OP = toChecksumAddress("0x4200000000000000000000000000000000000006");
 
+// Issue #898 fixtures. WETH (`0x4200…0006`) is a price connector on every
+// OP-stack chain, so it can no longer stand in for a "generic untrusted token";
+// SNX on Optimism is a real token that is NOT a connector and NOT blacklisted,
+// used wherever a test needs a token with no positive trust signal.
+const SNX_OP = toChecksumAddress("0x8700dAec35aF8Ff88c16BdF0418774CB3D7599B4");
+// Canonical superchain WETH on Mode (34443) — a connector token that captured
+// zero on-chain WhitelistToken events (the bug this issue fixes).
+const MODE = 34443;
+const WETH_SUPERCHAIN = toChecksumAddress(
+  "0x4200000000000000000000000000000000000006",
+);
+// Already-whitelisted Base connector — the regression anchor: must stay WL.
+const USDC_BASE = toChecksumAddress(
+  "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+);
+
+// Maps each price_connectors.json key to its chain ID. A drift guard below
+// asserts this stays in lockstep with the JSON, so adding a chain to the config
+// without a chain ID here fails loudly rather than silently skipping coverage.
+const CONNECTOR_CHAIN_IDS: Record<string, number> = {
+  optimism: 10,
+  base: 8453,
+  mode: 34443,
+  lisk: 1135,
+  fraxtal: 252,
+  soneium: 1868,
+  ink: 57073,
+  metal: 1750,
+  unichain: 130,
+  celo: 42220,
+  superseed: 5330,
+  swellchain: 1923,
+};
+
 function makeToken(overrides: Partial<Token> = {}): Token {
   const chainId = overrides.chainId ?? 10;
   const address = overrides.address ?? WETH_OP;
@@ -91,6 +128,50 @@ function makeToken(overrides: Partial<Token> = {}): Token {
 }
 
 describe("PriceTrust", () => {
+  describe("isConnectorToken (#898)", () => {
+    it("returns true for a chain's configured price connector (WETH/Mode)", () => {
+      expect(isConnectorToken(MODE, WETH_SUPERCHAIN)).toBe(true);
+    });
+
+    it("returns false for a token that is not a connector (SNX/Optimism)", () => {
+      expect(isConnectorToken(10, SNX_OP)).toBe(false);
+    });
+
+    it("is case-insensitive on the address", () => {
+      expect(isConnectorToken(MODE, WETH_SUPERCHAIN.toLowerCase())).toBe(true);
+    });
+
+    it("returns false for an unknown chain", () => {
+      expect(isConnectorToken(999999, WETH_SUPERCHAIN)).toBe(false);
+    });
+  });
+
+  describe("getGateDecisionFromSignals connector path (#898)", () => {
+    it("trusts a non-whitelisted connector with reason CONNECTOR (WETH/Mode)", () => {
+      expect(getGateDecisionFromSignals(MODE, WETH_SUPERCHAIN, false)).toEqual({
+        trusted: true,
+        outcome: PRICE_TRUST_OUTCOME.TRUSTED,
+        reason: PRICE_TRUST_REASON.CONNECTOR,
+      });
+    });
+
+    it("reports WL (not CONNECTOR) when a connector is also whitelisted — protocol signal wins", () => {
+      expect(getGateDecisionFromSignals(MODE, WETH_SUPERCHAIN, true)).toEqual({
+        trusted: true,
+        outcome: PRICE_TRUST_OUTCOME.TRUSTED,
+        reason: PRICE_TRUST_REASON.WL,
+      });
+    });
+
+    it("still reports NON_WL for a non-whitelisted, non-connector token (SNX/Optimism)", () => {
+      expect(getGateDecisionFromSignals(10, SNX_OP, false)).toEqual({
+        trusted: false,
+        outcome: PRICE_TRUST_OUTCOME.UNTRUSTED,
+        reason: PRICE_TRUST_REASON.NON_WL,
+      });
+    });
+  });
+
   describe("isTrusted", () => {
     it("returns true for WL + not-BL", () => {
       expect(isTrusted(makeToken({ isWhitelisted: true }))).toBe(true);
@@ -105,8 +186,10 @@ describe("PriceTrust", () => {
       expect(isTrusted(token)).toBe(false);
     });
 
-    it("returns false for non-WL + not-BL", () => {
-      expect(isTrusted(makeToken({ isWhitelisted: false }))).toBe(false);
+    it("returns false for non-WL + not-BL (not a connector)", () => {
+      expect(
+        isTrusted(makeToken({ isWhitelisted: false, address: SNX_OP })),
+      ).toBe(false);
     });
 
     it("returns false for non-WL + BL (both signals agree)", () => {
@@ -120,6 +203,22 @@ describe("PriceTrust", () => {
 
     it("returns false for undefined token", () => {
       expect(isTrusted(undefined)).toBe(false);
+    });
+
+    it("returns true for a non-whitelisted connector token (#898)", () => {
+      // WETH on Mode is a connector but never captured a WhitelistToken event.
+      const token = makeToken({
+        chainId: MODE,
+        address: WETH_SUPERCHAIN,
+        isWhitelisted: false,
+      });
+      expect(isTrusted(token)).toBe(true);
+    });
+
+    it("returns false for a non-whitelisted, non-connector token", () => {
+      expect(
+        isTrusted(makeToken({ isWhitelisted: false, address: SNX_OP })),
+      ).toBe(false);
     });
   });
 
@@ -145,8 +244,10 @@ describe("PriceTrust", () => {
       });
     });
 
-    it("returns trusted=false and reason='NON_WL' for non-WL (not blacklisted)", () => {
-      expect(getGateDecision(makeToken({ isWhitelisted: false }))).toEqual({
+    it("returns trusted=false and reason='NON_WL' for non-WL (not blacklisted, not a connector)", () => {
+      expect(
+        getGateDecision(makeToken({ isWhitelisted: false, address: SNX_OP })),
+      ).toEqual({
         trusted: false,
         outcome: PRICE_TRUST_OUTCOME.UNTRUSTED,
         reason: PRICE_TRUST_REASON.NON_WL,
@@ -209,6 +310,7 @@ describe("PriceTrust", () => {
       const { context, writes } = makeMockContext();
       const stale = makeToken({
         isWhitelisted: false,
+        address: SNX_OP,
         priceTrustOutcome: PRICE_TRUST_OUTCOME.TRUSTED,
         priceTrustReason: PRICE_TRUST_REASON.WL,
       });
@@ -315,12 +417,28 @@ describe("PriceTrust", () => {
       );
     });
 
-    it("returns 0n for a non-whitelisted token regardless of price", () => {
+    it("returns 0n for a non-whitelisted, non-connector token regardless of price", () => {
       const token = makeToken({
         isWhitelisted: false,
+        address: SNX_OP,
         pricePerUSDNew: 1n * TEN_TO_THE_18_BI,
       });
       expect(getTrustedUSD(2n * TEN_TO_THE_18_BI, token)).toBe(0n);
+    });
+
+    it("returns amount × price for a non-whitelisted connector token (#898)", () => {
+      // The fix: a connector leg now contributes USD even with no WhitelistToken
+      // event — this is what un-zeroes Mode/Swell TVL and Soneium/Metal WETH.
+      const token = makeToken({
+        chainId: MODE,
+        address: WETH_SUPERCHAIN,
+        isWhitelisted: false,
+        decimals: 18n,
+        pricePerUSDNew: 1500n * TEN_TO_THE_18_BI,
+      });
+      expect(getTrustedUSD(2n * TEN_TO_THE_18_BI, token)).toBe(
+        3000n * TEN_TO_THE_18_BI,
+      );
     });
 
     it("returns 0n for a WL + BL token (blacklist overrides oracle output)", () => {
@@ -360,6 +478,7 @@ describe("PriceTrust", () => {
       const ratio1e18 = 50_000_000_000_000n;
       const untrusted = makeToken({
         isWhitelisted: false,
+        address: SNX_OP,
         pricePerUSDNew: 2000n * TEN_TO_THE_18_BI,
       });
       expect(getPoolImpliedUSD(ratio1e18, untrusted)).toBe(0n);
@@ -447,6 +566,69 @@ describe("PriceTrust", () => {
       expect(getHardAnchorUnitUSD(BASE, undefined)).toBe(0n);
       const usdc = makeToken({ chainId: BASE, address: BASE_USDC });
       expect(getHardAnchorUnitUSD(999999, usdc)).toBe(0n);
+    });
+  });
+
+  // AC (#898): "A test asserts connector tokens are trusted on each chain that
+  // defines a connector list." Data-driven straight from price_connectors.json
+  // so config and trust policy can never silently drift apart.
+  describe("every configured connector resolves to TRUSTED/CONNECTOR (#898)", () => {
+    it("covers exactly the chains defined in price_connectors.json (no silent gaps)", () => {
+      expect(Object.keys(PriceConnectors).sort()).toEqual(
+        Object.keys(CONNECTOR_CHAIN_IDS).sort(),
+      );
+    });
+
+    for (const [chainName, chainId] of Object.entries(CONNECTOR_CHAIN_IDS)) {
+      const connectors = (
+        PriceConnectors as Record<string, { address: string }[]>
+      )[chainName];
+
+      it(`${chainName} (${chainId}): all ${connectors.length} connectors trusted with reason CONNECTOR when not whitelisted`, () => {
+        expect(connectors.length).toBeGreaterThan(0);
+        for (const { address } of connectors) {
+          expect(isConnectorToken(chainId, address)).toBe(true);
+          expect(
+            getGateDecisionFromSignals(
+              chainId,
+              toChecksumAddress(address),
+              false,
+            ),
+          ).toEqual({
+            trusted: true,
+            outcome: PRICE_TRUST_OUTCOME.TRUSTED,
+            reason: PRICE_TRUST_REASON.CONNECTOR,
+          });
+        }
+      });
+    }
+
+    // The CONNECTOR reason above assumes no connector is also blacklisted. If
+    // that ever changes, the operator BLACKLIST must still win — blacklist is
+    // checked after the trust-signal gate, so such a token resolves
+    // UNTRUSTED/BLACKLISTED — and these assertions force a deliberate review.
+    it("no configured connector is also blacklisted (connector-trust ∩ BLACKLIST = ∅)", () => {
+      for (const [chainName, chainId] of Object.entries(CONNECTOR_CHAIN_IDS)) {
+        const connectors = (
+          PriceConnectors as Record<string, { address: string }[]>
+        )[chainName];
+        for (const { address } of connectors) {
+          expect(isBlacklistedToken(chainId, toChecksumAddress(address))).toBe(
+            false,
+          );
+        }
+      }
+    });
+  });
+
+  // Regression (#898): chains/tokens that were already correct must not move.
+  describe("regression: already-whitelisted connectors keep reason WL (#898)", () => {
+    it("Base USDC (whitelisted connector) stays TRUSTED/WL, not CONNECTOR", () => {
+      expect(getGateDecisionFromSignals(BASE, USDC_BASE, true)).toEqual({
+        trusted: true,
+        outcome: PRICE_TRUST_OUTCOME.TRUSTED,
+        reason: PRICE_TRUST_REASON.WL,
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary
- Treat each chain's configured **price connectors** as a positive trust signal alongside the protocol whitelist, so leaf deployments that never captured `WhitelistToken` events (**Mode** 34443, **Swell** 1923) and **WETH** on **Soneium**/**Metal** stop reading `$0` across every USD field. Decision recorded in **ADR 0002 (Option A)**.
- `src/PriceTrust.ts`: new `isConnectorToken` (O(1) eager per-chain Set); `getGateDecisionFromSignals` restructured — trust = whitelist **OR** connector, operator `BLACKLIST` still overrides; new `PRICE_TRUST_REASON.CONNECTOR`. `isTrusted` now delegates to the gate so the live USD gate and the persisted `priceTrust*` fields cannot diverge.
- Optimism is a **no-op** (16/16 connectors already whitelisted); Base newly trusts only **USDe** (~$400 correction across 5 small pools, a legit $1 stable previously zeroed).
- Tests: data-driven over `price_connectors.json` (every connector trusted on every chain) + a blacklist-disjointness guard; the #761 Voter de-whitelist tests are scoped to a non-connector token, plus new "connector stays `TRUSTED/CONNECTOR` after de-whitelist" coverage.
- Docs: ADR 0002 + `docs/querying.md` price-trust caveat.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `biome check` clean on changed files
- [x] `vitest run test/PriceTrust.test.ts` — 61 pass (incl. data-driven over all 12 chains + blacklist-disjointness guard)
- [x] Full suite green after the fix — the #761 `Voter`/`SuperchainLeafVoter` de-whitelist tests were updated (they had used WETH, now connector-trusted); the other ~1622 tests are unaffected
- [ ] After a replay/re-index: Mode (34443) & Swell (1923) canonical pools (e.g. WETH/USDC) report non-zero `totalLiquidityUSD`/`totalVolumeUSD` *(needs human — runtime/replay observation)*
- [ ] After a replay: a few known Base/OP pools' TVL is stable, no regression *(needs human — runtime/replay observation)*

### Bounded-risk note
Trusting connectors means a connector with an unreliable **local** price now contributes to USD. This is bounded: Optimism is all-already-whitelisted (no change; incl. the pre-existing sUSD-$0.23 oddity this PR does not introduce); Base only adds USDe ($1); leaf-chain connectors price sanely (verified live on deploy `21b81aa`); Metal WETH's ~30%-high local price is already capped/rebound by #892/#897 on main.

Closes #898

🤖 Generated with [Claude Code](https://claude.com/claude-code)