### PR TITLE
Align live & per-user V2 staked USD with the capped total (#899 residual)

### DIFF
--- a/src/Aggregators/Pool.ts
+++ b/src/Aggregators/Pool.ts
@@ -861,6 +861,24 @@ export async function updatePool(
     };
   }
 
+  // Issue #899 residual: staked liquidity is a subset of total liquidity, so its
+  // USD companion can never exceed totalLiquidityUSD. The snapshot recompute
+  // above already derives V2 staked from the (#892-capped) total — ≤ total by
+  // construction — but the *live* entity between snapshots is written by the
+  // gauge path (computeNonCLPoolStakedUSD / CL computeCLStakedReservesOnGaugeEvent)
+  // through the UNCAPPED calculateTotalUSD, so on a #892-capped pool it can land
+  // above the capped total. Clamp on every write, regardless of which path wrote
+  // it — the USD analog of the units lockstep above (#857) and the #891
+  // staked ≤ liquidityInRange clamp. One-directional (only lowers), so it can
+  // never inflate a correct value; a transient stale-low total just under-counts
+  // staked until the next Sync (the accepted #891 tradeoff).
+  if (updated.currentLiquidityStakedUSD > updated.totalLiquidityUSD) {
+    updated = {
+      ...updated,
+      currentLiquidityStakedUSD: updated.totalLiquidityUSD,
+    };
+  }
+
   context.Pool.set(updated);
 }
 

--- a/src/Aggregators/UserStatsPerPool.ts
+++ b/src/Aggregators/UserStatsPerPool.ts
@@ -8,7 +8,7 @@ import {
   UserStatsPerPoolId,
 } from "../Constants";
 import { getRehydrated } from "../EntityTimestamps";
-import { computeNonCLStakedUSD, concentratedLiquidityToUSD } from "../Helpers";
+import { concentratedLiquidityToUSD } from "../Helpers";
 import { getSnapshotEpoch, shouldSnapshot } from "../Snapshots/Shared";
 import { setUserStatsPerPoolSnapshot } from "../Snapshots/UserStatsPerPoolSnapshot";
 import type { PoolData } from "./Pool";
@@ -435,11 +435,6 @@ export async function updateUserStatsPerPool(
         }
       }
       if (poolEntity) {
-        const poolData = {
-          liquidityPoolAggregator: poolEntity,
-          token0Instance: token0Instance ?? undefined,
-          token1Instance: token1Instance ?? undefined,
-        };
         if (
           poolEntity.isCL &&
           poolEntity.sqrtPriceX96 &&
@@ -474,12 +469,22 @@ export async function updateUserStatsPerPool(
           }
           updated = { ...updated, currentLiquidityStakedUSD: stakedUSD };
         } else if (!poolEntity.isCL) {
-          const stakedUSD = computeNonCLStakedUSD(
-            updated.currentLiquidityStaked,
-            poolEntity,
-            poolData,
-            context,
-          );
+          // Issue #899 residual: per-user non-CL staked USD must share the pool's
+          // #892-capped totalLiquidityUSD basis. Derive the user's staked share as
+          // a fraction of the capped total — totalLiquidityUSD × min(staked, supply)
+          // / supply — rather than re-valuing reserves through the uncapped
+          // computeNonCLStakedUSD path, which would re-inject the inflated
+          // DEUS-class oracle. min(staked, supply) bounds the fraction at 1; summed
+          // across users this reconciles with the pool's currentLiquidityStakedUSD.
+          const supply = poolEntity.totalLPTokenSupply;
+          const stakedShare =
+            updated.currentLiquidityStaked < supply
+              ? updated.currentLiquidityStaked
+              : supply;
+          const stakedUSD =
+            supply > 0n
+              ? (poolEntity.totalLiquidityUSD * stakedShare) / supply
+              : 0n;
           updated = { ...updated, currentLiquidityStakedUSD: stakedUSD };
         }
       }

--- a/test/Aggregators/PoolStakedUSDLockstep.test.ts
+++ b/test/Aggregators/PoolStakedUSDLockstep.test.ts
@@ -390,6 +390,73 @@ describe("Pool staked-USD recompute on the non-CL snapshot path (issue #899)", (
     );
   });
 
+  it("clamps the live currentLiquidityStakedUSD to totalLiquidityUSD when the gauge path writes an uncapped value (no snapshot crossing)", async () => {
+    // Residual of #899: between hourly snapshots the live entity is written by
+    // the gauge path (computeNonCLPoolStakedUSD → uncapped calculateTotalUSD).
+    // On a #892-capped pool that value can land above the capped totalLiquidityUSD
+    // (DEUS-class), so the persisted Pool row shows staked > total until the next
+    // snapshot. A diff carrying that inflated USD (same-epoch ⇒ no snapshot
+    // recompute) must be clamped to total on the way out.
+    const pool = common.createMockPool({
+      poolAddress,
+      chainId,
+      isCL: false,
+      // same epoch as the update below -> shouldSnapshot is false, no recompute
+      lastSnapshotTimestamp: lastSnapshot,
+      lastUpdatedTimestamp: lastSnapshot,
+      currentLiquidityStaked: 50n * TEN_TO_THE_18_BI,
+      totalLiquidityUSD: 100n * TEN_TO_THE_18_BI, // #892-capped
+      currentLiquidityStakedUSD: 0n,
+    });
+
+    const setMock = vi.fn();
+    const ctx = buildMockContext(setMock);
+
+    await updatePool(
+      // gauge-path diff carrying an uncapped staked-USD above the capped total
+      { currentLiquidityStakedUSD: 300n * TEN_TO_THE_18_BI },
+      pool,
+      lastSnapshot, // same epoch -> live path, no snapshot block
+      ctx,
+      chainId,
+      131_536_921,
+    );
+
+    const updated = setMock.mock.calls[0]?.[0] as Pool;
+    expect(updated.currentLiquidityStakedUSD).toBe(100n * TEN_TO_THE_18_BI);
+    expect(updated.currentLiquidityStakedUSD).toBeLessThanOrEqual(
+      updated.totalLiquidityUSD,
+    );
+  });
+
+  it("leaves a live currentLiquidityStakedUSD already ≤ total unchanged (clamp is one-directional)", async () => {
+    const pool = common.createMockPool({
+      poolAddress,
+      chainId,
+      isCL: false,
+      lastSnapshotTimestamp: lastSnapshot,
+      lastUpdatedTimestamp: lastSnapshot,
+      currentLiquidityStaked: 50n * TEN_TO_THE_18_BI,
+      totalLiquidityUSD: 400n * TEN_TO_THE_18_BI,
+      currentLiquidityStakedUSD: 0n,
+    });
+
+    const setMock = vi.fn();
+    const ctx = buildMockContext(setMock);
+
+    await updatePool(
+      { currentLiquidityStakedUSD: 200n * TEN_TO_THE_18_BI }, // ≤ total
+      pool,
+      lastSnapshot,
+      ctx,
+      chainId,
+      131_536_921,
+    );
+
+    const updated = setMock.mock.calls[0]?.[0] as Pool;
+    expect(updated.currentLiquidityStakedUSD).toBe(200n * TEN_TO_THE_18_BI);
+  });
+
   it("preserves the prior staked USD when totalLPTokenSupply is transiently 0 (no overwrite to 0)", async () => {
     // supply === 0n with a positive stake is an inconsistent transient (e.g. a
     // full-burn Sync while the staked-units counter lags). Dividing by it is

--- a/test/Aggregators/Users.test.ts
+++ b/test/Aggregators/Users.test.ts
@@ -740,8 +740,8 @@ describe("UserStatsPerPool Aggregator", () => {
 
       // Should not query positions (non-CL pool)
       expect(snapshotCtx.NonFungiblePosition.getWhere).not.toHaveBeenCalled();
-      // Non-CL staked USD is computed at snapshot time via pro-rata
-      // With default mock pool (totalLPTokenSupply=0), computeNonCLStakedUSD returns 0
+      // Non-CL staked USD is the staked share of totalLiquidityUSD; the default
+      // mock pool has totalLPTokenSupply=0, so the supply>0 guard yields 0.
       expect(result.currentLiquidityStakedUSD).toBe(0n);
     });
 
@@ -771,6 +771,9 @@ describe("UserStatsPerPool Aggregator", () => {
         reserve0: 1000000000n, // 1000 tokens (6 decimals)
         reserve1: 1000000000n,
         totalLPTokenSupply: 1000000000000000000000n, // 1000 LP tokens
+        // Capped TVL, set consistent with reserves (1000 + 1000 @ $1 = $2000) so
+        // the staked share derives to the same value the reserve math would.
+        totalLiquidityUSD: 2000000000000000000000n, // $2000
       });
 
       const mockToken0 = {
@@ -807,9 +810,52 @@ describe("UserStatsPerPool Aggregator", () => {
         currentTimestamp,
       );
 
-      // 100 LP / 1000 total * 1000 reserve0 = 100 tokens (6 dec) → normalized to 18 dec = 100e18
-      // USD: 100e18 * 1e18 / 1e18 = 100e18 per token, total = 200e18
+      // Staked share of the (capped) total: $2000 * 100 LP / 1000 LP = $200.
       expect(result.currentLiquidityStakedUSD).toBe(200000000000000000000n);
+    });
+
+    it("derives non-CL per-user staked USD from the capped total, not the uncapped reserves (#892-capped pool)", async () => {
+      const { createMockUserStatsPerPool, createMockPool } = setupCommon();
+      const oldTimestamp = new Date(Date.now() - 2 * 60 * 60 * 1000);
+      const currentTimestamp = new Date();
+
+      const existingUserStats = createMockUserStatsPerPool({
+        userAddress: mockUserAddress,
+        poolAddress: mockPoolAddress,
+        chainId: mockChainId,
+        currentLiquidityStaked: 100000000000000000000n, // 100 LP (10% of supply)
+        currentLiquidityStakedUSD: 0n,
+        lastSnapshotTimestamp: oldTimestamp,
+      });
+
+      // Reserves would imply ~$2000 uncapped, but #892 deflated totalLiquidityUSD
+      // to $100 at Sync (poisoned-oracle token). The per-user share must follow
+      // the capped total: $100 * 100/1000 = $10, NOT the uncapped $200.
+      const cappedPool = createMockPool({
+        poolAddress: mockPoolAddress,
+        chainId: mockChainId,
+        isCL: false,
+        reserve0: 1000000000n,
+        reserve1: 1000000000n,
+        totalLPTokenSupply: 1000000000000000000000n, // 1000 LP
+        totalLiquidityUSD: 100000000000000000000n, // $100, #892-capped
+      });
+
+      const snapshotCtx = {
+        ...mockContext,
+        Pool: { get: vi.fn().mockResolvedValue(cappedPool) },
+        Token: { get: vi.fn().mockResolvedValue(undefined) },
+        NonFungiblePosition: { getWhere: vi.fn() },
+      } as unknown as handlerContext;
+
+      const result = await updateUserStatsPerPool(
+        { lastActivityTimestamp: currentTimestamp },
+        existingUserStats,
+        snapshotCtx,
+        currentTimestamp,
+      );
+
+      expect(result.currentLiquidityStakedUSD).toBe(10000000000000000000n); // $10
     });
 
     it("should NOT compute staked USD at snapshot time when LPA is not found", async () => {

--- a/test/EventHandlers/Gauges/GaugeSharedLogic.test.ts
+++ b/test/EventHandlers/Gauges/GaugeSharedLogic.test.ts
@@ -113,7 +113,10 @@ describe("GaugeSharedLogic", () => {
       isStable: true,
       reserve0: 1000000000n, // 1000 tokens (6 decimals) - enough for 100 LP tokens to represent 100 tokens each
       reserve1: 1000000000n, // 1000 tokens (6 decimals)
-      totalLiquidityUSD: 2000000000000000000000000n, // 2M USD in 18 decimals
+      // $2000 — consistent with reserves (1000 token0 + 1000 token1 at $1). The
+      // per-user/pool staked-USD (#899 residual) now derives from this capped
+      // total, so it must agree with the reserves rather than be an arbitrary value.
+      totalLiquidityUSD: 2000000000000000000000n,
       token0Price: 1000000000000000000n,
       token1Price: 1000000000000000000n,
       gaugeAddress: mockGaugeAddress,


### PR DESCRIPTION
## Summary
Follow-up to #899 / PR #906, which fixed only the **hourly snapshot** recompute of V2 `currentLiquidityStakedUSD`. Two write paths were still left on the uncapped valuation:

- **Live pool entity** — between snapshots, the gauge deposit/withdraw path writes `Pool.currentLiquidityStakedUSD` through the uncapped `computeNonCLStakedUSD`, so on a #892-capped pool (DEUS-class frozen oracle) it could exceed the capped `totalLiquidityUSD` until the next hourly boundary re-capped it.
- **Per-user entry** — `UserStatsPerPool.currentLiquidityStakedUSD` for non-CL pools was computed the same uncapped way.

This PR aligns both with the #892-capped basis:

- **Pool**: clamp `currentLiquidityStakedUSD <= totalLiquidityUSD` on every write at the `updatePool` exit — the USD analog of the #857 units lockstep and the #891 `staked <= liquidityInRange` clamp. One-directional (only lowers), so it can never inflate a correct value.
- **UserStatsPerPool**: derive non-CL per-user staked-USD as a fraction of the capped total — `totalLiquidityUSD * min(staked, supply) / supply` — instead of re-valuing reserves through the uncapped path. Summed across users this reconciles with the pool's `currentLiquidityStakedUSD`.

CL pools are untouched; no per-swap cost (clamp is a single comparison at an existing write site).

## Test plan
- [x] `tsc --noEmit` clean
- [x] `biome check` clean on changed files
- [x] Full suite green (1607 passed / 1607)
- [x] New clamp tests in `PoolStakedUSDLockstep.test.ts` (live value > total → clamped to total; already ≤ total → unchanged)
- [x] Per-user proportional tests in `Users.test.ts` (#892-capped pool derives per-user staked-USD from the capped total)
- [x] `GaugeSharedLogic.test.ts` fixture made internally consistent (reserves $2000 ⇔ `totalLiquidityUSD` $2000) so the proportional derivation matches reserves

🤖 Generated with [Claude Code](https://claude.com/claude-code)